### PR TITLE
feat: Show published components on content picker

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -212,6 +212,11 @@ const LibraryAuthoringPage = ({ returnToLibrarySelection }: LibraryAuthoringPage
     />
   ) : undefined;
 
+  const extraFilter = [`context_key = "${libraryId}"`];
+  if (componentPickerMode) {
+    extraFilter.push('last_published IS NOT NULL');
+  }
+
   return (
     <div className="d-flex">
       <div className="flex-grow-1">
@@ -230,7 +235,7 @@ const LibraryAuthoringPage = ({ returnToLibrarySelection }: LibraryAuthoringPage
         )}
         <Container className="px-4 mt-4 mb-5 library-authoring-page">
           <SearchContextProvider
-            extraFilter={`context_key = "${libraryId}"`}
+            extraFilter={extraFilter}
           >
             <SubHeader
               title={<SubHeaderTitle title={libraryData.title} />}

--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -148,6 +148,7 @@ const LibraryAuthoringPage = ({ returnToLibrarySelection }: LibraryAuthoringPage
     libraryData,
     isLoadingLibraryData,
     componentPickerMode,
+    showOnlyPublished,
     sidebarBodyComponent,
     openInfoSidebar,
   } = useLibraryContext();
@@ -213,7 +214,7 @@ const LibraryAuthoringPage = ({ returnToLibrarySelection }: LibraryAuthoringPage
   ) : undefined;
 
   const extraFilter = [`context_key = "${libraryId}"`];
-  if (componentPickerMode) {
+  if (showOnlyPublished) {
     extraFilter.push('last_published IS NOT NULL');
   }
 

--- a/src/library-authoring/LibraryRecentlyModified.tsx
+++ b/src/library-authoring/LibraryRecentlyModified.tsx
@@ -56,11 +56,21 @@ const RecentlyModified: React.FC<Record<never, never>> = () => {
 };
 
 const LibraryRecentlyModified: React.FC<Record<never, never>> = () => {
-  const { libraryId } = useLibraryContext();
+  const { libraryId, componentPickerMode } = useLibraryContext();
+
+  const extraFilter = [`context_key = "${libraryId}"`];
+  if (componentPickerMode) {
+    extraFilter.push('last_published IS NOT NULL');
+  }
+
   return (
     <SearchContextProvider
-      extraFilter={`context_key = "${libraryId}"`}
-      overrideSearchSortOrder={SearchSortOption.RECENTLY_MODIFIED}
+      extraFilter={extraFilter}
+      overrideSearchSortOrder={
+        componentPickerMode
+          ? SearchSortOption.RECENTLY_PUBLISHED
+          : SearchSortOption.RECENTLY_MODIFIED
+      }
     >
       <RecentlyModified />
     </SearchContextProvider>

--- a/src/library-authoring/LibraryRecentlyModified.tsx
+++ b/src/library-authoring/LibraryRecentlyModified.tsx
@@ -56,10 +56,10 @@ const RecentlyModified: React.FC<Record<never, never>> = () => {
 };
 
 const LibraryRecentlyModified: React.FC<Record<never, never>> = () => {
-  const { libraryId, componentPickerMode } = useLibraryContext();
+  const { libraryId, showOnlyPublished } = useLibraryContext();
 
   const extraFilter = [`context_key = "${libraryId}"`];
-  if (componentPickerMode) {
+  if (showOnlyPublished) {
     extraFilter.push('last_published IS NOT NULL');
   }
 
@@ -67,7 +67,7 @@ const LibraryRecentlyModified: React.FC<Record<never, never>> = () => {
     <SearchContextProvider
       extraFilter={extraFilter}
       overrideSearchSortOrder={
-        componentPickerMode
+        showOnlyPublished
           ? SearchSortOption.RECENTLY_PUBLISHED
           : SearchSortOption.RECENTLY_MODIFIED
       }

--- a/src/library-authoring/__mocks__/collection-search.json
+++ b/src/library-authoring/__mocks__/collection-search.json
@@ -34,6 +34,10 @@
             "key": [
               "my-first-collection"
             ]
+          },
+          "published": {
+            "display_name": "Introduction to Testing",
+            "description": "Testing"
           }
         },
         {
@@ -64,6 +68,10 @@
             "key": [
               "my-first-collection"
             ]
+          },
+          "published": {
+            "display_name": "Second Text Component",
+            "description": "Second Testing"
           }
         },
         {
@@ -97,6 +105,10 @@
               "my-first-collection",
               "my-second-collection"
             ]
+          },
+          "published": {
+            "display_name": "Third Text component",
+            "description": "Third Testing"
           }
         },
         {
@@ -128,6 +140,10 @@
             "key": [
               "my-first-collection"
             ]
+          },
+          "published": {
+            "display_name": "Text 4",
+            "description": "Testing 4"
           }
         },
         {
@@ -159,6 +175,10 @@
             "key": [
               "my-first-collection"
             ]
+          },
+          "published": {
+            "display_name": "Blank Problem",
+            "description": "Problem"
           }
         }
       ],

