### PR TITLE
"Other" (e.g Surveys) components should use grey (background: #646464) in the card title bar, not white [FC-0062]

### DIFF
--- a/src/generic/block-type-utils/constants.ts
+++ b/src/generic/block-type-utils/constants.ts
@@ -67,4 +67,5 @@ export const COMPONENT_TYPE_STYLE_COLOR_MAP = {
   sequential: 'component-style-default',
   chapter: 'component-style-default',
   collection: 'component-style-collection',
+  other: 'component-style-other',
 };

--- a/src/generic/block-type-utils/index.tsx
+++ b/src/generic/block-type-utils/index.tsx
@@ -11,5 +11,5 @@ export function getItemIcon(blockType: string): React.ComponentType {
 }
 
 export function getComponentStyleColor(blockType: string): string {
-  return COMPONENT_TYPE_STYLE_COLOR_MAP[blockType] ?? 'bg-component';
+  return COMPONENT_TYPE_STYLE_COLOR_MAP[blockType] ?? COMPONENT_TYPE_STYLE_COLOR_MAP.other;
 }


### PR DESCRIPTION
## Description

Lets the default Card.Header background color be grey, not white.

## Supporting information

Bug reported on Slack: [comment](https://openedx.slack.com/archives/C06JG6RFE4V/p1726850094053179)
Private-ref: [FAL-3859](https://tasks.opencraft.com/browse/FAL-3859)

Previously:

![image](https://github.com/user-attachments/assets/eb715e82-9291-4396-82ba-41dd833ba46a)

With this change:

![image](https://github.com/user-attachments/assets/04714380-225f-4bd2-bd59-1aed54f2ad1f)

## Testing instructions

1. Locate / create a course in the Authoring MFE, and add a Survey or Poll or other Advanced component to that course.
2. Use the ... menu for the block to "copy to clipboard"
3. Locate / create a library in the Authoring MFE, and click the "New" button to open the "add component" sidebar.
4. Click "Paste from Clipboard" to paste the Advanced component into the library.
5. Note that the header background color is grey, as shown in screenshot.