### PR TITLE
Display library title in browser tab [FC-0062]

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.test.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.test.tsx
@@ -1,4 +1,6 @@
+import { getConfig } from '@edx/frontend-platform';
 import fetchMock from 'fetch-mock-jest';
+import { Helmet } from 'react-helmet';
 import {
   fireEvent,
   initializeMocks,
@@ -121,6 +123,10 @@ describe('<LibraryAuthoringPage />', () => {
 
     expect(await screen.findByText('Content library')).toBeInTheDocument();
     expect((await screen.findAllByText(libraryTitle))[0]).toBeInTheDocument();
+
+    const browserTabTitle = Helmet.peek().title.join('');
+    const siteName = getConfig().SITE_NAME;
+    expect(browserTabTitle).toEqual(`${libraryTitle} | ${siteName}`);
 
     expect(screen.queryByText('You have not added any content to this library yet.')).not.toBeInTheDocument();
 

--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect } from 'react';
+import { Helmet } from 'react-helmet';
 import classNames from 'classnames';
 import { StudioFooter } from '@edx/frontend-component-footer';
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -156,6 +157,7 @@ const LibraryAuthoringPage = () => {
   return (
     <div className="d-flex">
       <div className="flex-grow-1">
+        <Helmet><title>{libraryData.title} | {process.env.SITE_NAME}</title></Helmet>
         <Header
           number={libraryData.slug}
           title={libraryData.title}


### PR DESCRIPTION
## Description

This sets the browser tab title to the title of the current library.

| Before | After |
|--|--|
| ![Before](https://github.com/user-attachments/assets/27bc8526-06a6-4e75-b77f-dd3640dbd863) | ![After](https://github.com/user-attachments/assets/721b2dc6-4ad6-42fa-bb8c-c53de261f2ed) |


## Supporting information

This is a drive-by fix while working on [Private ref: [FAL-3827](https://tasks.opencraft.com/browse/FAL-3827)].

## Testing instructions

Check out a few different libraries in the MFE. Check the title in the browser.
