### PR TITLE
fix: don't revert to advanced editor if problem contains fields like url_name [FC-0062]

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -670,7 +670,8 @@ export class OLXParser {
 
     Object.keys(this.problem).forEach((key) => {
       if (key.indexOf('@_') !== -1 && !settingsOlxAttributes.includes(key) && !ignoredOlxAttributes.includes(key)) {
-        throw new Error(`Unrecognized attribute "${key}" associated with problem, opening in advanced editor`);
+        const plainKey = key.replace(/^@_/, '');
+        throw new Error(`Unrecognized attribute "${plainKey}" associated with problem, opening in advanced editor`);
       }
     });
 

--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -58,7 +58,7 @@ describe('OLXParser', () => {
           labelDescriptionQuestionOlxParser.getParsedOLXData();
         } catch (e) {
           expect(e).toBeInstanceOf(Error);
-          expect(e.message).toBe('Misc Attributes associated with problem, opening in advanced editor');
+          expect(e.message).toBe('Unrecognized attribute "markdown" associated with problem, opening in advanced editor');
         }
       });
     });

--- a/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
@@ -2,7 +2,7 @@
 // lint is disabled for this file due to strict spacing
 
 export const checkboxesOLXWithFeedbackAndHintsOLX = {
-  rawOLX: `<problem>
+  rawOLX: `<problem url_name="this_should_be_ignored">
   <choiceresponse>
     <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for checkboxes with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
   <label>Add the question text, or prompt, here. This text is required.</label>

--- a/src/editors/data/constants/problem.ts
+++ b/src/editors/data/constants/problem.ts
@@ -235,7 +235,7 @@ export const settingsOlxAttributes = [
 ] as const;
 
 export const ignoredOlxAttributes = [
-  '@_markdown',
+  // '@_markdown',  // Not sure if this is safe to ignore; some tests seem to indicate it's not.
   '@_url_name',
   '@_x-is-pointer-node',
 ] as const;


### PR DESCRIPTION
## Description

Fixes https://github.com/openedx/frontend-app-authoring/issues/1377

## Supporting information

See the issue for details. Note that at the same time, we're also working on fixes in `edx-platform` to prevent these fields from showing up in the first place.

## Testing instructions

Paste a library problem into a course. Make sure the visual editor still works. Try the opposite (course -> library).

