### PR TITLE
fix: Fix content overflow in the Pages & Resources modal windows

### DIFF
--- a/src/pages-and-resources/app-settings-modal/AppSettingsModalBase.jsx
+++ b/src/pages-and-resources/app-settings-modal/AppSettingsModalBase.jsx
@@ -25,6 +25,7 @@ const AppSettingsModalBase = ({
       variant={variant}
       hasCloseButton={isMobile}
       isFullscreenOnMobile
+      isOverflowVisible={false}
     >
       <ModalDialog.Header>
         <ModalDialog.Title data-testid="modal-title">{title}</ModalDialog.Title>


### PR DESCRIPTION
This is backport from master branch - https://github.com/openedx/frontend-app-authoring/pull/1301

## Description

This fix is similar to the adjacent fix - https://github.com/openedx/frontend-app-authoring/pull/1291, but now applied to modals on the Pages and Resources page

Before

https://github.com/user-attachments/assets/159f0c1a-d130-4ed4-beb2-f1bf88a9b5d1

https://github.com/user-attachments/assets/39ad2755-d41b-400b-91d4-d2e5d62dffaf

After

https://github.com/user-attachments/assets/bfdff6eb-7f6f-4a52-bfcf-50752d1ac55f