### PR TITLE
feat: remove new library button if user does not have create access for v1 libraries (#1216)

### DIFF
--- a/src/studio-home/StudioHome.jsx
+++ b/src/studio-home/StudioHome.jsx
@@ -49,6 +49,7 @@ const StudioHome = ({ intl }) => {
     studioRequestEmail,
     libraryAuthoringMfeUrl,
     redirectToLibraryAuthoringMfe,
+    showNewLibraryButton,
   } = studioHomeData;
 
   function getHeaderButtons() {
@@ -78,23 +79,25 @@ const StudioHome = ({ intl }) => {
       );
     }
 
-    let libraryHref = `${getConfig().STUDIO_BASE_URL}/home_library`;
-    if (redirectToLibraryAuthoringMfe) {
-      libraryHref = `${libraryAuthoringMfeUrl}/create`;
-    }
+    if (showNewLibraryButton) {
+      let libraryHref = `${getConfig().STUDIO_BASE_URL}/home_library`;
+      if (redirectToLibraryAuthoringMfe) {
+        libraryHref = `${libraryAuthoringMfeUrl}/create`;
+      }
 
-    headerButtons.push(
-      <Button
-        variant="outline-primary"
-        iconBefore={AddIcon}
-        size="sm"
-        disabled={showNewCourseContainer}
-        href={libraryHref}
-        data-testid="new-library-button"
-      >
-        {intl.formatMessage(messages.addNewLibraryBtnText)}
-      </Button>,
-    );
+      headerButtons.push(
+        <Button
+          variant="outline-primary"
+          iconBefore={AddIcon}
+          size="sm"
+          disabled={showNewCourseContainer}
+          href={libraryHref}
+          data-testid="new-library-button"
+        >
+          {intl.formatMessage(messages.addNewLibraryBtnText)}
+        </Button>,
+      );
+    }
 
     return headerButtons;
   }

--- a/src/studio-home/StudioHome.test.jsx
+++ b/src/studio-home/StudioHome.test.jsx
@@ -171,6 +171,15 @@ describe('<StudioHome />', async () => {
       });
     });
 
+    it('do not render new library button if showNewLibraryButton is False', () => {
+      useSelector.mockReturnValue({
+        ...studioHomeMock,
+        showNewLibraryButton: false,
+      });
+      const { queryByTestId } = render(<RootWrapper />);
+      expect(queryByTestId('new-library-button')).not.toBeInTheDocument();
+    });
+
     it('should render create new course container', async () => {
       useSelector.mockReturnValue({
         ...studioHomeMock,


### PR DESCRIPTION
## Description

Based on #1216 

Currently the New Library button is shown to studio users even if they don't have the required access to create a library. This creates a confusing user experince for the user, since if such an user tries to create a library, they get a error down the UI flow.

This PR fixes this behavior for V1 libraries inline with the the legacy Studio UI

## Testing instructions

Refer #1216


## Other information

Private Ref: [BB-9077](https://tasks.opencraft.com/browse/BB-9077)