### PR TITLE
feat: show confirmation dialog before discarding library changes [FC-0062]

### DIFF
--- a/src/generic/delete-modal/DeleteModal.jsx
+++ b/src/generic/delete-modal/DeleteModal.jsx
@@ -18,11 +18,15 @@ const DeleteModal = ({
   description,
   variant,
   btnState,
+  btnDefaultLabel,
+  btnPendingLabel,
 }) => {
   const intl = useIntl();
 
   const modalTitle = title || intl.formatMessage(messages.title, { category });
   const modalDescription = description || intl.formatMessage(messages.description, { category });
+  const defaultBtnLabel = btnDefaultLabel || intl.formatMessage(messages.deleteButton);
+  const pendingBtnLabel = btnPendingLabel || intl.formatMessage(messages.pendingDeleteButton);
 
   return (
     <AlertModal
@@ -51,8 +55,8 @@ const DeleteModal = ({
               onDeleteSubmit();
             }}
             labels={{
-              default: intl.formatMessage(messages.deleteButton),
-              pending: intl.formatMessage(messages.pendingDeleteButton),
+              default: defaultBtnLabel,
+              pending: pendingBtnLabel,
             }}
           />
         </ActionRow>
@@ -69,6 +73,8 @@ DeleteModal.defaultProps = {
   description: '',
   variant: 'default',
   btnState: 'default',
+  btnDefaultLabel: '',
+  btnPendingLabel: '',
 };
 
 DeleteModal.propTypes = {
@@ -80,6 +86,8 @@ DeleteModal.propTypes = {
   description: PropTypes.string,
   variant: PropTypes.string,
   btnState: PropTypes.string,
+  btnDefaultLabel: PropTypes.string,
+  btnPendingLabel: PropTypes.string,
 };
 
 export default DeleteModal;

--- a/src/library-authoring/LibraryAuthoringPage.test.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.test.tsx
@@ -486,7 +486,7 @@ describe('<LibraryAuthoringPage />', () => {
     await renderLibraryPage();
 
     // Open menu
-    fireEvent.click(screen.getAllByTestId('component-card-menu-toggle')[0]);
+    fireEvent.click((await screen.findAllByTestId('component-card-menu-toggle'))[0]);
     // Click add to collection
     fireEvent.click(screen.getByRole('button', { name: 'Add to collection' }));
 

--- a/src/library-authoring/library-info/LibraryInfo.test.tsx
+++ b/src/library-authoring/library-info/LibraryInfo.test.tsx
@@ -161,6 +161,8 @@ describe('<LibraryInfo />', () => {
 
     const discardButton = screen.getByRole('button', { name: /discard changes/i });
     fireEvent.click(discardButton);
+    const confirmBtn = screen.getByRole('button', { name: /discard/i });
+    fireEvent.click(confirmBtn);
 
     await waitFor(() => {
       expect(axiosMock.history.delete[0].url).toEqual(url);
@@ -177,6 +179,8 @@ describe('<LibraryInfo />', () => {
 
     const discardButton = screen.getByRole('button', { name: /discard changes/i });
     fireEvent.click(discardButton);
+    const confirmBtn = screen.getByRole('button', { name: /discard/i });
+    fireEvent.click(confirmBtn);
 
     await waitFor(() => {
       expect(axiosMock.history.delete[0].url).toEqual(url);

--- a/src/library-authoring/library-info/messages.ts
+++ b/src/library-authoring/library-info/messages.ts
@@ -61,6 +61,21 @@ const messages = defineMessages({
     defaultMessage: 'There was an error updating the library',
     description: 'Message when there is an error when updating the library',
   },
+  discardChangesTitle: {
+    id: 'course-authoring.library-authoring.library.discardChangesTitle',
+    defaultMessage: 'Discard changes',
+    description: 'Title text for confirmation modal shown before discard library changes',
+  },
+  discardChangesDescription: {
+    id: 'course-authoring.library-authoring.library.discardChangesDescription',
+    defaultMessage: 'Are you sure you want to discard all unpublished changes in this library? This will include changes made by other users',
+    description: 'Description text for confirmation modal shown before discard library changes',
+  },
+  discardChangesDefaultBtnLabel: {
+    id: 'course-authoring.library-authoring.library.discardChangesDefaultBtnLabel',
+    defaultMessage: 'Discard',
+    description: 'Button text for confirmation modal shown before discard library changes',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description

Issue: https://github.com/openedx/frontend-app-authoring/issues/1405

https://github.com/user-attachments/assets/5c3313de-3f0a-4f34-b07b-8d4cbff4506c

## Testing instructions

* add a component in any library
* Click on `Discard changes` button in sidebar and verify the confirmation modal.