--- a/src/library-authoring/__mocks__/library-search.json
+++ b/src/library-authoring/__mocks__/library-search.json
@@ -26,7 +26,11 @@
           "block_type": "html",
           "context_key": "lib:Axim:TEST",
           "org": "Axim",
-          "access_id": 15
+          "access_id": 15,
+          "published": {
+            "display_name": "Introduction to Testing",
+            "description": "Testing"
+          }
         },
         {
           "id": "lbaximtesthtml73a22298-bcd9-4f4c-ae34-0bc2b0612480-46b4a7f2",
@@ -48,7 +52,11 @@
           "block_type": "html",
           "context_key": "lib:Axim:TEST",
           "org": "Axim",
-          "access_id": 15
+          "access_id": 15,
+          "published": {
+            "display_name": "Second Text Component",
+            "description": "Second Testing"
+          }
         },
         {
           "id": "lbaximtesthtmlbe5b5db9-26ba-4fac-86af-654538c70b5e-73dbaa95",
@@ -71,7 +79,11 @@
           "block_type": "html",
           "context_key": "lib:Axim:TEST",
           "org": "Axim",
-          "access_id": 15
+          "access_id": 15,
+          "published": {
+            "display_name": "Third Text component",
+            "description": "Third Testing"
+          }
         },
         {
           "id": "lbaximtesthtmle59e8c73-4056-4894-bca4-062781fb3f68-46a404b2",
@@ -94,7 +106,11 @@
           "block_type": "html",
           "context_key": "lib:Axim:TEST",
           "org": "Axim",
-          "access_id": 15
+          "access_id": 15,
+          "published": {
+            "display_name": "Text 4",
+            "description": "Testing 4"
+          }
         },
         {
           "id": "lbaximtestproblemf16116c9-516e-4bb9-b99e-103599f62417-f2798115",
@@ -117,7 +133,11 @@
           "block_type": "problem",
           "context_key": "lib:Axim:TEST",
           "org": "Axim",
-          "access_id": 15
+          "access_id": 15,
+          "published": {
+            "display_name": "Blank Problem",
+            "description": "Problem"
+          }
         },
         {
           "id": "lbaximtestproblem2ace6b9b-6620-413c-a66f-19c797527f34-3a7973b7",
@@ -143,7 +163,11 @@
           "block_type": "problem",
           "context_key": "lib:Axim:TEST",
           "org": "Axim",
-          "access_id": 15
+          "access_id": 15,
+          "published": {
+            "display_name": "Multiple Choice Problem",
+            "description": "Problem"
+          }
         },
         {
           "id": "lbaximtestproblem7d7e98ba-3ac9-4aa8-8946-159129b39a28-3a7973b7",
@@ -169,7 +193,11 @@
           "block_type": "problem",
           "context_key": "lib:Axim:TEST",
           "org": "Axim",
-          "access_id": 15
+          "access_id": 15,
+          "published": {
+            "display_name": "Single Choice Problem",
+            "description": "Problem"
+          }
         },
         {
           "id": "lbaximtestproblem4e1a72f9-ac93-42aa-a61c-ab5f9698c398-3a7973b7",
@@ -195,7 +223,11 @@
           "block_type": "problem",
           "context_key": "lib:Axim:TEST",
           "org": "Axim",
-          "access_id": 15
+          "access_id": 15,
+          "published": {
+            "display_name": "Numerical Response Problem",
+            "description": "Problem"
+          }
         },
         {
           "id": "lbaximtestproblemad483625-ade2-4712-88d8-c9743abbd291-3a7973b7",
@@ -221,7 +253,11 @@
           "block_type": "problem",
           "context_key": "lib:Axim:TEST",
           "org": "Axim",
-          "access_id": 15
+          "access_id": 15,
+          "published": {
+            "display_name": "Option Response Problem",
+            "description": "Problem"
+          }
         },
         {
           "id": "lbaximtestproblemb4c859cb-de70-421a-917b-e6e01ce44bd8-3a7973b7",
@@ -247,7 +283,11 @@
           "block_type": "problem",
           "context_key": "lib:Axim:TEST",
           "org": "Axim",
-          "access_id": 15
+          "access_id": 15,
+          "published": {
+            "display_name": "String Response Problem",
+            "description": "Problem"
+          }
         }
       ],
       "query": "",

