### PR TITLE
Content Libraries: Advanced Component Info & OLX Editor [FC-0062]

### DIFF
--- a/src/generic/CodeEditor.tsx
+++ b/src/generic/CodeEditor.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import React from 'react';
 import { basicSetup, EditorView } from 'codemirror';
 import { EditorState, Compartment } from '@codemirror/state';

--- a/src/generic/CodeEditor.tsx
+++ b/src/generic/CodeEditor.tsx
@@ -1,0 +1,55 @@
+/* eslint-disable import/prefer-default-export */
+import React from 'react';
+import { basicSetup, EditorView } from 'codemirror';
+import { EditorState, Compartment } from '@codemirror/state';
+import { xml } from '@codemirror/lang-xml';
+
+export type EditorAccessor = EditorView;
+
+interface Props {
+  readOnly?: boolean;
+  children?: string;
+  editorRef?: React.MutableRefObject<EditorAccessor | undefined>;
+}
+
+export const CodeEditor: React.FC<Props> = ({
+  readOnly = false,
+  children = '',
+  editorRef,
+}) => {
+  const divRef = React.useRef<HTMLDivElement>(null);
+  const language = React.useMemo(() => new Compartment(), []);
+  const tabSize = React.useMemo(() => new Compartment(), []);
+
+  React.useEffect(() => {
+    if (!divRef.current) { return; }
+    const state = EditorState.create({
+      doc: children,
+      extensions: [
+        basicSetup,
+        language.of(xml()),
+        tabSize.of(EditorState.tabSize.of(2)),
+        EditorState.readOnly.of(readOnly),
+      ],
+    });
+
+    const view = new EditorView({
+      state,
+      parent: divRef.current,
+    });
+    if (editorRef) {
+      // eslint-disable-next-line no-param-reassign
+      editorRef.current = view;
+    }
+    // eslint-disable-next-line consistent-return
+    return () => {
+      if (editorRef) {
+        // eslint-disable-next-line no-param-reassign
+        editorRef.current = undefined;
+      }
+      view.destroy(); // Clean up
+    };
+  }, [divRef.current, readOnly, editorRef]);
+
+  return <div ref={divRef} />;
+};

