### PR TITLE
fix: upload codecov report as a separate workflow step

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,24 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
     - run: make validate.ci
+    - name: Archive code coverage results
+      uses: actions/upload-artifact@v4
+      with:
+        name: code-coverage-report-${{ matrix.node }}
+        # When we're only using Node 20, replace the line above with the following:
+        # name: code-coverage-report
+        path: coverage/*.*
+  coverage:
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+    - uses: actions/checkout@v3
+    - name: Download code coverage results
+      uses: actions/download-artifact@v4
+      with:
+        name: code-coverage-report-20
+        # When we're only using Node 20, replace the line above with the following:
+        # name: code-coverage-report
     - name: Upload coverage
       uses: codecov/codecov-action@v4
       with:


### PR DESCRIPTION
## Description

We're seeing PRs like https://github.com/openedx/frontend-app-authoring/pull/1331 fail because of temporary CodeCov errors. To fix this, it's necessary to run the entire workflow all over again. This PR makes the same improvement we recently made to frontend-app-learning in https://github.com/openedx/frontend-app-learning/pull/1476 so that codecov uploading is a separate step that can be re-tried without needing to run the tests all over again. This makes it faster to resolve the issue, and makes it more clear what step failed.

## Supporting information

Same as https://github.com/openedx/frontend-app-learning/pull/1476

## Testing instructions

You can only test this by checking that the CI build ran correctly.
