### PR TITLE
perf: don't load advanced info details before they're needed [FC-0062]

### DIFF
--- a/src/library-authoring/component-info/ComponentAdvancedInfo.tsx
+++ b/src/library-authoring/component-info/ComponentAdvancedInfo.tsx
@@ -20,7 +20,7 @@ import {
 } from '../data/apiHooks';
 import messages from './messages';
 
-export const ComponentAdvancedInfo: React.FC<Record<never, never>> = () => {
+const ComponentAdvancedInfoInner: React.FC<Record<never, never>> = () => {
   const intl = useIntl();
   const { readOnly, sidebarComponentUsageKey: usageKey } = useLibraryContext();
 
@@ -49,71 +49,78 @@ export const ComponentAdvancedInfo: React.FC<Record<never, never>> = () => {
   }, [editorRef, olxUpdater, intl]);
 
   return (
+    <>
+      <h3 className="h5"><FormattedMessage {...messages.advancedDetailsUsageKey} /></h3>
+      <p className="text-monospace small">{usageKey}</p>
+      <h3 className="h5"><FormattedMessage {...messages.advancedDetailsOLX} /></h3>
+      {(() => {
+        if (isOLXLoading) { return <LoadingSpinner />; }
+        if (!olx) { return <FormattedMessage {...messages.advancedDetailsOLXError} />; }
+        return (
+          <div className="mb-4">
+            {olxUpdater.error && (
+              <Alert variant="danger">
+                <p><strong><FormattedMessage {...messages.advancedDetailsOLXEditFailed} /></strong></p>
+                {/*
+                  TODO: fix the API so it returns 400 errors in a JSON object, not HTML 500 errors. Then display
+                  a useful error message here like "parsing the XML failed on line 3".
+                  (olxUpdater.error as Record<string, any>)?.customAttributes?.httpErrorResponseData.errorMessage
+                */}
+              </Alert>
+            )}
+            <CodeEditor key={usageKey} readOnly={!isEditingOLX} editorRef={editorRef}>{olx}</CodeEditor>
+            {
+              isEditingOLX ? (
+                <>
+                  <Button variant="primary" onClick={updateOlx} disabled={olxUpdater.isLoading}>
+                    <FormattedMessage {...messages.advancedDetailsOLXSaveButton} />
+                  </Button>
+                  <Button variant="link" onClick={() => setEditingOLX(false)} disabled={olxUpdater.isLoading}>
+                    <FormattedMessage {...messages.advancedDetailsOLXCancelButton} />
+                  </Button>
+                </>
+              ) : !readOnly ? (
+                <OverlayTrigger
+                  placement="bottom-start"
+                  overlay={(
+                    <Tooltip id="olx-edit-button">
+                      <FormattedMessage {...messages.advancedDetailsOLXEditWarning} />
+                    </Tooltip>
+                  )}
+                >
+                  <Button variant="link" onClick={() => setEditingOLX(true)}>
+                    <FormattedMessage {...messages.advancedDetailsOLXEditButton} />
+                  </Button>
+                </OverlayTrigger>
+              ) : (
+                null
+              )
+            }
+          </div>
+        );
+      })()}
+      <h3 className="h5"><FormattedMessage {...messages.advancedDetailsAssets} /></h3>
+      <ul>
+        { areAssetsLoading ? <li><LoadingSpinner /></li> : null }
+        { assets?.map(a => (
+          <li key={a.path}>
+            <a href={a.url}>{a.path}</a>{' '}
+            (<FormattedNumber value={a.size} notation="compact" unit="byte" unitDisplay="narrow" />)
+          </li>
+        )) }
+      </ul>
+    </>
+  );
+};
+
+export const ComponentAdvancedInfo: React.FC<Record<never, never>> = () => {
+  const intl = useIntl();
+  return (
     <Collapsible
       styling="basic"
       title={intl.formatMessage(messages.advancedDetailsTitle)}
     >
-      <dl>
-        <h3 className="h5"><FormattedMessage {...messages.advancedDetailsUsageKey} /></h3>
-        <p className="text-monospace small">{usageKey}</p>
-        <h3 className="h5"><FormattedMessage {...messages.advancedDetailsOLX} /></h3>
-        {(() => {
-          if (isOLXLoading) { return <LoadingSpinner />; }
-          if (!olx) { return <FormattedMessage {...messages.advancedDetailsOLXError} />; }
-          return (
-            <div className="mb-4">
-              {olxUpdater.error && (
-                <Alert variant="danger">
-                  <p><strong><FormattedMessage {...messages.advancedDetailsOLXEditFailed} /></strong></p>
-                  {/*
-                    TODO: fix the API so it returns 400 errors in a JSON object, not HTML 500 errors. Then display
-                    a useful error message here like "parsing the XML failed on line 3".
-                    (olxUpdater.error as Record<string, any>)?.customAttributes?.httpErrorResponseData.errorMessage
-                  */}
-                </Alert>
-              )}
-              <CodeEditor key={usageKey} readOnly={!isEditingOLX} editorRef={editorRef}>{olx}</CodeEditor>
-              {
-                isEditingOLX ? (
-                  <>
-                    <Button variant="primary" onClick={updateOlx} disabled={olxUpdater.isLoading}>
-                      <FormattedMessage {...messages.advancedDetailsOLXSaveButton} />
-                    </Button>
-                    <Button variant="link" onClick={() => setEditingOLX(false)} disabled={olxUpdater.isLoading}>
-                      <FormattedMessage {...messages.advancedDetailsOLXCancelButton} />
-                    </Button>
-                  </>
-                ) : !readOnly ? (
-                  <OverlayTrigger
-                    placement="bottom-start"
-                    overlay={(
-                      <Tooltip id="olx-edit-button">
-                        <FormattedMessage {...messages.advancedDetailsOLXEditWarning} />
-                      </Tooltip>
-                    )}
-                  >
-                    <Button variant="link" onClick={() => setEditingOLX(true)}>
-                      <FormattedMessage {...messages.advancedDetailsOLXEditButton} />
-                    </Button>
-                  </OverlayTrigger>
-                ) : (
-                  null
-                )
-              }
-            </div>
-          );
-        })()}
-        <h3 className="h5"><FormattedMessage {...messages.advancedDetailsAssets} /></h3>
-        <ul>
-          { areAssetsLoading ? <li><LoadingSpinner /></li> : null }
-          { assets?.map(a => (
-            <li key={a.path}>
-              <a href={a.url}>{a.path}</a>{' '}
-              (<FormattedNumber value={a.size} notation="compact" unit="byte" unitDisplay="narrow" />)
-            </li>
-          )) }
-        </ul>
-      </dl>
+      <ComponentAdvancedInfoInner />
     </Collapsible>
   );
 };


### PR DESCRIPTION
## Description

Currently when you open a component in the sidebar, the OLX and static assets are loaded from the backend API, even if you never click on the "Details" tab nor expand the "Advanced Details" collapsible.

This PR is a simple fix so that the OLX and static asset data are only loaded when needed - if the user actually expands and views the "Advanced details" section.

![Screenshot 2024-10-18 at 9 25 03 PM](https://github.com/user-attachments/assets/2eb0317e-e335-4dae-8fae-76719645f1c2)


## Testing instructions

Check your CMS request logs or browser's Network log when viewing a component in the sidebar, before and after this change.

Note there are some other inefficient requests, but we can tackle that another time.

Private ref: [FAL-3905](https://tasks.opencraft.com/browse/FAL-3905)