--- a/src/library-authoring/component-info/ComponentAdvancedInfo.test.tsx
+++ b/src/library-authoring/component-info/ComponentAdvancedInfo.test.tsx
@@ -1,0 +1,113 @@
+import {
+  fireEvent,
+  initializeMocks,
+  render,
+  screen,
+  waitFor,
+} from '../../testUtils';
+import {
+  mockContentLibrary,
+  mockLibraryBlockMetadata,
+  mockSetXBlockOLX,
+  mockXBlockAssets,
+  mockXBlockOLX,
+} from '../data/api.mocks';
+import { LibraryProvider } from '../common/context';
+import { ComponentAdvancedInfo } from './ComponentAdvancedInfo';
+
+mockContentLibrary.applyMock();
+mockLibraryBlockMetadata.applyMock();
+mockXBlockAssets.applyMock();
+mockXBlockOLX.applyMock();
+const setOLXspy = mockSetXBlockOLX.applyMock();
+
+const withLibraryId = (libraryId: string = mockContentLibrary.libraryId) => ({
+  extraWrapper: ({ children }: { children: React.ReactNode }) => (
+    <LibraryProvider libraryId={libraryId}>{children}</LibraryProvider>
+  ),
+});
+
+describe('<ComponentAdvancedInfo />', () => {
+  it('should display nothing when collapsed', async () => {
+    initializeMocks();
+    render(<ComponentAdvancedInfo usageKey={mockLibraryBlockMetadata.usageKeyPublished} />, withLibraryId());
+    const expandButton = await screen.findByRole('button', { name: /Advanced details/ });
+    expect(expandButton).toBeInTheDocument();
+    expect(screen.queryByText(mockLibraryBlockMetadata.usageKeyPublished)).not.toBeInTheDocument();
+  });
+
+  it('should display the usage key of the block (when expanded)', async () => {
+    initializeMocks();
+    render(<ComponentAdvancedInfo usageKey={mockLibraryBlockMetadata.usageKeyPublished} />, withLibraryId());
+    const expandButton = await screen.findByRole('button', { name: /Advanced details/ });
+    fireEvent.click(expandButton);
+    expect(await screen.findByText(mockLibraryBlockMetadata.usageKeyPublished)).toBeInTheDocument();
+  });
+
+  it('should display the static assets of the block (when expanded)', async () => {
+    initializeMocks();
+    render(<ComponentAdvancedInfo usageKey={mockLibraryBlockMetadata.usageKeyPublished} />, withLibraryId());
+    const expandButton = await screen.findByRole('button', { name: /Advanced details/ });
+    fireEvent.click(expandButton);
+    expect(await screen.findByText(/static\/image1\.png/)).toBeInTheDocument();
+    expect(await screen.findByText(/\(12M\)/)).toBeInTheDocument(); // size of the above file
+    expect(await screen.findByText(/static\/data\.csv/)).toBeInTheDocument();
+    expect(await screen.findByText(/\(8K\)/)).toBeInTheDocument(); // size of the above file
+  });
+
+  it('should display the OLX source of the block (when expanded)', async () => {
+    initializeMocks();
+    render(<ComponentAdvancedInfo usageKey={mockXBlockOLX.usageKeyHtml} />, withLibraryId());
+    const expandButton = await screen.findByRole('button', { name: /Advanced details/ });
+    fireEvent.click(expandButton);
+    // Because of syntax highlighting, the OLX will be borken up by many different tags so we need to search for
+    // just a substring:
+    const olxPart = /This is a text component which uses/;
+    expect(await screen.findByText(olxPart)).toBeInTheDocument();
+  });
+
+  it('does not display "Edit OLX" button when the library is read-only', async () => {
+    initializeMocks();
+    render(
+      <ComponentAdvancedInfo usageKey={mockXBlockOLX.usageKeyHtml} />,
+      withLibraryId(mockContentLibrary.libraryIdReadOnly),
+    );
+    const expandButton = await screen.findByRole('button', { name: /Advanced details/ });
+    fireEvent.click(expandButton);
+    expect(screen.queryByRole('button', { name: /Edit OLX/ })).not.toBeInTheDocument();
+  });
+
+  it('can edit the OLX', async () => {
+    initializeMocks();
+    render(<ComponentAdvancedInfo usageKey={mockLibraryBlockMetadata.usageKeyPublished} />, withLibraryId());
+    const expandButton = await screen.findByRole('button', { name: /Advanced details/ });
+    fireEvent.click(expandButton);
+    const editButton = await screen.findByRole('button', { name: /Edit OLX/ });
+    fireEvent.click(editButton);
+
+    expect(setOLXspy).not.toHaveBeenCalled();
+
+    const saveButton = await screen.findByRole('button', { name: /Save/ });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(setOLXspy).toHaveBeenCalled());
+  });
+
+  it('displays an error if editing the OLX failed', async () => {
+    initializeMocks();
+
+    setOLXspy.mockImplementation(async () => {
+      throw new Error('Example error - setting OLX failed');
+    });
+
+    render(<ComponentAdvancedInfo usageKey={mockLibraryBlockMetadata.usageKeyPublished} />, withLibraryId());
+    const expandButton = await screen.findByRole('button', { name: /Advanced details/ });
+    fireEvent.click(expandButton);
+    const editButton = await screen.findByRole('button', { name: /Edit OLX/ });
+    fireEvent.click(editButton);
+    const saveButton = await screen.findByRole('button', { name: /Save/ });
+    fireEvent.click(saveButton);
+
+    expect(await screen.findByText(/An error occurred and the OLX could not be saved./)).toBeInTheDocument();
+  });
+});

--- a/src/library-authoring/component-info/ComponentAdvancedInfo.tsx
+++ b/src/library-authoring/component-info/ComponentAdvancedInfo.tsx
@@ -1,26 +1,28 @@
-/* istanbul ignore file */
 /* eslint-disable import/prefer-default-export */
-// This file doesn't need test coverage nor i18n because it's only seen by devs
 import React from 'react';
+import { Collapsible } from '@openedx/paragon';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
+
 import { LoadingSpinner } from '../../generic/Loading';
 import { useXBlockOLX } from '../data/apiHooks';
+import messages from './messages';
 
 interface Props {
   usageKey: string;
 }
 
