### PR TITLE
Minimal Library Asset Support

### DIFF
--- a/src/library-authoring/LibraryBlock/LibraryBlock.tsx
+++ b/src/library-authoring/LibraryBlock/LibraryBlock.tsx
@@ -20,7 +20,7 @@ interface LibraryBlockProps {
 const LibraryBlock = ({ onBlockNotification, usageKey }: LibraryBlockProps) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [iFrameHeight, setIFrameHeight] = useState(600);
-  const lmsBaseUrl = getConfig().LMS_BASE_URL;
+  const studioBaseUrl = getConfig().STUDIO_BASE_URL;
 
   const intl = useIntl();
 
@@ -74,7 +74,7 @@ const LibraryBlock = ({ onBlockNotification, usageKey }: LibraryBlockProps) => {
       <iframe
         ref={iframeRef}
         title={intl.formatMessage(messages.iframeTitle)}
-        src={`${lmsBaseUrl}/xblocks/v2/${usageKey}/embed/student_view/`}
+        src={`${studioBaseUrl}/xblocks/v2/${usageKey}/embed/student_view/`}
         data-testid="block-preview"
         style={{
           width: '100%',

--- a/src/library-authoring/component-info/ComponentPreview.test.tsx
+++ b/src/library-authoring/component-info/ComponentPreview.test.tsx
@@ -15,7 +15,7 @@ describe('<ComponentPreview />', () => {
     const usageKey = mockLibraryBlockMetadata.usageKeyPublished;
     render(<ComponentPreview usageKey={usageKey} />);
     const iframe = (await screen.findByTitle('Preview')) as HTMLIFrameElement;
-    expect(iframe.src).toEqual(`http://localhost:18000/xblocks/v2/${usageKey}/embed/student_view/`);
+    expect(iframe.src).toEqual(`http://localhost:18010/xblocks/v2/${usageKey}/embed/student_view/`);
   });
 
   it('shows an expanded preview of the component', async () => {
@@ -30,6 +30,6 @@ describe('<ComponentPreview />', () => {
     const dialogIframe = dialog.querySelector('iframe')!;
     expect(dialogIframe).not.toBeNull();
     expect(dialogIframe).toHaveAttribute('title', 'Preview');
-    expect(dialogIframe.src).toEqual(`http://localhost:18000/xblocks/v2/${usageKey}/embed/student_view/`);
+    expect(dialogIframe.src).toEqual(`http://localhost:18010/xblocks/v2/${usageKey}/embed/student_view/`);
   });
 });


### PR DESCRIPTION
This is a subset of https://github.com/openedx/frontend-app-authoring/pull/1349 that doesn't have all the Files & Uploads changes, but just has:

- **refactor: switch Content Library XBlock preview to Studio**
- **fix: disable static asset mangling for v2 Content Libraries**