### PR TITLE
fix: responsiveness on library authoring sidebar [FC-0062]

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -61,3 +61,7 @@ body {
     background-color: $light-100;
   }
 }
+
+mark {
+  padding: 0;
+}

--- a/src/library-authoring/LibraryAuthoringPage.scss
+++ b/src/library-authoring/LibraryAuthoringPage.scss
@@ -11,9 +11,8 @@
 }
 
 .library-authoring-sidebar {
-  min-width: 300px;
-  max-width: map-get($grid-breakpoints, "sm");
   z-index: 1001; // to appear over header
+  flex: 450px 0 0;
   position: sticky;
   top: 0;
   right: 0;

--- a/src/library-authoring/LibraryAuthoringPage.scss
+++ b/src/library-authoring/LibraryAuthoringPage.scss
@@ -6,6 +6,7 @@
 
     .open-border {
       border: 2px solid;
+      margin: -1px 0;
     }
   }
 }

--- a/src/library-authoring/LibraryCollections.tsx
+++ b/src/library-authoring/LibraryCollections.tsx
@@ -1,5 +1,3 @@
-import { CardGrid } from '@openedx/paragon';
-
 import { useLoadOnScroll } from '../hooks';
 import { useSearchContext } from '../search-manager';
 import { NoComponents, NoSearchResults } from './EmptyStates';
@@ -41,22 +39,14 @@ const LibraryCollections = ({ variant }: LibraryCollectionsProps) => {
   }
 
   return (
-    <CardGrid
-      columnSizes={{
-        sm: 12,
-        md: 6,
-        lg: 4,
-        xl: 3,
-      }}
-      hasEqualColumnHeights
-    >
+    <div className="library-cards-grid">
       { collectionList.map((collectionHit) => (
         <CollectionCard
           key={collectionHit.id}
           collectionHit={collectionHit}
         />
       )) }
-    </CardGrid>
+    </div>
   );
 };
 

--- a/src/library-authoring/component-info/ComponentInfoHeader.tsx
+++ b/src/library-authoring/component-info/ComponentInfoHeader.tsx
@@ -62,7 +62,7 @@ const ComponentInfoHeader = ({ library, usageKey }: ComponentInfoHeaderProps) =>
 
   return (
     <Stack direction="horizontal">
-      { inputIsActive
+      {inputIsActive
         ? (
           <Form.Control
             autoFocus
@@ -86,6 +86,7 @@ const ComponentInfoHeader = ({ library, usageKey }: ComponentInfoHeaderProps) =>
                 iconAs={Icon}
                 alt={intl.formatMessage(messages.editNameButtonAlt)}
                 onClick={handleClick}
+                size="inline"
               />
             )}
           </>

--- a/src/library-authoring/components/ComponentCard.scss
+++ b/src/library-authoring/components/ComponentCard.scss
@@ -1,8 +1,4 @@
 .library-component-card {
-  .pgn__card {
-    height: 100%;
-  }
-
   .library-component-header {
     border-top-left-radius: .375rem;
     border-top-right-radius: .375rem;

--- a/src/library-authoring/components/LibraryComponents.tsx
+++ b/src/library-authoring/components/LibraryComponents.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react';
-import { CardGrid } from '@openedx/paragon';
 
 import { useLoadOnScroll } from '../../hooks';
 import { useSearchContext } from '../../search-manager';
@@ -56,15 +55,7 @@ const LibraryComponents = ({ libraryId, variant }: LibraryComponentsProps) => {
   }
 
   return (
-    <CardGrid
-      columnSizes={{
-        sm: 12,
-        md: 6,
-        lg: 4,
-        xl: 3,
-      }}
-      hasEqualColumnHeights
-    >
+    <div className="library-cards-grid">
       { componentList.map((contentHit) => (
         <ComponentCard
           key={contentHit.id}
@@ -72,7 +63,7 @@ const LibraryComponents = ({ libraryId, variant }: LibraryComponentsProps) => {
           blockTypeDisplayName={blockTypes[contentHit.blockType]?.displayName ?? ''}
         />
       )) }
-    </CardGrid>
+    </div>
   );
 };
 

--- a/src/library-authoring/index.scss
+++ b/src/library-authoring/index.scss
@@ -2,3 +2,10 @@
 @import "./components/ComponentCard";
 @import "./generic";
 @import "./LibraryAuthoringPage";
+
+.library-cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  grid-gap: 2rem;
+  justify-items: center;
+}


### PR DESCRIPTION
## Description

This PR fixes the library authoring sidebar width and change the card grid to have auto-columns instead for breakpoints.

### Before:
![image](https://github.com/user-attachments/assets/2a8b833e-8fe2-49d2-90e8-130625fa6519)


### After:
![image](https://github.com/user-attachments/assets/748f9393-bd39-4618-b7eb-d700400a5b23)

### Responsiveness:
![sidebar-responsiveness-fixed](https://github.com/user-attachments/assets/cdf30ed0-505e-4543-bc21-fe916ccfbcb9)

### Tabs
![sidebar-responsiveness-tabs](https://github.com/user-attachments/assets/b9508724-6f1b-4aa3-9d5d-aa5a79125e17)



## More information
Part of:
- https://github.com/openedx/frontend-app-course-authoring/issues/1221

## Testing instructions
- Checkout this branch
- Open the library authoring page for a library with some components
- Resize the screen and check the responsiveness for the 'Components` and the 'Collections' tabs.
___
Private ref: [FAL-3820](https://tasks.opencraft.com/browse/FAL-3820)