### PR TITLE
feat: add onComponentSelected callback function and componentPickerMode types [FC-0062]

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -61,6 +61,7 @@ const App = () => {
         <Route path="/library/create" element={<CreateLibrary />} />
         <Route path="/library/:libraryId/*" element={<LibraryLayout />} />
         <Route path="/component-picker" element={<ComponentPicker />} />
+        <Route path="/component-picker/multiple" element={<ComponentPicker componentPickerMode="multiple" />} />
         <Route path="/legacy/preview-changes/:usageKey" element={<PreviewChangesEmbed />} />
         <Route path="/course/:courseId/*" element={<CourseAuthoringRoutes />} />
         <Route path="/course_rerun/:courseId" element={<CourseRerun />} />

--- a/src/library-authoring/common/context.tsx
+++ b/src/library-authoring/common/context.tsx
@@ -26,6 +26,7 @@ export interface LibraryContextData {
   setCollectionId: (collectionId?: string) => void;
   // Whether we're in "component picker" mode
   componentPickerMode: boolean;
+  onComponentSelected?: (usageKey: string, category: string) => void;
   // Sidebar stuff - only one sidebar is active at any given time:
   sidebarBodyComponent: SidebarBodyComponentId | null;
   closeLibrarySidebar: () => void;
@@ -69,6 +70,8 @@ interface LibraryProviderProps {
   /** The component picker mode is a special mode where the user is selecting a component to add to a Unit (or another
    *  XBlock) */
   componentPickerMode?: boolean;
+  /** Function to call when a component is selected */
+  onComponentSelected?: (usageKey: string, category: string) => void;
   /** Only used for testing */
   initialSidebarComponentUsageKey?: string;
   /** Only used for testing */
@@ -83,6 +86,7 @@ export const LibraryProvider = ({
   libraryId,
   collectionId: collectionIdProp,
   componentPickerMode = false,
+  onComponentSelected,
   initialSidebarComponentUsageKey,
   initialSidebarCollectionId,
 }: LibraryProviderProps) => {
@@ -140,6 +144,7 @@ export const LibraryProvider = ({
     readOnly,
     isLoadingLibraryData,
     componentPickerMode,
+    onComponentSelected,
     sidebarBodyComponent,
     closeLibrarySidebar,
     openAddContentSidebar,
@@ -165,6 +170,7 @@ export const LibraryProvider = ({
     readOnly,
     isLoadingLibraryData,
     componentPickerMode,
+    onComponentSelected,
     sidebarBodyComponent,
     closeLibrarySidebar,
     openAddContentSidebar,

--- a/src/library-authoring/common/context.tsx
+++ b/src/library-authoring/common/context.tsx
@@ -256,6 +256,7 @@ export const LibraryProvider = ({
     onComponentSelected,
     addComponentToSelectedComponents,
     removeComponentFromSelectedComponents,
+    selectedComponents,
     sidebarBodyComponent,
     closeLibrarySidebar,
     openAddContentSidebar,

--- a/src/library-authoring/common/context.tsx
+++ b/src/library-authoring/common/context.tsx
@@ -193,6 +193,7 @@ export const LibraryProvider = ({
     selectedComponent: SelectedComponent,
   ) => {
     setSelectedComponents((prevSelectedComponents) => {
+      // istanbul ignore if: this should never happen
       if (prevSelectedComponents.some((component) => component.usageKey === selectedComponent.usageKey)) {
         return prevSelectedComponents;
       }
@@ -206,6 +207,7 @@ export const LibraryProvider = ({
     selectedComponent: SelectedComponent,
   ) => {
     setSelectedComponents((prevSelectedComponents) => {
+      // istanbul ignore if: this should never happen
       if (!prevSelectedComponents.some((component) => component.usageKey === selectedComponent.usageKey)) {
         return prevSelectedComponents;
       }

--- a/src/library-authoring/common/context.tsx
+++ b/src/library-authoring/common/context.tsx
@@ -15,6 +15,7 @@ interface SelectedComponent {
 }
 
 export type ComponentSelectedEvent = (selectedComponent: SelectedComponent) => void;
+export type ComponentSelectionChangedEvent = (selectedComponents: SelectedComponent[]) => void;
 
 type NoComponentPickerType = {
   componentPickerMode?: undefined;
@@ -95,16 +96,19 @@ const LibraryContext = React.createContext<LibraryContextData | undefined>(undef
 type NoComponentPickerProps = {
   componentPickerMode?: undefined;
   onComponentSelected?: never;
+  onChangeComponentSelection?: never;
 };
 
 export type ComponentPickerSingleProps = {
   componentPickerMode: 'single';
   onComponentSelected: ComponentSelectedEvent;
+  onChangeComponentSelection?: never;
 };
 
 export type ComponentPickerMultipleProps = {
   componentPickerMode: 'multiple';
   onComponentSelected?: never;
+  onChangeComponentSelection?: ComponentSelectionChangedEvent;
 };
 
 type ComponentPickerProps = NoComponentPickerProps | ComponentPickerSingleProps | ComponentPickerMultipleProps;
@@ -129,6 +133,7 @@ export const LibraryProvider = ({
   collectionId: collectionIdProp,
   componentPickerMode,
   onComponentSelected,
+  onChangeComponentSelection,
   initialSidebarComponentUsageKey,
   initialSidebarCollectionId,
 }: LibraryProviderProps) => {
@@ -183,7 +188,9 @@ export const LibraryProvider = ({
       if (prevSelectedComponents.some((component) => component.usageKey === selectedComponent.usageKey)) {
         return prevSelectedComponents;
       }
-      return [...prevSelectedComponents, selectedComponent];
+      const newSelectedComponents = [...prevSelectedComponents, selectedComponent];
+      onChangeComponentSelection?.(newSelectedComponents);
+      return newSelectedComponents;
     });
   }, []);
 
@@ -194,7 +201,11 @@ export const LibraryProvider = ({
       if (!prevSelectedComponents.some((component) => component.usageKey === selectedComponent.usageKey)) {
         return prevSelectedComponents;
       }
-      return prevSelectedComponents.filter((component) => component.usageKey !== selectedComponent.usageKey);
+      const newSelectedComponents = prevSelectedComponents.filter(
+        (component) => component.usageKey !== selectedComponent.usageKey,
+      );
+      onChangeComponentSelection?.(newSelectedComponents);
+      return newSelectedComponents;
     });
   }, []);
 
@@ -257,6 +268,7 @@ export const LibraryProvider = ({
     addComponentToSelectedComponents,
     removeComponentFromSelectedComponents,
     selectedComponents,
+    onChangeComponentSelection,
     sidebarBodyComponent,
     closeLibrarySidebar,
     openAddContentSidebar,

--- a/src/library-authoring/common/context.tsx
+++ b/src/library-authoring/common/context.tsx
@@ -9,6 +9,8 @@ import React, {
 import type { ContentLibrary } from '../data/api';
 import { useContentLibrary } from '../data/apiHooks';
 
+export type ComponentPickerMode = 'single' | 'multiple';
+
 export enum SidebarBodyComponentId {
   AddContent = 'add-content',
   Info = 'info',
@@ -25,7 +27,7 @@ export interface LibraryContextData {
   collectionId: string | undefined;
   setCollectionId: (collectionId?: string) => void;
   // Whether we're in "component picker" mode
-  componentPickerMode: boolean;
+  componentPickerMode?: ComponentPickerMode;
   onComponentSelected?: (usageKey: string, category: string) => void;
   // Sidebar stuff - only one sidebar is active at any given time:
   sidebarBodyComponent: SidebarBodyComponentId | null;
@@ -69,7 +71,7 @@ interface LibraryProviderProps {
   collectionId?: string;
   /** The component picker mode is a special mode where the user is selecting a component to add to a Unit (or another
    *  XBlock) */
-  componentPickerMode?: boolean;
+  componentPickerMode?: ComponentPickerMode;
   /** Function to call when a component is selected */
   onComponentSelected?: (usageKey: string, category: string) => void;
   /** Only used for testing */
@@ -85,7 +87,7 @@ export const LibraryProvider = ({
   children,
   libraryId,
   collectionId: collectionIdProp,
-  componentPickerMode = false,
+  componentPickerMode,
   onComponentSelected,
   initialSidebarComponentUsageKey,
   initialSidebarCollectionId,
@@ -134,7 +136,7 @@ export const LibraryProvider = ({
 
   const { data: libraryData, isLoading: isLoadingLibraryData } = useContentLibrary(libraryId);
 
-  const readOnly = componentPickerMode || !libraryData?.canEditLibrary;
+  const readOnly = !!componentPickerMode || !libraryData?.canEditLibrary;
 
   const context = useMemo<LibraryContextData>(() => ({
     libraryId,

--- a/src/library-authoring/component-info/ComponentInfo.tsx
+++ b/src/library-authoring/component-info/ComponentInfo.tsx
@@ -1,11 +1,14 @@
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Button,
-  Form,
   Tab,
   Tabs,
   Stack,
 } from '@openedx/paragon';
+import {
+  CheckBoxIcon,
+  CheckBoxOutlineBlank,
+} from '@openedx/paragon/icons';
 
 import { useLibraryContext } from '../common/context';
 import { ComponentMenu } from '../components';
@@ -46,32 +49,37 @@ const AddComponentWidget = () => {
           onComponentSelected({ usageKey, blockType: getBlockType(usageKey) });
         }}
       >
-        {intl.formatMessage(messages.addComponentToCourse)}
+        {intl.formatMessage(messages.componentPickerSingleSelect)}
       </Button>
     );
   }
 
   if (componentPickerMode === 'multiple') {
-    const handleChange = (event) => {
+    const isChecked = selectedComponents.some((component) => component.usageKey === usageKey);
+    const handleChange = () => {
       const selectedComponent = {
         usageKey,
         blockType: getBlockType(usageKey),
       };
-      if (event.target.checked) {
+      if (!isChecked) {
         addComponentToSelectedComponents(selectedComponent);
       } else {
         removeComponentFromSelectedComponents(selectedComponent);
       }
     };
 
-    const isChecked = selectedComponents.some((component) => component.usageKey === usageKey);
     return (
-      <Form.Checkbox checked={isChecked} onChange={handleChange}>
-        {intl.formatMessage(messages.addComponentToCourse)}
-      </Form.Checkbox>
+      <Button
+        variant="outline-primary"
+        iconBefore={isChecked ? CheckBoxIcon : CheckBoxOutlineBlank}
+        onClick={handleChange}
+      >
+        {intl.formatMessage(messages.componentPickerMultipleSelect)}
+      </Button>
     );
   }
 
+  // istanbul ignore next: this should never happen
   return null;
 };
 

--- a/src/library-authoring/component-info/ComponentInfo.tsx
+++ b/src/library-authoring/component-info/ComponentInfo.tsx
@@ -5,6 +5,7 @@ import {
   Tabs,
   Stack,
 } from '@openedx/paragon';
+import { useCallback } from 'react';
 
 import { useLibraryContext } from '../common/context';
 import { ComponentMenu } from '../components';
@@ -23,6 +24,7 @@ const ComponentInfo = () => {
     readOnly,
     openComponentEditor,
     componentPickerMode,
+    onComponentSelected,
   } = useLibraryContext();
 
   // istanbul ignore if: this should never happen
@@ -32,13 +34,9 @@ const ComponentInfo = () => {
 
   const canEdit = canEditComponent(usageKey);
 
-  const handleAddComponentToCourse = () => {
-    window.parent.postMessage({
-      usageKey,
-      type: 'pickerComponentSelected',
-      category: getBlockType(usageKey),
-    }, '*');
-  };
+  const handleAddComponentToCourse = useCallback(() => {
+    onComponentSelected?.(usageKey, getBlockType(usageKey));
+  }, [usageKey]);
 
   return (
     <Stack>

--- a/src/library-authoring/component-info/messages.ts
+++ b/src/library-authoring/component-info/messages.ts
@@ -166,15 +166,15 @@ const messages = defineMessages({
     defaultMessage: 'This component is not organized into any collection.',
     description: 'Message to display in manage collections section when component is not part of any collection.',
   },
-  addComponentToCourse: {
-    id: 'course-authoring.library-authoring.component.add-to-course',
-    defaultMessage: 'Add to Course',
+  componentPickerSingleSelect: {
+    id: 'course-authoring.library-authoring.component-picker.single-select',
+    defaultMessage: 'Add to Course', // TODO: Change this message to a generic one?
     description: 'Button to add component to course',
   },
-  addComponentToCourseError: {
-    id: 'course-authoring.library-authoring.component.add-to-course-error',
-    defaultMessage: 'Failed to add component to course',
-    description: 'Error message when adding component to course fails',
+  componentPickerMultipleSelect: {
+    id: 'course-authoring.library-authoring.component-picker.multiple-select',
+    defaultMessage: 'Select',
+    description: 'Button to select component',
   },
 });
 

--- a/src/library-authoring/component-picker/ComponentPicker.test.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.test.tsx
@@ -231,7 +231,7 @@ describe('<ComponentPicker />', () => {
 
     const sidebar = await screen.findByTestId('library-sidebar');
 
-    // Click the add component from the component sidebar
+    // Click the select component from the component sidebar
     fireEvent.click(within(sidebar).getByRole('button', { name: 'Select' }));
 
     await waitFor(() => expect(onChange).toHaveBeenCalledWith([
@@ -240,5 +240,12 @@ describe('<ComponentPicker />', () => {
         blockType: 'html',
       },
     ]));
+
+    onChange.mockClear();
+
+    // Click to deselect component from the component sidebar
+    fireEvent.click(within(sidebar).getByRole('button', { name: 'Select' }));
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith([]));
   });
 });

--- a/src/library-authoring/component-picker/ComponentPicker.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.tsx
@@ -19,8 +19,22 @@ const InnerComponentPicker: React.FC<LibraryComponentPickerProps> = ({ returnToL
   return <LibraryAuthoringPage returnToLibrarySelection={returnToLibrarySelection} />;
 };
 
+const defaultComponentSelectedCallback = (usageKey: string, category: string) => {
+  window.parent.postMessage({
+    usageKey,
+    type: 'pickerComponentSelected',
+    category,
+  }, '*');
+};
+
+interface ComponentPickerProps {
+  onComponentSelected?: (usageKey: string, category: string) => void;
+}
+
 // eslint-disable-next-line import/prefer-default-export
-export const ComponentPicker = () => {
+export const ComponentPicker: React.FC<ComponentPickerProps> = ({
+  onComponentSelected = defaultComponentSelectedCallback,
+}) => {
   const [currentStep, setCurrentStep] = useState('select-library');
   const [selectedLibrary, setSelectedLibrary] = useState('');
 
@@ -43,7 +57,7 @@ export const ComponentPicker = () => {
       </Stepper.Step>
 
       <Stepper.Step eventKey="pick-components" title="Pick some components">
-        <LibraryProvider libraryId={selectedLibrary} componentPickerMode>
+        <LibraryProvider libraryId={selectedLibrary} componentPickerMode onComponentSelected={onComponentSelected}>
           <InnerComponentPicker returnToLibrarySelection={returnToLibrarySelection} />
         </LibraryProvider>
       </Stepper.Step>

--- a/src/library-authoring/component-picker/ComponentPicker.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.tsx
@@ -25,12 +25,14 @@ const InnerComponentPicker: React.FC<LibraryComponentPickerProps> = ({ returnToL
   return <LibraryAuthoringPage returnToLibrarySelection={returnToLibrarySelection} />;
 };
 
+/** Default handler in single-select mode. Used by the legacy UI for adding a single selected component to a course. */
 const defaultComponentSelectedCallback: ComponentSelectedEvent = ({ usageKey, blockType }) => {
-  window.parent.postMessage({
-    usageKey,
-    type: 'pickerComponentSelected',
-    category: blockType,
-  }, '*');
+  window.parent.postMessage({ usageKey, type: 'pickerComponentSelected', category: blockType }, '*');
+};
+
+/** Default handler in multi-select mode. Used by the legacy UI for adding components to a problem bank. */
+const defaultSelectionChangedCallback: ComponentSelectionChangedEvent = (selections) => {
+  window.parent.postMessage({ type: 'pickerSelectionChanged', selections }, '*');
 };
 
 type ComponentPickerProps = {
@@ -50,7 +52,7 @@ export const ComponentPicker: React.FC<ComponentPickerProps> = ({
    * when the component picker is used in an iframe.
    */
   onComponentSelected = defaultComponentSelectedCallback,
-  onChangeComponentSelection,
+  onChangeComponentSelection = defaultSelectionChangedCallback,
 }) => {
   const [currentStep, setCurrentStep] = useState('select-library');
   const [selectedLibrary, setSelectedLibrary] = useState('');

--- a/src/library-authoring/component-picker/ComponentPicker.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
 import { Stepper } from '@openedx/paragon';
 
-import { type ComponentPickerMode, LibraryProvider, useLibraryContext } from '../common/context';
+import {
+  type ComponentSelectedEvent,
+  LibraryProvider,
+  useLibraryContext,
+} from '../common/context';
 import LibraryAuthoringPage from '../LibraryAuthoringPage';
 import LibraryCollectionPage from '../collections/LibraryCollectionPage';
 import SelectLibrary from './SelectLibrary';
@@ -19,18 +23,21 @@ const InnerComponentPicker: React.FC<LibraryComponentPickerProps> = ({ returnToL
   return <LibraryAuthoringPage returnToLibrarySelection={returnToLibrarySelection} />;
 };
 
-const defaultComponentSelectedCallback = (usageKey: string, category: string) => {
+const defaultComponentSelectedCallback: ComponentSelectedEvent = ({ usageKey, blockType }) => {
   window.parent.postMessage({
     usageKey,
     type: 'pickerComponentSelected',
-    category,
+    category: blockType,
   }, '*');
 };
 
-interface ComponentPickerProps {
-  onComponentSelected?: (usageKey: string, category: string) => void;
-  componentPickerMode?: ComponentPickerMode;
-}
+type ComponentPickerProps = {
+  componentPickerMode?: 'single',
+  onComponentSelected?: ComponentSelectedEvent,
+} | {
+  componentPickerMode: 'multiple'
+  onComponentSelected: never,
+};
 
 // eslint-disable-next-line import/prefer-default-export
 export const ComponentPicker: React.FC<ComponentPickerProps> = ({
@@ -53,6 +60,13 @@ export const ComponentPicker: React.FC<ComponentPickerProps> = ({
     setSelectedLibrary('');
   };
 
+  const libraryProviderProps = componentPickerMode === 'single' ? {
+    componentPickerMode,
+    onComponentSelected,
+  } : {
+    componentPickerMode,
+  };
+
   return (
     <Stepper
       activeKey={currentStep}
@@ -64,8 +78,7 @@ export const ComponentPicker: React.FC<ComponentPickerProps> = ({
       <Stepper.Step eventKey="pick-components" title="Pick some components">
         <LibraryProvider
           libraryId={selectedLibrary}
-          componentPickerMode={componentPickerMode}
-          onComponentSelected={onComponentSelected}
+          {...libraryProviderProps}
         >
           <InnerComponentPicker returnToLibrarySelection={returnToLibrarySelection} />
         </LibraryProvider>

--- a/src/library-authoring/component-picker/ComponentPicker.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Stepper } from '@openedx/paragon';
 
-import { LibraryProvider, useLibraryContext } from '../common/context';
+import { type ComponentPickerMode, LibraryProvider, useLibraryContext } from '../common/context';
 import LibraryAuthoringPage from '../LibraryAuthoringPage';
 import LibraryCollectionPage from '../collections/LibraryCollectionPage';
 import SelectLibrary from './SelectLibrary';
@@ -29,10 +29,15 @@ const defaultComponentSelectedCallback = (usageKey: string, category: string) =>
 
 interface ComponentPickerProps {
   onComponentSelected?: (usageKey: string, category: string) => void;
+  componentPickerMode?: ComponentPickerMode;
 }
 
 // eslint-disable-next-line import/prefer-default-export
 export const ComponentPicker: React.FC<ComponentPickerProps> = ({
+  componentPickerMode = 'single',
+  /** This default callback is used to send the selected component back to the parent window,
+   * when the component picker is used in an iframe.
+   */
   onComponentSelected = defaultComponentSelectedCallback,
 }) => {
   const [currentStep, setCurrentStep] = useState('select-library');
@@ -57,7 +62,11 @@ export const ComponentPicker: React.FC<ComponentPickerProps> = ({
       </Stepper.Step>
 
       <Stepper.Step eventKey="pick-components" title="Pick some components">
-        <LibraryProvider libraryId={selectedLibrary} componentPickerMode onComponentSelected={onComponentSelected}>
+        <LibraryProvider
+          libraryId={selectedLibrary}
+          componentPickerMode={componentPickerMode}
+          onComponentSelected={onComponentSelected}
+        >
           <InnerComponentPicker returnToLibrarySelection={returnToLibrarySelection} />
         </LibraryProvider>
       </Stepper.Step>

--- a/src/library-authoring/component-picker/ComponentPicker.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.tsx
@@ -3,6 +3,7 @@ import { Stepper } from '@openedx/paragon';
 
 import {
   type ComponentSelectedEvent,
+  type ComponentSelectionChangedEvent,
   LibraryProvider,
   useLibraryContext,
 } from '../common/context';
@@ -34,9 +35,11 @@ const defaultComponentSelectedCallback: ComponentSelectedEvent = ({ usageKey, bl
 type ComponentPickerProps = {
   componentPickerMode?: 'single',
   onComponentSelected?: ComponentSelectedEvent,
+  onChangeComponentSelection?: never,
 } | {
   componentPickerMode: 'multiple'
-  onComponentSelected: never,
+  onComponentSelected?: never,
+  onChangeComponentSelection?: ComponentSelectionChangedEvent,
 };
 
 // eslint-disable-next-line import/prefer-default-export
@@ -46,6 +49,7 @@ export const ComponentPicker: React.FC<ComponentPickerProps> = ({
    * when the component picker is used in an iframe.
    */
   onComponentSelected = defaultComponentSelectedCallback,
+  onChangeComponentSelection,
 }) => {
   const [currentStep, setCurrentStep] = useState('select-library');
   const [selectedLibrary, setSelectedLibrary] = useState('');
@@ -65,6 +69,7 @@ export const ComponentPicker: React.FC<ComponentPickerProps> = ({
     onComponentSelected,
   } : {
     componentPickerMode,
+    onChangeComponentSelection,
   };
 
   return (

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -77,9 +77,9 @@ export const ComponentMenu = ({ usageKey }: { usageKey: string }) => {
           <FormattedMessage {...messages.menuCopyToClipboard} />
         </Dropdown.Item>
         {collectionId && (
-        <Dropdown.Item onClick={removeFromCollection}>
-          <FormattedMessage {...messages.menuRemoveFromCollection} />
-        </Dropdown.Item>
+          <Dropdown.Item onClick={removeFromCollection}>
+            <FormattedMessage {...messages.menuRemoveFromCollection} />
+          </Dropdown.Item>
         )}
         <Dropdown.Item disabled>
           <FormattedMessage {...messages.menuAddToCollection} />
@@ -110,7 +110,7 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
   const displayName = formatted?.displayName ?? '';
 
   const handleAddComponentToCourse = () => {
-    onComponentSelected?.(usageKey, blockType);
+    onComponentSelected?.({ usageKey, blockType });
   };
 
   return (

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -7,7 +7,12 @@ import {
   Icon,
   IconButton,
 } from '@openedx/paragon';
-import { AddCircleOutline, MoreVert } from '@openedx/paragon/icons';
+import {
+  AddCircleOutline,
+  CheckBoxIcon,
+  CheckBoxOutlineBlank,
+  MoreVert,
+} from '@openedx/paragon/icons';
 
 import { STUDIO_CLIPBOARD_CHANNEL } from '../../constants';
 import { updateClipboard } from '../../generic/data/api';
@@ -89,11 +94,80 @@ export const ComponentMenu = ({ usageKey }: { usageKey: string }) => {
   );
 };
 
+interface AddComponentWidgetProps {
+  usageKey: string;
+  blockType: string;
+}
+
+const AddComponentWidget = ({ usageKey, blockType }: AddComponentWidgetProps) => {
+  const intl = useIntl();
+
+  const {
+    componentPickerMode,
+    onComponentSelected,
+    addComponentToSelectedComponents,
+    removeComponentFromSelectedComponents,
+    selectedComponents,
+  } = useLibraryContext();
+
+  // istanbul ignore if: this should never happen
+  if (!usageKey) {
+    throw new Error('usageKey is required');
+  }
+
+  // istanbul ignore if: this should never happen
+  if (!componentPickerMode) {
+    return null;
+  }
+
+  if (componentPickerMode === 'single') {
+    return (
+      <Button
+        variant="outline-primary"
+        iconBefore={AddCircleOutline}
+        onClick={() => {
+          onComponentSelected({ usageKey, blockType });
+        }}
+      >
+        <FormattedMessage {...messages.componentPickerSingleSelectTitle} />
+      </Button>
+    );
+  }
+
+  if (componentPickerMode === 'multiple') {
+    const isChecked = selectedComponents.some((component) => component.usageKey === usageKey);
+
+    const handleChange = () => {
+      const selectedComponent = {
+        usageKey,
+        blockType,
+      };
+      if (!isChecked) {
+        addComponentToSelectedComponents(selectedComponent);
+      } else {
+        removeComponentFromSelectedComponents(selectedComponent);
+      }
+    };
+
+    return (
+      <Button
+        variant="outline-primary"
+        iconBefore={isChecked ? CheckBoxIcon : CheckBoxOutlineBlank}
+        onClick={handleChange}
+      >
+        {intl.formatMessage(messages.componentPickerMultipleSelectTitle)}
+      </Button>
+    );
+  }
+
+  // istanbul ignore next: this should never happen
+  return null;
+};
+
 const ComponentCard = ({ contentHit }: ComponentCardProps) => {
   const {
     openComponentInfoSidebar,
     componentPickerMode,
-    onComponentSelected,
   } = useLibraryContext();
 
   const {
@@ -109,10 +183,6 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
   ) ?? '';/* eslint-enable */
   const displayName = formatted?.displayName ?? '';
 
-  const handleAddComponentToCourse = () => {
-    onComponentSelected?.({ usageKey, blockType });
-  };
-
   return (
     <BaseComponentCard
       componentType={blockType}
@@ -122,13 +192,7 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
       actions={(
         <ActionRow>
           {componentPickerMode ? (
-            <Button
-              variant="outline-primary"
-              iconBefore={AddCircleOutline}
-              onClick={handleAddComponentToCourse}
-            >
-              <FormattedMessage {...messages.addComponentToCourseButtonTitle} />
-            </Button>
+            <AddComponentWidget usageKey={usageKey} blockType={blockType} />
           ) : (
             <ComponentMenu usageKey={usageKey} />
           )}

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -93,6 +93,7 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
   const {
     openComponentInfoSidebar,
     componentPickerMode,
+    onComponentSelected,
   } = useLibraryContext();
 
   const {
@@ -109,11 +110,7 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
   const displayName = formatted?.displayName ?? '';
 
   const handleAddComponentToCourse = () => {
-    window.parent.postMessage({
-      usageKey,
-      type: 'pickerComponentSelected',
-      category: blockType,
-    }, '*');
+    onComponentSelected?.(usageKey, blockType);
   };
 
   return (

--- a/src/library-authoring/components/messages.ts
+++ b/src/library-authoring/components/messages.ts
@@ -91,15 +91,15 @@ const messages = defineMessages({
     defaultMessage: 'Failed to undo delete collection operation',
     description: 'Message to display on failure to undo delete collection',
   },
-  addComponentToCourseButtonTitle: {
-    id: 'course-authoring.library-authoring.component-picker.button.title',
+  componentPickerSingleSelectTitle: {
+    id: 'course-authoring.library-authoring.component-picker.single..title',
     defaultMessage: 'Add',
     description: 'Button title for picking a component',
   },
-  addComponentToCourseError: {
-    id: 'course-authoring.library-authoring.component-picker.error',
-    defaultMessage: 'Failed to add component to course',
-    description: 'Error message for failed to add component to course',
+  componentPickerMultipleSelectTitle: {
+    id: 'course-authoring.library-authoring.component-picker.multiple.title',
+    defaultMessage: 'Select',
+    description: 'Button title for selecting multiple components',
   },
 });
 


### PR DESCRIPTION
## Description
This PR refactors the `ComponentPicker` and adds the multiple-select feature to be used in https://github.com/openedx/edx-platform/pull/35679 and https://github.com/openedx/frontend-app-authoring/issues/1173.

![image](https://github.com/user-attachments/assets/aa93e411-feab-4553-96a3-c8905bc0bfe4)

## More information
- Part of:
  - https://github.com/openedx/frontend-app-authoring/issues/1173

## Testing instructions
- This can be tested changing [this](https://github.com/open-craft/frontend-app-course-authoring/blob/037ffcf10bae3f1407310b2c161512d18ea091b1/src/library-authoring/component-picker/ComponentPicker.tsx#L44) following line from `'single'` to `'multiple'` and opening http://apps.local.edly.io:2001/course-authoring/component-picker
___
Private ref: [FAL-3901}](https://tasks.opencraft.com/browse/FAL-3901)