### PR TITLE
fix: Create button remains deactivated until pick a new org

### DIFF
--- a/src/editors/sharedComponents/TypeaheadDropdown/index.jsx
+++ b/src/editors/sharedComponents/TypeaheadDropdown/index.jsx
@@ -90,7 +90,7 @@ class TypeaheadDropdown extends React.Component {
       this.setValue(opt);
       this.setState({ displayValue: opt });
     } else {
-      this.setValue('');
+      this.setValue(normalized);
       this.setState({ displayValue: value });
     }
   }


### PR DESCRIPTION
## Description

The fix concerns this [**issue**](https://github.com/openedx/frontend-app-course-authoring/issues/1199). Specifically the case when switching between fields is done using the `Tab` button.