### PR TITLE
feat: [FC-0044] Course unit - Edit/move modals for xblocks

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -27,6 +27,7 @@ export const NOTIFICATION_MESSAGES = {
   copying: 'Copying',
   pasting: 'Pasting',
   discardChanges: 'Discarding changes',
+  undoMoving: 'Undo moving',
   publishing: 'Publishing',
   hidingFromStudents: 'Hiding from students',
   makingVisibleToStudents: 'Making visible to students',

--- a/src/course-unit/CourseUnit.jsx
+++ b/src/course-unit/CourseUnit.jsx
@@ -2,11 +2,16 @@ import { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
-import { Container, Layout, Stack } from '@openedx/paragon';
+import {
+  Container, Layout, Stack, Button, TransitionReplace,
+} from '@openedx/paragon';
 import { getConfig } from '@edx/frontend-platform';
 import { useIntl, injectIntl } from '@edx/frontend-platform/i18n';
 import { DraggableList, ErrorAlert } from '@edx/frontend-lib-content-components';
-import { Warning as WarningIcon } from '@openedx/paragon/icons';
+import {
+  Warning as WarningIcon,
+  CheckCircle as CheckCircleIcon,
+} from '@openedx/paragon/icons';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 
 import { getProcessingNotification } from '../generic/processing-notification/data/selectors';
@@ -61,6 +66,10 @@ const CourseUnit = ({ courseId }) => {
     courseVerticalChildren,
     handleXBlockDragAndDrop,
     canPasteComponent,
+    movedXBlockParams,
+    handleRollbackMovedXBlock,
+    handleCloseXBlockMovedAlert,
+    handleNavigateToTargetUnit,
   } = useCourseUnit({ courseId, blockId });
 
   const initialXBlocksData = useMemo(() => courseVerticalChildren.children ?? [], [courseVerticalChildren.children]);
@@ -101,6 +110,34 @@ const CourseUnit = ({ courseId }) => {
     <>
       <Container size="xl" className="course-unit px-4">
         <section className="course-unit-container mb-4 mt-5">
+          <TransitionReplace>
+            {movedXBlockParams.isSuccess ? (
+              <AlertMessage
+                key="xblock-moved-alert"
+                data-testid="xblock-moved-alert"
+                show={movedXBlockParams.isSuccess}
+                variant="success"
+                icon={CheckCircleIcon}
+                title={movedXBlockParams.isUndo
+                  ? intl.formatMessage(messages.alertMoveCancelTitle)
+                  : intl.formatMessage(messages.alertMoveSuccessTitle)}
+                description={movedXBlockParams.isUndo
+                  ? intl.formatMessage(messages.alertMoveCancelDescription, { title: movedXBlockParams.title })
+                  : intl.formatMessage(messages.alertMoveSuccessDescription, { title: movedXBlockParams.title })}
+                aria-hidden={movedXBlockParams.isSuccess}
+                dismissible
+                actions={movedXBlockParams.isUndo ? null : [
+                  <Button onClick={handleRollbackMovedXBlock}>
+                    {intl.formatMessage(messages.undoMoveButton)}
+                  </Button>,
+                  <Button onClick={handleNavigateToTargetUnit}>
+                    {intl.formatMessage(messages.newLocationButton)}
+                  </Button>,
+                ]}
+                onClose={handleCloseXBlockMovedAlert}
+              />
+            ) : null}
+          </TransitionReplace>
           <ErrorAlert hideHeading isError={savingStatus === RequestStatus.FAILED && isErrorAlert}>
             {intl.formatMessage(messages.alertFailedGeneric, { actionName: 'save', type: 'changes' })}
           </ErrorAlert>

--- a/src/course-unit/CourseUnit.jsx
+++ b/src/course-unit/CourseUnit.jsx
@@ -43,6 +43,7 @@ const CourseUnit = ({ courseId }) => {
   const intl = useIntl();
   const {
     isLoading,
+    isLoadingFailed,
     sequenceId,
     unitTitle,
     isQueryPending,
@@ -92,7 +93,7 @@ const CourseUnit = ({ courseId }) => {
     return <Loading />;
   }
 
-  if (sequenceStatus === RequestStatus.FAILED) {
+  if (isLoadingFailed || sequenceStatus === RequestStatus.FAILED) {
     return (
       <Container size="xl" className="course-unit px-4 mt-4">
         <ConnectionErrorAlert />

--- a/src/course-unit/CourseUnit.test.jsx
+++ b/src/course-unit/CourseUnit.test.jsx
@@ -149,9 +149,9 @@ describe('<CourseUnit />', () => {
     store = initializeStore();
     axiosMock = new MockAdapter(getAuthenticatedHttpClient());
     axiosMock
-      .onGet(getCourseUnitApiUrl(courseId))
+      .onGet(getCourseUnitApiUrl(blockId))
       .reply(200, courseUnitIndexMock);
-    await executeThunk(fetchCourseUnitQuery(courseId), store.dispatch);
+    await executeThunk(fetchCourseUnitQuery(blockId), store.dispatch);
     axiosMock
       .onGet(getCourseSectionVerticalApiUrl(blockId))
       .reply(200, courseSectionVerticalMock);
@@ -1036,7 +1036,7 @@ describe('<CourseUnit />', () => {
       .reply(200, { dummy: 'value' });
     axiosMock
       .onGet(getCourseUnitApiUrl(blockId))
-      .replyOnce(200, {
+      .reply(200, {
         ...courseUnitIndexMock,
         visibility_state: UNIT_VISIBILITY_STATES.staffOnly,
         has_explicit_staff_lock: true,

--- a/src/course-unit/course-xblock/CourseIFrame.jsx
+++ b/src/course-unit/course-xblock/CourseIFrame.jsx
@@ -1,0 +1,35 @@
+import { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+
+import { IFRAME_FEATURE_POLICY } from './constants';
+
+const CourseIFrame = forwardRef(({ title, ...props }, ref) => (
+  <iframe
+    title={title}
+    // allowing 'autoplay' is required to allow the video XBlock to control the YouTube iframe it has.
+    allow={IFRAME_FEATURE_POLICY}
+    referrerPolicy="origin"
+    frameBorder={0}
+    scrolling="no"
+    ref={ref}
+    sandbox={[
+      'allow-forms',
+      'allow-modals',
+      'allow-popups',
+      'allow-popups-to-escape-sandbox',
+      'allow-presentation',
+      'allow-same-origin', // This is only secure IF the IFrame source
+      // is served from a completely different domain name
+      // e.g. labxchange-xblocks.net vs www.labxchange.org
+      'allow-scripts',
+      'allow-top-navigation-by-user-activation',
+    ].join(' ')}
+    {...props}
+  />
+));
+
+CourseIFrame.propTypes = {
+  title: PropTypes.string.isRequired,
+};
+
+export default CourseIFrame;

--- a/src/course-unit/course-xblock/CourseXBlock.jsx
+++ b/src/course-unit/course-xblock/CourseXBlock.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
@@ -9,20 +9,27 @@ import { EditOutline as EditIcon, MoreVert as MoveVertIcon } from '@openedx/para
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import { getCanEdit, getCourseId } from 'CourseAuthoring/course-unit/data/selectors';
+import { getCanEdit, getCourseId } from '../data/selectors';
+import { useOverflowControl } from '../../generic/hooks';
 import DeleteModal from '../../generic/delete-modal/DeleteModal';
 import ConfigureModal from '../../generic/configure-modal/ConfigureModal';
 import SortableItem from '../../generic/drag-helper/SortableItem';
 import { scrollToElement } from '../../course-outline/utils';
 import { COURSE_BLOCK_NAMES } from '../../constants';
 import { copyToClipboard } from '../../generic/data/thunks';
+import { fetchCourseUnitQuery, fetchCourseVerticalChildrenData } from '../data/thunk';
+import { updateMovedXBlockParams } from '../data/slice';
 import { COMPONENT_TYPES } from '../constants';
 import XBlockMessages from './xblock-messages/XBlockMessages';
 import messages from './messages';
+import { getXBlockActionsBasePath } from './utils';
+import CourseIFrame from './CourseIFrame';
+
+const XBLOCK_LEGACY_MODAL_CLASS_NAME = 'xblock-edit-modal';
 
 const CourseXBlock = ({
   id, title, type, unitXBlockActions, shouldScroll, userPartitionInfo,
-  handleConfigureSubmit, validationMessages, ...props
+  handleConfigureSubmit, validationMessages, renderError, blockId, ...props
 }) => {
   const courseXBlockElementRef = useRef(null);
   const [isDeleteModalOpen, openDeleteModal, closeDeleteModal] = useToggle(false);
@@ -32,6 +39,38 @@ const CourseXBlock = ({
   const canEdit = useSelector(getCanEdit);
   const courseId = useSelector(getCourseId);
   const intl = useIntl();
+  const [showLegacyEditModal, toggleLegacyEditModal] = useState(false);
+  const [showLegacyMoveModal, toggleLegacyMoveModal] = useState(false);
+  const xblockLegacyModalRef = useRef(null);
+
+  useOverflowControl(`.${XBLOCK_LEGACY_MODAL_CLASS_NAME}`);
+
+  useEffect(() => {
+    const handleMessage = (event) => {
+      const { method, params } = event.data;
+
+      if (method === 'close_modal') {
+        toggleLegacyEditModal(false);
+        dispatch(fetchCourseVerticalChildrenData(blockId));
+        dispatch(fetchCourseUnitQuery(blockId));
+      } else if (method === 'move_xblock') {
+        toggleLegacyMoveModal(false);
+        dispatch(updateMovedXBlockParams({
+          title: params.sourceDisplayName,
+          isSuccess: true,
+          sourceLocator: params.sourceLocator,
+          targetParentLocator: params.targetParentLocator,
+        }));
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, [xblockLegacyModalRef]);
 
   const [searchParams] = useSearchParams();
   const locatorId = searchParams.get('show');
@@ -40,6 +79,10 @@ const CourseXBlock = ({
   const visibilityMessage = userPartitionInfo.selectedGroupsLabel
     ? intl.formatMessage(messages.visibilityMessage, { selectedGroupsLabel: userPartitionInfo.selectedGroupsLabel })
     : null;
+
+  useEffect(() => {
+    localStorage.removeItem('editedXBlockId');
+  }, []);
 
   const currentItemData = {
     category: COURSE_BLOCK_NAMES.component.id,
@@ -61,7 +104,20 @@ const CourseXBlock = ({
       navigate(`/course/${courseId}/editor/${type}/${id}`);
       break;
     default:
+      toggleLegacyEditModal(true);
+      localStorage.setItem('editedXBlockId', id);
     }
+  };
+
+  const handleXBlockMove = () => {
+    toggleLegacyMoveModal(true);
+    dispatch(updateMovedXBlockParams({
+      isSuccess: false,
+      isUndo: false,
+      title: '',
+      sourceLocator: '',
+      targetParentLocator: '',
+    }));
   };
 
   const onConfigureSubmit = (...arg) => {
@@ -76,92 +132,118 @@ const CourseXBlock = ({
   }, [isScrolledToElement]);
 
   return (
-    <div
-      ref={courseXBlockElementRef}
-      {...props}
-      className={classNames('course-unit__xblock', {
-        'xblock-highlight': isScrolledToElement,
-      })}
-    >
-      <Card
-        as={SortableItem}
+    <>
+      {showLegacyEditModal && (
+        <div className={XBLOCK_LEGACY_MODAL_CLASS_NAME}>
+          <CourseIFrame
+            title="xblock-edit-modal-iframe"
+            key="xblock-edit-modal-key"
+            ref={xblockLegacyModalRef}
+            src={`${getXBlockActionsBasePath(id)}/edit`}
+          />
+        </div>
+      )}
+      {showLegacyMoveModal && (
+        <div className={XBLOCK_LEGACY_MODAL_CLASS_NAME}>
+          <CourseIFrame
+            title="xblock-move-modal-iframe"
+            key="xblock-move-modal-key"
+            ref={xblockLegacyModalRef}
+            src={`${getXBlockActionsBasePath(id)}/move`}
+          />
+        </div>
+      )}
+      <div
         id={id}
-        draggable
-        category="xblock"
-        componentStyle={{ marginBottom: 0 }}
+        ref={courseXBlockElementRef}
+        {...props}
+        className={classNames('course-unit__xblock', {
+          'xblock-highlight': isScrolledToElement,
+        })}
       >
-        <Card.Header
-          title={title}
-          subtitle={visibilityMessage}
-          actions={(
-            <ActionRow className="mr-2">
-              <IconButton
-                alt={intl.formatMessage(messages.blockAltButtonEdit)}
-                iconAs={EditIcon}
-                onClick={handleEdit}
-              />
-              <Dropdown>
-                <Dropdown.Toggle
-                  id={id}
-                  as={IconButton}
-                  src={MoveVertIcon}
-                  alt={intl.formatMessage(messages.blockActionsDropdownAlt)}
-                  iconAs={Icon}
+        <Card
+          as={SortableItem}
+          id={id}
+          draggable
+          category="xblock"
+          componentStyle={{ marginBottom: 0 }}
+        >
+          <Card.Header
+            title={title}
+            subtitle={visibilityMessage}
+            actions={(
+              <ActionRow className="mr-2">
+                <IconButton
+                  alt={intl.formatMessage(messages.blockAltButtonEdit)}
+                  iconAs={EditIcon}
+                  onClick={handleEdit}
                 />
-                <Dropdown.Menu>
-                  <Dropdown.Item onClick={() => unitXBlockActions.handleDuplicate(id)}>
-                    {intl.formatMessage(messages.blockLabelButtonDuplicate)}
-                  </Dropdown.Item>
-                  <Dropdown.Item>
-                    {intl.formatMessage(messages.blockLabelButtonMove)}
-                  </Dropdown.Item>
-                  {canEdit && (
-                    <Dropdown.Item onClick={() => dispatch(copyToClipboard(id))}>
-                      {intl.formatMessage(messages.blockLabelButtonCopyToClipboard)}
+                <Dropdown>
+                  <Dropdown.Toggle
+                    id={id}
+                    as={IconButton}
+                    src={MoveVertIcon}
+                    alt={intl.formatMessage(messages.blockActionsDropdownAlt)}
+                    iconAs={Icon}
+                  />
+                  <Dropdown.Menu>
+                    <Dropdown.Item onClick={() => unitXBlockActions.handleDuplicate(id)}>
+                      {intl.formatMessage(messages.blockLabelButtonDuplicate)}
                     </Dropdown.Item>
-                  )}
-                  <Dropdown.Item onClick={openConfigureModal}>
-                    {intl.formatMessage(messages.blockLabelButtonManageAccess)}
-                  </Dropdown.Item>
-                  <Dropdown.Item onClick={openDeleteModal}>
-                    {intl.formatMessage(messages.blockLabelButtonDelete)}
-                  </Dropdown.Item>
-                </Dropdown.Menu>
-              </Dropdown>
-              <DeleteModal
-                category="component"
-                isOpen={isDeleteModalOpen}
-                close={closeDeleteModal}
-                onDeleteSubmit={onDeleteSubmit}
-              />
-              <ConfigureModal
-                isXBlockComponent
-                isOpen={isConfigureModalOpen}
-                onClose={closeConfigureModal}
-                onConfigureSubmit={onConfigureSubmit}
-                currentItemData={currentItemData}
-              />
-            </ActionRow>
-          )}
-        />
-        <Card.Section>
-          <XBlockMessages validationMessages={validationMessages} />
-          <div className="w-100 bg-gray-100" style={{ height: 200 }} data-block-id={id} />
-        </Card.Section>
-      </Card>
-    </div>
+                    <Dropdown.Item onClick={handleXBlockMove}>
+                      {intl.formatMessage(messages.blockLabelButtonMove)}
+                    </Dropdown.Item>
+                    {canEdit && (
+                      <Dropdown.Item onClick={() => dispatch(copyToClipboard(id))}>
+                        {intl.formatMessage(messages.blockLabelButtonCopyToClipboard)}
+                      </Dropdown.Item>
+                    )}
+                    <Dropdown.Item onClick={openConfigureModal}>
+                      {intl.formatMessage(messages.blockLabelButtonManageAccess)}
+                    </Dropdown.Item>
+                    <Dropdown.Item onClick={openDeleteModal}>
+                      {intl.formatMessage(messages.blockLabelButtonDelete)}
+                    </Dropdown.Item>
+                  </Dropdown.Menu>
+                </Dropdown>
+                <DeleteModal
+                  category="component"
+                  isOpen={isDeleteModalOpen}
+                  close={closeDeleteModal}
+                  onDeleteSubmit={onDeleteSubmit}
+                />
+                <ConfigureModal
+                  isXBlockComponent
+                  isOpen={isConfigureModalOpen}
+                  onClose={closeConfigureModal}
+                  onConfigureSubmit={onConfigureSubmit}
+                  currentItemData={currentItemData}
+                />
+              </ActionRow>
+            )}
+          />
+          <Card.Section>
+            <XBlockMessages validationMessages={validationMessages} />
+            <div className="w-100 bg-gray-100" style={{ height: 200 }} data-block-id={id} />
+          </Card.Section>
+        </Card>
+      </div>
+    </>
   );
 };
 
 CourseXBlock.defaultProps = {
   validationMessages: [],
   shouldScroll: false,
+  renderError: undefined,
 };
 
 CourseXBlock.propTypes = {
   id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
+  blockId: PropTypes.string.isRequired,
+  renderError: PropTypes.string,
   shouldScroll: PropTypes.bool,
   validationMessages: PropTypes.arrayOf(PropTypes.shape({
     type: PropTypes.string,

--- a/src/course-unit/course-xblock/CourseXBlock.scss
+++ b/src/course-unit/course-xblock/CourseXBlock.scss
@@ -34,3 +34,17 @@
     margin-bottom: 0;
   }
 }
+
+.xblock-edit-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: $zindex-modal;
+
+  iframe {
+    width: inherit;
+    height: inherit;
+  }
+}

--- a/src/course-unit/course-xblock/CourseXBlock.test.jsx
+++ b/src/course-unit/course-xblock/CourseXBlock.test.jsx
@@ -51,6 +51,10 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
+jest.mock('../../generic/hooks', () => ({
+  useOverflowControl: () => jest.fn(),
+}));
+
 const renderComponent = (props) => render(
   <AppProvider store={store}>
     <IntlProvider locale="en">

--- a/src/course-unit/course-xblock/constants.js
+++ b/src/course-unit/course-xblock/constants.js
@@ -1,4 +1,7 @@
-// eslint-disable-next-line import/prefer-default-export
+export const IFRAME_FEATURE_POLICY = (
+  'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture;'
+);
+
 export const MESSAGE_ERROR_TYPES = {
   error: 'error',
   warning: 'warning',

--- a/src/course-unit/course-xblock/utils.js
+++ b/src/course-unit/course-xblock/utils.js
@@ -1,0 +1,11 @@
+import { getConfig } from '@edx/frontend-platform';
+
+/**
+ * Retrieves the base path for XBlock actions.
+ * @param {string} xblockId - The ID of the XBlock.
+ * @returns {string} The base path for XBlock actions.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function getXBlockActionsBasePath(xblockId) {
+  return `${getConfig().STUDIO_BASE_URL}/xblock/${xblockId}/actions`;
+}

--- a/src/course-unit/data/api.js
+++ b/src/course-unit/data/api.js
@@ -150,6 +150,22 @@ export async function duplicateUnitItem(itemId, XBlockId) {
 }
 
 /**
+ * Rolls back a unit item to its previous state.
+ * @param {string} itemId - The ID of the item to be rolled back.
+ * @param {string} xblockId - The ID of the XBlock associated with the item.
+ * @returns {Promise<any>} - A promise that resolves to the response data from the server.
+ */
+export async function rollbackUnitItem(itemId, xblockId) {
+  const { data } = await getAuthenticatedHttpClient()
+    .patch(postXBlockBaseApiUrl(), {
+      parent_locator: itemId,
+      move_source_locator: xblockId,
+    });
+
+  return data;
+}
+
+/**
  * Sets the order list of XBlocks.
  * @param {string} blockId - The identifier of the course unit.
  * @param {Object[]} children - The array of child elements representing the updated order of XBlocks.

--- a/src/course-unit/data/selectors.js
+++ b/src/course-unit/data/selectors.js
@@ -13,6 +13,7 @@ export const getCourseId = (state) => state.courseDetail.courseId;
 export const getSequenceId = (state) => state.courseUnit.sequenceId;
 export const getCourseVerticalChildren = (state) => state.courseUnit.courseVerticalChildren;
 const getLoadingStatuses = (state) => state.courseUnit.loadingStatus;
+export const getMovedXBlockParams = (state) => state.courseUnit.movedXBlockParams;
 export const getIsLoading = createSelector(
   [getLoadingStatuses],
   loadingStatus => Object.values(loadingStatus)

--- a/src/course-unit/data/selectors.js
+++ b/src/course-unit/data/selectors.js
@@ -19,3 +19,8 @@ export const getIsLoading = createSelector(
   loadingStatus => Object.values(loadingStatus)
     .some((status) => status === RequestStatus.IN_PROGRESS),
 );
+export const getIsLoadingFailed = createSelector(
+  [getLoadingStatuses],
+  loadingStatus => Object.values(loadingStatus)
+    .some((status) => status === RequestStatus.FAILED),
+);

--- a/src/course-unit/data/slice.js
+++ b/src/course-unit/data/slice.js
@@ -10,6 +10,13 @@ const slice = createSlice({
     isQueryPending: false,
     isTitleEditFormOpen: false,
     canEdit: true,
+    movedXBlockParams: {
+      isSuccess: false,
+      isUndo: false,
+      title: '',
+      sourceLocator: '',
+      targetParentLocator: '',
+    },
     loadingStatus: {
       fetchUnitLoadingStatus: RequestStatus.IN_PROGRESS,
       courseSectionVerticalLoadingStatus: RequestStatus.IN_PROGRESS,
@@ -32,6 +39,9 @@ const slice = createSlice({
     },
     updateQueryPendingStatus: (state, { payload }) => {
       state.isQueryPending = payload;
+    },
+    updateMovedXBlockParams: (state, { payload }) => {
+      state.movedXBlockParams = { ...state.movedXBlockParams, ...payload };
     },
     changeEditTitleFormOpen: (state, { payload }) => {
       state.isTitleEditFormOpen = payload;
@@ -130,6 +140,7 @@ export const {
   duplicateXBlock,
   fetchStaticFileNoticesSuccess,
   reorderXBlockList,
+  updateMovedXBlockParams,
 } = slice.actions;
 
 export const {

--- a/src/course-unit/data/slice.js
+++ b/src/course-unit/data/slice.js
@@ -73,12 +73,6 @@ const slice = createSlice({
         courseSectionVerticalLoadingStatus: payload.status,
       };
     },
-    updateLoadingCourseXblockStatus: (state, { payload }) => {
-      state.loadingStatus = {
-        ...state.loadingStatus,
-        createUnitXblockLoadingStatus: payload.status,
-      };
-    },
     addNewUnitStatus: (state, { payload }) => {
       state.loadingStatus = {
         ...state.loadingStatus,
@@ -133,7 +127,6 @@ export const {
   updateLoadingCourseSectionVerticalDataStatus,
   changeEditTitleFormOpen,
   updateQueryPendingStatus,
-  updateLoadingCourseXblockStatus,
   updateCourseVerticalChildren,
   updateCourseVerticalChildrenLoadingStatus,
   deleteXBlock,

--- a/src/course-unit/data/thunk.js
+++ b/src/course-unit/data/thunk.js
@@ -29,7 +29,6 @@ import {
   fetchSequenceSuccess,
   fetchCourseSectionVerticalDataSuccess,
   updateLoadingCourseSectionVerticalDataStatus,
-  updateLoadingCourseXblockStatus,
   updateCourseVerticalChildren,
   updateCourseVerticalChildrenLoadingStatus,
   updateQueryPendingStatus,
@@ -147,7 +146,6 @@ export function editCourseUnitVisibilityAndData(itemId, type, isVisible, groupAc
 
 export function createNewCourseXBlock(body, callback, blockId) {
   return async (dispatch) => {
-    dispatch(updateLoadingCourseXblockStatus({ status: RequestStatus.IN_PROGRESS }));
     dispatch(updateSavingStatus({ status: RequestStatus.PENDING }));
 
     if (body.stagedContent) {
@@ -175,7 +173,6 @@ export function createNewCourseXBlock(body, callback, blockId) {
           const courseVerticalChildrenData = await getCourseVerticalChildren(blockId);
           dispatch(updateCourseVerticalChildren(courseVerticalChildrenData));
           dispatch(hideProcessingNotification());
-          dispatch(updateLoadingCourseXblockStatus({ status: RequestStatus.SUCCESSFUL }));
           dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
           if (callback) {
             callback(result);
@@ -187,7 +184,6 @@ export function createNewCourseXBlock(body, callback, blockId) {
       });
     } catch (error) {
       dispatch(hideProcessingNotification());
-      dispatch(updateLoadingCourseXblockStatus({ status: RequestStatus.FAILED }));
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
   };

--- a/src/course-unit/hooks.jsx
+++ b/src/course-unit/hooks.jsx
@@ -13,6 +13,7 @@ import {
   duplicateUnitItemQuery,
   setXBlockOrderListQuery,
   editCourseUnitVisibilityAndData,
+  rollbackUnitItemQuery,
 } from './data/thunk';
 import {
   getCourseSectionVertical,
@@ -23,11 +24,17 @@ import {
   getSequenceStatus,
   getStaticFileNotices,
   getCanEdit,
+  getMovedXBlockParams,
 } from './data/selectors';
-import { changeEditTitleFormOpen, updateQueryPendingStatus } from './data/slice';
+import {
+  changeEditTitleFormOpen,
+  updateQueryPendingStatus,
+  updateMovedXBlockParams,
+} from './data/slice';
 import { PUBLISH_TYPES } from './constants';
 
 import { useCopyToClipboard } from '../generic/clipboard';
+import { createCorrectInternalRoute } from '../utils';
 
 // eslint-disable-next-line import/prefer-default-export
 export const useCourseUnit = ({ courseId, blockId }) => {
@@ -39,6 +46,7 @@ export const useCourseUnit = ({ courseId, blockId }) => {
   const courseUnit = useSelector(getCourseUnitData);
   const savingStatus = useSelector(getSavingStatus);
   const isLoading = useSelector(getIsLoading);
+  const movedXBlockParams = useSelector(getMovedXBlockParams);
   const sequenceStatus = useSelector(getSequenceStatus);
   const { draftPreviewLink, publishedPreviewLink } = useSelector(getCourseSectionVertical);
   const courseVerticalChildren = useSelector(getCourseVerticalChildren);
@@ -116,6 +124,19 @@ export const useCourseUnit = ({ courseId, blockId }) => {
     dispatch(setXBlockOrderListQuery(blockId, xblockListIds, restoreCallback));
   };
 
+  const handleRollbackMovedXBlock = () => {
+    dispatch(rollbackUnitItemQuery(blockId, movedXBlockParams.sourceLocator, movedXBlockParams.title));
+  };
+
+  const handleCloseXBlockMovedAlert = () => {
+    dispatch(updateMovedXBlockParams({ isSuccess: false }));
+  };
+
+  const handleNavigateToTargetUnit = () => {
+    const correctInternalRoute = createCorrectInternalRoute(`/course/${courseId}/container/${movedXBlockParams.targetParentLocator}`);
+    navigate(correctInternalRoute);
+  };
+
   useEffect(() => {
     if (savingStatus === RequestStatus.SUCCESSFUL) {
       dispatch(updateQueryPendingStatus(true));
@@ -130,6 +151,7 @@ export const useCourseUnit = ({ courseId, blockId }) => {
     dispatch(fetchCourseVerticalChildrenData(blockId));
 
     handleNavigate(sequenceId);
+    dispatch(updateMovedXBlockParams({ isSuccess: false }));
   }, [courseId, blockId, sequenceId]);
 
   return {
@@ -157,6 +179,10 @@ export const useCourseUnit = ({ courseId, blockId }) => {
     handleConfigureSubmit,
     courseVerticalChildren,
     handleXBlockDragAndDrop,
+    handleRollbackMovedXBlock,
+    handleCloseXBlockMovedAlert,
+    movedXBlockParams,
+    handleNavigateToTargetUnit,
     canPasteComponent,
   };
 };

--- a/src/course-unit/hooks.jsx
+++ b/src/course-unit/hooks.jsx
@@ -23,6 +23,7 @@ import {
   getSavingStatus,
   getSequenceStatus,
   getStaticFileNotices,
+  getIsLoadingFailed,
   getCanEdit,
   getMovedXBlockParams,
 } from './data/selectors';
@@ -46,6 +47,7 @@ export const useCourseUnit = ({ courseId, blockId }) => {
   const courseUnit = useSelector(getCourseUnitData);
   const savingStatus = useSelector(getSavingStatus);
   const isLoading = useSelector(getIsLoading);
+  const isLoadingFailed = useSelector(getIsLoadingFailed);
   const movedXBlockParams = useSelector(getMovedXBlockParams);
   const sequenceStatus = useSelector(getSequenceStatus);
   const { draftPreviewLink, publishedPreviewLink } = useSelector(getCourseSectionVertical);
@@ -165,6 +167,7 @@ export const useCourseUnit = ({ courseId, blockId }) => {
     staticFileNotices,
     currentlyVisibleToStudents,
     isLoading,
+    isLoadingFailed,
     isTitleEditFormOpen,
     isInternetConnectionAlertFailed: savingStatus === RequestStatus.FAILED,
     sharedClipboardData,

--- a/src/course-unit/messages.js
+++ b/src/course-unit/messages.js
@@ -13,6 +13,36 @@ const messages = defineMessages({
     id: 'course-authoring.course-unit.paste-component.btn.text',
     defaultMessage: 'Paste component',
   },
+  alertMoveSuccessTitle: {
+    id: 'course-authoring.course-unit.alert.xblock.move.success.title',
+    defaultMessage: 'Success!',
+    description: 'Title for the success alert when an XBlock is moved successfully',
+  },
+  alertMoveSuccessDescription: {
+    id: 'course-authoring.course-unit.alert.xblock.move.success.description',
+    defaultMessage: '{title} has been moved',
+    description: 'Description for the success alert when an XBlock is moved successfully',
+  },
+  alertMoveCancelTitle: {
+    id: 'course-authoring.course-unit.alert.xblock.move.cancel.title',
+    defaultMessage: 'Move cancelled',
+    description: 'Title for the alert when moving an XBlock is cancelled',
+  },
+  alertMoveCancelDescription: {
+    id: 'course-authoring.course-unit.alert.xblock.move.cancel.description',
+    defaultMessage: '{title} has been moved back to its original location',
+    description: 'Description for the alert when moving an XBlock is cancelled and the XBlock is moved back to its original location',
+  },
+  undoMoveButton: {
+    id: 'course-authoring.course-unit.alert.xblock.move.undo.btn.text',
+    defaultMessage: 'Undo move',
+    description: 'Text for the button allowing users to undo a move action of an XBlock',
+  },
+  newLocationButton: {
+    id: 'course-authoring.course-unit.alert.xblock.new.location.btn.text',
+    defaultMessage: 'Take me to the new location',
+    description: 'Text for the button allowing users to navigate to the new location after an XBlock has been moved',
+  },
 });
 
 export default messages;

--- a/src/generic/hooks/index.js
+++ b/src/generic/hooks/index.js
@@ -1,0 +1,2 @@
+/* eslint-disable import/prefer-default-export */
+export { default as useOverflowControl } from './useOverflowControl';

--- a/src/generic/hooks/useOverflowControl.js
+++ b/src/generic/hooks/useOverflowControl.js
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+/**
+ * Hook to control the overflow property of the body based on the presence of an element in the DOM.
+ * @param {string} targetSelector - Selector of the target element for overflow control.
+ * @returns {void}
+ */
+const useOverflowControl = (targetSelector) => {
+  useEffect(() => {
+    const handleOverflow = () => {
+      const body = document.querySelector('body');
+      const targetElement = document.querySelector(targetSelector);
+
+      body.style.overflow = targetElement ? 'hidden' : 'auto';
+    };
+
+    handleOverflow();
+
+    const observer = new MutationObserver(handleOverflow);
+    observer.observe(document.body, { attributes: true, childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [targetSelector]);
+};
+
+export default useOverflowControl;

--- a/src/generic/hooks/useOverflowControl.test.jsx
+++ b/src/generic/hooks/useOverflowControl.test.jsx
@@ -1,0 +1,53 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import useOverflowControl from './useOverflowControl';
+
+const observerInstance = {
+  observe: jest.fn(),
+  disconnect: jest.fn(),
+};
+
+let observerCallback = jest.fn();
+
+const mutationObserverMock = jest.fn((callback) => {
+  observerCallback = callback;
+  return observerInstance;
+});
+
+describe('useOverflowControl', () => {
+  const targetElement = document.createElement('div');
+  targetElement.className = 'target-element';
+  document.body.appendChild(targetElement);
+
+  beforeEach(() => {
+    global.MutationObserver = mutationObserverMock;
+  });
+
+  afterEach(() => delete global.MutationObserver);
+
+  it('should set body overflow to hidden when target element is present', () => {
+    const { unmount } = renderHook(() => useOverflowControl('.target-element'));
+
+    // Simulate the MutationObserver callback with added nodes
+    observerCallback([{ addedNodes: [targetElement] }]);
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unmount();
+
+    document.body.style.overflow = 'auto';
+    expect(document.body.style.overflow).toBe('auto');
+  });
+
+  it('should set body overflow to auto when target element is not present', () => {
+    const { unmount } = renderHook(() => useOverflowControl('.non-existent-target-element'));
+
+    // Simulate the MutationObserver callback with added nodes
+    observerCallback([{ removedNodes: [document.querySelector('.non-existent-target-element')] }]);
+    expect(document.body.style.overflow).toBe('auto');
+
+    unmount();
+
+    document.body.style.overflow = 'auto';
+    expect(document.body.style.overflow).toBe('auto');
+  });
+});


### PR DESCRIPTION
## Settings
```yaml
EDX_PLATFORM_REPOSITORY: https://github.com/raccoongang/edx-platform.git
EDX_PLATFORM_VERSION: ts-develop

TUTOR_GROVE_WAFFLE_FLAGS:
  - name: contentstore.new_studio_mfe.use_new_unit_page
    everyone: true

TUTOR_GROVE_MFE_LMS_COMMON_SETTINGS:
  MFE_CONFIG:
    ENABLE_UNIT_PAGE: true
```
## Description

Modal windows for moving and editing xblocks.

## Supporting information

- Issue: https://github.com/openedx/platform-roadmap/issues/321

## Testing instructions

- Run master devstack.
- Start platform `make dev.up.lms+cms+frontend-app-course-authoring` and make checkout on this branch.
- Enable the new Unit page by adding a waffle flag `contentstore.new_studio_mfe.use_new_unit_page` in the CMS admin panel.
- Go to the Course Unit page from the Course Outline page.
- Add a new xblock component.


## Other information

https://github.com/openedx/frontend-app-course-authoring/assets/93188219/4888c7d0-1a77-4b20-bd14-e2f9471a9b32


