### PR TITLE
fix: display start and end time for blackout dates

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/utils.js
+++ b/src/pages-and-resources/discussions/app-config-form/utils.js
@@ -34,6 +34,8 @@ export const isSameYear = (startDate, endDate) => moment(startDate).isSame(endDa
 export const getTime = (dateTime) => dateTime.split('T')[1] || '';
 export const hasValidDateFormat = (date) => moment(date, ['MM/DD/YYYY', 'YYYY-MM-DD'], true).isValid();
 export const hasValidTimeFormat = (time) => time && moment(time, validTimeFormats, true).isValid();
+export const startOfDayTime = (time) => time || moment().startOf('day').format('HH:mm');
+export const endOfDayTime = (time) => time || moment().endOf('day').format('HH:mm');
 export const normalizeTime = (time) => time && moment(time, validTimeFormats, true).format('HH:mm');
 export const normalizeDate = (date) => moment(
   date, ['MM/DD/YYYY', 'YYYY-MM-DDTHH:mm', 'YYYY-MM-DD'], true,
@@ -48,7 +50,7 @@ export const decodeDateTime = (date, time) => {
 
 export const sortBlackoutDatesByStatus = (data, status, order) => (
   _.orderBy(data.filter(date => date.status === status),
-    [(obj) => decodeDateTime(obj.startDate, obj.startTime)], [order])
+    [(obj) => decodeDateTime(obj.startDate, startOfDayTime(obj.startTime))], [order])
 );
 
 export const formatBlackoutDates = ({
@@ -58,11 +60,11 @@ export const formatBlackoutDates = ({
   const hasSameDay = isSameDay(startDate, endDate);
   const hasSameMonth = isSameMonth(startDate, endDate);
   const hasSameYear = isSameYear(startDate, endDate);
-  const isTimeAvailable = Boolean(startTime && endTime);
+  const isTimeAvailable = Boolean(startTime || endTime);
   const mStartDate = moment(startDate);
   const mEndDate = moment(endDate);
-  const mStartDateTime = decodeDateTime(startDate, startTime);
-  const mEndDateTime = decodeDateTime(endDate, endTime);
+  const mStartDateTime = decodeDateTime(startDate, startOfDayTime(startTime));
+  const mEndDateTime = decodeDateTime(endDate, endOfDayTime(endTime));
 
   if (hasSameDay && !isTimeAvailable) {
     formattedDate = mStartDate.format('MMMM D, YYYY');

--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -10,6 +10,8 @@ import {
   normalizeDate,
   normalizeTime,
   getTime,
+  startOfDayTime,
+  endOfDayTime,
 } from '../app-config-form/utils';
 import { blackoutDatesStatus as constants } from './constants';
 
@@ -129,11 +131,11 @@ export function denormalizeBlackoutDate(blackoutPeriod) {
   return [
     mergeDateTime(
       normalizeDate(blackoutPeriod.startDate),
-      normalizeTime(blackoutPeriod.startTime),
+      normalizeTime(startOfDayTime(blackoutPeriod.startTime)),
     ),
     mergeDateTime(
       normalizeDate(blackoutPeriod.endDate),
-      normalizeTime(blackoutPeriod.endTime),
+      normalizeTime(endOfDayTime(blackoutPeriod.endTime)),
     ),
   ];
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,7 @@ import { getCourseAppSettingValue, getLoadingStatus } from './pages-and-resource
 import { fetchCourseAppSettings, updateCourseAppSetting } from './pages-and-resources/data/thunks';
 import { PagesAndResourcesContext } from './pages-and-resources/PagesAndResourcesProvider';
 import {
-  hasValidDateFormat, hasValidTimeFormat, decodeDateTime,
+  hasValidDateFormat, hasValidTimeFormat, decodeDateTime, endOfDayTime, startOfDayTime,
 } from './pages-and-resources/discussions/app-config-form/utils';
 
 export const executeThunk = async (thunk, dispatch, getState) => {
@@ -106,8 +106,8 @@ export function setupYupExtensions() {
         return true;
       }
 
-      const startDateTime = decodeDateTime(this.parent.startDate, this.parent.startTime);
-      const endDateTime = decodeDateTime(this.parent.endDate, this.parent.endTime);
+      const startDateTime = decodeDateTime(this.parent.startDate, startOfDayTime(this.parent.startTime));
+      const endDateTime = decodeDateTime(this.parent.endDate, endOfDayTime(this.parent.endTime));
       let isInvalidStartDateTime;
 
       if (type === 'date') {


### PR DESCRIPTION
[TNL-8803](https://openedx.atlassian.net/browse/TNL-8803)
- Display only dates when start and end times are not selected
- Display the end of the last day (11:59 PM, unless otherwise specified). The end date is a required field and will always be set.
- Display all days start at the same time (12:00 AM) unless otherwise specified.

<img width="681" alt="Screenshot 2021-10-29 at 4 04 44 PM" src="https://user-images.githubusercontent.com/79941147/139427744-b89770d2-3d5d-4a97-93e2-1c80278e59ed.png">
<img width="694" alt="Screenshot 2021-10-29 at 4 04 52 PM" src="https://user-images.githubusercontent.com/79941147/139427754-0bac41c8-d512-4fde-9526-85a7117e8fb9.png">
<img width="680" alt="Screenshot 2021-10-29 at 4 06 03 PM" src="https://user-images.githubusercontent.com/79941147/139427756-39ab2d26-8974-4746-841c-15c1780bcac1.png">
<img width="688" alt="Screenshot 2021-10-29 at 4 06 08 PM" src="https://user-images.githubusercontent.com/79941147/139427759-2afab708-3305-4a8d-b56a-8431dfda15b8.png">
<img width="686" alt="Screenshot 2021-10-29 at 4 09 09 PM" src="https://user-images.githubusercontent.com/79941147/139427760-c320b494-ffd0-4359-acd2-b83610dfa1ea.png">
<img width="695" alt="Screenshot 2021-10-29 at 4 09 15 PM" src="https://user-images.githubusercontent.com/79941147/139427883-c3b4e583-f195-4f6b-8702-f8d38ad79c1b.png">