-/* istanbul ignore next */
-export const ComponentDeveloperInfo: React.FC<Props> = ({ usageKey }) => {
+export const ComponentAdvancedInfo: React.FC<Props> = ({ usageKey }) => {
+  const intl = useIntl();
   const { data: olx, isLoading: isOLXLoading } = useXBlockOLX(usageKey);
   return (
-    <>
-      <hr className="w-100" />
-      <h3 className="h5">Developer Component Details</h3>
-      <p><small>(This panel is only visible in development builds.)</small></p>
+    <Collapsible
+      styling="basic"
+      title={intl.formatMessage(messages.advancedDetailsTitle)}
+    >
       <dl>
-        <dt>Usage key</dt>
-        <dd><code>{usageKey}</code></dd>
-        <dt>OLX</dt>
+        <dt><FormattedMessage {...messages.advancedDetailsUsageKey} /></dt>
+        <dd className="text-monospace small">{usageKey}</dd>
+        <dt>OLX Source</dt>
         <dd>
           {
             olx ? <code className="micro">{olx}</code> : // eslint-disable-line
@@ -29,6 +31,6 @@ export const ComponentDeveloperInfo: React.FC<Props> = ({ usageKey }) => {
           }
         </dd>
       </dl>
-    </>
+    </Collapsible>
   );
 };

--- a/src/library-authoring/component-info/ComponentAdvancedInfo.tsx
+++ b/src/library-authoring/component-info/ComponentAdvancedInfo.tsx
@@ -68,8 +68,12 @@ export const ComponentAdvancedInfo: React.FC<Props> = ({ usageKey }) => {
                 isEditingOLX
                   ? (
                     <>
-                      <Button variant="primary" onClick={updateOlx} disabled={olxUpdater.isLoading}>Save</Button>
-                      <Button variant="link" onClick={() => setEditingOLX(false)} disabled={olxUpdater.isLoading}>Cancel</Button>
+                      <Button variant="primary" onClick={updateOlx} disabled={olxUpdater.isLoading}>
+                        <FormattedMessage {...messages.advancedDetailsOLXSaveButton} />
+                      </Button>
+                      <Button variant="link" onClick={() => setEditingOLX(false)} disabled={olxUpdater.isLoading}>
+                        <FormattedMessage {...messages.advancedDetailsOLXCancelButton} />
+                      </Button>
                     </>
                   )
                   : (

--- a/src/library-authoring/component-info/ComponentAdvancedInfo.tsx
+++ b/src/library-authoring/component-info/ComponentAdvancedInfo.tsx
@@ -7,11 +7,11 @@ import {
   OverlayTrigger,
   Tooltip,
 } from '@openedx/paragon';
-import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, FormattedNumber, useIntl } from '@edx/frontend-platform/i18n';
 
 import { LoadingSpinner } from '../../generic/Loading';
 import { CodeEditor, EditorAccessor } from '../../generic/CodeEditor';
-import { useUpdateXBlockOLX, useXBlockOLX } from '../data/apiHooks';
+import { useUpdateXBlockOLX, useXBlockAssets, useXBlockOLX } from '../data/apiHooks';
 import messages from './messages';
 
 interface Props {
@@ -22,6 +22,7 @@ export const ComponentAdvancedInfo: React.FC<Props> = ({ usageKey }) => {
   const intl = useIntl();
   // TODO: hide the "Edit" button if the library is read only
   const { data: olx, isLoading: isOLXLoading } = useXBlockOLX(usageKey);
+  const { data: assets, isLoading: areAssetsLoading } = useXBlockAssets(usageKey);
   const editorRef = React.useRef<EditorAccessor | undefined>(undefined);
   const [isEditingOLX, setEditingOLX] = React.useState(false);
   const olxUpdater = useUpdateXBlockOLX(usageKey);
@@ -87,6 +88,15 @@ export const ComponentAdvancedInfo: React.FC<Props> = ({ usageKey }) => {
             </>
           );
         })()}
+        </dd>
+        <dt><FormattedMessage {...messages.advancedDetailsAssets} /></dt>
+        <dd>
+          <ul>
+            { areAssetsLoading ? <li><LoadingSpinner /></li> : null }
+            { assets?.map(a => (
+              <li key={a.path}><a href={a.url}>{a.path}</a> (<FormattedNumber value={a.size} notation="compact" unit="byte" unitDisplay="narrow" />)</li>
+            )) }
+          </ul>
         </dd>
       </dl>
     </Collapsible>

--- a/src/library-authoring/component-info/ComponentAdvancedInfo.tsx
+++ b/src/library-authoring/component-info/ComponentAdvancedInfo.tsx
@@ -54,14 +54,14 @@ export const ComponentAdvancedInfo: React.FC<Props> = ({ usageKey }) => {
       title={intl.formatMessage(messages.advancedDetailsTitle)}
     >
       <dl>
-        <dt><FormattedMessage {...messages.advancedDetailsUsageKey} /></dt>
-        <dd className="text-monospace small">{usageKey}</dd>
-        <dt><FormattedMessage {...messages.advancedDetailsOLX} /></dt>
-        <dd>{(() => {
+        <h3 className="h5"><FormattedMessage {...messages.advancedDetailsUsageKey} /></h3>
+        <p className="text-monospace small">{usageKey}</p>
+        <h3 className="h5"><FormattedMessage {...messages.advancedDetailsOLX} /></h3>
+        {(() => {
           if (isOLXLoading) { return <LoadingSpinner />; }
           if (!olx) { return <FormattedMessage {...messages.advancedDetailsOLXError} />; }
           return (
-            <>
+            <div className="mb-4">
               {olxUpdater.error && (
                 <Alert variant="danger">
                   <p><strong><FormattedMessage {...messages.advancedDetailsOLXEditFailed} /></strong></p>
@@ -72,7 +72,7 @@ export const ComponentAdvancedInfo: React.FC<Props> = ({ usageKey }) => {
                   */}
                 </Alert>
               )}
-              <CodeEditor readOnly={!isEditingOLX} editorRef={editorRef}>{olx}</CodeEditor>
+              <CodeEditor key={usageKey} readOnly={!isEditingOLX} editorRef={editorRef}>{olx}</CodeEditor>
               {
                 isEditingOLX ? (
                   <>
@@ -100,22 +100,19 @@ export const ComponentAdvancedInfo: React.FC<Props> = ({ usageKey }) => {
                   null
                 )
               }
-            </>
+            </div>
           );
         })()}
-        </dd>
-        <dt><FormattedMessage {...messages.advancedDetailsAssets} /></dt>
-        <dd>
-          <ul>
-            { areAssetsLoading ? <li><LoadingSpinner /></li> : null }
-            { assets?.map(a => (
-              <li key={a.path}>
-                <a href={a.url}>{a.path}</a>{' '}
-                (<FormattedNumber value={a.size} notation="compact" unit="byte" unitDisplay="narrow" />)
-              </li>
-            )) }
-          </ul>
-        </dd>
+        <h3 className="h5"><FormattedMessage {...messages.advancedDetailsAssets} /></h3>
+        <ul>
+          { areAssetsLoading ? <li><LoadingSpinner /></li> : null }
+          { assets?.map(a => (
+            <li key={a.path}>
+              <a href={a.url}>{a.path}</a>{' '}
+              (<FormattedNumber value={a.size} notation="compact" unit="byte" unitDisplay="narrow" />)
+            </li>
+          )) }
+        </ul>
       </dl>
     </Collapsible>
   );

--- a/src/library-authoring/component-info/ComponentDetails.test.tsx
+++ b/src/library-authoring/component-info/ComponentDetails.test.tsx
@@ -3,28 +3,37 @@ import {
   render,
   screen,
 } from '../../testUtils';
-import { mockLibraryBlockMetadata } from '../data/api.mocks';
+import { mockContentLibrary, mockLibraryBlockMetadata } from '../data/api.mocks';
+import { LibraryProvider } from '../common/context';
 import ComponentDetails from './ComponentDetails';
+
+mockContentLibrary.applyMock();
+
+const withLibraryId = (libraryId: string = mockContentLibrary.libraryId) => ({
+  extraWrapper: ({ children }: { children: React.ReactNode }) => (
+    <LibraryProvider libraryId={libraryId}>{children}</LibraryProvider>
+  ),
+});
 
 describe('<ComponentDetails />', () => {
   it('should render the component details loading', async () => {
     initializeMocks();
     mockLibraryBlockMetadata.applyMock();
-    render(<ComponentDetails usageKey={mockLibraryBlockMetadata.usageKeyThatNeverLoads} />);
+    render(<ComponentDetails usageKey={mockLibraryBlockMetadata.usageKeyThatNeverLoads} />, withLibraryId());
     expect(await screen.findByText('Loading...')).toBeInTheDocument();
   });
 
   it('should render the component details error', async () => {
     initializeMocks();
     mockLibraryBlockMetadata.applyMock();
-    render(<ComponentDetails usageKey={mockLibraryBlockMetadata.usageKeyError404} />);
+    render(<ComponentDetails usageKey={mockLibraryBlockMetadata.usageKeyError404} />, withLibraryId());
     expect(await screen.findByText(/Mocked request failed with status code 404/)).toBeInTheDocument();
   });
 
   it('should render the component usage', async () => {
     initializeMocks();
     mockLibraryBlockMetadata.applyMock();
-    render(<ComponentDetails usageKey={mockLibraryBlockMetadata.usageKeyNeverPublished} />);
+    render(<ComponentDetails usageKey={mockLibraryBlockMetadata.usageKeyNeverPublished} />, withLibraryId());
     expect(await screen.findByText('Component Usage')).toBeInTheDocument();
     // TODO: replace with actual data when implement tag list
     expect(screen.queryByText('This will show the courses that use this component.')).toBeInTheDocument();
@@ -33,7 +42,7 @@ describe('<ComponentDetails />', () => {
   it('should render the component history', async () => {
     initializeMocks();
     mockLibraryBlockMetadata.applyMock();
-    render(<ComponentDetails usageKey={mockLibraryBlockMetadata.usageKeyNeverPublished} />);
+    render(<ComponentDetails usageKey={mockLibraryBlockMetadata.usageKeyNeverPublished} />, withLibraryId());
     // Show created date
     expect(await screen.findByText('June 20, 2024')).toBeInTheDocument();
     // Show modified date

--- a/src/library-authoring/component-info/ComponentDetails.test.tsx
+++ b/src/library-authoring/component-info/ComponentDetails.test.tsx
@@ -3,11 +3,19 @@ import {
   render,
   screen,
 } from '../../testUtils';
-import { mockContentLibrary, mockLibraryBlockMetadata } from '../data/api.mocks';
+import {
+  mockContentLibrary,
+  mockLibraryBlockMetadata,
+  mockXBlockAssets,
+  mockXBlockOLX,
+} from '../data/api.mocks';
 import { LibraryProvider } from '../common/context';
 import ComponentDetails from './ComponentDetails';
 
 mockContentLibrary.applyMock();
+mockLibraryBlockMetadata.applyMock();
+mockXBlockAssets.applyMock();
+mockXBlockOLX.applyMock();
 
 const withLibraryId = (libraryId: string = mockContentLibrary.libraryId) => ({
   extraWrapper: ({ children }: { children: React.ReactNode }) => (
@@ -16,23 +24,21 @@ const withLibraryId = (libraryId: string = mockContentLibrary.libraryId) => ({
 });
 
 describe('<ComponentDetails />', () => {
-  it('should render the component details loading', async () => {
+  beforeEach(() => {
     initializeMocks();
-    mockLibraryBlockMetadata.applyMock();
+  });
+
+  it('should render the component details loading', async () => {
     render(<ComponentDetails usageKey={mockLibraryBlockMetadata.usageKeyThatNeverLoads} />, withLibraryId());
     expect(await screen.findByText('Loading...')).toBeInTheDocument();
   });
 
   it('should render the component details error', async () => {
-    initializeMocks();
-    mockLibraryBlockMetadata.applyMock();
     render(<ComponentDetails usageKey={mockLibraryBlockMetadata.usageKeyError404} />, withLibraryId());
     expect(await screen.findByText(/Mocked request failed with status code 404/)).toBeInTheDocument();
   });
 
   it('should render the component usage', async () => {
-    initializeMocks();
-    mockLibraryBlockMetadata.applyMock();
     render(<ComponentDetails usageKey={mockLibraryBlockMetadata.usageKeyNeverPublished} />, withLibraryId());
     expect(await screen.findByText('Component Usage')).toBeInTheDocument();
     // TODO: replace with actual data when implement tag list
@@ -40,8 +46,6 @@ describe('<ComponentDetails />', () => {
   });
 
   it('should render the component history', async () => {
-    initializeMocks();
-    mockLibraryBlockMetadata.applyMock();
     render(<ComponentDetails usageKey={mockLibraryBlockMetadata.usageKeyNeverPublished} />, withLibraryId());
     // Show created date
     expect(await screen.findByText('June 20, 2024')).toBeInTheDocument();

--- a/src/library-authoring/component-info/ComponentDetails.tsx
+++ b/src/library-authoring/component-info/ComponentDetails.tsx
@@ -5,7 +5,7 @@ import AlertError from '../../generic/alert-error';
 import Loading from '../../generic/Loading';
 import { useLibraryBlockMetadata } from '../data/apiHooks';
 import HistoryWidget from '../generic/history-widget';
-import { ComponentDeveloperInfo } from './ComponentDeveloperInfo';
+import { ComponentAdvancedInfo } from './ComponentAdvancedInfo';
 import messages from './messages';
 
 interface ComponentDetailsProps {
@@ -46,10 +46,7 @@ const ComponentDetails = ({ usageKey }: ComponentDetailsProps) => {
           {...componentMetadata}
         />
       </div>
-      {
-        // istanbul ignore next: this is only shown in development
-        (process.env.NODE_ENV === 'development' ? <ComponentDeveloperInfo usageKey={usageKey} /> : null)
-      }
+      <ComponentAdvancedInfo usageKey={usageKey} />
     </Stack>
   );
 };

--- a/src/library-authoring/component-info/ComponentPreview.test.tsx
+++ b/src/library-authoring/component-info/ComponentPreview.test.tsx
@@ -1,0 +1,35 @@
+import {
+  fireEvent,
+  initializeMocks,
+  render,
+  screen,
+} from '../../testUtils';
+import { mockLibraryBlockMetadata } from '../data/api.mocks';
+import ComponentPreview from './ComponentPreview';
+
+mockLibraryBlockMetadata.applyMock();
+
+describe('<ComponentPreview />', () => {
+  it('renders a preview of the component', async () => {
+    initializeMocks();
+    const usageKey = mockLibraryBlockMetadata.usageKeyPublished;
+    render(<ComponentPreview usageKey={usageKey} />);
+    const iframe = (await screen.findByTitle('Preview')) as HTMLIFrameElement;
+    expect(iframe.src).toEqual(`http://localhost:18000/xblocks/v2/${usageKey}/embed/student_view/`);
+  });
+
+  it('shows an expanded preview of the component', async () => {
+    initializeMocks();
+    const usageKey = mockLibraryBlockMetadata.usageKeyPublished;
+    render(<ComponentPreview usageKey={usageKey} />);
+    await screen.findByTitle('Preview'); // Wait for the preview to appear
+    const expandButton = screen.getByRole('button', { name: /Expand/ });
+    fireEvent.click(expandButton);
+
+    const dialog = await screen.findByRole('dialog', { name: /component preview/i });
+    const dialogIframe = dialog.querySelector('iframe')!;
+    expect(dialogIframe).not.toBeNull();
+    expect(dialogIframe).toHaveAttribute('title', 'Preview');
+    expect(dialogIframe.src).toEqual(`http://localhost:18000/xblocks/v2/${usageKey}/embed/student_view/`);
+  });
+});

--- a/src/library-authoring/component-info/ComponentPreview.tsx
+++ b/src/library-authoring/component-info/ComponentPreview.tsx
@@ -5,6 +5,7 @@ import { OpenInFull } from '@openedx/paragon/icons';
 
 import { LibraryBlock } from '../LibraryBlock';
 import messages from './messages';
+import { useLibraryBlockMetadata } from '../data/apiHooks';
 
 interface ModalComponentPreviewProps {
   isOpen: boolean;
@@ -36,6 +37,7 @@ const ComponentPreview = ({ usageKey }: ComponentPreviewProps) => {
   const intl = useIntl();
 
   const [isModalOpen, openModal, closeModal] = useToggle();
+  const { data: componentMetadata } = useLibraryBlockMetadata(usageKey);
 
   return (
     <>
@@ -49,7 +51,12 @@ const ComponentPreview = ({ usageKey }: ComponentPreviewProps) => {
         >
           {intl.formatMessage(messages.previewExpandButtonTitle)}
         </Button>
-        <LibraryBlock usageKey={usageKey} />
+        {
+          // key=modified below is used to auto-refresh the preview when changes are made, e.g. via OLX editor
+          componentMetadata
+            ? <LibraryBlock usageKey={usageKey} key={componentMetadata.modified} />
+            : null
+        }
       </div>
       <ModalComponentPreview isOpen={isModalOpen} close={closeModal} usageKey={usageKey} />
     </>

--- a/src/library-authoring/component-info/messages.ts
+++ b/src/library-authoring/component-info/messages.ts
@@ -6,6 +6,11 @@ const messages = defineMessages({
     defaultMessage: 'Advanced details',
     description: 'Heading for the advanced technical details of a component',
   },
+  advancedDetailsAssets: {
+    id: 'course-authoring.library-authoring.component.advanced.assets',
+    defaultMessage: 'Assets (Files)',
+    description: 'Heading for files attached to the component',
+  },
   advancedDetailsOLX: {
     id: 'course-authoring.library-authoring.component.advanced.olx',
     defaultMessage: 'OLX Source',

--- a/src/library-authoring/component-info/messages.ts
+++ b/src/library-authoring/component-info/messages.ts
@@ -11,6 +11,26 @@ const messages = defineMessages({
     defaultMessage: 'OLX Source',
     description: 'Heading for the component\'s OLX source code',
   },
+  advancedDetailsOLXEditButton: {
+    id: 'course-authoring.library-authoring.component.advanced.olx-edit',
+    defaultMessage: 'Edit OLX',
+    description: 'Heading for the component\'s OLX source code',
+  },
+  advancedDetailsOLXEditWarning: {
+    id: 'course-authoring.library-authoring.component.advanced.olx-warning',
+    defaultMessage: 'Be careful! This is an advanced feature and errors may break the component.',
+    description: 'Warning for users about editing OLX directly.',
+  },
+  advancedDetailsOLXEditFailed: {
+    id: 'course-authoring.library-authoring.component.advanced.olx-failed',
+    defaultMessage: 'An error occurred and the OLX could not be saved.',
+    description: 'Error message shown when saving the OLX fails.',
+  },
+  advancedDetailsOLXError: {
+    id: 'course-authoring.library-authoring.component.advanced.olx-error',
+    defaultMessage: 'Unable to load OLX',
+    description: 'Error message if OLX is unavailable',
+  },
   advancedDetailsUsageKey: {
     id: 'course-authoring.library-authoring.component.advanced.usage-key',
     defaultMessage: 'ID (Usage key)',

--- a/src/library-authoring/component-info/messages.ts
+++ b/src/library-authoring/component-info/messages.ts
@@ -19,7 +19,17 @@ const messages = defineMessages({
   advancedDetailsOLXEditButton: {
     id: 'course-authoring.library-authoring.component.advanced.olx-edit',
     defaultMessage: 'Edit OLX',
-    description: 'Heading for the component\'s OLX source code',
+    description: 'Label for button to enable editing the OLX',
+  },
+  advancedDetailsOLXSaveButton: {
+    id: 'course-authoring.library-authoring.component.advanced.olx-save',
+    defaultMessage: 'Save',
+    description: 'Button to save changes to the OLX',
+  },
+  advancedDetailsOLXCancelButton: {
+    id: 'course-authoring.library-authoring.component.advanced.olx-save',
+    defaultMessage: 'Cancel',
+    description: 'Button to cancel changes to the OLX',
   },
   advancedDetailsOLXEditWarning: {
     id: 'course-authoring.library-authoring.component.advanced.olx-warning',

--- a/src/library-authoring/component-info/messages.ts
+++ b/src/library-authoring/component-info/messages.ts
@@ -1,6 +1,21 @@
 import { defineMessages } from '@edx/frontend-platform/i18n';
 
 const messages = defineMessages({
+  advancedDetailsTitle: {
+    id: 'course-authoring.library-authoring.component.advanced.title',
+    defaultMessage: 'Advanced details',
+    description: 'Heading for the advanced technical details of a component',
+  },
+  advancedDetailsOLX: {
+    id: 'course-authoring.library-authoring.component.advanced.olx',
+    defaultMessage: 'OLX Source',
+    description: 'Heading for the component\'s OLX source code',
+  },
+  advancedDetailsUsageKey: {
+    id: 'course-authoring.library-authoring.component.advanced.usage-key',
+    defaultMessage: 'ID (Usage key)',
+    description: 'Heading for the component\'s ID',
+  },
   editNameButtonAlt: {
     id: 'course-authoring.library-authoring.component.edit-name.alt',
     defaultMessage: 'Edit component name',

--- a/src/library-authoring/data/api.mocks.ts
+++ b/src/library-authoring/data/api.mocks.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 import { mockContentTaxonomyTagsData } from '../../content-tags-drawer/data/api.mocks';
+import { getBlockType } from '../../generic/key-utils';
 import { createAxiosError } from '../../testUtils';
 import * as api from './api';
 
@@ -269,3 +270,53 @@ mockGetCollectionMetadata.collectionData = {
 mockGetCollectionMetadata.applyMock = () => {
   jest.spyOn(api, 'getCollectionMetadata').mockImplementation(mockGetCollectionMetadata);
 };
+
+/**
+ * Mock for `getXBlockOLX()`
+ *
+ * This mock returns different data/responses depending on the ID of the block
+ * that you request. Use `mockXBlockOLX.applyMock()` to apply it to the whole
+ * test suite.
+ */
+export async function mockXBlockOLX(usageKey: string): Promise<string> {
+  const thisMock = mockXBlockOLX;
+  switch (usageKey) {
+    case thisMock.usageKeyHtml: return thisMock.olxHtml;
+    default: {
+      const blockType = getBlockType(usageKey);
+      return `<${blockType}>This is mock OLX for usageKey "${usageKey}"</${blockType}>`;
+    }
+  }
+}
+// Mock of a "regular" HTML (Text) block:
+mockXBlockOLX.usageKeyHtml = mockXBlockFields.usageKeyHtml;
+mockXBlockOLX.olxHtml = `
+  <html display_name="${mockXBlockFields.dataHtml.displayName}">
+    ${mockXBlockFields.dataHtml.data}
+  </html>
+`;
+/** Apply this mock. Returns a spy object that can tell you if it's been called. */
+mockXBlockOLX.applyMock = () => jest.spyOn(api, 'getXBlockOLX').mockImplementation(mockXBlockOLX);
+
+/**
+ * Mock for `setXBlockOLX()`
+ */
+export async function mockSetXBlockOLX(_usageKey: string, newOLX: string): Promise<string> {
+  return newOLX;
+}
+/** Apply this mock. Returns a spy object that can tell you if it's been called. */
+mockSetXBlockOLX.applyMock = () => jest.spyOn(api, 'setXBlockOLX').mockImplementation(mockSetXBlockOLX);
+
+/**
+ * Mock for `getXBlockAssets()`
+ *
+ * Use `getXBlockAssets.applyMock()` to apply it to the whole test suite.
+ */
+export async function mockXBlockAssets(): ReturnType<typeof api['getXBlockAssets']> {
+  return [
+    { path: 'static/image1.png', url: 'https://cdn.test.none/image1.png', size: 12_345_000 },
+    { path: 'static/data.csv', url: 'https://cdn.test.none/data.csv', size: 8_000 },
+  ];
+}
+/** Apply this mock. Returns a spy object that can tell you if it's been called. */
+mockXBlockAssets.applyMock = () => jest.spyOn(api, 'getXBlockAssets').mockImplementation(mockXBlockAssets);

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -42,6 +42,10 @@ export const getXBlockFieldsApiUrl = (usageKey: string) => `${getApiBaseUrl()}/a
   */
 export const getXBlockOLXApiUrl = (usageKey: string) => `${getApiBaseUrl()}/api/libraries/v2/blocks/${usageKey}/olx/`;
 /**
+  * Get the URL for the xblock Assets List API
+  */
+export const getXBlockAssetsApiUrl = (usageKey: string) => `${getApiBaseUrl()}/api/libraries/v2/blocks/${usageKey}/assets/`;
+/**
  * Get the URL for the Library Collections API.
  */
 export const getLibraryCollectionsApiUrl = (libraryId: string) => `${getApiBaseUrl()}/api/libraries/v2/${libraryId}/collections/`;
@@ -312,6 +316,14 @@ export async function getXBlockOLX(usageKey: string): Promise<string> {
 export async function setXBlockOLX(usageKey: string, newOLX: string): Promise<string> {
   const { data } = await getAuthenticatedHttpClient().post(getXBlockOLXApiUrl(usageKey), { olx: newOLX });
   return data.olx;
+}
+
+/**
+ * Fetch the asset (static file) list for the given XBlock.
+ */
+export async function getXBlockAssets(usageKey: string): Promise<{ path: string; url: string; size: number }[]> {
+  const { data } = await getAuthenticatedHttpClient().get(getXBlockAssetsApiUrl(usageKey));
+  return data.files;
 }
 
 /**

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -304,6 +304,7 @@ export async function createCollection(libraryId: string, collectionData: Create
 /**
  * Fetch the OLX for the given XBlock.
  */
+// istanbul ignore next
 export async function getXBlockOLX(usageKey: string): Promise<string> {
   const { data } = await getAuthenticatedHttpClient().get(getXBlockOLXApiUrl(usageKey));
   return data.olx;
@@ -313,6 +314,7 @@ export async function getXBlockOLX(usageKey: string): Promise<string> {
  * Set the OLX for the given XBlock.
  * Returns the OLX as it was actually saved.
  */
+// istanbul ignore next
 export async function setXBlockOLX(usageKey: string, newOLX: string): Promise<string> {
   const { data } = await getAuthenticatedHttpClient().post(getXBlockOLXApiUrl(usageKey), { olx: newOLX });
   return data.olx;
@@ -321,6 +323,7 @@ export async function setXBlockOLX(usageKey: string, newOLX: string): Promise<st
 /**
  * Fetch the asset (static file) list for the given XBlock.
  */
+// istanbul ignore next
 export async function getXBlockAssets(usageKey: string): Promise<{ path: string; url: string; size: number }[]> {
   const { data } = await getAuthenticatedHttpClient().get(getXBlockAssetsApiUrl(usageKey));
   return data.files;

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -306,6 +306,15 @@ export async function getXBlockOLX(usageKey: string): Promise<string> {
 }
 
 /**
+ * Set the OLX for the given XBlock.
+ * Returns the OLX as it was actually saved.
+ */
+export async function setXBlockOLX(usageKey: string, newOLX: string): Promise<string> {
+  const { data } = await getAuthenticatedHttpClient().post(getXBlockOLXApiUrl(usageKey), { olx: newOLX });
+  return data.olx;
+}
+
+/**
  * Get the collection metadata.
  */
 export async function getCollectionMetadata(libraryId: string, collectionId: string): Promise<Collection> {

--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -31,6 +31,7 @@ import {
   type CreateLibraryCollectionDataRequest,
   getCollectionMetadata,
   setXBlockOLX,
+  getXBlockAssets,
 } from './api';
 
 export const libraryQueryPredicate = (query: Query, libraryId: string): boolean => {
@@ -76,6 +77,8 @@ export const xblockQueryKeys = {
   xblockFields: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'fields'],
   /** OLX (XML representation of the fields/content) */
   xblockOLX: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'OLX'],
+  /** assets (static files) */
+  xblockAssets: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'assets'],
   componentMetadata: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'componentMetadata'],
 };
 
@@ -283,6 +286,15 @@ export const useUpdateXBlockOLX = (usageKey: string) => {
     },
   });
 };
+
+/** Get the list of assets (static files) attached to a library component */
+export const useXBlockAssets = (usageKey: string) => (
+  useQuery({
+    queryKey: xblockQueryKeys.xblockAssets(usageKey),
+    queryFn: () => getXBlockAssets(usageKey),
+    enabled: !!usageKey,
+  })
+);
 
 /**
  * Get the metadata for a collection in a library


### PR DESCRIPTION
## Description

This PR adds a new "Advanced details" section to the "Details" tab of library components in the Authoring MFE. This replaces the previous "developer info" panel that was only visible in development builds. This one is visible to everyone, but hidden behind a collapsible widget.

| Collapsed (default) | Expanded |
|---|---|
| ![Screenshot](https://github.com/user-attachments/assets/eb526a8f-1327-4a9f-8b67-97dd6da93028) <br><br><br><br><br><br><br><br><br><br><br><br> | ![Screenshot](https://github.com/user-attachments/assets/5156110e-a6e5-4d44-90f7-975ff1fa308a) |

It includes the **OLX editor**, with a warning that you need to be very careful using it:

![Screenshot](https://github.com/user-attachments/assets/9de5d019-8468-483c-8013-b651a16cc43d)

If you make a mistake in the OLX and it's invalid, you'll get an **error message** like this:

![Screenshot](https://github.com/user-attachments/assets/781839c6-47ff-42b7-ad86-fcf2fc871c36)

I also added a **list of assets**, though it depends on [this WIP](https://github.com/openedx/edx-platform/pull/35557/files#r1779876292):

![Screenshot 2024-09-28 at 7 15 02 PM](https://github.com/user-attachments/assets/fe72ef92-025c-41eb-aecf-5a698ada593f)


#### TODO before merging

- [x] fix: the preview in the Preview tab does not reflect changes unless you click "Expand"
- [x] add tests?
- [x] rebase on https://github.com/openedx/frontend-app-authoring/pull/1345 and add support for read-only mode ?

Private ref: [FAL-3880](https://tasks.opencraft.com/browse/FAL-3880)