### PR TITLE
fix: Calendar icon over datepicker modal

### DIFF
--- a/src/assets/scss/_form.scss
+++ b/src/assets/scss/_form.scss
@@ -79,3 +79,7 @@
     color: $black;
   }
 }
+
+.react-datepicker-popper {
+  z-index: 3;
+}


### PR DESCRIPTION
## Description

This is a minor issue where the calendar icon appears over the opened datepicker modal window.

Before
<img width="1840" alt="Снимок экрана 2024-10-06 в 12 52 42" src="https://github.com/user-attachments/assets/e0b472f5-acc2-47e2-8881-8f287b6e3dc4">

After
<img width="1840" alt="Снимок экрана 2024-10-06 в 12 53 30" src="https://github.com/user-attachments/assets/c51e165f-549c-4070-9601-6e396b4314ea">
