### PR TITLE
[BB-9078] Adjust styling when title is truncated

### DIFF
--- a/src/course-outline/card-header/CardHeader.scss
+++ b/src/course-outline/card-header/CardHeader.scss
@@ -5,7 +5,7 @@
   .item-card-header__title-btn {
     justify-content: flex-start;
     padding: 0;
-    width: fit-content;
+    flex: 1 1 0%;
     height: 1.5rem;
     margin-right: .25rem;
     background: transparent;
@@ -15,6 +15,7 @@
   .item-card-edit-icon {
     opacity: 0;
     transition: opacity .3s linear;
+    margin-right: .5rem;
 
     &:focus {
       opacity: 1;


### PR DESCRIPTION
## Description
This PR fixes a styling issue seen when the title of a subsection is really long and gets truncated.

## Supporting information

OpenCraft Internal Jira ticket: [BB-9078](https://tasks.opencraft.com/browse/BB-9078)

## Screenshots

Before styling fix:

![Screenshot from 2024-09-04 15-43-57](https://github.com/user-attachments/assets/98b5bc30-7c5b-4723-b95a-28f311ca1ad7)


After styling fix:

![Screenshot from 2024-09-17 14-06-50-cropped](https://github.com/user-attachments/assets/a1580308-4a5e-4d87-ae60-1cbcd20ec08f)
