### PR TITLE
Allow filtering library by publish status [FC-0062]

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -31,6 +31,7 @@ import {
   ClearFiltersButton,
   FilterByBlockType,
   FilterByTags,
+  FilterByPublished,
   SearchContextProvider,
   SearchKeywordsField,
   SearchSortWidget,
@@ -249,6 +250,7 @@ const LibraryAuthoringPage = ({ returnToLibrarySelection }: LibraryAuthoringPage
             <div className="d-flex mt-3 align-items-center">
               <FilterByTags />
               <FilterByBlockType />
+              <FilterByPublished />
               <ClearFiltersButton />
               <div className="flex-grow-1" />
               <SearchSortWidget />

--- a/src/library-authoring/components/BaseComponentCard.tsx
+++ b/src/library-authoring/components/BaseComponentCard.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import {
+  Badge,
   Card,
   Container,
   Icon,
@@ -11,12 +12,14 @@ import TagCount from '../../generic/tag-count';
 import { BlockTypeLabel, type ContentHitTags, Highlight } from '../../search-manager';
 
 type BaseComponentCardProps = {
-  componentType: string,
-  displayName: string, description: string,
-  numChildren?: number,
-  tags: ContentHitTags,
-  actions: React.ReactNode,
-  openInfoSidebar: () => void
+  componentType: string;
+  displayName: string;
+  description: string;
+  numChildren?: number;
+  tags: ContentHitTags;
+  actions: React.ReactNode;
+  openInfoSidebar: () => void;
+  hasUnpublishedChanges?: boolean;
 };
 
 const BaseComponentCard = ({
@@ -27,6 +30,7 @@ const BaseComponentCard = ({
   tags,
   actions,
   openInfoSidebar,
+  ...props
 } : BaseComponentCardProps) => {
   const tagCount = useMemo(() => {
     if (!tags) {
@@ -75,7 +79,8 @@ const BaseComponentCard = ({
             <div className="text-truncate h3 mt-2">
               <Highlight text={displayName} />
             </div>
-            <Highlight text={description} />
+            <Highlight text={description} /><br />
+            {props.hasUnpublishedChanges ? <Badge variant="warning">Unpublished changes</Badge> : null}
           </Card.Section>
         </Card.Body>
       </Card>

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -189,6 +189,8 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
     formatted,
     tags,
     usageKey,
+    modified,
+    lastPublished,
   } = contentHit;
   const componentDescription: string = (
     showOnlyPublished ? formatted.published?.description : formatted.description
@@ -213,6 +215,7 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
         </ActionRow>
       )}
       openInfoSidebar={() => openComponentInfoSidebar(usageKey)}
+      hasUnpublishedChanges={modified >= (lastPublished ?? 0)}
     />
   );
 };

--- a/src/search-manager/FilterByPublished.tsx
+++ b/src/search-manager/FilterByPublished.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import {
   Badge,
   Form,
@@ -8,7 +7,6 @@ import {
 } from '@openedx/paragon';
 import { FilterList } from '@openedx/paragon/icons';
 import SearchFilterWidget from './SearchFilterWidget';
-import messages from './messages';
 import { useSearchContext } from './SearchManager';
 import { PublishStatus } from './data/api';
 
@@ -17,16 +15,17 @@ import { PublishStatus } from './data/api';
  */
 const FilterByPublished: React.FC<Record<never, never>> = () => {
   const {
-    publishedFilter,
-    setPublishedFilter,
+    publishStatus,
+    publishStatusFilter,
+    setPublishStatusFilter,
   } = useSearchContext();
 
   const clearFilters = React.useCallback(() => {
-    setPublishedFilter([]);
+    setPublishStatusFilter([]);
   }, []);
 
   const toggleFilterMode = React.useCallback((mode: PublishStatus) => {
-    setPublishedFilter(oldList => {
+    setPublishStatusFilter(oldList => {
       if (oldList.includes(mode)) {
         return oldList.filter(m => m !== mode);
       }
@@ -44,7 +43,7 @@ const FilterByPublished: React.FC<Record<never, never>> = () => {
       <Form.Group className="mb-0">
         <Form.CheckboxSet
           name="block-type-filter"
-          value={publishedFilter}
+          value={publishStatusFilter}
         >
           <Menu className="block-type-refinement-menu" style={{ boxShadow: 'none' }}>
             <MenuItem
@@ -54,7 +53,7 @@ const FilterByPublished: React.FC<Record<never, never>> = () => {
             >
               <div>
                 Published
-                {' '}<Badge variant="light" pill>15</Badge>
+                {' '}<Badge variant="light" pill>{publishStatus[PublishStatus.Published] ?? 0}</Badge>
               </div>
             </MenuItem>
             <MenuItem
@@ -64,7 +63,7 @@ const FilterByPublished: React.FC<Record<never, never>> = () => {
             >
               <div>
                 Modified since publish
-                {' '}<Badge variant="light" pill>5</Badge>
+                {' '}<Badge variant="light" pill>{publishStatus[PublishStatus.Modified] ?? 0}</Badge>
               </div>
             </MenuItem>
             <MenuItem
@@ -74,7 +73,7 @@ const FilterByPublished: React.FC<Record<never, never>> = () => {
             >
               <div>
                 Never published
-                {' '}<Badge variant="light" pill>2</Badge>
+                {' '}<Badge variant="light" pill>{publishStatus[PublishStatus.NeverPublished] ?? 0}</Badge>
               </div>
             </MenuItem>
           </Menu>

--- a/src/search-manager/FilterByPublished.tsx
+++ b/src/search-manager/FilterByPublished.tsx
@@ -9,19 +9,29 @@ import {
 import { FilterList } from '@openedx/paragon/icons';
 import SearchFilterWidget from './SearchFilterWidget';
 import messages from './messages';
-// import { useSearchContext } from './SearchManager';
+import { useSearchContext } from './SearchManager';
+import { PublishStatus } from './data/api';
 
 /**
  * A button with a dropdown that allows filtering the current search by publish status
  */
 const FilterByPublished: React.FC<Record<never, never>> = () => {
-  // const {
-  //   publishedFilter,
-  //   setPublishedFilter,
-  // } = useSearchContext();
+  const {
+    publishedFilter,
+    setPublishedFilter,
+  } = useSearchContext();
 
   const clearFilters = React.useCallback(() => {
-    // setPublishedFilter(undefined);
+    setPublishedFilter([]);
+  }, []);
+
+  const toggleFilterMode = React.useCallback((mode: PublishStatus) => {
+    setPublishedFilter(oldList => {
+      if (oldList.includes(mode)) {
+        return oldList.filter(m => m !== mode);
+      }
+      return [...oldList, mode];
+    });
   }, []);
 
   return (
@@ -34,37 +44,37 @@ const FilterByPublished: React.FC<Record<never, never>> = () => {
       <Form.Group className="mb-0">
         <Form.CheckboxSet
           name="block-type-filter"
-          value={[]}
+          value={publishedFilter}
         >
           <Menu className="block-type-refinement-menu" style={{ boxShadow: 'none' }}>
             <MenuItem
               as={Form.Checkbox}
-              value={1}
-              onChange={() => {}}
+              value={PublishStatus.Published}
+              onChange={() => { toggleFilterMode(PublishStatus.Published); }}
             >
               <div>
                 Published
-                <Badge variant="light" pill>15</Badge>
+                {' '}<Badge variant="light" pill>15</Badge>
               </div>
             </MenuItem>
             <MenuItem
               as={Form.Checkbox}
-              value={2}
-              onChange={() => {}}
+              value={PublishStatus.Modified}
+              onChange={() => { toggleFilterMode(PublishStatus.Modified); }}
             >
               <div>
                 Modified since publish
-                <Badge variant="light" pill>5</Badge>
+                {' '}<Badge variant="light" pill>5</Badge>
               </div>
             </MenuItem>
             <MenuItem
               as={Form.Checkbox}
-              value={3}
-              onChange={() => {}}
+              value={PublishStatus.NeverPublished}
+              onChange={() => { toggleFilterMode(PublishStatus.NeverPublished); }}
             >
               <div>
                 Never published
-                <Badge variant="light" pill>2</Badge>
+                {' '}<Badge variant="light" pill>2</Badge>
               </div>
             </MenuItem>
           </Menu>

--- a/src/search-manager/FilterByPublished.tsx
+++ b/src/search-manager/FilterByPublished.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import {
+  Badge,
+  Form,
+  Menu,
+  MenuItem,
+} from '@openedx/paragon';
+import { FilterList } from '@openedx/paragon/icons';
+import SearchFilterWidget from './SearchFilterWidget';
+import messages from './messages';
+// import { useSearchContext } from './SearchManager';
+
+/**
+ * A button with a dropdown that allows filtering the current search by publish status
+ */
+const FilterByPublished: React.FC<Record<never, never>> = () => {
+  // const {
+  //   publishedFilter,
+  //   setPublishedFilter,
+  // } = useSearchContext();
+
+  const clearFilters = React.useCallback(() => {
+    // setPublishedFilter(undefined);
+  }, []);
+
+  return (
+    <SearchFilterWidget
+      appliedFilters={[]}
+      label="Publish Status"
+      clearFilter={clearFilters}
+      icon={FilterList}
+    >
+      <Form.Group className="mb-0">
+        <Form.CheckboxSet
+          name="block-type-filter"
+          value={[]}
+        >
+          <Menu className="block-type-refinement-menu" style={{ boxShadow: 'none' }}>
+            <MenuItem
+              as={Form.Checkbox}
+              value={1}
+              onChange={() => {}}
+            >
+              <div>
+                Published
+                <Badge variant="light" pill>15</Badge>
+              </div>
+            </MenuItem>
+            <MenuItem
+              as={Form.Checkbox}
+              value={2}
+              onChange={() => {}}
+            >
+              <div>
+                Modified since publish
+                <Badge variant="light" pill>5</Badge>
+              </div>
+            </MenuItem>
+            <MenuItem
+              as={Form.Checkbox}
+              value={3}
+              onChange={() => {}}
+            >
+              <div>
+                Never published
+                <Badge variant="light" pill>2</Badge>
+              </div>
+            </MenuItem>
+          </Menu>
+        </Form.CheckboxSet>
+      </Form.Group>
+    </SearchFilterWidget>
+  );
+};
+
+export default FilterByPublished;

--- a/src/search-manager/SearchManager.ts
+++ b/src/search-manager/SearchManager.ts
@@ -27,12 +27,13 @@ export interface SearchContextData {
   setBlockTypesFilter: React.Dispatch<React.SetStateAction<string[]>>;
   problemTypesFilter: string[];
   setProblemTypesFilter: React.Dispatch<React.SetStateAction<string[]>>;
-  publishedFilter: PublishStatus[];
-  setPublishedFilter: React.Dispatch<React.SetStateAction<PublishStatus[]>>;
+  publishStatusFilter: PublishStatus[];
+  setPublishStatusFilter: React.Dispatch<React.SetStateAction<PublishStatus[]>>;
   tagsFilter: string[];
   setTagsFilter: React.Dispatch<React.SetStateAction<string[]>>;
   blockTypes: Record<string, number>;
   problemTypes: Record<string, number>;
+  publishStatus: Record<string, number>;
   extraFilter?: Filter;
   canClearFilters: boolean;
   clearFilters: () => void;
@@ -105,7 +106,7 @@ export const SearchContextProvider: React.FC<{
   const [searchKeywords, setSearchKeywords] = React.useState('');
   const [blockTypesFilter, setBlockTypesFilter] = React.useState<string[]>([]);
   const [problemTypesFilter, setProblemTypesFilter] = React.useState<string[]>([]);
-  const [publishedFilter, setPublishedFilter] = React.useState<PublishStatus[]>([]);
+  const [publishStatusFilter, setPublishStatusFilter] = React.useState<PublishStatus[]>([]);
   const [tagsFilter, setTagsFilter] = React.useState<string[]>([]);
   const [usageKey, setUsageKey] = useStateWithUrlSearchParam(
     '',
@@ -170,7 +171,7 @@ export const SearchContextProvider: React.FC<{
     searchKeywords,
     blockTypesFilter,
     problemTypesFilter,
-    publishedFilter,
+    publishStatusFilter,
     tagsFilter,
     sort,
     skipBlockTypeFetch,
@@ -186,8 +187,8 @@ export const SearchContextProvider: React.FC<{
       setBlockTypesFilter,
       problemTypesFilter,
       setProblemTypesFilter,
-      publishedFilter,
-      setPublishedFilter,
+      publishStatusFilter,
+      setPublishStatusFilter,
       tagsFilter,
       setTagsFilter,
       extraFilter,

--- a/src/search-manager/SearchManager.ts
+++ b/src/search-manager/SearchManager.ts
@@ -10,7 +10,11 @@ import { MeiliSearch, type Filter } from 'meilisearch';
 import { union } from 'lodash';
 
 import {
-  CollectionHit, ContentHit, SearchSortOption, forceArray,
+  CollectionHit,
+  ContentHit,
+  SearchSortOption,
+  forceArray,
+  type PublishStatus,
 } from './data/api';
 import { useContentSearchConnection, useContentSearchResults } from './data/apiHooks';
 
@@ -23,6 +27,8 @@ export interface SearchContextData {
   setBlockTypesFilter: React.Dispatch<React.SetStateAction<string[]>>;
   problemTypesFilter: string[];
   setProblemTypesFilter: React.Dispatch<React.SetStateAction<string[]>>;
+  publishedFilter: PublishStatus[];
+  setPublishedFilter: React.Dispatch<React.SetStateAction<PublishStatus[]>>;
   tagsFilter: string[];
   setTagsFilter: React.Dispatch<React.SetStateAction<string[]>>;
   blockTypes: Record<string, number>;
@@ -99,6 +105,7 @@ export const SearchContextProvider: React.FC<{
   const [searchKeywords, setSearchKeywords] = React.useState('');
   const [blockTypesFilter, setBlockTypesFilter] = React.useState<string[]>([]);
   const [problemTypesFilter, setProblemTypesFilter] = React.useState<string[]>([]);
+  const [publishedFilter, setPublishedFilter] = React.useState<PublishStatus[]>([]);
   const [tagsFilter, setTagsFilter] = React.useState<string[]>([]);
   const [usageKey, setUsageKey] = useStateWithUrlSearchParam(
     '',
@@ -163,6 +170,7 @@ export const SearchContextProvider: React.FC<{
     searchKeywords,
     blockTypesFilter,
     problemTypesFilter,
+    publishedFilter,
     tagsFilter,
     sort,
     skipBlockTypeFetch,
@@ -178,6 +186,8 @@ export const SearchContextProvider: React.FC<{
       setBlockTypesFilter,
       problemTypesFilter,
       setProblemTypesFilter,
+      publishedFilter,
+      setPublishedFilter,
       tagsFilter,
       setTagsFilter,
       extraFilter,

--- a/src/search-manager/data/apiHooks.ts
+++ b/src/search-manager/data/apiHooks.ts
@@ -54,7 +54,7 @@ export const useContentSearchResults = ({
   searchKeywords,
   blockTypesFilter = [],
   problemTypesFilter = [],
-  publishedFilter = [],
+  publishStatusFilter = [],
   tagsFilter = [],
   sort = [],
   skipBlockTypeFetch = false,
@@ -71,7 +71,7 @@ export const useContentSearchResults = ({
   blockTypesFilter?: string[];
   /** Only search for these problem types (e.g. `["choiceresponse", "multiplechoiceresponse"]`) */
   problemTypesFilter?: string[];
-  publishedFilter?: PublishStatus[];
+  publishStatusFilter?: PublishStatus[];
   /** Required tags (all must match), e.g. `["Difficulty > Hard", "Subject > Math"]` */
   tagsFilter?: string[];
   /** Sort search results using these options */
@@ -91,7 +91,7 @@ export const useContentSearchResults = ({
       searchKeywords,
       blockTypesFilter,
       problemTypesFilter,
-      publishedFilter,
+      publishStatusFilter,
       tagsFilter,
       sort,
     ],
@@ -107,7 +107,7 @@ export const useContentSearchResults = ({
         searchKeywords,
         blockTypesFilter,
         problemTypesFilter,
-        publishedFilter,
+        publishStatusFilter,
         tagsFilter,
         sort,
         // For infinite pagination of results, we can retrieve additional pages if requested.
@@ -133,6 +133,7 @@ export const useContentSearchResults = ({
     // The distribution of block type filter options
     blockTypes: pages?.[0]?.blockTypes ?? {},
     problemTypes: pages?.[0]?.problemTypes ?? {},
+    publishStatus: pages?.[0]?.publishStatus ?? {},
     status: query.status,
     isLoading: query.isLoading,
     isError: query.isError,

--- a/src/search-manager/data/apiHooks.ts
+++ b/src/search-manager/data/apiHooks.ts
@@ -10,6 +10,7 @@ import {
   fetchTagsThatMatchKeyword,
   getContentSearchConfig,
   fetchBlockTypes,
+  type PublishStatus,
 } from './api';
 
 /**
@@ -53,6 +54,7 @@ export const useContentSearchResults = ({
   searchKeywords,
   blockTypesFilter = [],
   problemTypesFilter = [],
+  publishedFilter = [],
   tagsFilter = [],
   sort = [],
   skipBlockTypeFetch = false,
@@ -69,6 +71,7 @@ export const useContentSearchResults = ({
   blockTypesFilter?: string[];
   /** Only search for these problem types (e.g. `["choiceresponse", "multiplechoiceresponse"]`) */
   problemTypesFilter?: string[];
+  publishedFilter?: PublishStatus[];
   /** Required tags (all must match), e.g. `["Difficulty > Hard", "Subject > Math"]` */
   tagsFilter?: string[];
   /** Sort search results using these options */
@@ -88,6 +91,7 @@ export const useContentSearchResults = ({
       searchKeywords,
       blockTypesFilter,
       problemTypesFilter,
+      publishedFilter,
       tagsFilter,
       sort,
     ],
@@ -103,6 +107,7 @@ export const useContentSearchResults = ({
         searchKeywords,
         blockTypesFilter,
         problemTypesFilter,
+        publishedFilter,
         tagsFilter,
         sort,
         // For infinite pagination of results, we can retrieve additional pages if requested.

--- a/src/search-manager/index.ts
+++ b/src/search-manager/index.ts
@@ -3,6 +3,7 @@ export { default as BlockTypeLabel } from './BlockTypeLabel';
 export { default as ClearFiltersButton } from './ClearFiltersButton';
 export { default as FilterByBlockType } from './FilterByBlockType';
 export { default as FilterByTags } from './FilterByTags';
+export { default as FilterByPublished } from './FilterByPublished';
 export { default as Highlight } from './Highlight';
 export { default as SearchKeywordsField } from './SearchKeywordsField';
 export { default as SearchSortWidget } from './SearchSortWidget';


### PR DESCRIPTION
## Description

Adds a filter widget:

![Screenshot 2024-10-18 at 6 02 06 PM](https://github.com/user-attachments/assets/8301ebb5-180c-4aeb-8404-ecc47aa3e02a)

And an "Unpublished changes" badge:

![Screenshot 2024-10-18 at 6 02 25 PM](https://github.com/user-attachments/assets/07ae7b8d-93d4-4b94-bc8d-d81ac0dc7be9)

## TODO

Get the filter working properly - add a filterable "publish_status" field on the backend Meilisearch index which is set to "published", "modified", or "never". It seems that this is necessary because Meilisearch can filter on things like `modified > 23849345` but NOT on things like `modified > last_published`
Fix i18n
Write tests