### PR TITLE
Improve LibraryContext, convert tests to testUtils [FC-0062]

### DIFF
--- a/src/library-authoring/EmptyStates.tsx
+++ b/src/library-authoring/EmptyStates.tsx
@@ -1,4 +1,3 @@
-import { useParams } from 'react-router';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import type { MessageDescriptor } from 'react-intl';
 import {
@@ -8,6 +7,7 @@ import { Add } from '@openedx/paragon/icons';
 import { ClearFiltersButton } from '../search-manager';
 import messages from './messages';
 import { useContentLibrary } from './data/apiHooks';
+import { useLibraryContext } from './common/context';
 
 export const NoComponents = ({
   infoText = messages.noComponents,
@@ -18,7 +18,7 @@ export const NoComponents = ({
   addBtnText?: MessageDescriptor;
   handleBtnClick: () => void;
 }) => {
-  const { libraryId } = useParams();
+  const { libraryId } = useLibraryContext();
   const { data: libraryData } = useContentLibrary(libraryId);
   const canEditLibrary = libraryData?.canEditLibrary ?? false;
 

--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import classNames from 'classnames';
 import { StudioFooter } from '@edx/frontend-component-footer';
@@ -13,7 +13,7 @@ import {
 } from '@openedx/paragon';
 import { Add, InfoOutline } from '@openedx/paragon/icons';
 import {
-  Routes, Route, useLocation, useNavigate, useParams, useSearchParams,
+  Routes, Route, useLocation, useNavigate, useSearchParams,
 } from 'react-router-dom';
 
 import Loading from '../generic/Loading';
@@ -33,7 +33,7 @@ import LibraryCollections from './collections/LibraryCollections';
 import LibraryHome from './LibraryHome';
 import { useContentLibrary } from './data/apiHooks';
 import { LibrarySidebar } from './library-sidebar';
-import { LibraryContext, SidebarBodyComponentId } from './common/context';
+import { SidebarBodyComponentId, useLibraryContext } from './common/context';
 import messages from './messages';
 
 enum TabList {
@@ -53,7 +53,7 @@ const HeaderActions = ({ canEditLibrary }: HeaderActionsProps) => {
     openInfoSidebar,
     closeLibrarySidebar,
     sidebarBodyComponent,
-  } = useContext(LibraryContext);
+  } = useLibraryContext();
 
   if (!canEditLibrary) {
     return null;
@@ -119,11 +119,7 @@ const LibraryAuthoringPage = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const { libraryId } = useParams();
-  if (!libraryId) {
-    // istanbul ignore next - This shouldn't be possible; it's just here to satisfy the type checker.
-    throw new Error('Rendered without libraryId URL parameter');
-  }
+  const { libraryId } = useLibraryContext();
   const { data: libraryData, isLoading } = useContentLibrary(libraryId);
 
   const currentPath = location.pathname.split('/').pop();
@@ -131,7 +127,7 @@ const LibraryAuthoringPage = () => {
   const {
     sidebarBodyComponent,
     openInfoSidebar,
-  } = useContext(LibraryContext);
+  } = useLibraryContext();
 
   useEffect(() => {
     openInfoSidebar();
@@ -196,16 +192,12 @@ const LibraryAuthoringPage = () => {
               <Route
                 path={TabList.home}
                 element={(
-                  <LibraryHome
-                    libraryId={libraryId}
-                    tabList={TabList}
-                    handleTabChange={handleTabChange}
-                  />
+                  <LibraryHome tabList={TabList} handleTabChange={handleTabChange} />
                 )}
               />
               <Route
                 path={TabList.components}
-                element={<LibraryComponents libraryId={libraryId} variant="full" />}
+                element={<LibraryComponents variant="full" />}
               />
               <Route
                 path={TabList.collections}

--- a/src/library-authoring/LibraryHome.tsx
+++ b/src/library-authoring/LibraryHome.tsx
@@ -1,4 +1,3 @@
-import React, { useContext } from 'react';
 import { Stack } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
@@ -9,22 +8,21 @@ import { LibraryComponents } from './components';
 import LibrarySection from './components/LibrarySection';
 import LibraryRecentlyModified from './LibraryRecentlyModified';
 import messages from './messages';
-import { LibraryContext } from './common/context';
+import { useLibraryContext } from './common/context';
 
 type LibraryHomeProps = {
-  libraryId: string,
   tabList: { home: string, components: string, collections: string },
   handleTabChange: (key: string) => void,
 };
 
-const LibraryHome = ({ libraryId, tabList, handleTabChange } : LibraryHomeProps) => {
+const LibraryHome = ({ tabList, handleTabChange } : LibraryHomeProps) => {
   const intl = useIntl();
   const {
     totalHits: componentCount,
     totalCollectionHits: collectionCount,
     isFiltered,
   } = useSearchContext();
-  const { openAddContentSidebar } = useContext(LibraryContext);
+  const { openAddContentSidebar } = useLibraryContext();
 
   const renderEmptyState = () => {
     if (componentCount === 0 && collectionCount === 0) {
@@ -35,7 +33,7 @@ const LibraryHome = ({ libraryId, tabList, handleTabChange } : LibraryHomeProps)
 
   return (
     <Stack gap={3}>
-      <LibraryRecentlyModified libraryId={libraryId} />
+      <LibraryRecentlyModified />
       {
         renderEmptyState()
         || (
@@ -52,7 +50,7 @@ const LibraryHome = ({ libraryId, tabList, handleTabChange } : LibraryHomeProps)
               contentCount={componentCount}
               viewAllAction={() => handleTabChange(tabList.components)}
             >
-              <LibraryComponents libraryId={libraryId} variant="preview" />
+              <LibraryComponents variant="preview" />
             </LibrarySection>
           </>
         )

--- a/src/library-authoring/LibraryLayout.tsx
+++ b/src/library-authoring/LibraryLayout.tsx
@@ -50,7 +50,7 @@ const LibraryLayout = () => {
   }, [goBack]);
 
   return (
-    <LibraryProvider>
+    <LibraryProvider libraryId={libraryId}>
       <Routes>
         {/*
           TODO: we should be opening this editor as a modal, not making it a separate page/URL.

--- a/src/library-authoring/LibraryRecentlyModified.tsx
+++ b/src/library-authoring/LibraryRecentlyModified.tsx
@@ -10,8 +10,9 @@ import messages from './messages';
 import ComponentCard from './components/ComponentCard';
 import { useLibraryBlockTypes } from './data/apiHooks';
 import CollectionCard from './components/CollectionCard';
+import { useLibraryContext } from './common/context';
 
-const RecentlyModified: React.FC<{ libraryId: string }> = ({ libraryId }) => {
+const RecentlyModified: React.FC<Record<never, never>> = () => {
   const intl = useIntl();
   const {
     hits,
@@ -19,6 +20,7 @@ const RecentlyModified: React.FC<{ libraryId: string }> = ({ libraryId }) => {
     totalHits,
     totalCollectionHits,
   } = useSearchContext();
+  const { libraryId } = useLibraryContext();
 
   const componentCount = totalHits + totalCollectionHits;
   // Since we only display a fixed number of items in preview,
@@ -77,13 +79,16 @@ const RecentlyModified: React.FC<{ libraryId: string }> = ({ libraryId }) => {
     : null;
 };
 
-const LibraryRecentlyModified: React.FC<{ libraryId: string }> = ({ libraryId }) => (
-  <SearchContextProvider
-    extraFilter={`context_key = "${libraryId}"`}
-    overrideSearchSortOrder={SearchSortOption.RECENTLY_MODIFIED}
-  >
-    <RecentlyModified libraryId={libraryId} />
-  </SearchContextProvider>
-);
+const LibraryRecentlyModified: React.FC<Record<never, never>> = () => {
+  const { libraryId } = useLibraryContext();
+  return (
+    <SearchContextProvider
+      extraFilter={`context_key = "${libraryId}"`}
+      overrideSearchSortOrder={SearchSortOption.RECENTLY_MODIFIED}
+    >
+      <RecentlyModified />
+    </SearchContextProvider>
+  );
+};
 
 export default LibraryRecentlyModified;

--- a/src/library-authoring/add-content/AddContentContainer.tsx
+++ b/src/library-authoring/add-content/AddContentContainer.tsx
@@ -23,9 +23,9 @@ import { useCopyToClipboard } from '../../generic/clipboard';
 import { getCanEdit } from '../../course-unit/data/selectors';
 import { useCreateLibraryBlock, useLibraryPasteClipboard, useUpdateCollectionComponents } from '../data/apiHooks';
 import { getEditUrl } from '../components/utils';
+import { useLibraryContext } from '../common/context';
 
 import messages from './messages';
-import { LibraryContext } from '../common/context';
 
 type ContentType = {
   name: string,
@@ -73,7 +73,7 @@ const AddContentContainer = () => {
   const { showPasteXBlock } = useCopyToClipboard(canEdit);
   const {
     openCreateCollectionModal,
-  } = React.useContext(LibraryContext);
+  } = useLibraryContext();
 
   const collectionButtonData = {
     name: intl.formatMessage(messages.collectionButton),

--- a/src/library-authoring/collections/LibraryCollectionComponents.tsx
+++ b/src/library-authoring/collections/LibraryCollectionComponents.tsx
@@ -1,14 +1,13 @@
-import { useContext } from 'react';
 import { Stack } from '@openedx/paragon';
 import { NoComponents, NoSearchResults } from '../EmptyStates';
 import { useSearchContext } from '../../search-manager';
 import { LibraryComponents } from '../components';
 import messages from './messages';
-import { LibraryContext } from '../common/context';
+import { useLibraryContext } from '../common/context';
 
-const LibraryCollectionComponents = ({ libraryId }: { libraryId: string }) => {
+const LibraryCollectionComponents = () => {
   const { totalHits: componentCount, isFiltered } = useSearchContext();
-  const { openAddContentSidebar } = useContext(LibraryContext);
+  const { openAddContentSidebar } = useLibraryContext();
 
   if (componentCount === 0) {
     return isFiltered
@@ -25,7 +24,7 @@ const LibraryCollectionComponents = ({ libraryId }: { libraryId: string }) => {
   return (
     <Stack direction="vertical" gap={3}>
       <h3 className="text-gray">Content ({componentCount})</h3>
-      <LibraryComponents libraryId={libraryId} variant="full" />
+      <LibraryComponents variant="full" />
     </Stack>
   );
 };

--- a/src/library-authoring/collections/LibraryCollectionPage.tsx
+++ b/src/library-authoring/collections/LibraryCollectionPage.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react';
+import { useEffect } from 'react';
 import { StudioFooter } from '@edx/frontend-component-footer';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
@@ -27,7 +27,7 @@ import {
   SearchSortWidget,
 } from '../../search-manager';
 import { useCollection, useContentLibrary } from '../data/apiHooks';
-import { LibraryContext } from '../common/context';
+import { useLibraryContext } from '../common/context';
 import messages from './messages';
 import { LibrarySidebar } from '../library-sidebar';
 import LibraryCollectionComponents from './LibraryCollectionComponents';
@@ -36,7 +36,7 @@ const HeaderActions = ({ canEditLibrary }: { canEditLibrary: boolean; }) => {
   const intl = useIntl();
   const {
     openAddContentSidebar,
-  } = useContext(LibraryContext);
+  } = useLibraryContext();
 
   if (!canEditLibrary) {
     return null;
@@ -104,7 +104,7 @@ const LibraryCollectionPage = () => {
   const {
     sidebarBodyComponent,
     openCollectionInfoSidebar,
-  } = useContext(LibraryContext);
+  } = useLibraryContext();
 
   const {
     data: collectionData,
@@ -189,7 +189,7 @@ const LibraryCollectionPage = () => {
               <div className="flex-grow-1" />
               <SearchSortWidget />
             </div>
-            <LibraryCollectionComponents libraryId={libraryId} />
+            <LibraryCollectionComponents />
           </SearchContextProvider>
         </Container>
         <StudioFooter />

--- a/src/library-authoring/collections/LibraryCollections.tsx
+++ b/src/library-authoring/collections/LibraryCollections.tsx
@@ -1,12 +1,10 @@
-import { useContext } from 'react';
-
 import { useLoadOnScroll } from '../../hooks';
 import { useSearchContext } from '../../search-manager';
 import { NoComponents, NoSearchResults } from '../EmptyStates';
 import CollectionCard from '../components/CollectionCard';
 import { LIBRARY_SECTION_PREVIEW_LIMIT } from '../components/LibrarySection';
 import messages from './messages';
-import { LibraryContext } from '../common/context';
+import { useLibraryContext } from '../common/context';
 
 type LibraryCollectionsProps = {
   variant: 'full' | 'preview',
@@ -29,7 +27,7 @@ const LibraryCollections = ({ variant }: LibraryCollectionsProps) => {
     isFiltered,
   } = useSearchContext();
 
-  const { openCreateCollectionModal } = useContext(LibraryContext);
+  const { openCreateCollectionModal } = useLibraryContext();
 
   const collectionList = variant === 'preview' ? collectionHits.slice(0, LIBRARY_SECTION_PREVIEW_LIMIT) : collectionHits;
 

--- a/src/library-authoring/common/context.tsx
+++ b/src/library-authoring/common/context.tsx
@@ -116,6 +116,7 @@ export const LibraryProvider = (props: { children?: React.ReactNode, libraryId: 
 export function useLibraryContext(): LibraryContextData {
   const ctx = React.useContext(LibraryContext);
   if (ctx === undefined) {
+    /* istanbul ignore next */
     throw new Error('useLibraryContext() was used in a component without a <LibraryProvider> ancestor.');
   }
   return ctx;

--- a/src/library-authoring/common/context.tsx
+++ b/src/library-authoring/common/context.tsx
@@ -1,6 +1,5 @@
 import { useToggle } from '@openedx/paragon';
 import React from 'react';
-import { useParams } from 'react-router-dom';
 
 export enum SidebarBodyComponentId {
   AddContent = 'add-content',
@@ -41,13 +40,7 @@ const LibraryContext = React.createContext<LibraryContextData | undefined>(undef
 /**
  * React component to provide `LibraryContext`
  */
-export const LibraryProvider = (props: { children?: React.ReactNode }) => {
-  const { libraryId } = useParams();
-
-  if (libraryId === undefined) {
-    // istanbul ignore next - This shouldn't be possible; it's just here to satisfy the type checker.
-    throw new Error('Error: route is missing libraryId.');
-  }
+export const LibraryProvider = (props: { children?: React.ReactNode, libraryId: string }) => {
   const [sidebarBodyComponent, setSidebarBodyComponent] = React.useState<SidebarBodyComponentId | null>(null);
   const [currentComponentUsageKey, setCurrentComponentUsageKey] = React.useState<string>();
   const [currentCollectionId, setcurrentCollectionId] = React.useState<string>();
@@ -86,7 +79,7 @@ export const LibraryProvider = (props: { children?: React.ReactNode }) => {
   }, []);
 
   const context = React.useMemo<LibraryContextData>(() => ({
-    libraryId,
+    libraryId: props.libraryId,
     sidebarBodyComponent,
     closeLibrarySidebar,
     openAddContentSidebar,
@@ -99,7 +92,7 @@ export const LibraryProvider = (props: { children?: React.ReactNode }) => {
     openCollectionInfoSidebar,
     currentCollectionId,
   }), [
-    libraryId,
+    props.libraryId,
     sidebarBodyComponent,
     closeLibrarySidebar,
     openAddContentSidebar,

--- a/src/library-authoring/components/CollectionCard.test.tsx
+++ b/src/library-authoring/components/CollectionCard.test.tsx
@@ -1,10 +1,12 @@
+import React from 'react';
 import {
   initializeMocks,
   fireEvent,
-  render,
+  render as baseRender,
   screen,
 } from '../../testUtils';
 
+import { LibraryProvider } from '../common/context';
 import { type CollectionHit } from '../../search-manager';
 import CollectionCard from './CollectionCard';
 
@@ -27,6 +29,10 @@ const CollectionHitSample: CollectionHit = {
   numChildren: 2,
   tags: {},
 };
+
+const render = (ui: React.ReactElement) => baseRender(ui, {
+  extraWrapper: ({ children }) => <LibraryProvider libraryId="lib:Axim:TEST">{ children }</LibraryProvider>,
+});
 
 describe('<CollectionCard />', () => {
   beforeEach(() => {

--- a/src/library-authoring/components/CollectionCard.tsx
+++ b/src/library-authoring/components/CollectionCard.tsx
@@ -6,11 +6,10 @@ import {
   IconButton,
 } from '@openedx/paragon';
 import { MoreVert } from '@openedx/paragon/icons';
-import { useContext } from 'react';
 import { Link } from 'react-router-dom';
 
 import { type CollectionHit } from '../../search-manager';
-import { LibraryContext } from '../common/context';
+import { useLibraryContext } from '../common/context';
 import BaseComponentCard from './BaseComponentCard';
 import messages from './messages';
 
@@ -48,7 +47,7 @@ const CollectionCard = ({ collectionHit }: CollectionCardProps) => {
   const intl = useIntl();
   const {
     openCollectionInfoSidebar,
-  } = useContext(LibraryContext);
+  } = useLibraryContext();
 
   const {
     type,

--- a/src/library-authoring/components/ComponentCard.test.tsx
+++ b/src/library-authoring/components/ComponentCard.test.tsx
@@ -1,27 +1,21 @@
-import React from 'react';
-import { AppProvider } from '@edx/frontend-platform/react';
-import { initializeMockApp } from '@edx/frontend-platform';
-import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
-import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { render, fireEvent, waitFor } from '@testing-library/react';
-import MockAdapter from 'axios-mock-adapter';
-import type { Store } from 'redux';
-
-import { ToastProvider } from '../../generic/toast-context';
+import {
+  fireEvent,
+  render as baseRender,
+  screen,
+  waitFor,
+  initializeMocks,
+} from '../../testUtils';
+import { LibraryProvider } from '../common/context';
 import { getClipboardUrl } from '../../generic/data/api';
 import { ContentHit } from '../../search-manager';
-import initializeStore from '../../store';
 import ComponentCard from './ComponentCard';
-
-let store: Store;
-let axiosMock: MockAdapter;
 
 const contentHit: ContentHit = {
   id: '1',
   usageKey: 'lb:org1:demolib:html:a1fa8bdd-dc67-4976-9bf5-0ea75a9bca3d',
   type: 'library_block',
   blockId: 'a1fa8bdd-dc67-4976-9bf5-0ea75a9bca3d',
-  contextKey: 'lb:org1:Demo_Course',
+  contextKey: 'lib:org1:Demo_Course',
   org: 'org1',
   breadcrumbs: [{ displayName: 'Demo Lib' }],
   displayName: 'Text Display Name',
@@ -47,57 +41,32 @@ const clipboardBroadcastChannelMock = {
 
 (global as any).BroadcastChannel = jest.fn(() => clipboardBroadcastChannelMock);
 
-const RootWrapper = () => (
-  <AppProvider store={store}>
-    <IntlProvider locale="en">
-      <ToastProvider>
-        <ComponentCard
-          contentHit={contentHit}
-          blockTypeDisplayName="text"
-        />
-      </ToastProvider>
-    </IntlProvider>
-  </AppProvider>
-);
+const libraryId = 'lib:org1:Demo_Course';
+const render = () => baseRender(<ComponentCard contentHit={contentHit} blockTypeDisplayName="text" />, {
+  extraWrapper: ({ children }) => <LibraryProvider libraryId={libraryId}>{ children }</LibraryProvider>,
+});
 
 describe('<ComponentCard />', () => {
-  beforeEach(() => {
-    initializeMockApp({
-      authenticatedUser: {
-        userId: 3,
-        username: 'abc123',
-        administrator: true,
-        roles: [],
-      },
-    });
-    store = initializeStore();
-
-    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-    axiosMock.restore();
-  });
-
   it('should render the card with title and description', () => {
-    const { getByText } = render(<RootWrapper />);
+    initializeMocks();
+    render();
 
-    expect(getByText('Text Display Formated Name')).toBeInTheDocument();
-    expect(getByText('This is a text: ID=1')).toBeInTheDocument();
+    expect(screen.getByText('Text Display Formated Name')).toBeInTheDocument();
+    expect(screen.getByText('This is a text: ID=1')).toBeInTheDocument();
   });
 
   it('should call the updateClipboard function when the copy button is clicked', async () => {
+    const { axiosMock, mockShowToast } = initializeMocks();
     axiosMock.onPost(getClipboardUrl()).reply(200, {});
-    const { getByRole, getByTestId, getByText } = render(<RootWrapper />);
+    render();
 
     // Open menu
-    expect(getByTestId('component-card-menu-toggle')).toBeInTheDocument();
-    fireEvent.click(getByTestId('component-card-menu-toggle'));
+    expect(screen.getByTestId('component-card-menu-toggle')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('component-card-menu-toggle'));
 
     // Click copy to clipboard
-    expect(getByRole('button', { name: 'Copy to clipboard' })).toBeInTheDocument();
-    fireEvent.click(getByRole('button', { name: 'Copy to clipboard' }));
+    expect(screen.getByRole('button', { name: 'Copy to clipboard' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Copy to clipboard' }));
 
     expect(axiosMock.history.post.length).toBe(1);
     expect(axiosMock.history.post[0].data).toBe(
@@ -105,21 +74,22 @@ describe('<ComponentCard />', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Component copied to clipboard')).toBeInTheDocument();
+      expect(mockShowToast).toHaveBeenCalledWith('Component copied to clipboard');
     });
   });
 
   it('should show error message if the api call fails', async () => {
+    const { axiosMock, mockShowToast } = initializeMocks();
     axiosMock.onPost(getClipboardUrl()).reply(400);
-    const { getByRole, getByTestId, getByText } = render(<RootWrapper />);
+    render();
 
     // Open menu
-    expect(getByTestId('component-card-menu-toggle')).toBeInTheDocument();
-    fireEvent.click(getByTestId('component-card-menu-toggle'));
+    expect(screen.getByTestId('component-card-menu-toggle')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('component-card-menu-toggle'));
 
     // Click copy to clipboard
-    expect(getByRole('button', { name: 'Copy to clipboard' })).toBeInTheDocument();
-    fireEvent.click(getByRole('button', { name: 'Copy to clipboard' }));
+    expect(screen.getByRole('button', { name: 'Copy to clipboard' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Copy to clipboard' }));
 
     expect(axiosMock.history.post.length).toBe(1);
     expect(axiosMock.history.post[0].data).toBe(
@@ -127,7 +97,7 @@ describe('<ComponentCard />', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Failed to copy component to clipboard')).toBeInTheDocument();
+      expect(mockShowToast).toHaveBeenCalledWith('Failed to copy component to clipboard');
     });
   });
 });

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -12,7 +12,7 @@ import { Link } from 'react-router-dom';
 import { updateClipboard } from '../../generic/data/api';
 import { ToastContext } from '../../generic/toast-context';
 import { type ContentHit } from '../../search-manager';
-import { LibraryContext } from '../common/context';
+import { useLibraryContext } from '../common/context';
 import messages from './messages';
 import { STUDIO_CLIPBOARD_CHANNEL } from '../../constants';
 import { getEditUrl } from './utils';
@@ -66,7 +66,7 @@ export const ComponentMenu = ({ usageKey }: { usageKey: string }) => {
 const ComponentCard = ({ contentHit, blockTypeDisplayName } : ComponentCardProps) => {
   const {
     openComponentInfoSidebar,
-  } = useContext(LibraryContext);
+  } = useLibraryContext();
 
   const {
     blockType,

--- a/src/library-authoring/components/LibraryComponents.test.tsx
+++ b/src/library-authoring/components/LibraryComponents.test.tsx
@@ -1,26 +1,24 @@
-import { AppProvider } from '@edx/frontend-platform/react';
-import { initializeMockApp } from '@edx/frontend-platform';
-import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
-import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, fireEvent } from '@testing-library/react';
-import MockAdapter from 'axios-mock-adapter';
 import fetchMock from 'fetch-mock-jest';
-import type { Store } from 'redux';
 
+import {
+  fireEvent,
+  render,
+  screen,
+  initializeMocks,
+} from '../../testUtils';
 import { getContentSearchConfigUrl } from '../../search-manager/data/api';
-import { SearchContextProvider } from '../../search-manager/SearchManager';
+import { mockLibraryBlockTypes, mockContentLibrary } from '../data/api.mocks';
 import mockEmptyResult from '../../search-modal/__mocks__/empty-search-result.json';
-import initializeStore from '../../store';
+import { LibraryProvider } from '../common/context';
 import { libraryComponentsMock } from '../__mocks__';
 import LibraryComponents from './LibraryComponents';
 
 const searchEndpoint = 'http://mock.meilisearch.local/multi-search';
 
-const mockUseLibraryBlockTypes = jest.fn();
+mockLibraryBlockTypes.applyMock();
+mockContentLibrary.applyMock();
 const mockFetchNextPage = jest.fn();
 const mockUseSearchContext = jest.fn();
-const mockUseContentLibrary = jest.fn();
 
 const data = {
   totalHits: 1,
@@ -32,17 +30,6 @@ const data = {
   searchKeywords: '',
   isFiltered: false,
 };
-
-let store: Store;
-let axiosMock: MockAdapter;
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-    },
-  },
-});
 
 const returnEmptyResult = (_url: string, req) => {
   const requestData = JSON.parse(req.body?.toString() ?? '');
@@ -56,28 +43,6 @@ const returnEmptyResult = (_url: string, req) => {
   return mockEmptyResult;
 };
 
-const blockTypeData = {
-  data: [
-    {
-      blockType: 'html',
-      displayName: 'Text',
-    },
-    {
-      blockType: 'video',
-      displayName: 'Video',
-    },
-    {
-      blockType: 'problem',
-      displayName: 'Problem',
-    },
-  ],
-};
-
-jest.mock('../data/apiHooks', () => ({
-  useLibraryBlockTypes: () => mockUseLibraryBlockTypes(),
-  useContentLibrary: () => mockUseContentLibrary(),
-}));
-
 jest.mock('../../search-manager', () => ({
   ...jest.requireActual('../../search-manager'),
   useSearchContext: () => mockUseSearchContext(),
@@ -90,36 +55,19 @@ const clipboardBroadcastChannelMock = {
 
 (global as any).BroadcastChannel = jest.fn(() => clipboardBroadcastChannelMock);
 
-const RootWrapper = (props) => (
-  <AppProvider store={store}>
-    <IntlProvider locale="en" messages={{}}>
-      <QueryClientProvider client={queryClient}>
-        <SearchContextProvider>
-          <LibraryComponents libraryId="1" {...props} />
-        </SearchContextProvider>
-      </QueryClientProvider>
-    </IntlProvider>
-  </AppProvider>
-);
+const withLibraryId = (libraryId: string) => ({
+  extraWrapper: ({ children }: { children: React.ReactNode }) => (
+    <LibraryProvider libraryId={libraryId}>{children}</LibraryProvider>
+  ),
+});
 
 describe('<LibraryComponents />', () => {
   beforeEach(() => {
-    initializeMockApp({
-      authenticatedUser: {
-        userId: 3,
-        username: 'abc123',
-        administrator: true,
-        roles: [],
-      },
-    });
-    store = initializeStore();
-    mockUseLibraryBlockTypes.mockReturnValue(blockTypeData);
-    mockUseSearchContext.mockReturnValue(data);
+    const { axiosMock } = initializeMocks();
 
     fetchMock.post(searchEndpoint, returnEmptyResult, { overwriteRoutes: true });
 
     // The API method to get the Meilisearch connection details uses Axios:
-    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
     axiosMock.onGet(getContentSearchConfigUrl()).reply(200, {
       url: 'http://mock.meilisearch.local',
       index_name: 'studio',
@@ -128,7 +76,8 @@ describe('<LibraryComponents />', () => {
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    fetchMock.reset();
+    mockFetchNextPage.mockReset();
   });
 
   it('should render empty state', async () => {
@@ -136,15 +85,10 @@ describe('<LibraryComponents />', () => {
       ...data,
       totalHits: 0,
     });
-    mockUseContentLibrary.mockReturnValue({
-      data: {
-        canEditLibrary: true,
-      },
-    });
 
-    render(<RootWrapper />);
+    render(<LibraryComponents variant="full" />, withLibraryId(mockContentLibrary.libraryId));
     expect(await screen.findByText(/you have not added any content to this library yet\./i));
-    expect(screen.getByRole('button', { name: /add component/i })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /add component/i })).toBeInTheDocument();
   });
 
   it('should render empty state without add content button', async () => {
@@ -152,13 +96,8 @@ describe('<LibraryComponents />', () => {
       ...data,
       totalHits: 0,
     });
-    mockUseContentLibrary.mockReturnValue({
-      data: {
-        canEditLibrary: false,
-      },
-    });
 
-    render(<RootWrapper />);
+    render(<LibraryComponents variant="full" />, withLibraryId(mockContentLibrary.libraryIdReadOnly));
     expect(await screen.findByText(/you have not added any content to this library yet\./i));
     expect(screen.queryByRole('button', { name: /add component/i })).not.toBeInTheDocument();
   });
@@ -169,7 +108,7 @@ describe('<LibraryComponents />', () => {
       hits: libraryComponentsMock,
       isFetching: false,
     });
-    render(<RootWrapper variant="full" />);
+    render(<LibraryComponents variant="full" />, withLibraryId(mockContentLibrary.libraryId));
 
     expect(await screen.findByText('This is a text: ID=1')).toBeInTheDocument();
     expect(screen.getByText('This is a text: ID=2')).toBeInTheDocument();
@@ -185,7 +124,7 @@ describe('<LibraryComponents />', () => {
       hits: libraryComponentsMock,
       isFetching: false,
     });
-    render(<RootWrapper variant="preview" />);
+    render(<LibraryComponents variant="preview" />, withLibraryId(mockContentLibrary.libraryId));
 
     expect(await screen.findByText('This is a text: ID=1')).toBeInTheDocument();
     expect(screen.getByText('This is a text: ID=2')).toBeInTheDocument();
@@ -203,7 +142,7 @@ describe('<LibraryComponents />', () => {
       hasNextPage: true,
     });
 
-    render(<RootWrapper variant="full" />);
+    render(<LibraryComponents variant="full" />, withLibraryId(mockContentLibrary.libraryId));
 
     Object.defineProperty(window, 'innerHeight', { value: 800 });
     Object.defineProperty(document.body, 'scrollHeight', { value: 1600 });
@@ -221,7 +160,7 @@ describe('<LibraryComponents />', () => {
       hasNextPage: true,
     });
 
-    render(<RootWrapper variant="preview" />);
+    render(<LibraryComponents variant="preview" />, withLibraryId(mockContentLibrary.libraryId));
 
     Object.defineProperty(window, 'innerHeight', { value: 800 });
     Object.defineProperty(document.body, 'scrollHeight', { value: 1600 });

--- a/src/library-authoring/components/LibraryComponents.tsx
+++ b/src/library-authoring/components/LibraryComponents.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import { useLoadOnScroll } from '../../hooks';
 import { useSearchContext } from '../../search-manager';
@@ -6,10 +6,9 @@ import { NoComponents, NoSearchResults } from '../EmptyStates';
 import { useLibraryBlockTypes } from '../data/apiHooks';
 import ComponentCard from './ComponentCard';
 import { LIBRARY_SECTION_PREVIEW_LIMIT } from './LibrarySection';
-import { LibraryContext } from '../common/context';
+import { useLibraryContext } from '../common/context';
 
 type LibraryComponentsProps = {
-  libraryId: string,
   variant: 'full' | 'preview',
 };
 
@@ -20,7 +19,7 @@ type LibraryComponentsProps = {
  *   - 'full': Show all components with Infinite scroll pagination.
  *   - 'preview': Show first 4 components without pagination.
  */
-const LibraryComponents = ({ libraryId, variant }: LibraryComponentsProps) => {
+const LibraryComponents = ({ variant }: LibraryComponentsProps) => {
   const {
     hits,
     totalHits: componentCount,
@@ -29,11 +28,11 @@ const LibraryComponents = ({ libraryId, variant }: LibraryComponentsProps) => {
     fetchNextPage,
     isFiltered,
   } = useSearchContext();
-  const { openAddContentSidebar } = useContext(LibraryContext);
+  const { libraryId, openAddContentSidebar } = useLibraryContext();
 
   const componentList = variant === 'preview' ? hits.slice(0, LIBRARY_SECTION_PREVIEW_LIMIT) : hits;
 
-  // TODO add this to LibraryContext
+  // TODO get rid of "useLibraryBlockTypes". Use <BlockTypeLabel> instead.
   const { data: blockTypesData } = useLibraryBlockTypes(libraryId);
   const blockTypes = useMemo(() => {
     const result = {};

--- a/src/library-authoring/create-collection/CreateCollectionModal.tsx
+++ b/src/library-authoring/create-collection/CreateCollectionModal.tsx
@@ -5,12 +5,12 @@ import {
   Form,
   ModalDialog,
 } from '@openedx/paragon';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Formik } from 'formik';
 import * as Yup from 'yup';
 import FormikControl from '../../generic/FormikControl';
-import { LibraryContext } from '../common/context';
+import { useLibraryContext } from '../common/context';
 import messages from './messages';
 import { useCreateLibraryCollection } from '../data/apiHooks';
 import { ToastContext } from '../../generic/toast-context';
@@ -18,15 +18,12 @@ import { ToastContext } from '../../generic/toast-context';
 const CreateCollectionModal = () => {
   const intl = useIntl();
   const navigate = useNavigate();
-  const { libraryId } = useParams();
-  if (!libraryId) {
-    throw new Error('Rendered without libraryId URL parameter');
-  }
-  const create = useCreateLibraryCollection(libraryId!);
   const {
+    libraryId,
     isCreateCollectionModalOpen,
     closeCreateCollectionModal,
-  } = React.useContext(LibraryContext);
+  } = useLibraryContext();
+  const create = useCreateLibraryCollection(libraryId!);
   const { showToast } = React.useContext(ToastContext);
 
   const handleCreate = React.useCallback((values) => {

--- a/src/library-authoring/create-collection/CreateCollectionModal.tsx
+++ b/src/library-authoring/create-collection/CreateCollectionModal.tsx
@@ -23,7 +23,7 @@ const CreateCollectionModal = () => {
     isCreateCollectionModalOpen,
     closeCreateCollectionModal,
   } = useLibraryContext();
-  const create = useCreateLibraryCollection(libraryId!);
+  const create = useCreateLibraryCollection(libraryId);
   const { showToast } = React.useContext(ToastContext);
 
   const handleCreate = React.useCallback((values) => {

--- a/src/library-authoring/library-sidebar/LibrarySidebar.tsx
+++ b/src/library-authoring/library-sidebar/LibrarySidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import {
   Stack,
   Icon,
@@ -10,7 +10,7 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { AddContentContainer, AddContentHeader } from '../add-content';
 import { CollectionInfo, CollectionInfoHeader } from '../collections';
 import { ContentLibrary } from '../data/api';
-import { LibraryContext, SidebarBodyComponentId } from '../common/context';
+import { SidebarBodyComponentId, useLibraryContext } from '../common/context';
 import { ComponentInfo, ComponentInfoHeader } from '../component-info';
 import { LibraryInfo, LibraryInfoHeader } from '../library-info';
 import messages from '../messages';
@@ -35,7 +35,7 @@ const LibrarySidebar = ({ library }: LibrarySidebarProps) => {
     closeLibrarySidebar,
     currentComponentUsageKey,
     currentCollectionId,
-  } = useContext(LibraryContext);
+  } = useLibraryContext();
 
   const bodyComponentMap = {
     [SidebarBodyComponentId.AddContent]: <AddContentContainer />,

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -46,6 +46,10 @@ export interface RouteOptions {
   routerProps?: MemoryRouterProps;
 }
 
+export interface WrapperOptions {
+  extraWrapper?: React.FunctionComponent<{ children: React.ReactNode; }>;
+}
+
 /**
  * This component works together with the custom `render()` method we have in
  * this file to provide whatever react-router context you need for your
@@ -111,14 +115,14 @@ const RouterAndRoute: React.FC<RouteOptions> = ({
   );
 };
 
-function makeWrapper({ ...routeArgs }: RouteOptions) {
+function makeWrapper({ extraWrapper, ...routeArgs }: WrapperOptions & RouteOptions) {
   const AllTheProviders = ({ children }) => (
     <AppProvider store={reduxStore} wrapWithRouter={false}>
       <IntlProvider locale="en" messages={{}}>
         <QueryClientProvider client={queryClient}>
           <ToastContext.Provider value={mockToastContext}>
             <RouterAndRoute {...routeArgs}>
-              {children}
+              {extraWrapper ? React.createElement(extraWrapper, undefined, children) : children}
             </RouterAndRoute>
           </ToastContext.Provider>
         </QueryClientProvider>
@@ -132,7 +136,7 @@ function makeWrapper({ ...routeArgs }: RouteOptions) {
  * Same as render() from `@testing-library/react` but this one provides all the
  * wrappers our React components need to render properly.
  */
-function customRender(ui: React.ReactElement, options: RouteOptions = {}): RenderResult {
+function customRender(ui: React.ReactElement, options: WrapperOptions & RouteOptions = {}): RenderResult {
   return render(ui, { wrapper: makeWrapper(options) });
 }
 


### PR DESCRIPTION
## Description

This PR simplifies some of the library code by moving `libraryId` into the `LibraryContext`. So components can be simplified like this:

![Screenshot](https://github.com/user-attachments/assets/454aeda1-4853-4a8a-91cd-32df9d4dc6e0)

... and no longer have to pass `libraryId` using "prop drilling".

This PR is purely a code refactor to pave the way for some changes I need to make to `LibraryContext` in a following PR. There are no changes to functionality. It removes 82 lines of code 😎.

This is part of my work toward https://github.com/openedx/frontend-app-authoring/issues/1321

Private ref: [FAL-3861](https://tasks.opencraft.com/browse/FAL-3861)