### PR TITLE
fix: this repo has been renamed to frontend-app-authoring

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-APP_ID='course-authoring'
+APP_ID='authoring'
 NODE_ENV='production'
 ACCESS_TOKEN_COOKIE_NAME=''
 BASE_URL=''

--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-APP_ID='course-authoring'
+APP_ID='authoring'
 NODE_ENV='development'
 ACCESS_TOKEN_COOKIE_NAME='edx-jwt-cookie-header-payload'
 BASE_URL='http://localhost:2001'

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,4 @@
-APP_ID='course-authoring'
+APP_ID='authoring'
 ACCESS_TOKEN_COOKIE_NAME='edx-jwt-cookie-header-payload'
 BASE_URL='http://localhost:2001'
 CREDENTIALS_BASE_URL='http://localhost:18150'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-# The following users are the maintainers of all frontend-app-course-authoring files
+# The following users are the maintainers of all frontend-app-authoring files
 *       @openedx/2u-tnl

--- a/README.rst
+++ b/README.rst
@@ -339,8 +339,8 @@ The production build is created with ``npm run build``.
    :target: https://travis-ci.com/edx/frontend-app-course-authoring
 .. |Codecov| image:: https://codecov.io/gh/edx/frontend-app-course-authoring/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/edx/frontend-app-course-authoring
-.. |license| image:: https://img.shields.io/npm/l/@edx/frontend-app-course-authoring.svg
-   :target: @edx/frontend-app-course-authoring
+.. |license| image:: https://img.shields.io/npm/l/@edx/frontend-app-authoring.svg
+   :target: @edx/frontend-app-authoring
 
 Internationalization
 ====================

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,11 +4,11 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: 'frontend-app-course-authoring'
-  description: "The frontend (MFE) for Open edX Course Authoring (aka Studio)"
+  name: 'frontend-app-authoring'
+  description: "The frontend (MFE) for Open edX Authoring (aka Studio)"
   links:
-    - url: "https://github.com/openedx/frontend-app-course-authoring"
-      title: "Frontend app course authoring"
+    - url: "https://github.com/openedx/frontend-app-authoring"
+      title: "Frontend app authoring"
       icon: "Web"
   annotations:
     openedx.org/arch-interest-groups: ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@edx/frontend-app-course-authoring",
+  "name": "@edx/frontend-app-authoring",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@edx/frontend-app-course-authoring",
+      "name": "@edx/frontend-app-authoring",
       "version": "0.1.0",
       "license": "AGPL-3.0",
       "dependencies": {
@@ -20942,14 +20942,14 @@
       "name": "@openedx-plugins/course-app-calculator",
       "version": "0.1.0",
       "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "prop-types": "*",
         "react": "*"
       },
       "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
           "optional": true
         }
       }
@@ -20958,14 +20958,14 @@
       "name": "@openedx-plugins/course-app-edxnotes",
       "version": "0.1.0",
       "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "prop-types": "*",
         "react": "*"
       },
       "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
           "optional": true
         }
       }
@@ -20974,7 +20974,7 @@
       "name": "@openedx-plugins/course-app-learning_assistant",
       "version": "0.1.0",
       "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "prop-types": "*",
@@ -20982,7 +20982,7 @@
         "yup": "*"
       },
       "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
           "optional": true
         }
       }
@@ -20991,7 +20991,7 @@
       "name": "@openedx-plugins/course-app-live",
       "version": "0.1.0",
       "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "@reduxjs/toolkit": "*",
@@ -21003,7 +21003,7 @@
         "yup": "*"
       },
       "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
           "optional": true
         }
       }
@@ -21012,7 +21012,7 @@
       "name": "@openedx-plugins/course-app-ora_settings",
       "version": "0.1.0",
       "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "prop-types": "*",
@@ -21021,7 +21021,7 @@
         "yup": "*"
       },
       "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
           "optional": true
         }
       }
@@ -21030,7 +21030,7 @@
       "name": "@openedx-plugins/course-app-proctoring",
       "version": "0.1.0",
       "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "classnames": "*",
@@ -21040,7 +21040,7 @@
         "react": "*"
       },
       "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
           "optional": true
         }
       }
@@ -21049,7 +21049,7 @@
       "name": "@openedx-plugins/course-app-progress",
       "version": "0.1.0",
       "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "prop-types": "*",
@@ -21057,7 +21057,7 @@
         "yup": "*"
       },
       "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
           "optional": true
         }
       }
@@ -21066,7 +21066,7 @@
       "name": "@openedx-plugins/course-app-teams",
       "version": "0.1.0",
       "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "formik": "*",
@@ -21076,7 +21076,7 @@
         "yup": "*"
       },
       "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
           "optional": true
         }
       }
@@ -21085,7 +21085,7 @@
       "name": "@openedx-plugins/course-app-wiki",
       "version": "0.1.0",
       "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "prop-types": "*",
@@ -21093,7 +21093,7 @@
         "yup": "*"
       },
       "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
           "optional": true
         }
       }
@@ -21102,7 +21102,7 @@
       "name": "@openedx-plugins/course-app-xpert_unit_summary",
       "version": "0.1.0",
       "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "formik": "*",
