### PR TITLE
fix: isInitialized selector depends on unitUrl for course blocks

### DIFF
--- a/src/editors/data/redux/app/selectors.js
+++ b/src/editors/data/redux/app/selectors.js
@@ -40,11 +40,35 @@ export const returnUrl = createSelector(
   ),
 );
 
+export const isLibrary = createSelector(
+  [
+    module.simpleSelectors.learningContextId,
+    module.simpleSelectors.blockId,
+  ],
+  (learningContextId, blockId) => {
+    if (learningContextId && learningContextId.startsWith('library-v1')) {
+      return true;
+    }
+    if (blockId && blockId.startsWith('lb:')) {
+      return true;
+    }
+    return false;
+  },
+);
+
 export const isInitialized = createSelector(
   [
+    module.simpleSelectors.unitUrl,
     module.simpleSelectors.blockValue,
+    module.isLibrary,
   ],
-  (blockValue) => !!(blockValue),
+  (unitUrl, blockValue, isLibraryBlock) => {
+    if (isLibraryBlock) {
+      return !!blockValue;
+    }
+
+    return !!blockValue && !!unitUrl;
+  },
 );
 
 export const displayTitle = createSelector(
@@ -74,22 +98,6 @@ export const analytics = createSelector(
   (blockId, blockType, learningContextId) => (
     { blockId, blockType, learningContextId }
   ),
-);
-
-export const isLibrary = createSelector(
-  [
-    module.simpleSelectors.learningContextId,
-    module.simpleSelectors.blockId,
-  ],
-  (learningContextId, blockId) => {
-    if (learningContextId && learningContextId.startsWith('library-v1')) {
-      return true;
-    }
-    if (blockId && blockId.startsWith('lb:')) {
-      return true;
-    }
-    return false;
-  },
 );
 
 export default {

--- a/src/editors/data/redux/app/selectors.test.js
+++ b/src/editors/data/redux/app/selectors.test.js
@@ -78,21 +78,40 @@ describe('app selectors unit tests', () => {
     });
   });
   describe('isInitialized selector', () => {
-    it('is memoized based on editorInitialized and blockValue', () => {
+    it('is memoized based on editorInitialized, unitUrl, isLibrary and blockValue', () => {
       expect(selectors.isInitialized.preSelectors).toEqual([
+        simpleSelectors.unitUrl,
         simpleSelectors.blockValue,
+        selectors.isLibrary,
       ]);
     });
-    it('returns true iff blockValue and editorInitialized are truthy', () => {
-      const { cb } = selectors.isInitialized;
-      const truthy = {
-        blockValue: { block: 'value' },
-      };
+    describe('for library blocks', () => {
+      it('returns true if blockValue, and editorInitialized are truthy', () => {
+        const { cb } = selectors.isInitialized;
+        const truthy = {
+          blockValue: { block: 'value' },
+        };
 
-      [
-        [[truthy.blockValue], true],
-        [[null], false],
-      ].map(([args, expected]) => expect(cb(...args)).toEqual(expected));
+        [
+          [[null, truthy.blockValue, true], true],
+          [[null, null, true], false],
+        ].map(([args, expected]) => expect(cb(...args)).toEqual(expected));
+      });
+    });
+    describe('for course blocks', () => {
+      it('returns true if blockValue, unitUrl, and editorInitialized are truthy', () => {
+        const { cb } = selectors.isInitialized;
+        const truthy = {
+          blockValue: { block: 'value' },
+          unitUrl: { url: 'data' },
+        };
+
+        [
+          [[null, truthy.blockValue, false], false],
+          [[truthy.unitUrl, null, false], false],
+          [[truthy.unitUrl, truthy.blockValue, false], true],
+        ].map(([args, expected]) => expect(cb(...args)).toEqual(expected));
+      });
     });
   });
   describe('displayTitle', () => {


### PR DESCRIPTION
## Description

This change impacts course authors. Editors for course block depend on `unitUrl` to navigate the user back to the unit page. When trying to save a course block and the `unitUrl` is not defined, the user can fall into a infinite loop of trying to save and the page just reloading the editor. The issue does not occur in library blocks because their return URLs are constructed from the `learningContextId` or use a parent function to exit.

## Testing instructions

1. Open a course block
2. Confirm that the block loads
3. Click "Save"
4. Should be navigated back to the unit page
5. Open a V1 library block
6. Confirm that the block loads
7. Click "Save"
8. Should be navigated back to the V1 library page
9. Open a V2 library block
10. Confirm that the block loads
11. Click "Save"
12. Should be navigated back to the V2 library page
