### PR TITLE
fix: Fix content overflow in the Overwrite Files modal window

### DIFF
--- a/src/files-and-videos/files-page/FileValidationModal.jsx
+++ b/src/files-and-videos/files-page/FileValidationModal.jsx
@@ -32,6 +32,7 @@ const FileValidationModal = ({
       title={intl.formatMessage(messages.overwriteModalTitle)}
       isOpen={isOpen}
       onClose={close}
+      isOverflowVisible={false}
     >
       <ModalDialog.Header>
         <ModalDialog.Title>


### PR DESCRIPTION
## Description

This bug was discussed [here](https://github.com/orgs/openedx/projects/28/views/16?pane=issue&itemId=62425234), [here](https://github.com/orgs/openedx/projects/28/views/16?pane=issue&itemId=63933528) and fixed in [this PR](https://github.com/openedx/paragon/pull/2939). However, the fix was not applied to all modal windows in course authoring. In this PR, we have added the fix to the 'Overwrite Files' modal window

Before fix

https://github.com/user-attachments/assets/c138600b-4e17-4acd-b242-9c2865340404

After fix

https://github.com/user-attachments/assets/07599f21-b0a1-4a09-8671-9c8120316717