@@ -21113,7 +21113,7 @@
         "yup": "*"
       },
       "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@edx/frontend-app-course-authoring",
+  "name": "@edx/frontend-app-authoring",
   "version": "0.1.0",
   "description": "Frontend application template",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openedx/frontend-app-course-authoring.git"
+    "url": "git+https://github.com/openedx/frontend-app-authoring.git"
   },
   "browserslist": [
     "extends @edx/browserslist-config"
@@ -18,7 +18,7 @@
     "snapshot": "TZ=UTC fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
     "start:with-theme": "paragon install-theme && npm start && npm install",
-    "dev": "PUBLIC_PATH=/course-authoring/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
+    "dev": "PUBLIC_PATH=/authoring/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
     "test": "TZ=UTC fedx-scripts jest --coverage --passWithNoTests",
     "test:ci": "TZ=UTC fedx-scripts jest --silent --coverage --passWithNoTests",
     "types": "tsc --noEmit"
@@ -30,12 +30,12 @@
   },
   "author": "edX",
   "license": "AGPL-3.0",
-  "homepage": "https://github.com/openedx/frontend-app-course-authoring#readme",
+  "homepage": "https://github.com/openedx/frontend-app-authoring#readme",
   "publishConfig": {
     "access": "public"
   },
   "bugs": {
-    "url": "https://github.com/openedx/frontend-app-course-authoring/issues"
+    "url": "https://github.com/openedx/frontend-app-authoring/issues"
   },
   "dependencies": {
     "@codemirror/lang-html": "^6.0.0",

--- a/plugins/course-apps/calculator/package.json
+++ b/plugins/course-apps/calculator/package.json
@@ -3,14 +3,14 @@
     "version": "0.1.0",
     "description": "Calculator configuration for courses using it",
     "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "prop-types": "*",
         "react": "*"
     },
     "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
             "optional": true
         }
     }

--- a/plugins/course-apps/edxnotes/package.json
+++ b/plugins/course-apps/edxnotes/package.json
@@ -3,14 +3,14 @@
     "version": "0.1.0",
     "description": "edxnotes configuration for courses using it",
     "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "prop-types": "*",
         "react": "*"
     },
     "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
             "optional": true
         }
     }

--- a/plugins/course-apps/learning_assistant/package.json
+++ b/plugins/course-apps/learning_assistant/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "description": "Learning Assistant configuration for courses using it",
     "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "prop-types": "*",
@@ -11,7 +11,7 @@
         "yup": "*"
     },
     "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
             "optional": true
         }
     }

--- a/plugins/course-apps/live/package.json
+++ b/plugins/course-apps/live/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "description": "Live course configuration for courses using it",
     "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "@reduxjs/toolkit": "*",
@@ -15,7 +15,7 @@
         "yup": "*"
     },
     "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
             "optional": true
         }
     }

--- a/plugins/course-apps/ora_settings/package.json
+++ b/plugins/course-apps/ora_settings/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "description": "Open Response Assessment configuration for courses using it",
     "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "prop-types": "*",
@@ -12,7 +12,7 @@
         "yup": "*"
     },
     "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
             "optional": true
         }
     }

--- a/plugins/course-apps/proctoring/package.json
+++ b/plugins/course-apps/proctoring/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "description": "Proctoring configuration for courses using it",
     "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "classnames": "*",
@@ -13,7 +13,7 @@
         "moment": "*"
     },
     "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
             "optional": true
         }
     }

--- a/plugins/course-apps/progress/package.json
+++ b/plugins/course-apps/progress/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "description": "Progress configuration for courses using it",
     "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "prop-types": "*",
@@ -11,7 +11,7 @@
         "yup": "*"
     },
     "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
             "optional": true
         }
     }

--- a/plugins/course-apps/teams/package.json
+++ b/plugins/course-apps/teams/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "description": "Teams configuration for courses using it",
     "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "formik": "*",
@@ -13,7 +13,7 @@
         "yup": "*"
     },
     "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
             "optional": true
         }
     }

--- a/plugins/course-apps/wiki/package.json
+++ b/plugins/course-apps/wiki/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "description": "Wiki configuration for courses using it",
     "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "prop-types": "*",
@@ -11,7 +11,7 @@
         "yup": "*"
     },
     "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
             "optional": true
         }
     }

--- a/plugins/course-apps/xpert_unit_summary/package.json
+++ b/plugins/course-apps/xpert_unit_summary/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "description": "Xpert Unit Summaries configuration for courses using it",
     "peerDependencies": {
-        "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-app-authoring": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "formik": "*",
@@ -14,7 +14,7 @@
         "react-router-dom": "*"
     },
     "peerDependenciesMeta": {
-        "@edx/frontend-app-course-authoring": {
+        "@edx/frontend-app-authoring": {
             "optional": true
         }
     }


### PR DESCRIPTION
After I updated `tutor-mfe`, I wasn't able to run this with `npm run dev` because it had `PUBLIC_PATH=/course-authoring/` specified. Then I realized there were still a whole lot more things that need to be updated.

This PR changes the name of the npm package. I'm not sure if that will cause any issues? It's working fine on my devstack though.