--- a/src/library-authoring/__mocks__/libraryComponentsMock.ts
+++ b/src/library-authoring/__mocks__/libraryComponentsMock.ts
@@ -9,6 +9,7 @@ export default [
       content: {
         htmlContent: 'This is a text: ID=1',
       },
+      description: 'This is a text: ID=1',
     },
     tags: {
       level0: ['1', '2', '3'],
@@ -25,6 +26,7 @@ export default [
       content: {
         htmlContent: 'This is a text: ID=2',
       },
+      description: 'This is a text: ID=2',
     },
     tags: {
       level0: ['1', '2', '3'],
@@ -68,6 +70,7 @@ export default [
       content: {
         capaContent: 'This is a problem: ID=5',
       },
+      description: 'This is a problem: ID=5',
     },
     blockType: 'problem',
   },
@@ -81,6 +84,7 @@ export default [
       content: {
         capaContent: 'This is a problem: ID=6',
       },
+      description: 'This is a problem: ID=6',
     },
     blockType: 'problem',
   },

--- a/src/library-authoring/__mocks__/libraryComponentsMock.ts
+++ b/src/library-authoring/__mocks__/libraryComponentsMock.ts
@@ -3,6 +3,7 @@ export default [
     id: '1',
     usageKey: 'lb:org:lib:html:1',
     displayName: 'Text Component 1',
+    description: 'This is a text: ID=1',
     formatted: {
       displayName: 'Text Component 1',
       content: {
@@ -18,6 +19,7 @@ export default [
     id: '2',
     usageKey: 'lb:org:lib:html:2',
     displayName: 'Text Component 2',
+    description: 'This is a text: ID=2',
     formatted: {
       displayName: 'Text Component 2',
       content: {
@@ -60,6 +62,7 @@ export default [
     id: '5',
     usageKey: 'lb:org:lib:problem:5',
     displayName: 'Problem',
+    description: 'This is a problem: ID=5',
     formatted: {
       displayName: 'Problem',
       content: {
@@ -72,6 +75,7 @@ export default [
     id: '6',
     usageKey: 'lb:org:lib:problem:6',
     displayName: 'Problem',
+    description: 'This is a problem: ID=6',
     formatted: {
       displayName: 'Problem',
       content: {

--- a/src/library-authoring/collections/LibraryCollectionPage.tsx
+++ b/src/library-authoring/collections/LibraryCollectionPage.tsx
@@ -175,6 +175,11 @@ const LibraryCollectionPage = () => {
     />
   );
 
+  const extraFilter = [`context_key = "${libraryId}"`, `collections.key = "${collectionId}"`];
+  if (componentPickerMode) {
+    extraFilter.push('last_published IS NOT NULL');
+  }
+
   return (
     <div className="d-flex">
       <div className="flex-grow-1">
@@ -189,7 +194,7 @@ const LibraryCollectionPage = () => {
         )}
         <Container size="xl" className="px-4 mt-4 mb-5 library-authoring-page">
           <SearchContextProvider
-            extraFilter={[`context_key = "${libraryId}"`, `collections.key = "${collectionId}"`]}
+            extraFilter={extraFilter}
             overrideQueries={{ collections: { limit: 0 } }}
           >
             <SubHeader

--- a/src/library-authoring/collections/LibraryCollectionPage.tsx
+++ b/src/library-authoring/collections/LibraryCollectionPage.tsx
@@ -107,6 +107,7 @@ const LibraryCollectionPage = () => {
     sidebarBodyComponent,
     openCollectionInfoSidebar,
     componentPickerMode,
+    showOnlyPublished,
     setCollectionId,
   } = useLibraryContext();
 
@@ -176,7 +177,7 @@ const LibraryCollectionPage = () => {
   );
 
   const extraFilter = [`context_key = "${libraryId}"`, `collections.key = "${collectionId}"`];
-  if (componentPickerMode) {
+  if (showOnlyPublished) {
     extraFilter.push('last_published IS NOT NULL');
   }
 

--- a/src/library-authoring/common/context.tsx
+++ b/src/library-authoring/common/context.tsx
@@ -26,6 +26,8 @@ export interface LibraryContextData {
   setCollectionId: (collectionId?: string) => void;
   // Whether we're in "component picker" mode
   componentPickerMode: boolean;
+  // Only show published components
+  showOnlyPublished: boolean;
   // Sidebar stuff - only one sidebar is active at any given time:
   sidebarBodyComponent: SidebarBodyComponentId | null;
   closeLibrarySidebar: () => void;
@@ -69,6 +71,7 @@ interface LibraryProviderProps {
   /** The component picker mode is a special mode where the user is selecting a component to add to a Unit (or another
    *  XBlock) */
   componentPickerMode?: boolean;
+  showOnlyPublished?: boolean;
   /** Only used for testing */
   initialSidebarComponentUsageKey?: string;
   /** Only used for testing */
@@ -83,6 +86,7 @@ export const LibraryProvider = ({
   libraryId,
   collectionId: collectionIdProp,
   componentPickerMode = false,
+  showOnlyPublished = false,
   initialSidebarComponentUsageKey,
   initialSidebarCollectionId,
 }: LibraryProviderProps) => {
@@ -140,6 +144,7 @@ export const LibraryProvider = ({
     readOnly,
     isLoadingLibraryData,
     componentPickerMode,
+    showOnlyPublished,
     sidebarBodyComponent,
     closeLibrarySidebar,
     openAddContentSidebar,
@@ -165,6 +170,7 @@ export const LibraryProvider = ({
     readOnly,
     isLoadingLibraryData,
     componentPickerMode,
+    showOnlyPublished,
     sidebarBodyComponent,
     closeLibrarySidebar,
     openAddContentSidebar,

--- a/src/library-authoring/component-info/ComponentInfoHeader.test.tsx
+++ b/src/library-authoring/component-info/ComponentInfoHeader.test.tsx
@@ -8,7 +8,7 @@ import {
   initializeMocks,
 } from '../../testUtils';
 import { mockContentLibrary } from '../data/api.mocks';
-import { getXBlockFieldsApiUrl } from '../data/api';
+import { getXBlockFieldsVersionApiUrl, getXBlockFieldsApiUrl } from '../data/api';
 import { LibraryProvider } from '../common/context';
 import ComponentInfoHeader from './ComponentInfoHeader';
 
@@ -39,7 +39,7 @@ describe('<ComponentInfoHeader />', () => {
   beforeEach(() => {
     const mocks = initializeMocks();
     axiosMock = mocks.axiosMock;
-    axiosMock.onGet(getXBlockFieldsApiUrl(usageKey)).reply(200, xBlockFields);
+    axiosMock.onGet(getXBlockFieldsVersionApiUrl(usageKey, 'draft')).reply(200, xBlockFields);
     mockShowToast = mocks.mockShowToast;
   });
 
@@ -91,7 +91,7 @@ describe('<ComponentInfoHeader />', () => {
   });
 
   it('should close edit library title on press Escape', async () => {
-    const url = getXBlockFieldsApiUrl(usageKey);
+    const url = getXBlockFieldsVersionApiUrl(usageKey, 'draft');
     axiosMock.onPost(url).reply(200);
     render();
 

--- a/src/library-authoring/component-info/ComponentInfoHeader.tsx
+++ b/src/library-authoring/component-info/ComponentInfoHeader.tsx
@@ -20,6 +20,7 @@ const ComponentInfoHeader = () => {
   const {
     sidebarComponentUsageKey: usageKey,
     readOnly,
+    showOnlyPublished,
   } = useLibraryContext();
 
   // istanbul ignore next
@@ -28,7 +29,7 @@ const ComponentInfoHeader = () => {
   }
   const {
     data: xblockFields,
-  } = useXBlockFields(usageKey);
+  } = useXBlockFields(usageKey, showOnlyPublished ? 'published' : 'draft');
 
   const updateMutation = useUpdateXBlockFields(usageKey);
   const { showToast } = useContext(ToastContext);

--- a/src/library-authoring/component-info/ComponentPreview.tsx
+++ b/src/library-authoring/component-info/ComponentPreview.tsx
@@ -15,7 +15,7 @@ interface ModalComponentPreviewProps {
 
 const ModalComponentPreview = ({ isOpen, close, usageKey }: ModalComponentPreviewProps) => {
   const intl = useIntl();
-  const { componentPickerMode } = useLibraryContext();
+  const { showOnlyPublished } = useLibraryContext();
 
   return (
     <StandardModal
@@ -27,7 +27,7 @@ const ModalComponentPreview = ({ isOpen, close, usageKey }: ModalComponentPrevie
     >
       <LibraryBlock
         usageKey={usageKey}
-        version={componentPickerMode ? 'published' : undefined}
+        version={showOnlyPublished ? 'published' : undefined}
       />
     </StandardModal>
   );

--- a/src/library-authoring/component-info/ComponentPreview.tsx
+++ b/src/library-authoring/component-info/ComponentPreview.tsx
@@ -15,6 +15,7 @@ interface ModalComponentPreviewProps {
 
 const ModalComponentPreview = ({ isOpen, close, usageKey }: ModalComponentPreviewProps) => {
   const intl = useIntl();
+  const { componentPickerMode } = useLibraryContext();
 
   return (
     <StandardModal
@@ -24,7 +25,10 @@ const ModalComponentPreview = ({ isOpen, close, usageKey }: ModalComponentPrevie
       isOverflowVisible={false}
       className="component-preview-modal"
     >
-      <LibraryBlock usageKey={usageKey} />
+      <LibraryBlock
+        usageKey={usageKey}
+        version={componentPickerMode ? 'published' : undefined}
+      />
     </StandardModal>
   );
 };
@@ -33,7 +37,7 @@ const ComponentPreview = () => {
   const intl = useIntl();
 
   const [isModalOpen, openModal, closeModal] = useToggle();
-  const { sidebarComponentUsageKey: usageKey } = useLibraryContext();
+  const { sidebarComponentUsageKey: usageKey, componentPickerMode } = useLibraryContext();
 
   // istanbul ignore if: this should never happen
   if (!usageKey) {
@@ -57,7 +61,13 @@ const ComponentPreview = () => {
         {
           // key=modified below is used to auto-refresh the preview when changes are made, e.g. via OLX editor
           componentMetadata
-            ? <LibraryBlock usageKey={usageKey} key={componentMetadata.modified} />
+            ? (
+              <LibraryBlock
+                usageKey={usageKey}
+                key={componentMetadata.modified}
+                version={componentPickerMode ? 'published' : undefined}
+              />
+            )
             : null
         }
       </div>

--- a/src/library-authoring/component-picker/ComponentPicker.test.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.test.tsx
@@ -17,6 +17,15 @@ import {
 
 import { ComponentPicker } from './ComponentPicker';
 
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => ({
+    pathname: '/evilguy',
+    search: {
+      variant: 'published',
+    },
+  }),
+}));
 mockContentLibrary.applyMock();
 mockContentSearchConfig.applyMock();
 mockGetCollectionMetadata.applyMock();

--- a/src/library-authoring/component-picker/ComponentPicker.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Stepper } from '@openedx/paragon';
 
 import { LibraryProvider, useLibraryContext } from '../common/context';
@@ -24,6 +25,11 @@ export const ComponentPicker = () => {
   const [currentStep, setCurrentStep] = useState('select-library');
   const [selectedLibrary, setSelectedLibrary] = useState('');
 
+  const location = useLocation();
+
+  const queryParams = new URLSearchParams(location.search);
+  const variant = queryParams.get('variant') || 'draft';
+
   const handleLibrarySelection = (library: string) => {
     setCurrentStep('pick-components');
     setSelectedLibrary(library);
@@ -43,7 +49,7 @@ export const ComponentPicker = () => {
       </Stepper.Step>
 
       <Stepper.Step eventKey="pick-components" title="Pick some components">
-        <LibraryProvider libraryId={selectedLibrary} componentPickerMode>
+        <LibraryProvider libraryId={selectedLibrary} componentPickerMode showOnlyPublished={variant === 'published'}>
           <InnerComponentPicker returnToLibrarySelection={returnToLibrarySelection} />
         </LibraryProvider>
       </Stepper.Step>

--- a/src/library-authoring/components/ComponentCard.test.tsx
+++ b/src/library-authoring/components/ComponentCard.test.tsx
@@ -19,6 +19,7 @@ const contentHit: ContentHit = {
   org: 'org1',
   breadcrumbs: [{ displayName: 'Demo Lib' }],
   displayName: 'Text Display Name',
+  description: 'This is a text: ID=1',
   formatted: {
     displayName: 'Text Display Formated Name',
     content: {

--- a/src/library-authoring/components/ComponentCard.test.tsx
+++ b/src/library-authoring/components/ComponentCard.test.tsx
@@ -25,6 +25,7 @@ const contentHit: ContentHit = {
     content: {
       htmlContent: 'This is a text: ID=1',
     },
+    description: 'This is a text: ID=1',
   },
   tags: {
     level0: ['1', '2', '3'],

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -101,6 +101,7 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
   const {
     openComponentInfoSidebar,
     componentPickerMode,
+    showOnlyPublished,
   } = useLibraryContext();
 
   const {
@@ -112,10 +113,10 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
     published,
   } = contentHit;
   const componentDescription: string = (
-    componentPickerMode ? published?.description : description
+    showOnlyPublished ? published?.description : description
   ) ?? '';
   const displayName: string = (
-    componentPickerMode ? published?.displayName : formatted?.displayName
+    showOnlyPublished ? published?.displayName : formatted?.displayName
   ) ?? '';
 
   const handleAddComponentToCourse = () => {

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -109,14 +109,12 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
     formatted,
     tags,
     usageKey,
-    description,
-    published,
   } = contentHit;
   const componentDescription: string = (
-    showOnlyPublished ? published?.description : description
+    showOnlyPublished ? formatted.published?.description : formatted.description
   ) ?? '';
   const displayName: string = (
-    showOnlyPublished ? published?.displayName : formatted?.displayName
+    showOnlyPublished ? formatted.published?.displayName : formatted.displayName
   ) ?? '';
 
   const handleAddComponentToCourse = () => {

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -108,13 +108,15 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
     formatted,
     tags,
     usageKey,
+    description,
+    published,
   } = contentHit;
-  const description: string = (/* eslint-disable */
-    blockType === 'html' ? formatted?.content?.htmlContent :
-      blockType === 'problem' ? formatted?.content?.capaContent :
-        undefined
-  ) ?? '';/* eslint-enable */
-  const displayName = formatted?.displayName ?? '';
+  const componentDescription: string = (
+    componentPickerMode ? published?.description : description
+  ) ?? '';
+  const displayName: string = (
+    componentPickerMode ? published?.displayName : formatted?.displayName
+  ) ?? '';
 
   const handleAddComponentToCourse = () => {
     window.parent.postMessage({
@@ -128,7 +130,7 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
     <BaseComponentCard
       componentType={blockType}
       displayName={displayName}
-      description={description}
+      description={componentDescription}
       tags={tags}
       actions={(
         <ActionRow>

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -52,6 +52,8 @@ export const getLibraryPasteClipboardUrl = (libraryId: string) => `${getApiBaseU
   * Get the URL for the xblock fields/metadata API.
   */
 export const getXBlockFieldsApiUrl = (usageKey: string) => `${getApiBaseUrl()}/api/xblock/v2/xblocks/${usageKey}/fields/`;
+export const getXBlockFieldsVersionApiUrl = (usageKey: string, version: string) => `${getApiBaseUrl()}/api/xblock/v2/xblocks/${usageKey}@${version}/fields/`;
+
 /**
   * Get the URL for the xblock OLX API
   */
@@ -379,8 +381,8 @@ export async function getLibraryBlockMetadata(usageKey: string): Promise<Library
 /**
  * Fetch xblock fields.
  */
-export async function getXBlockFields(usageKey: string): Promise<XBlockFields> {
-  const { data } = await getAuthenticatedHttpClient().get(getXBlockFieldsApiUrl(usageKey));
+export async function getXBlockFields(usageKey: string, version: string = 'draft'): Promise<XBlockFields> {
+  const { data } = await getAuthenticatedHttpClient().get(getXBlockFieldsVersionApiUrl(usageKey, version));
   return camelCaseObject(data);
 }
 

--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -289,10 +289,10 @@ export const useLibraryBlockMetadata = (usageId: string) => (
   })
 );
 
-export const useXBlockFields = (usageKey: string) => (
+export const useXBlockFields = (usageKey: string, version: string = 'draft') => (
   useQuery({
     queryKey: xblockQueryKeys.xblockFields(usageKey),
-    queryFn: () => getXBlockFields(usageKey),
+    queryFn: () => getXBlockFields(usageKey, version),
     enabled: !!usageKey,
   })
 );

--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -88,7 +88,7 @@ export const xblockQueryKeys = {
    */
   xblock: (usageKey?: string) => [...xblockQueryKeys.all, usageKey],
   /** Fields (i.e. the content, display name, etc.) of an XBlock */
-  xblockFields: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'fields'],
+  xblockFields: (usageKey: string, version: string = 'draft') => [...xblockQueryKeys.xblock(usageKey), 'fields', version],
   /** OLX (XML representation of the fields/content) */
   xblockOLX: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'OLX'],
   /** assets (static files) */
@@ -291,7 +291,7 @@ export const useLibraryBlockMetadata = (usageId: string) => (
 
 export const useXBlockFields = (usageKey: string, version: string = 'draft') => (
   useQuery({
-    queryKey: xblockQueryKeys.xblockFields(usageKey),
+    queryKey: xblockQueryKeys.xblockFields(usageKey, version),
     queryFn: () => getXBlockFields(usageKey, version),
     enabled: !!usageKey,
   })

--- a/src/search-manager/data/api.ts
+++ b/src/search-manager/data/api.ts
@@ -127,9 +127,20 @@ export interface ContentHit extends BaseContentHit {
    * - After that is the name and usage key of any parent Section/Subsection/Unit/etc.
    */
   breadcrumbs: [{ displayName: string }, ...Array<{ displayName: string, usageKey: string }>];
+  description?: string;
   content?: ContentDetails;
   lastPublished: number | null;
   collections: { displayName?: string[], key?: string[] },
+  published?: ContentPublishedData,
+}
+
+/**
+ * Information about the published data of single Xblock returned in search results
+ * Defined in edx-platform/openedx/core/djangoapps/content/search/documents.py
+ */
+export interface ContentPublishedData {
+  description?: string,
+  displayName?: string,
 }
 
 /**

--- a/src/search-manager/data/api.ts
+++ b/src/search-manager/data/api.ts
@@ -130,8 +130,9 @@ export interface ContentHit extends BaseContentHit {
   description?: string;
   content?: ContentDetails;
   lastPublished: number | null;
-  collections: { displayName?: string[], key?: string[] },
-  published?: ContentPublishedData,
+  collections: { displayName?: string[], key?: string[] };
+  published?: ContentPublishedData;
+  formatted: BaseContentHit['formatted'] & { published?: ContentPublishedData, };
 }
 
 /**
@@ -163,6 +164,7 @@ export function formatSearchHit(hit: Record<string, any>): ContentHit | Collecti
     displayName: _formatted?.display_name,
     content: _formatted?.content ?? {},
     description: _formatted?.description,
+    published: _formatted?.published,
   };
   return camelCaseObject(newHit);
 }
@@ -258,10 +260,10 @@ export async function fetchSearchResults({
       ...extraFilterFormatted,
       ...tagsFilterFormatted,
     ],
-    attributesToHighlight: ['display_name', 'content'],
+    attributesToHighlight: ['display_name', 'description', 'published'],
     highlightPreTag: HIGHLIGHT_PRE_TAG,
     highlightPostTag: HIGHLIGHT_POST_TAG,
-    attributesToCrop: ['content'],
+    attributesToCrop: ['description', 'published'],
     sort,
     offset,
     limit,


### PR DESCRIPTION
## Description

Updated the Content Picker to show published components.

- Which edX user roles will this change impact?  "Course Author"

## Testing instructions

- Create or use a library.
- Create new components and publish the library
- Follow instructions from PR: https://github.com/openedx/frontend-app-authoring/pull/1356 to add library components to a course.
- Select the library and verify that only you can see the published components.
- Create new components. Don't publish the library
- Select the library on the content picker and verify that only you can see the published components (Don't see the new components).
- Publish the library.
- Select the library on the content picker and verify that only you can see the published components.
- Update the title and descriptions of components. Don't publish the library.
- On the content picker verify the title, description and preview of the components.
- Publish the library.
- On the content picker verify the title, description and preview of the components.
