### PR TITLE
feat: Add tags to info sidebar of library component [FC-0062]

### DIFF
--- a/src/content-tags-drawer/ContentTagsDrawer.test.jsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.test.jsx
@@ -97,8 +97,8 @@ describe('<ContentTagsDrawer />', () => {
   it('shows content using params', async () => {
     renderDrawer(undefined, { id: 'test' });
     expect(await screen.findByText('Loading...')).toBeInTheDocument();
-    expect(screen.getByText('Unit 1')).toBeInTheDocument();
-    expect(screen.queryByText('Manage tags')).toBeInTheDocument();
+    expect(await screen.findByText('Unit 1')).toBeInTheDocument();
+    expect(await screen.findByText('Manage tags')).toBeInTheDocument();
   });
 
   it('shows the taxonomies data including tag numbers after the query is complete', async () => {

--- a/src/content-tags-drawer/ContentTagsDrawer.tsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.tsx
@@ -187,16 +187,15 @@ const ContentTagsComponentVariantFooter = () => {
                 {intl.formatMessage(messages.tagsDrawerSaveButtonText)}
               </Button>
             </Stack>
-          )
-            : (
-              <div className='d-flex justify-content-center'>
-                <Spinner
-                  animation="border"
-                  size="xl"
-                  screenReaderText={intl.formatMessage(messages.loadingMessage)}
-                />
-              </div>
-            )}
+          ) : (
+            <div className="d-flex justify-content-center">
+              <Spinner
+                animation="border"
+                size="xl"
+                screenReaderText={intl.formatMessage(messages.loadingMessage)}
+              />
+            </div>
+          )}
         </div>
       ) : (
         <Button
@@ -311,20 +310,33 @@ const ContentTagsDrawer = ({
 
   return (
     <ContentTagsDrawerContext.Provider value={context}>
-      <div id="content-tags-drawer" className={classNames(
-        "mt-1 tags-drawer d-flex flex-column justify-content-between pt-3", {
-          "min-vh-100": variant === 'drawer',
-        }
-      )}>
-        <Container size="xl" className={classNames({
-          "p-0": variant === 'component',
-        })}>
+      <div
+        id="content-tags-drawer"
+        className={classNames(
+          'mt-1 tags-drawer d-flex flex-column justify-content-between pt-3',
+          {
+            'min-vh-100': variant === 'drawer',
+          },
+        )}
+      >
+        <Container
+          size="xl"
+          className={classNames(
+            {
+              'p-0': variant === 'component',
+            },
+          )}
+        >
           {variant === 'drawer' && (
             <ContentTagsDrawerTittle />
           )}
-          <Container className={classNames({
-            "p-0": variant === 'component',
-          })}>
+          <Container
+            className={classNames(
+              {
+                'p-0': variant === 'component',
+              },
+            )}
+          >
             {variant === 'drawer' && (
               <p className="h4 text-gray-500 font-weight-bold">
                 {intl.formatMessage(messages.headerSubtitle)}

--- a/src/content-tags-drawer/ContentTagsDrawer.tsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.tsx
@@ -36,7 +36,7 @@ const TaxonomyList = ({ contentId }: TaxonomyListProps) => {
       return (
         <div>
           { tagsByTaxonomy.map((data) => (
-            <div key={`taxonomy-tags-collapsible-${data.id}`}>
+            <div key={data.id}>
               <ContentTagsCollapsible
                 contentId={contentId}
                 taxonomyAndTagsData={data}
@@ -356,7 +356,7 @@ const ContentTagsDrawer = ({
                 </p>
                 { isTaxonomyListLoaded && isContentTaxonomyTagsLoaded && (
                   otherTaxonomies.map((data) => (
-                    <div key={`taxonomy-tags-collapsible-${data.id}`}>
+                    <div key={data.id}>
                       <ContentTagsCollapsible
                         contentId={contentId}
                         taxonomyAndTagsData={data}

--- a/src/content-tags-drawer/ContentTagsDrawer.tsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.tsx
@@ -181,6 +181,7 @@ const ContentTagsComponentVariantFooter = () => {
                 variant="dark"
                 className="rounded-0"
                 onClick={commitGlobalStagedTags}
+                block
               >
                 {intl.formatMessage(messages.tagsDrawerSaveButtonText)}
               </Button>
@@ -198,6 +199,7 @@ const ContentTagsComponentVariantFooter = () => {
         <Button
           variant="outline-primary"
           onClick={toEditMode}
+          block
         >
           {intl.formatMessage(messages.manageTagsButton)}
         </Button>
@@ -209,8 +211,6 @@ const ContentTagsComponentVariantFooter = () => {
 interface ContentTagsDrawerProps {
   id?: string;
   onClose?: () => void;
-  hideTitle?: boolean;
-  hideSubtitle?: boolean;
   variant?: 'drawer' | 'component';
 }
 
@@ -226,8 +226,6 @@ interface ContentTagsDrawerProps {
 const ContentTagsDrawer = ({
   id,
   onClose,
-  hideTitle,
-  hideSubtitle,
   variant = 'drawer',
 }: ContentTagsDrawerProps) => {
   const intl = useIntl();
@@ -312,11 +310,11 @@ const ContentTagsDrawer = ({
     <ContentTagsDrawerContext.Provider value={context}>
       <div id="content-tags-drawer" className="mt-1 tags-drawer d-flex flex-column justify-content-between min-vh-100 pt-3">
         <Container size="xl">
-          {!hideTitle && (
+          {variant === 'drawer' && (
             <ContentTagsDrawerTittle />
           )}
           <Container>
-            {!hideSubtitle && (
+            {variant === 'drawer' && (
               <p className="h4 text-gray-500 font-weight-bold">
                 {intl.formatMessage(messages.headerSubtitle)}
               </p>

--- a/src/content-tags-drawer/ContentTagsDrawer.tsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.tsx
@@ -8,6 +8,7 @@ import {
 } from '@openedx/paragon';
 import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 import { useParams, useNavigate } from 'react-router-dom';
+import classNames from 'classnames';
 import messages from './messages';
 import ContentTagsCollapsible from './ContentTagsCollapsible';
 import Loading from '../generic/Loading';
@@ -188,11 +189,13 @@ const ContentTagsComponentVariantFooter = () => {
             </Stack>
           )
             : (
-              <Spinner
-                animation="border"
-                size="xl"
-                screenReaderText={intl.formatMessage(messages.loadingMessage)}
-              />
+              <div className='d-flex justify-content-center'>
+                <Spinner
+                  animation="border"
+                  size="xl"
+                  screenReaderText={intl.formatMessage(messages.loadingMessage)}
+                />
+              </div>
             )}
         </div>
       ) : (
@@ -308,12 +311,20 @@ const ContentTagsDrawer = ({
 
   return (
     <ContentTagsDrawerContext.Provider value={context}>
-      <div id="content-tags-drawer" className="mt-1 tags-drawer d-flex flex-column justify-content-between min-vh-100 pt-3">
-        <Container size="xl">
+      <div id="content-tags-drawer" className={classNames(
+        "mt-1 tags-drawer d-flex flex-column justify-content-between pt-3", {
+          "min-vh-100": variant === 'drawer',
+        }
+      )}>
+        <Container size="xl" className={classNames({
+          "p-0": variant === 'component',
+        })}>
           {variant === 'drawer' && (
             <ContentTagsDrawerTittle />
           )}
-          <Container>
+          <Container className={classNames({
+            "p-0": variant === 'component',
+          })}>
             {variant === 'drawer' && (
               <p className="h4 text-gray-500 font-weight-bold">
                 {intl.formatMessage(messages.headerSubtitle)}

--- a/src/content-tags-drawer/ContentTagsDrawer.tsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.tsx
@@ -131,7 +131,6 @@ const ContentTagsDrawerVariantFooter = ({ onClose }: ContentTagsDrawerVariantFoo
                 : messages.tagsDrawerCloseButtonText)}
             </Button>
             <Button
-              variant="dark"
               className="rounded-0"
               onClick={isEditMode
                 ? commitGlobalStagedTags
@@ -179,7 +178,6 @@ const ContentTagsComponentVariantFooter = () => {
                 {intl.formatMessage(messages.tagsDrawerCancelButtonText)}
               </Button>
               <Button
-                variant="dark"
                 className="rounded-0"
                 onClick={commitGlobalStagedTags}
                 block
@@ -257,28 +255,33 @@ const ContentTagsDrawer = ({
   } = context;
 
   let onCloseDrawer: () => void;
-  if (onClose === undefined) {
-    onCloseDrawer = () => {
-      // "*" allows communication with any origin
-      window.parent.postMessage('closeManageTagsDrawer', '*');
-    };
-  } else {
-    onCloseDrawer = onClose;
+  if (variant === 'drawer') {
+    if (onClose === undefined) {
+      onCloseDrawer = () => {
+        // "*" allows communication with any origin
+        window.parent.postMessage('closeManageTagsDrawer', '*');
+      };
+    } else {
+      onCloseDrawer = onClose;
+    }
   }
 
   useEffect(() => {
-    const handleEsc = (event) => {
-      /* Close drawer when ESC-key is pressed and selectable dropdown box not open */
-      const selectableBoxOpen = document.querySelector('[data-selectable-box="taxonomy-tags"]');
-      if (event.key === 'Escape' && !selectableBoxOpen && !blockingSheet) {
-        onCloseDrawer();
-      }
-    };
-    document.addEventListener('keydown', handleEsc);
+    if (variant === 'drawer') {
+      const handleEsc = (event) => {
+        /* Close drawer when ESC-key is pressed and selectable dropdown box not open */
+        const selectableBoxOpen = document.querySelector('[data-selectable-box="taxonomy-tags"]');
+        if (event.key === 'Escape' && !selectableBoxOpen && !blockingSheet) {
+          onCloseDrawer();
+        }
+      };
+      document.addEventListener('keydown', handleEsc);
 
-    return () => {
-      document.removeEventListener('keydown', handleEsc);
-    };
+      return () => {
+        document.removeEventListener('keydown', handleEsc);
+      };
+    }
+    return () => {};
   }, [blockingSheet]);
 
   useEffect(() => {

--- a/src/content-tags-drawer/data/api.mocks.ts
+++ b/src/content-tags-drawer/data/api.mocks.ts
@@ -1,0 +1,378 @@
+import * as api from './api';
+import * as taxonomyApi from '../../taxonomy/data/api';
+import { languageExportId } from '../utils';
+
+/**
+ * Mock for `getContentTaxonomyTagsData()`
+ */
+export async function mockContentTaxonomyTagsData(contentId: string): Promise<any> {
+  const thisMock = mockContentTaxonomyTagsData;
+  switch (contentId) {
+    case thisMock.stagedTagsId: return thisMock.stagedTags;
+    case thisMock.otherTagsId: return thisMock.otherTags;
+    case thisMock.languageWithTagsId: return thisMock.languageWithTags;
+    case thisMock.languageWithoutTagsId: return thisMock.languageWithoutTags;
+    case thisMock.largeTagsId: return thisMock.largeTags;
+    case thisMock.emptyTagsId: return thisMock.emptyTags;
+    default: throw new Error(`No mock has been set up for contentId "${contentId}"`);
+  }
+}
+mockContentTaxonomyTagsData.stagedTagsId = 'block-v1:StagedTagsOrg+STC1+2023_1+type@vertical+block@stagedTagsId';
+mockContentTaxonomyTagsData.stagedTags = {
+  taxonomies: [
+    {
+      name: 'Taxonomy 1',
+      taxonomyId: 123,
+      canTagObject: true,
+      tags: [
+        {
+          value: 'Tag 1',
+          lineage: ['Tag 1'],
+          canDeleteObjecttag: true,
+        },
+        {
+          value: 'Tag 2',
+          lineage: ['Tag 2'],
+          canDeleteObjecttag: true,
+        },
+      ],
+    },
+  ],
+};
+mockContentTaxonomyTagsData.otherTagsId = 'block-v1:StagedTagsOrg+STC1+2023_1+type@vertical+block@otherTagsId';
+mockContentTaxonomyTagsData.otherTags = {
+  taxonomies: [
+    {
+      name: 'Taxonomy 1',
+      taxonomyId: 123,
+      canTagObject: true,
+      tags: [
+        {
+          value: 'Tag 1',
+          lineage: ['Tag 1'],
+          canDeleteObjecttag: true,
+        },
+        {
+          value: 'Tag 2',
+          lineage: ['Tag 2'],
+          canDeleteObjecttag: true,
+        },
+      ],
+    },
+    {
+      name: 'Taxonomy 2',
+      taxonomyId: 1234,
+      canTagObject: false,
+      tags: [
+        {
+          value: 'Tag 3',
+          lineage: ['Tag 3'],
+          canDeleteObjecttag: true,
+        },
+        {
+          value: 'Tag 4',
+          lineage: ['Tag 4'],
+          canDeleteObjecttag: true,
+        },
+      ],
+    },
+  ],
+};
+mockContentTaxonomyTagsData.languageWithTagsId = 'block-v1:LanguageTagsOrg+STC1+2023_1+type@vertical+block@languageWithTagsId';
+mockContentTaxonomyTagsData.languageWithTags = {
+  taxonomies: [
+    {
+      name: 'Languages',
+      taxonomyId: 1234,
+      exportId: languageExportId,
+      canTagObject: true,
+      tags: [
+        {
+          value: 'Tag 1',
+          lineage: ['Tag 1'],
+          canDeleteObjecttag: true,
+        },
+      ],
+    },
+    {
+      name: 'Taxonomy 1',
+      taxonomyId: 12345,
+      canTagObject: true,
+      tags: [
+        {
+          value: 'Tag 1',
+          lineage: ['Tag 1'],
+          canDeleteObjecttag: true,
+        },
+        {
+          value: 'Tag 2',
+          lineage: ['Tag 2'],
+          canDeleteObjecttag: true,
+        },
+      ],
+    },
+  ],
+};
+mockContentTaxonomyTagsData.languageWithoutTagsId = 'block-v1:LanguageTagsOrg+STC1+2023_1+type@vertical+block@languageWithoutTagsId';
+mockContentTaxonomyTagsData.languageWithoutTags = {
+  taxonomies: [
+    {
+      name: 'Languages',
+      taxonomyId: 1234,
+      exportId: languageExportId,
+      canTagObject: true,
+      tags: [],
+    },
+    {
+      name: 'Taxonomy 1',
+      taxonomyId: 12345,
+      canTagObject: true,
+      tags: [
+        {
+          value: 'Tag 1',
+          lineage: ['Tag 1'],
+          canDeleteObjecttag: true,
+        },
+        {
+          value: 'Tag 2',
+          lineage: ['Tag 2'],
+          canDeleteObjecttag: true,
+        },
+      ],
+    },
+  ],
+};
+mockContentTaxonomyTagsData.largeTagsId = 'block-v1:LargeTagsOrg+STC1+2023_1+type@vertical+block@largeTagsId';
+mockContentTaxonomyTagsData.largeTags = {
+  taxonomies: [
+    {
+      name: 'Taxonomy 1',
+      taxonomyId: 123,
+      canTagObject: true,
+      tags: [
+        {
+          value: 'Tag 1',
+          lineage: ['Tag 1'],
+          canDeleteObjecttag: true,
+        },
+        {
+          value: 'Tag 2',
+          lineage: ['Tag 2'],
+          canDeleteObjecttag: true,
+        },
+      ],
+    },
+    {
+      name: 'Taxonomy 2',
+      taxonomyId: 124,
+      canTagObject: true,
+      tags: [
+        {
+          value: 'Tag 1',
+          lineage: ['Tag 1'],
+          canDeleteObjecttag: true,
+        },
+      ],
+    },
+    {
+      name: 'Taxonomy 3',
+      taxonomyId: 125,
+      canTagObject: true,
+      tags: [
+        {
+          value: 'Tag 1.1.1',
+          lineage: ['Tag 1', 'Tag 1.1', 'Tag 1.1.1'],
+          canDeleteObjecttag: true,
+        },
+      ],
+    },
+    {
+      name: '(B) Taxonomy 4',
+      taxonomyId: 126,
+      canTagObject: true,
+      tags: [],
+    },
+    {
+      name: '(A) Taxonomy 5',
+      taxonomyId: 127,
+      canTagObject: true,
+      tags: [],
+    },
+  ],
+};
+mockContentTaxonomyTagsData.emptyTagsId = 'block-v1:EmptyTagsOrg+STC1+2023_1+type@vertical+block@emptyTagsId';
+mockContentTaxonomyTagsData.emptyTags = {
+  taxonomies: [],
+};
+mockContentTaxonomyTagsData.applyMock = () => jest.spyOn(api, 'getContentTaxonomyTagsData').mockImplementation(mockContentTaxonomyTagsData);
+
+/**
+ * Mock for `getTaxonomyListData()`
+ */
+export async function mockTaxonomyListData(org: string): Promise<any> {
+  const thisMock = mockTaxonomyListData;
+  switch (org) {
+    case thisMock.stagedTagsOrg: return thisMock.stagedTags;
+    case thisMock.languageTagsOrg: return thisMock.languageTags;
+    case thisMock.largeTagsOrg: return thisMock.largeTags;
+    case thisMock.emptyTagsOrg: return thisMock.emptyTags;
+    default: throw new Error(`No mock has been set up for org "${org}"`);
+  }
+}
+mockTaxonomyListData.stagedTagsOrg = 'StagedTagsOrg';
+mockTaxonomyListData.stagedTags = {
+  results: [
+    {
+      id: 123,
+      name: 'Taxonomy 1',
+      description: 'This is a description 1',
+      canTagObject: true,
+    },
+  ],
+};
+mockTaxonomyListData.languageTagsOrg = 'LanguageTagsOrg';
+mockTaxonomyListData.languageTags = {
+  results: [
+    {
+      id: 1234,
+      name: 'Languages',
+      description: 'This is a description 1',
+      exportId: languageExportId,
+      canTagObject: true,
+    },
+    {
+      id: 12345,
+      name: 'Taxonomy 1',
+      description: 'This is a description 2',
+      canTagObject: true,
+    },
+  ],
+};
+mockTaxonomyListData.largeTagsOrg = 'LargeTagsOrg';
+mockTaxonomyListData.largeTags = {
+  results: [
+    {
+      id: 123,
+      name: 'Taxonomy 1',
+      description: 'This is a description 1',
+      canTagObject: true,
+    },
+    {
+      id: 124,
+      name: 'Taxonomy 2',
+      description: 'This is a description 2',
+      canTagObject: true,
+    },
+    {
+      id: 125,
+      name: 'Taxonomy 3',
+      description: 'This is a description 3',
+      canTagObject: true,
+    },
+    {
+      id: 127,
+      name: '(A) Taxonomy 5',
+      description: 'This is a description 5',
+      canTagObject: true,
+    },
+    {
+      id: 126,
+      name: '(B) Taxonomy 4',
+      description: 'This is a description 4',
+      canTagObject: true,
+    },
+  ],
+};
+mockTaxonomyListData.emptyTagsOrg = 'EmptyTagsOrg';
+mockTaxonomyListData.emptyTags = {
+  results: [],
+};
+mockTaxonomyListData.applyMock = () => jest.spyOn(taxonomyApi, 'getTaxonomyListData').mockImplementation(mockTaxonomyListData);
+
+/**
+ * Mock for `getTaxonomyTagsData()`
+ */
+export async function mockTaxonomyTagsData(taxonomyId: number): Promise<any> {
+  const thisMock = mockTaxonomyTagsData;
+  switch (taxonomyId) {
+    case thisMock.stagedTagsTaxonomy: return thisMock.stagedTags;
+    case thisMock.languageTagsTaxonomy: return thisMock.languageTags;
+    default: throw new Error(`No mock has been set up for taxonomyId "${taxonomyId}"`);
+  }
+}
+mockTaxonomyTagsData.stagedTagsTaxonomy = 123;
+mockTaxonomyTagsData.stagedTags = {
+  count: 3,
+  currentPage: 1,
+  next: null,
+  numPages: 1,
+  previous: null,
+  start: 1,
+  results: [
+    {
+      value: 'Tag 1',
+      externalId: null,
+      childCount: 0,
+      depth: 0,
+      parentValue: null,
+      id: 12345,
+      subTagsUrl: null,
+      canChangeTag: false,
+      canDeleteTag: false,
+    },
+    {
+      value: 'Tag 2',
+      externalId: null,
+      childCount: 0,
+      depth: 0,
+      parentValue: null,
+      id: 12346,
+      subTagsUrl: null,
+      canChangeTag: false,
+      canDeleteTag: false,
+    },
+    {
+      value: 'Tag 3',
+      externalId: null,
+      childCount: 0,
+      depth: 0,
+      parentValue: null,
+      id: 12347,
+      subTagsUrl: null,
+      canChangeTag: false,
+      canDeleteTag: false,
+    },
+  ],
+};
+mockTaxonomyTagsData.languageTagsTaxonomy = 1234;
+mockTaxonomyTagsData.languageTags = {
+  count: 1,
+  currentPage: 1,
+  next: null,
+  numPages: 1,
+  previous: null,
+  start: 1,
+  results: [{
+    value: 'Tag 1',
+    externalId: null,
+    childCount: 0,
+    depth: 0,
+    parentValue: null,
+    id: 12345,
+    subTagsUrl: null,
+    canChangeTag: false,
+    canDeleteTag: false,
+  }],
+};
+mockTaxonomyTagsData.applyMock = () => jest.spyOn(api, 'getTaxonomyTagsData').mockImplementation(mockTaxonomyTagsData);
+
+/**
+ * Mock for `getContentData()`
+ */
+export async function mockContentData(): Promise<any> {
+  return mockContentData.data;
+}
+mockContentData.data = {
+  displayName: 'Unit 1',
+};
+mockContentData.applyMock = () => jest.spyOn(api, 'getContentData').mockImplementation(mockContentData);

--- a/src/content-tags-drawer/data/apiHooks.jsx
+++ b/src/content-tags-drawer/data/apiHooks.jsx
@@ -14,6 +14,7 @@ import {
   updateContentTaxonomyTags,
   getContentTaxonomyTagsCount,
 } from './api';
+import { libraryQueryPredicate } from '../../library-authoring/data/apiHooks';
 
 /** @typedef {import("../../taxonomy/tag-list/data/types.mjs").TagListData} TagListData */
 /** @typedef {import("../../taxonomy/tag-list/data/types.mjs").TagData} TagData */
@@ -146,6 +147,11 @@ export const useContentTaxonomyTagsUpdater = (contentId) => {
         contentPattern = contentId.replace(/\+type@.*$/, '*');
       }
       queryClient.invalidateQueries({ queryKey: ['contentTagsCount', contentPattern] });
+      if (contentId.includes('lb:')) {
+        // Obtain library id from contentId
+        const libraryId = ['lib', ...contentId.split(':').slice(1, 3)].join(':');
+        queryClient.invalidateQueries(['content_search'], { predicate: (query) => libraryQueryPredicate(query, libraryId) })
+      }
     },
     onSuccess: /* istanbul ignore next */ () => {
       /* istanbul ignore next */

--- a/src/content-tags-drawer/data/apiHooks.jsx
+++ b/src/content-tags-drawer/data/apiHooks.jsx
@@ -14,7 +14,7 @@ import {
   updateContentTaxonomyTags,
   getContentTaxonomyTagsCount,
 } from './api';
-import { libraryQueryPredicate } from '../../library-authoring/data/apiHooks';
+import { libraryQueryPredicate, xblockQueryKeys } from '../../library-authoring/data/apiHooks';
 
 /** @typedef {import("../../taxonomy/tag-list/data/types.mjs").TagListData} TagListData */
 /** @typedef {import("../../taxonomy/tag-list/data/types.mjs").TagData} TagData */
@@ -150,7 +150,10 @@ export const useContentTaxonomyTagsUpdater = (contentId) => {
       if (contentId.includes('lb:')) {
         // Obtain library id from contentId
         const libraryId = ['lib', ...contentId.split(':').slice(1, 3)].join(':');
-        queryClient.invalidateQueries(['content_search'], { predicate: (query) => libraryQueryPredicate(query, libraryId) })
+        // Invalidate component metadata to update tags count
+        queryClient.invalidateQueries(xblockQueryKeys.componentMetadata(contentId));
+        // Invalidate content search to update tags count
+        queryClient.invalidateQueries(['content_search'], { predicate: (query) => libraryQueryPredicate(query, libraryId) });
       }
     },
     onSuccess: /* istanbul ignore next */ () => {

--- a/src/library-authoring/component-info/ComponentManagement.test.tsx
+++ b/src/library-authoring/component-info/ComponentManagement.test.tsx
@@ -8,6 +8,10 @@ import {
 import { mockLibraryBlockMetadata } from '../data/api.mocks';
 import ComponentManagement from './ComponentManagement';
 
+jest.mock('../../content-tags-drawer', () => ({
+  ContentTagsDrawer: () => <div>Mocked ContentTagsDrawer</div>,
+}));
+
 /*
  * FIXME: Summarize the reason here
  * https://stackoverflow.com/questions/47902335/innertext-is-undefined-in-jest-test
@@ -51,9 +55,8 @@ describe('<ComponentManagement />', () => {
     initializeMocks();
     mockLibraryBlockMetadata.applyMock();
     render(<ComponentManagement usageKey={mockLibraryBlockMetadata.usageKeyNeverPublished} />);
-    expect(await screen.findByText('Tags')).toBeInTheDocument();
-    // TODO: replace with actual data when implement tag list
-    expect(screen.queryByText('Tags placeholder')).toBeInTheDocument();
+    expect(await screen.findByText('Tags (0)')).toBeInTheDocument();
+    expect(screen.queryByText('Mocked ContentTagsDrawer')).toBeInTheDocument();
   });
 
   it('should not render draft status', async () => {

--- a/src/library-authoring/component-info/ComponentManagement.test.tsx
+++ b/src/library-authoring/component-info/ComponentManagement.test.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../testUtils';
 import { mockLibraryBlockMetadata } from '../data/api.mocks';
 import ComponentManagement from './ComponentManagement';
+import { mockContentTaxonomyTagsData } from '../../content-tags-drawer/data/api.mocks';
 
 jest.mock('../../content-tags-drawer', () => ({
   ContentTagsDrawer: () => <div>Mocked ContentTagsDrawer</div>,
@@ -69,5 +70,17 @@ describe('<ComponentManagement />', () => {
     render(<ComponentManagement usageKey={mockLibraryBlockMetadata.usageKeyNeverPublished} />);
     expect(await screen.findByText('Draft')).toBeInTheDocument();
     expect(screen.queryByText('Tags')).not.toBeInTheDocument();
+  });
+
+  it('should render tag count in tagging info', async () => {
+    setConfig({
+      ...getConfig(),
+      ENABLE_TAGGING_TAXONOMY_PAGES: 'true',
+    });
+    initializeMocks();
+    mockLibraryBlockMetadata.applyMock();
+    mockContentTaxonomyTagsData.applyMock();
+    render(<ComponentManagement usageKey={mockLibraryBlockMetadata.usageKeyForTags} />);
+    expect(await screen.findByText('Tags (6)')).toBeInTheDocument();
   });
 });

--- a/src/library-authoring/component-info/ComponentManagement.tsx
+++ b/src/library-authoring/component-info/ComponentManagement.tsx
@@ -38,7 +38,9 @@ const ComponentManagement = ({ usageKey }: ComponentManagementProps) => {
         >
           <ContentTagsDrawer
             id={usageKey}
+            variant="component"
             hideTitle
+            hideSubtitle
           />
         </Collapsible>
         )}

--- a/src/library-authoring/component-info/ComponentManagement.tsx
+++ b/src/library-authoring/component-info/ComponentManagement.tsx
@@ -31,7 +31,7 @@ const ComponentManagement = ({ usageKey }: ComponentManagementProps) => {
           title={(
             <Stack gap={1} direction="horizontal">
               <Icon src={Tag} />
-              {intl.formatMessage(messages.manageTabTagsTitle, {count: componentMetadata.tagsCount})}
+              {intl.formatMessage(messages.manageTabTagsTitle, { count: componentMetadata.tagsCount })}
             </Stack>
           )}
           className="border-0"

--- a/src/library-authoring/component-info/ComponentManagement.tsx
+++ b/src/library-authoring/component-info/ComponentManagement.tsx
@@ -6,6 +6,7 @@ import { Tag } from '@openedx/paragon/icons';
 import { useLibraryBlockMetadata } from '../data/apiHooks';
 import StatusWidget from '../generic/status-widget';
 import messages from './messages';
+import { ContentTagsDrawer } from '../../content-tags-drawer';
 
 interface ComponentManagementProps {
   usageKey: string;
@@ -35,7 +36,10 @@ const ComponentManagement = ({ usageKey }: ComponentManagementProps) => {
           )}
           className="border-0"
         >
-          Tags placeholder
+          <ContentTagsDrawer
+            id={usageKey}
+            hideTitle
+          />
         </Collapsible>
         )}
       <Collapsible

--- a/src/library-authoring/component-info/ComponentManagement.tsx
+++ b/src/library-authoring/component-info/ComponentManagement.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Collapsible, Icon, Stack } from '@openedx/paragon';
@@ -7,6 +8,7 @@ import { useLibraryBlockMetadata } from '../data/apiHooks';
 import StatusWidget from '../generic/status-widget';
 import messages from './messages';
 import { ContentTagsDrawer } from '../../content-tags-drawer';
+import { useContentTaxonomyTagsData } from '../../content-tags-drawer/data/apiHooks';
 
 interface ComponentManagementProps {
   usageKey: string;
@@ -14,6 +16,26 @@ interface ComponentManagementProps {
 const ComponentManagement = ({ usageKey }: ComponentManagementProps) => {
   const intl = useIntl();
   const { data: componentMetadata } = useLibraryBlockMetadata(usageKey);
+  const { data: componentTags } = useContentTaxonomyTagsData(usageKey);
+
+  const tagsCount = React.useMemo(() => {
+    if (!componentTags) {
+      return 0;
+    }
+    let result = 0;
+    componentTags.taxonomies.forEach((taxonomy) => {
+      const countedTags : string[] = [];
+      taxonomy.tags.forEach((tagData) => {
+        tagData.lineage.forEach((tag) => {
+          if (!countedTags.includes(tag)) {
+            result += 1;
+            countedTags.push(tag);
+          }
+        });
+      });
+    });
+    return result;
+  }, [componentTags]);
 
   if (!componentMetadata) {
     return null;
@@ -31,7 +53,7 @@ const ComponentManagement = ({ usageKey }: ComponentManagementProps) => {
           title={(
             <Stack gap={1} direction="horizontal">
               <Icon src={Tag} />
-              {intl.formatMessage(messages.manageTabTagsTitle, { count: componentMetadata.tagsCount })}
+              {intl.formatMessage(messages.manageTabTagsTitle, { count: tagsCount })}
             </Stack>
           )}
           className="border-0"

--- a/src/library-authoring/component-info/ComponentManagement.tsx
+++ b/src/library-authoring/component-info/ComponentManagement.tsx
@@ -31,7 +31,7 @@ const ComponentManagement = ({ usageKey }: ComponentManagementProps) => {
           title={(
             <Stack gap={1} direction="horizontal">
               <Icon src={Tag} />
-              {intl.formatMessage(messages.manageTabTagsTitle)}
+              {intl.formatMessage(messages.manageTabTagsTitle, {count: componentMetadata.tagsCount})}
             </Stack>
           )}
           className="border-0"
@@ -39,8 +39,6 @@ const ComponentManagement = ({ usageKey }: ComponentManagementProps) => {
           <ContentTagsDrawer
             id={usageKey}
             variant="component"
-            hideTitle
-            hideSubtitle
           />
         </Collapsible>
         )}

--- a/src/library-authoring/component-info/messages.ts
+++ b/src/library-authoring/component-info/messages.ts
@@ -38,7 +38,7 @@ const messages = defineMessages({
   },
   manageTabTagsTitle: {
     id: 'course-authoring.library-authoring.component.manage-tab.tags-title',
-    defaultMessage: 'Tags',
+    defaultMessage: 'Tags ({count})',
     description: 'Title for the Tags container in the management tab',
   },
   manageTabCollectionsTitle: {

--- a/src/library-authoring/data/api.mocks.ts
+++ b/src/library-authoring/data/api.mocks.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
+import { mockContentTaxonomyTagsData } from '../../content-tags-drawer/data/api.mocks';
 import { createAxiosError } from '../../testUtils';
 import * as api from './api';
 
@@ -219,6 +220,7 @@ export async function mockLibraryBlockMetadata(usageKey: string): Promise<api.Li
   switch (usageKey) {
     case thisMock.usageKeyNeverPublished: return thisMock.dataNeverPublished;
     case thisMock.usageKeyPublished: return thisMock.dataPublished;
+    case thisMock.usageKeyForTags: return thisMock.dataPublished;
     default: throw new Error(`No mock has been set up for usageKey "${usageKey}"`);
   }
 }
@@ -250,5 +252,6 @@ mockLibraryBlockMetadata.dataPublished = {
   created: '2024-06-20T13:54:21Z',
   tagsCount: 0,
 } satisfies api.LibraryBlockMetadata;
+mockLibraryBlockMetadata.usageKeyForTags = mockContentTaxonomyTagsData.largeTagsId;
 /** Apply this mock. Returns a spy object that can tell you if it's been called. */
 mockLibraryBlockMetadata.applyMock = () => jest.spyOn(api, 'getLibraryBlockMetadata').mockImplementation(mockLibraryBlockMetadata);

--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -29,7 +29,7 @@ import {
   type CreateLibraryCollectionDataRequest,
 } from './api';
 
-const libraryQueryPredicate = (query: Query, libraryId: string): boolean => {
+export const libraryQueryPredicate = (query: Query, libraryId: string): boolean => {
   // Invalidate all content queries related to this library.
   // If we allow searching "all courses and libraries" in the future,
   // then we'd have to invalidate all `["content_search", "results"]`


### PR DESCRIPTION
## Description

This:
- Adds the `drawer` (default) and `component` variants for `ContentTagsDrawer`.
- Adds `ContentTagsDawer` in the info sidebar of library components.
- Which edX user roles will this change impact? "Course Author"

![image](https://github.com/user-attachments/assets/915ea141-6223-4e09-ae1b-b7f3149863ae)

## Supporting information

Github Issue: https://github.com/openedx/frontend-app-authoring/issues/1286
Internal ticket: [FAL-3847](https://tasks.opencraft.com/browse/FAL-3847)

## Testing instructions

- Run this script to add taxonomies and tags: https://github.com/open-craft/taxonomy-sample-data
- Go to studio and create a new library if you don't have one created.
- Go to the library home of your library.
- Create a new component on your library
- Click on the component card to open the component info. Go to `Manage` tab.
- Verify that the `ContentTagsDrawer` is rendered. Click on `Manage tags` and add some tags. Save.
- Verify that the tag count on the component card and the component info sidebar is updated.
- Play with the `ContentTagsDrawer` (add more tags, delete tags, etc)