### PR TITLE
fix: component preview modal overflow  [FC-0062]

### DIFF
--- a/src/library-authoring/component-info/ComponentPreview.tsx
+++ b/src/library-authoring/component-info/ComponentPreview.tsx
@@ -20,6 +20,7 @@ const ModalComponentPreview = ({ isOpen, close, usageKey }: ModalComponentPrevie
       title={intl.formatMessage(messages.previewModalTitle)}
       isOpen={isOpen}
       onClose={close}
+      isOverflowVisible={false}
       className="component-preview-modal"
     >
       <LibraryBlock usageKey={usageKey} />


### PR DESCRIPTION
## Description

Fix the bug where the XBlock component overflowed the preview modal.

### Before:
![image](https://github.com/user-attachments/assets/e5c90996-b7f5-42df-bc2f-5de0b7d868bb)

### After:
![image](https://github.com/user-attachments/assets/45725436-3f0e-4021-af4e-77fc5cae0945)

## Testing instructions

1. Open the preview modal with an XBlock with long content
2. Reduce the viewport height to force modal to shrink
3. Check the results

___
Private-ref: [FAL-3850](https://tasks.opencraft.com/browse/FAL-3859)