### PR TITLE
fix: layout responsive for edit page

### DIFF
--- a/src/editors/EditorContainer.scss
+++ b/src/editors/EditorContainer.scss
@@ -1,0 +1,29 @@
+.editor-page {
+  .pgn__modal-body {
+    @include media-breakpoint-down(xs) {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+  }
+
+  .pgn-transition-replace-group .bg-light-300 {
+    @include media-breakpoint-down(xs) {
+      padding: 5px !important;
+    }
+  }
+
+  .pgn__form-control-set .pgn__action-row {
+    @include media-breakpoint-down(xs) {
+      flex-flow: column wrap;
+      align-items: flex-start;
+      justify-content: flex-start;
+      gap: 8px;
+    }
+  }
+}
+
+.pgn__modal.pgn__modal-scroll-fullscreen {
+  @include media-breakpoint-down(xs) {
+    margin: 0;
+  }
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -19,3 +19,4 @@
 @import "course-updates/CourseUpdates";
 @import "export-page/CourseExportPage";
 @import "import-page/CourseImportPage";
+@import "editors/EditorContainer";


### PR DESCRIPTION
**TL;DR -**

This pull request contains mobile phone adaptation fixes for Problem Editor page.
Added general rearrangement of pages, indentations, and fixed element deformation during adaptation.

**Related PRs:**
- frontend-lib-content-components main https://github.com/openedx/frontend-lib-content-components/pull/422
- frontend-app-course-authoring master https://github.com/openedx/frontend-app-course-authoring/pull/922
- frontend-app-course-authoring redwood https://github.com/openedx/frontend-app-course-authoring/pull/1058

**What changed?**

|  Before |  After |
|---|---|
|  <img width="431" alt="12" src="https://github.com/openedx/frontend-app-course-authoring/assets/17108583/52e7b744-0093-4d7e-9a3b-4f2926ce4583">  |  <img width="429" alt="11" src="https://github.com/openedx/frontend-app-course-authoring/assets/17108583/d02d0b3b-eb67-4d9d-8fb3-56fe1389bea7"> |

|  Before |  After |
|---|---|
|  <img width="375" alt="41" src="https://github.com/openedx/frontend-app-course-authoring/assets/17108583/09d03c56-96ea-4205-a52f-a3851e0b43e4">  |  <img width="375" alt="21" src="https://github.com/openedx/frontend-app-course-authoring/assets/17108583/1ffa7a79-899d-45e9-b198-4c102c939351"> |
