### PR TITLE
fix: confirmation window is displayed after save for dropdown

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.js
@@ -107,8 +107,8 @@ export const checkForNoAnswers = ({ openSaveWarningModal, problem }) => {
     let correctAnswer;
     answers.forEach(answer => {
       if (answer.correct) {
-        const title = simpleTextAreaProblems.includes(problemType) ? answer.title : answerTitles[answer.id];
-        if (title?.length > 0) {
+        const title = simpleTextAreaProblems.includes(problemType) ? answer.title.toString() : answerTitles[answer.id];
+        if (title.length > 0) {
           correctAnswer = true;
         }
       }

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.test.js
@@ -360,6 +360,22 @@ describe('EditProblemView hooks parseState', () => {
       expect(openSaveWarningModal).toHaveBeenCalled();
       expect(content).toEqual(null);
     });
+    it('should return the correct content if the user entered a number as the correct answer for a dropdown type problem', () => {
+      const problem = { ...problemState, answers: [{ id: 'A', title: 1234, correct: true }] };
+      const content = hooks.getContent({
+        isAdvancedProblemType: false,
+        problemState: problem,
+        editorRef,
+        assets,
+        lmsEndpointUrl,
+        openSaveWarningModal,
+      });
+      expect(openSaveWarningModal).toHaveBeenCalled();
+      expect(content).toEqual({
+        olx: mockBuiltOLX,
+        settings: expectedSettings,
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Description

"No answer specified" confirmation window is displayed all the time after the second save for dropdown.

<img width="910" alt="234" src="https://github.com/user-attachments/assets/ac92e126-6046-49d1-aeef-e54d48f1e20c">

### Steps to Reproduce: 
1. Add new `Unit`
2. Add new component `Problem`
3. Choose `Dropdown`
4. Fill in at least question and answers (for the correct answer, enter the number)
5. Click `Save`
5. Click on `Edit` for problem again
6. Click `Save`


