### PR TITLE
fix: library metadata times are actually displayed in local time

### DIFF
--- a/src/library-authoring/component-info/ComponentManagement.test.tsx
+++ b/src/library-authoring/component-info/ComponentManagement.test.tsx
@@ -29,7 +29,7 @@ describe('<ComponentManagement />', () => {
     render(<ComponentManagement usageKey={mockLibraryBlockMetadata.usageKeyNeverPublished} />);
     expect(await screen.findByText('Draft')).toBeInTheDocument();
     expect(await screen.findByText('(Never Published)')).toBeInTheDocument();
-    expect(screen.getByText(matchInnerText('SPAN', 'Draft saved on June 20, 2024 at 13:54 UTC.'))).toBeInTheDocument();
+    expect(screen.getByText(matchInnerText('SPAN', 'Draft saved on June 20, 2024 at 13:54.'))).toBeInTheDocument();
   });
 
   it('should render published status', async () => {
@@ -39,7 +39,7 @@ describe('<ComponentManagement />', () => {
     expect(await screen.findByText('Published')).toBeInTheDocument();
     expect(screen.getByText('Published')).toBeInTheDocument();
     expect(
-      screen.getByText(matchInnerText('SPAN', 'Last published on June 21, 2024 at 24:00 UTC by Luke.')),
+      screen.getByText(matchInnerText('SPAN', 'Last published on June 21, 2024 at 24:00 by Luke.')),
     ).toBeInTheDocument();
   });
 

--- a/src/library-authoring/generic/status-widget/messages.ts
+++ b/src/library-authoring/generic/status-widget/messages.ts
@@ -23,22 +23,22 @@ const messages = defineMessages({
   },
   lastPublishedMsg: {
     id: 'course-authoring.library-authoring.generic.status-widget.last-published',
-    defaultMessage: 'Last published on {date} at {time} UTC by {user}.',
+    defaultMessage: 'Last published on {date} at {time} by {user}.',
     description: 'Body message of the library authoring sidebar when the entity is published.',
   },
   lastPublishedMsgWithoutUser: {
     id: 'course-authoring.library-authoring.generic.status-widget.last-published-no-user',
-    defaultMessage: 'Last published on {date} at {time} UTC.',
+    defaultMessage: 'Last published on {date} at {time}.',
     description: 'Body message of the library authoring sidebar when the entity is published.',
   },
   lastDraftMsg: {
     id: 'course-authoring.library-authoring.generic.status-widget.last-draft',
-    defaultMessage: 'Draft saved on {date} at {time} UTC by {user}.',
+    defaultMessage: 'Draft saved on {date} at {time} by {user}.',
     description: 'Body message of the library authoring sidebar when the entity is on draft status.',
   },
   lastDraftMsgWithoutUser: {
     id: 'course-authoring.library-authoring.generic.status-widget.last-draft-no-user',
-    defaultMessage: 'Draft saved on {date} at {time} UTC.',
+    defaultMessage: 'Draft saved on {date} at {time}.',
     description: 'Body message of the library authoring sidebar when the entity is on draft status.',
   },
   publishButtonLabel: {


### PR DESCRIPTION
## Description

These times on the libraries metadata view are reported in local time (as they should be!), but were mis-labelled as UTC. This PR just removes the word "UTC".

![fix-utc](https://github.com/user-attachments/assets/920c35a8-30d5-44cf-a99e-301ce2070643)


Private ref: [FAL-3810](https://tasks.opencraft.com/browse/FAL-3810)