### PR TITLE
Don't revert to advanced problem editor when max_attempts is set

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -664,7 +664,7 @@ export class OLXParser {
     }
 
     if (Object.keys(this.problem).some((key) => key.indexOf('@_') !== -1 && !settingsOlxAttributes.includes(key))) {
-      throw new Error('Misc Attributes asscoiated with problem, opening in advanced editor');
+      throw new Error('Misc Attributes associated with problem, opening in advanced editor');
     }
 
     const problemType = this.getProblemType();

--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -58,7 +58,7 @@ describe('OLXParser', () => {
           labelDescriptionQuestionOlxParser.getParsedOLXData();
         } catch (e) {
           expect(e).toBeInstanceOf(Error);
-          expect(e.message).toBe('Misc Attributes asscoiated with problem, opening in advanced editor');
+          expect(e.message).toBe('Misc Attributes associated with problem, opening in advanced editor');
         }
       });
     });

--- a/src/editors/data/constants/problem.ts
+++ b/src/editors/data/constants/problem.ts
@@ -227,7 +227,7 @@ export const RichTextProblems = [ProblemTypeKeys.SINGLESELECT, ProblemTypeKeys.M
 export const settingsOlxAttributes = [
   '@_display_name',
   '@_weight',
-  '@_max_atempts',
+  '@_max_attempts',
   '@_showanswer',
   '@_show_reset_button',
   '@_submission_wait_seconds',


### PR DESCRIPTION
## Description

There was a bug causing problem components that have `max_attempts` set to open in the advanced editor:

![Screenshot](https://github.com/user-attachments/assets/ecbd21c4-e312-4d2c-84ad-ff1f370ec177)

The console log said:

```
The Problem Could Not Be Parsed from OLX. redirecting to Advanced editor. Error: Misc Attributes asscoiated with problem, opening in advanced editor
```

This PR fixes the issue so that the visual editor will still be used:

![Screenshot 2024-09-25 at 12 02 19 PM](https://github.com/user-attachments/assets/e80a1f69-ddf2-4e24-9101-d11e1d40d270)


## Supporting information

Part of https://github.com/openedx/frontend-app-authoring/issues/1091

Private ref: [FAL-3825](https://tasks.opencraft.com/browse/FAL-3825)

## Testing instructions

1. Create a problem in a library and change the "max attempts" setting (in the "Scoring" section). Save it and close the editor.
2. Re-open the editor and note it's the advanced XML editor.
3. Check out this branch
4. The editor should change in place to become the visual editor.
