### PR TITLE
refactor: picker component to only post message with block info [FC-0062]

### DIFF
--- a/src/library-authoring/component-info/ComponentInfo.tsx
+++ b/src/library-authoring/component-info/ComponentInfo.tsx
@@ -5,21 +5,18 @@ import {
   Tabs,
   Stack,
 } from '@openedx/paragon';
-import { useContext } from 'react';
 
-import { ToastContext } from '../../generic/toast-context';
 import { useLibraryContext } from '../common/context';
 import { ComponentMenu } from '../components';
 import { canEditComponent } from '../components/ComponentEditorModal';
-import { useAddComponentToCourse } from '../data/apiHooks';
 import ComponentDetails from './ComponentDetails';
 import ComponentManagement from './ComponentManagement';
 import ComponentPreview from './ComponentPreview';
 import messages from './messages';
+import { getBlockType } from '../../generic/key-utils';
 
 const ComponentInfo = () => {
   const intl = useIntl();
-  const { showToast } = useContext(ToastContext);
 
   const {
     sidebarComponentUsageKey: usageKey,
@@ -34,22 +31,15 @@ const ComponentInfo = () => {
     throw new Error('usageKey is required');
   }
 
-  const {
-    mutateAsync: addComponentToCourse,
-    reset,
-  } = useAddComponentToCourse(parentLocator, usageKey);
-
   const canEdit = canEditComponent(usageKey);
 
   const handleAddComponentToCourse = () => {
-    addComponentToCourse()
-      .then(() => {
-        window.parent.postMessage('closeComponentPicker', '*');
-      })
-      .catch(() => {
-        showToast(intl.formatMessage(messages.addComponentToCourseError));
-        reset();
-      });
+    window.parent.postMessage({
+      parentLocator,
+      usageKey,
+      type: 'pickerComponentSelected',
+      category: getBlockType(usageKey),
+    }, '*');
   };
 
   return (

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -14,7 +14,7 @@ import { updateClipboard } from '../../generic/data/api';
 import { ToastContext } from '../../generic/toast-context';
 import { type ContentHit } from '../../search-manager';
 import { useLibraryContext } from '../common/context';
-import { useAddComponentToCourse, useRemoveComponentsFromCollection } from '../data/apiHooks';
+import { useRemoveComponentsFromCollection } from '../data/apiHooks';
 import BaseComponentCard from './BaseComponentCard';
 import { canEditComponent } from './ComponentEditorModal';
 import messages from './messages';
@@ -90,14 +90,11 @@ export const ComponentMenu = ({ usageKey }: { usageKey: string }) => {
 };
 
 const ComponentCard = ({ contentHit }: ComponentCardProps) => {
-  const intl = useIntl();
-
   const {
     openComponentInfoSidebar,
     componentPickerMode,
     parentLocator,
   } = useLibraryContext();
-  const { showToast } = useContext(ToastContext);
 
   const {
     blockType,
@@ -112,20 +109,13 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
   ) ?? '';/* eslint-enable */
   const displayName = formatted?.displayName ?? '';
 
-  const {
-    mutateAsync: addComponentToCourse,
-    reset,
-  } = useAddComponentToCourse(parentLocator, contentHit.usageKey);
-
   const handleAddComponentToCourse = () => {
-    addComponentToCourse()
-      .then(() => {
-        window.parent.postMessage('closeComponentPicker', '*');
-      })
-      .catch(() => {
-        showToast(intl.formatMessage(messages.addComponentToCourseError));
-        reset();
-      });
+    window.parent.postMessage({
+      parentLocator,
+      usageKey,
+      type: 'pickerComponentSelected',
+      category: blockType,
+    }, '*');
   };
 
   return (

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -483,15 +483,3 @@ export async function updateComponentCollections(usageKey: string, collectionKey
     collection_keys: collectionKeys,
   });
 }
-
-/**
- * Add a component to a course.
- */
-// istanbul ignore next
-export async function addComponentToCourse(parentLocator: string, componentUsageKey: string) {
-  const client = getAuthenticatedHttpClient();
-  await client.post(getXBlockBaseApiUrl(), {
-    parent_locator: parentLocator,
-    library_content_key: componentUsageKey,
-  });
-}

--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -40,7 +40,6 @@ import {
   getXBlockAssets,
   updateComponentCollections,
   removeComponentsFromCollection,
-  addComponentToCourse,
 } from './api';
 
 export const libraryQueryPredicate = (query: Query, libraryId: string): boolean => {
@@ -474,18 +473,3 @@ export const useUpdateComponentCollections = (libraryId: string, usageKey: strin
     },
   });
 };
-
-/**
- * Use this mutation to add a component to a course
- */
-export const useAddComponentToCourse = (parentLocator: string | undefined, componentUsageKey: string) => (
-  useMutation({
-    mutationFn: () => {
-      // istanbul ignore if: this should never happen
-      if (!parentLocator) {
-        throw new Error('parentLocator is required');
-      }
-      return addComponentToCourse(parentLocator, componentUsageKey);
-    },
-  })
-);


### PR DESCRIPTION
## Description

The picker component will not call any api on selection.

## Supporting information

For: https://github.com/openedx/edx-platform/pull/35670

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.


## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.