### PR TITLE
feat: show children count in collection card

### DIFF
--- a/src/library-authoring/components/CollectionCard.test.tsx
+++ b/src/library-authoring/components/CollectionCard.test.tsx
@@ -17,6 +17,7 @@ const CollectionHitSample: CollectionHit = {
   },
   created: 1722434322294,
   modified: 1722434322294,
+  numChildren: 2,
   tags: {},
 };
 
@@ -32,7 +33,8 @@ describe('<CollectionCard />', () => {
   it('should render the card with title and description', () => {
     render(<CollectionCard collectionHit={CollectionHitSample} />);
 
-    expect(screen.getByText('Collection Display Formated Name')).toBeInTheDocument();
-    expect(screen.getByText('Collection description')).toBeInTheDocument();
+    expect(screen.queryByText('Collection Display Formated Name')).toBeInTheDocument();
+    expect(screen.queryByText('Collection description')).toBeInTheDocument();
+    expect(screen.queryByText('Collection (2)')).toBeInTheDocument();
   });
 });

--- a/src/library-authoring/components/CollectionCard.tsx
+++ b/src/library-authoring/components/CollectionCard.tsx
@@ -21,8 +21,13 @@ const CollectionCard = ({ collectionHit } : CollectionCardProps) => {
     type,
     formatted,
     tags,
+    numChildren,
   } = collectionHit;
   const { displayName = '', description = '' } = formatted;
+  const blockTypeDisplayName = numChildren ? intl.formatMessage(
+    messages.collectionTypeWithCount,
+    { numChildren },
+  ) : intl.formatMessage(messages.collectionType);
 
   return (
     <BaseComponentCard
@@ -40,7 +45,7 @@ const CollectionCard = ({ collectionHit } : CollectionCardProps) => {
           />
         </ActionRow>
       )}
-      blockTypeDisplayName={intl.formatMessage(messages.collectionType)}
+      blockTypeDisplayName={blockTypeDisplayName}
       openInfoSidebar={() => {}}
     />
   );

--- a/src/library-authoring/components/messages.ts
+++ b/src/library-authoring/components/messages.ts
@@ -16,6 +16,11 @@ const messages = defineMessages({
     defaultMessage: 'Collection',
     description: 'Collection type text',
   },
+  collectionTypeWithCount: {
+    id: 'course-authoring.library-authoring.collection.type-with-count',
+    defaultMessage: 'Collection ({numChildren})',
+    description: 'Collection type text with children count',
+  },
   menuEdit: {
     id: 'course-authoring.library-authoring.component.menu.edit',
     defaultMessage: 'Edit',

--- a/src/search-manager/data/api.ts
+++ b/src/search-manager/data/api.ts
@@ -135,7 +135,7 @@ export interface ContentHit extends BaseContentHit {
  */
 export interface CollectionHit extends BaseContentHit {
   description: string;
-  componentCount?: number;
+  numChildren?: number;
 }
 
 /**


### PR DESCRIPTION
## Description

Adds children count to collection cards.

![image](https://github.com/user-attachments/assets/58a50afb-4d39-4194-aeec-82b100620a64)


## Supporting information

`Private-ref`: [FAL-3837](https://tasks.opencraft.com/browse/FAL-3837)

## Testing instructions

**Two options:**

* Setup https://github.com/openedx/frontend-app-authoring/pull/1281 and follow its test instructions to add collection and its components.
* Check collections tab for children count

**OR**

* Follow test instructions from https://github.com/open-craft/edx-platform/pull/684 to add components to collection programmatically.
* Check collections tab for children count