### PR TITLE
fix: set original value for TypeaheadDropdown component

### DIFF
--- a/src/editors/sharedComponents/TypeaheadDropdown/index.jsx
+++ b/src/editors/sharedComponents/TypeaheadDropdown/index.jsx
@@ -90,7 +90,7 @@ class TypeaheadDropdown extends React.Component {
       this.setValue(opt);
       this.setState({ displayValue: opt });
     } else {
-      this.setValue(normalized);
+      this.setValue(value);
       this.setState({ displayValue: value });
     }
   }


### PR DESCRIPTION
Related to #1199

In TypeaheadDropdown component we set a normalized value instead of original one.
As a result - a lowercased value is saved into DB.

Test instruction:
- go to Home page
- click create new course
- type organization with upper case
- use TAB to move to the next field
- fill a Course number
- fill the Course run
- create course

AR:
- the Org is create in Lower case

ER:
- the org is create in original Upper case