### PR TITLE
fix: fix: use aria attribute correctly resolves wg-translations/issue…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,10 @@ module.exports = createConfig(
       'template-curly-spacing': 'off',
       'react-hooks/exhaustive-deps': 'off',
       'no-restricted-exports': 'off',
+      // This added because 'aria-description' is not reconginzed as valid prop for reac <=17
+      // ref: https://github.com/facebook/react/issues/21035 because it's new.
+      // once this MFE upgrade to react >18, it can be removed.
+      'jsx-a11y/aria-props': 'off',
     },
     settings: {
       // Import URLs should be resolved using aliases

--- a/src/advanced-settings/AdvancedSettings.jsx
+++ b/src/advanced-settings/AdvancedSettings.jsx
@@ -242,8 +242,8 @@ const AdvancedSettings = ({ intl, courseId }) => {
         <AlertMessage
           show={saveSettingsPrompt}
           aria-hidden={saveSettingsPrompt}
-          aria-label={intl.formatMessage(messages.alertWarning)}
-          aria-description={intl.formatMessage(messages.alertWarningDescriptions)}
+          aria-labelledby="advancedSettingsAlertWarningTitle"
+          aria-describedby="advancedSettingsAlertWarningDesc"
           role="dialog"
           actions={[
             !isQueryPending && (
@@ -261,7 +261,9 @@ const AdvancedSettings = ({ intl, courseId }) => {
           variant="warning"
           icon={Warning}
           title={intl.formatMessage(messages.alertWarning)}
+          titleId="advancedSettingsAlertWarningTitle"
           description={intl.formatMessage(messages.alertWarningDescriptions)}
+          descriptoinId="advancedSettingsAlertWarningDesc"
         />
       </div>
       <ModalError

--- a/src/advanced-settings/AdvancedSettings.jsx
+++ b/src/advanced-settings/AdvancedSettings.jsx
@@ -137,22 +137,20 @@ const AdvancedSettings = ({ intl, courseId }) => {
               icon={Info}
               proctoringErrorsData={proctoringErrors}
               aria-hidden="true"
-              aria-labelledby={intl.formatMessage(messages.alertProctoringAriaLabelledby)}
-              aria-describedby={intl.formatMessage(messages.alertProctoringDescribedby)}
             />
           )}
           <TransitionReplace>
             {showSuccessAlert ? (
               <AlertMessage
-                key={intl.formatMessage(messages.alertSuccessAriaLabelledby)}
+                key="alert-confirmation-title"
                 show={showSuccessAlert}
                 variant="success"
                 icon={CheckCircle}
                 title={intl.formatMessage(messages.alertSuccess)}
                 description={intl.formatMessage(messages.alertSuccessDescriptions)}
                 aria-hidden="true"
-                aria-labelledby={intl.formatMessage(messages.alertSuccessAriaLabelledby)}
-                aria-describedby={intl.formatMessage(messages.alertSuccessAriaDescribedby)}
+                aria-label={intl.formatMessage(messages.alertSuccess)}
+                aria-description={intl.formatMessage(messages.alertSuccessDescriptions)}
               />
             ) : null}
           </TransitionReplace>
@@ -244,8 +242,8 @@ const AdvancedSettings = ({ intl, courseId }) => {
         <AlertMessage
           show={saveSettingsPrompt}
           aria-hidden={saveSettingsPrompt}
-          aria-labelledby={intl.formatMessage(messages.alertWarningAriaLabelledby)}
-          aria-describedby={intl.formatMessage(messages.alertWarningAriaDescribedby)}
+          aria-label={intl.formatMessage(messages.alertWarning)}
+          aria-description={intl.formatMessage(messages.alertWarningDescriptions)}
           role="dialog"
           actions={[
             !isQueryPending && (

--- a/src/advanced-settings/messages.js
+++ b/src/advanced-settings/messages.js
@@ -57,30 +57,6 @@ const messages = defineMessages({
     id: 'course-authoring.advanced-settings.deprecated.button.hide',
     defaultMessage: 'Hide',
   },
-  alertWarningAriaLabelledby: {
-    id: 'course-authoring.advanced-settings.alert.warning.aria.labelledby',
-    defaultMessage: 'notification-warning-title',
-  },
-  alertWarningAriaDescribedby: {
-    id: 'course-authoring.advanced-settings.alert.warning.aria.describedby',
-    defaultMessage: 'notification-warning-description',
-  },
-  alertSuccessAriaLabelledby: {
-    id: 'course-authoring.advanced-settings.alert.success.aria.labelledby',
-    defaultMessage: 'alert-confirmation-title',
-  },
-  alertSuccessAriaDescribedby: {
-    id: 'course-authoring.advanced-settings.alert.success.aria.describedby',
-    defaultMessage: 'alert-confirmation-description',
-  },
-  alertProctoringAriaLabelledby: {
-    id: 'course-authoring.advanced-settings.alert.proctoring.error.aria.labelledby',
-    defaultMessage: 'alert-danger-title',
-  },
-  alertProctoringDescribedby: {
-    id: 'course-authoring.advanced-settings.alert.proctoring.error.aria.describedby',
-    defaultMessage: 'alert-danger-description',
-  },
 });
 
 export default messages;

--- a/src/course-outline/CourseOutline.jsx
+++ b/src/course-outline/CourseOutline.jsx
@@ -256,15 +256,15 @@ const CourseOutline = ({ courseId }) => {
           <TransitionReplace>
             {showSuccessAlert ? (
               <AlertMessage
-                key={intl.formatMessage(messages.alertSuccessAriaLabelledby)}
+                key="alert-confirmation-title"
                 show={showSuccessAlert}
                 variant="success"
                 icon={CheckCircleIcon}
                 title={intl.formatMessage(messages.alertSuccessTitle)}
                 description={intl.formatMessage(messages.alertSuccessDescription)}
                 aria-hidden="true"
-                aria-labelledby={intl.formatMessage(messages.alertSuccessAriaLabelledby)}
-                aria-describedby={intl.formatMessage(messages.alertSuccessAriaDescribedby)}
+                aria-label={intl.formatMessage(messages.alertSuccessTitle)}
+                aria-description={intl.formatMessage(messages.alertSuccessDescription)}
               />
             ) : null}
           </TransitionReplace>

--- a/src/course-outline/messages.js
+++ b/src/course-outline/messages.js
@@ -17,14 +17,6 @@ const messages = defineMessages({
     id: 'course-authoring.course-outline.reindex.alert.success.description',
     defaultMessage: 'Course has been successfully reindexed.',
   },
-  alertSuccessAriaLabelledby: {
-    id: 'course-authoring.course-outline.reindex.alert.success.aria.labelledby',
-    defaultMessage: 'alert-confirmation-title',
-  },
-  alertSuccessAriaDescribedby: {
-    id: 'course-authoring.course-outline.reindex.alert.success.aria.describedby',
-    defaultMessage: 'alert-confirmation-description',
-  },
   newSectionButton: {
     id: 'course-authoring.course-outline.section-list.button.new-section',
     defaultMessage: 'New section',

--- a/src/course-outline/page-alerts/PageAlerts.jsx
+++ b/src/course-outline/page-alerts/PageAlerts.jsx
@@ -20,7 +20,6 @@ import { RequestStatus } from '../../data/constants';
 import AlertMessage from '../../generic/alert-message';
 import AlertProctoringError from '../../generic/AlertProctoringError';
 import messages from './messages';
-import advancedSettingsMessages from '../../advanced-settings/messages';
 import { getPasteFileNotices } from '../data/selectors';
 import { dismissError, removePasteFileNotices } from '../data/slice';
 import { API_ERROR_TYPES } from '../constants';
@@ -195,8 +194,8 @@ const PageAlerts = ({
           icon={InfoOutlineIcon}
           proctoringErrorsData={proctoringErrors}
           aria-hidden="true"
-          aria-labelledby={intl.formatMessage(advancedSettingsMessages.alertProctoringAriaLabelledby)}
-          aria-describedby={intl.formatMessage(advancedSettingsMessages.alertProctoringDescribedby)}
+          aria-label={intl.formatMessage(messages.proctoringErrorTitle)}
+          aria-description={intl.formatMessage(messages.proctoringErrorText)}
         >
           <Alert.Heading>
             {intl.formatMessage(messages.proctoringErrorTitle)}

--- a/src/generic/alert-message/index.jsx
+++ b/src/generic/alert-message/index.jsx
@@ -2,21 +2,27 @@ import React from 'react';
 import { Alert } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 
-const AlertMessage = ({ title, description, ...props }) => (
+const AlertMessage = ({
+  title, titleId, description, descriptoinId, ...props
+}) => (
   <Alert {...props}>
-    <Alert.Heading>{title}</Alert.Heading>
-    <span>{description}</span>
+    <Alert.Heading id={titleId}>{title}</Alert.Heading>
+    <span id={descriptoinId}>{description}</span>
   </Alert>
 );
 
 AlertMessage.propTypes = {
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  titleId: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   description: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  descriptoinId: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 };
 
 AlertMessage.defaultProps = {
   title: undefined,
+  titleId: undefined,
   description: undefined,
+  descriptoinId: undefined,
 };
 
 export default AlertMessage;

--- a/src/generic/create-or-rerun-course/CreateOrRerunCourseForm.jsx
+++ b/src/generic/create-or-rerun-course/CreateOrRerunCourseForm.jsx
@@ -208,12 +208,7 @@ const CreateOrRerunCourseForm = ({
             icon={InfoIcon}
             title={postErrors.errMsg}
             aria-hidden="true"
-            aria-labelledby={intl.formatMessage(
-              messages.alertErrorExistsAriaLabelledBy,
-            )}
-            aria-describedby={intl.formatMessage(
-              messages.alertErrorExistsAriaDescribedBy,
-            )}
+            aria-label={postErrors.errMsg}
           />
         ) : null}
       </TransitionReplace>

--- a/src/generic/create-or-rerun-course/messages.js
+++ b/src/generic/create-or-rerun-course/messages.js
@@ -117,14 +117,6 @@ const messages = defineMessages({
     id: 'course-authoring.create-or-rerun-course.no-space.error',
     defaultMessage: 'Please do not use any spaces in this field.',
   },
-  alertErrorExistsAriaLabelledBy: {
-    id: 'course-authoring.create-or-rerun-course.error.already-exists.labelledBy',
-    defaultMessage: 'alert-already-exists-title',
-  },
-  alertErrorExistsAriaDescribedBy: {
-    id: 'course-authoring.create-or-rerun-course.error.already-exists.aria.describedBy',
-    defaultMessage: 'alert-confirmation-description',
-  },
 });
 
 export default messages;

--- a/src/generic/internet-connection-alert/index.jsx
+++ b/src/generic/internet-connection-alert/index.jsx
@@ -54,11 +54,11 @@ const InternetConnectionAlert = ({
       title={intl.formatMessage(messages.offlineWarningTitle)}
       description={intl.formatMessage(messages.offlineWarningDescription)}
       aria-hidden="true"
-      aria-labelledby={intl.formatMessage(
-        messages.offlineWarningTitleAriaLabelledBy,
+      aria-label={intl.formatMessage(
+        messages.offlineWarningTitle,
       )}
-      aria-describedby={intl.formatMessage(
-        messages.offlineWarningDescriptionAriaDescribedBy,
+      aria-description={intl.formatMessage(
+        messages.offlineWarningDescription,
       )}
     />
   );

--- a/src/generic/internet-connection-alert/messages.js
+++ b/src/generic/internet-connection-alert/messages.js
@@ -9,14 +9,6 @@ const messages = defineMessages({
     id: 'course-authoring.generic.alert.warning.offline.description',
     defaultMessage: 'This may be happening because of an error with our server or your internet connection. Try refreshing the page or making sure you are online.',
   },
-  offlineWarningTitleAriaLabelledBy: {
-    id: 'course-authoring.generic.alert.warning.offline.title.aria.labelled-by',
-    defaultMessage: 'alert-internet-error-title',
-  },
-  offlineWarningDescriptionAriaDescribedBy: {
-    id: 'course-authoring.generic.alert.warning.offline.subtitle.aria.described-by',
-    defaultMessage: 'alert-internet-error-description',
-  },
 });
 
 export default messages;

--- a/src/generic/saving-error-alert/SavingErrorAlert.jsx
+++ b/src/generic/saving-error-alert/SavingErrorAlert.jsx
@@ -45,11 +45,11 @@ const SavingErrorAlert = ({
         errorMessage || intl.formatMessage(messages.warningDescription)
       }
       aria-hidden="true"
-      aria-labelledby={intl.formatMessage(
-        messages.warningTitleAriaLabelledBy,
+      aria-label={intl.formatMessage(
+        messages.warningTitle,
       )}
-      aria-describedby={intl.formatMessage(
-        messages.warningDescriptionAriaDescribedBy,
+      aria-description={intl.formatMessage(
+        messages.warningDescription,
       )}
     />
   );

--- a/src/generic/saving-error-alert/messages.js
+++ b/src/generic/saving-error-alert/messages.js
@@ -11,16 +11,6 @@ const messages = defineMessages({
     defaultMessage: 'This may be happening because of an error with our server or your internet connection. Try refreshing the page or making sure you are online.',
     description: 'Description providing possible reasons and solutions for saving error in the studio environment',
   },
-  warningTitleAriaLabelledBy: {
-    id: 'course-authoring.generic.saving-error-alert.title.aria.labelled-by',
-    defaultMessage: 'saving-error-alert-title',
-    description: 'ARIA label ID for the title of the saving error alert',
-  },
-  warningDescriptionAriaDescribedBy: {
-    id: 'course-authoring.generic.saving-error-alert.aria.described-by',
-    defaultMessage: 'saving-error-alert-description',
-    description: 'ARIA description ID for the saving error alert',
-  },
 });
 
 export default messages;

--- a/src/grading-settings/GradingSettings.jsx
+++ b/src/grading-settings/GradingSettings.jsx
@@ -123,8 +123,7 @@ const GradingSettings = ({ intl, courseId }) => {
             icon={CheckCircle}
             title={intl.formatMessage(messages.alertSuccess)}
             aria-hidden="true"
-            aria-labelledby={intl.formatMessage(messages.alertSuccessAriaLabelledby)}
-            aria-describedby={intl.formatMessage(messages.alertSuccessAriaDescribedby)}
+            aria-label={intl.formatMessage(messages.alertSuccess)}
           />
         </div>
         <div>
@@ -235,8 +234,8 @@ const GradingSettings = ({ intl, courseId }) => {
         <AlertMessage
           show={showSavePrompt}
           aria-hidden={!showSavePrompt}
-          aria-labelledby={intl.formatMessage(messages.alertWarningAriaLabelledby)}
-          aria-describedby={intl.formatMessage(messages.alertWarningAriaDescribedby)}
+          aria-label={intl.formatMessage(messages.alertWarning)}
+          aria-description={intl.formatMessage(messages.alertWarningDescriptions)}
           data-testid="grading-settings-save-alert"
           role="dialog"
           actions={[

--- a/src/grading-settings/messages.js
+++ b/src/grading-settings/messages.js
@@ -41,22 +41,6 @@ const messages = defineMessages({
     id: 'course-authoring.grading-settings.alert.button.cancel',
     defaultMessage: 'Cancel',
   },
-  alertWarningAriaLabelledby: {
-    id: 'course-authoring.grading-settings.alert.warning.aria.labelledby',
-    defaultMessage: 'notification-warning-title',
-  },
-  alertWarningAriaDescribedby: {
-    id: 'course-authoring.grading-settings.alert.warning.aria.describedby',
-    defaultMessage: 'notification-warning-description',
-  },
-  alertSuccessAriaLabelledby: {
-    id: 'course-authoring.grading-settings.alert.success.aria.labelledby',
-    defaultMessage: 'alert-confirmation-title',
-  },
-  alertSuccessAriaDescribedby: {
-    id: 'course-authoring.grading-settings.alert.success.aria.describedby',
-    defaultMessage: 'alert-confirmation-description',
-  },
   creditEligibilitySectionTitle: {
     id: 'course-authoring.grading-settings.credit-eligibility.title',
     defaultMessage: 'Credit eligibility',

--- a/src/schedule-and-details/index.jsx
+++ b/src/schedule-and-details/index.jsx
@@ -181,11 +181,8 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
             icon={CheckCircleIcon}
             title={intl.formatMessage(messages.alertSuccess)}
             aria-hidden="true"
-            aria-labelledby={intl.formatMessage(
-              messages.alertSuccessAriaLabelledby,
-            )}
-            aria-describedby={intl.formatMessage(
-              messages.alertSuccessAriaDescribedby,
+            aria-label={intl.formatMessage(
+              messages.alertSuccess,
             )}
           />
           <AlertMessage
@@ -194,11 +191,8 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
             icon={ErrorOutlineIcon}
             title={intl.formatMessage(messages.alertLoadFail)}
             aria-hidden="true"
-            aria-labelledby={intl.formatMessage(
-              messages.alertFailAriaLabelledby,
-            )}
-            aria-describedby={intl.formatMessage(
-              messages.alertFailAriaDescribedby,
+            aria-label={intl.formatMessage(
+              messages.alertLoadFail,
             )}
           />
           <AlertMessage
@@ -207,11 +201,8 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
             icon={ErrorOutlineIcon}
             title={intl.formatMessage(messages.alertFail)}
             aria-hidden="true"
-            aria-labelledby={intl.formatMessage(
-              messages.alertFailAriaLabelledby,
-            )}
-            aria-describedby={intl.formatMessage(
-              messages.alertFailAriaDescribedby,
+            aria-label={intl.formatMessage(
+              messages.alertFail,
             )}
           />
           <header>
@@ -351,12 +342,8 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
         <AlertMessage
           show={showModifiedAlert}
           aria-hidden={showModifiedAlert}
-          aria-labelledby={intl.formatMessage(
-            messages.alertWarningAriaLabelledby,
-          )}
-          aria-describedby={intl.formatMessage(
-            messages.alertWarningAriaDescribedby,
-          )}
+          aria-label={alertWhileSavingTitle}
+          aria-description={alertWhileSavingDescription}
           role="dialog"
           actions={[
             !isQueryPending && (

--- a/src/schedule-and-details/messages.js
+++ b/src/schedule-and-details/messages.js
@@ -21,14 +21,6 @@ const messages = defineMessages({
     id: 'course-authoring.schedule.alert.button.cancel',
     defaultMessage: 'Cancel',
   },
-  alertWarningAriaLabelledby: {
-    id: 'course-authoring.schedule.alert.warning.aria.labelledby',
-    defaultMessage: 'notification-warning-title',
-  },
-  alertWarningAriaDescribedby: {
-    id: 'course-authoring.schedule.alert.warning.aria.describedby',
-    defaultMessage: 'notification-warning-description',
-  },
   alertWarning: {
     id: 'course-authoring.schedule.alert.warning',
     defaultMessage: 'You\'ve made some changes',
@@ -45,37 +37,13 @@ const messages = defineMessages({
     id: 'course-authoring.schedule.alert.warning.save.descriptions.error',
     defaultMessage: 'Please address the errors on this page first, and then save your progress.',
   },
-  alertSuccessAriaLabelledby: {
-    id: 'course-authoring.schedule.alert.success.aria.labelledby',
-    defaultMessage: 'alert-confirmation-title',
-  },
-  alertSuccessAriaDescribedby: {
-    id: 'course-authoring.schedule.alert.success.aria.describedby',
-    defaultMessage: 'alert-confirmation-description',
-  },
   alertSuccess: {
     id: 'course-authoring.schedule.alert.success',
     defaultMessage: 'Your changes have been saved.',
   },
-  alertLoadFailAriaLabelledby: {
-    id: 'course-authoring.schedule.alert.load.fail.aria.labelledby',
-    defaultMessage: 'alert-confirmation-title',
-  },
-  alertLoadFailAriaDescribedby: {
-    id: 'course-authoring.schedule.alert.load.fail.aria.describedby',
-    defaultMessage: 'alert-confirmation-description',
-  },
   alertLoadFail: {
     id: 'course-authoring.schedule.alert.load.fail',
     defaultMessage: 'We encountered an error when loading your settings.',
-  },
-  alertFailAriaLabelledby: {
-    id: 'course-authoring.schedule.alert.fail.aria.labelledby',
-    defaultMessage: 'alert-confirmation-title',
-  },
-  alertFailAriaDescribedby: {
-    id: 'course-authoring.schedule.alert.fail.aria.describedby',
-    defaultMessage: 'alert-confirmation-description',
   },
   alertFail: {
     id: 'course-authoring.schedule.alert.fail',


### PR DESCRIPTION
…s/33

  This change correct the usage of aria-* attributes  resolves
- https://github.com/openedx/wg-translations/issues/33

## Description

Before in part of code,  `aria-describedby` and `aria-labelledby` attributes were treated as having translatable text, which is not correct, since these  attributes suppose to link/refer to ids.

This PR resolve the issue by using `aria-label`, and `aria-description` instead, which can include raw text. 

Note: the eslint role for aria is switched off since, `aria-description` is a new attribute that is not recgnoized until react>=18 hence [this issue in react](https://github.com/facebook/react/issues/21035). 

Lastly, aria-descripedby and aria-labelledby could have been used, but that would have require some extensive code change, so that `id` is passed on the childern of `Alret` paragon component. 

This ready for review