### PR TITLE
fix: change collection stats component slots [FC-0062]

### DIFF
--- a/src/library-authoring/collections/CollectionDetails.test.tsx
+++ b/src/library-authoring/collections/CollectionDetails.test.tsx
@@ -124,6 +124,7 @@ describe('<CollectionDetails />', () => {
       { blockType: 'Total', count: 3 },
       { blockType: 'Text', count: 2 },
       { blockType: 'Problem', count: 1 },
+      { blockType: 'Video', count: 0 },
     ].forEach(({ blockType, count }) => {
       const blockCount = screen.getByText(blockType).closest('div') as HTMLDivElement;
       expect(within(blockCount).getByText(count.toString())).toBeInTheDocument();
@@ -149,10 +150,10 @@ describe('<CollectionDetails />', () => {
 
     [
       { blockType: 'Total', count: 36 },
-      { blockType: 'Video', count: 8 },
-      { blockType: 'Problem', count: 7 },
-      { blockType: 'Text', count: 6 },
-      { blockType: 'Other', count: 15 },
+      { blockType: 'Problem', count: 2 },
+      { blockType: 'Text', count: 3 },
+      { blockType: 'Video', count: 1 },
+      { blockType: 'Other', count: 30 },
     ].forEach(({ blockType, count }) => {
       const blockCount = screen.getByText(blockType).closest('div') as HTMLDivElement;
       expect(within(blockCount).getByText(count.toString())).toBeInTheDocument();

--- a/src/library-authoring/collections/CollectionDetails.tsx
+++ b/src/library-authoring/collections/CollectionDetails.tsx
@@ -51,15 +51,9 @@ const CollectionStatsWidget = ({ libraryId, collectionId }: CollectionStatsWidge
     return null;
   }
 
-  const blockTypesArray = Object.entries(blockTypes)
-    .map(([blockType, count]) => ({ blockType, count }))
-    .sort((a, b) => b.count - a.count);
+  const blockSlots = ['problem', 'html', 'video'];
 
-  const totalBlocksCount = blockTypesArray.reduce((acc, { count }) => acc + count, 0);
-  // Show the top 3 block type counts individually, and splice the remaining block types together under "Other".
-  const numBlockTypesShown = 3;
-  const otherBlocks = blockTypesArray.splice(numBlockTypesShown);
-  const otherBlocksCount = otherBlocks.reduce((acc, { count }) => acc + count, 0);
+  const totalBlocksCount = Object.values(blockTypes).reduce((acc, count) => acc + count, 0);
 
   if (totalBlocksCount === 0) {
     return (
@@ -74,6 +68,9 @@ const CollectionStatsWidget = ({ libraryId, collectionId }: CollectionStatsWidge
     );
   }
 
+  const otherBlocksCount = Object.entries(blockTypes).filter(([blockType]) => !blockSlots.includes(blockType))
+    .reduce((acc, [, count]) => acc + count, 0);
+
   return (
     <Stack direction="horizontal" className="p-2 justify-content-between" gap={2}>
       <BlockCount
@@ -81,15 +78,15 @@ const CollectionStatsWidget = ({ libraryId, collectionId }: CollectionStatsWidge
         count={totalBlocksCount}
         className="border-right"
       />
-      {blockTypesArray.map(({ blockType, count }) => (
+      {blockSlots.map((blockType) => (
         <BlockCount
           key={blockType}
           label={<BlockTypeLabel type={blockType} />}
           blockType={blockType}
-          count={count}
+          count={blockTypes[blockType] || 0}
         />
       ))}
-      {otherBlocks.length > 0 && (
+      {!!otherBlocksCount && (
         <BlockCount
           label={<FormattedMessage {...messages.detailsTabStatsOtherComponents} />}
           count={otherBlocksCount}

--- a/src/search-manager/data/api.mock.ts
+++ b/src/search-manager/data/api.mock.ts
@@ -51,14 +51,14 @@ export async function mockGetBlockTypes(
     noBlocks: {},
     someBlocks: { problem: 1, html: 2 },
     moreBlocks: {
-      advanced: 1,
-      discussion: 2,
-      library: 3,
-      drag_and_drop_v2: 4,
-      openassessment: 5,
-      html: 6,
-      problem: 7,
-      video: 8,
+      advanced: 8,
+      discussion: 7,
+      library: 6,
+      drag_and_drop_v2: 5,
+      openassessment: 4,
+      html: 3,
+      problem: 2,
+      video: 1,
     },
   };
   jest.spyOn(api, 'fetchBlockTypes').mockResolvedValue(mockResponseMap[mockResponse]);


### PR DESCRIPTION
## Description

This PR changes the components slots in the Collection Details sidebar to always show Problem, Text and Video component count.

![image](https://github.com/user-attachments/assets/f1362f03-8602-426c-8d57-4c9fd1aeae3b)

## Supporting information
- https://github.com/openedx/frontend-app-authoring/issues/1089#issuecomment-2387142825

## Testing instructions

- Add components to a Collection
- The Collection Stats should always show Problem, Text and Video slots, and group everything else on the Other slot

___
Private-ref: [FAL-3883](https://tasks.opencraft.com/browse/FAL-3883)