### PR TITLE
fix: use absolute URL for Export Tags menu item

### DIFF
--- a/src/course-outline/CourseOutline.jsx
+++ b/src/course-outline/CourseOutline.jsx
@@ -125,7 +125,8 @@ const CourseOutline = ({ courseId }) => {
   const [toastMessage, setToastMessage] = useState(/** @type{null|string} */ (null));
 
   useEffect(() => {
-    if (location.hash === '#export-tags') {
+    // Wait for the course data to load before exporting tags.
+    if (courseId && courseName && location.hash === '#export-tags') {
       setToastMessage(intl.formatMessage(messages.exportTagsCreatingToastMessage));
       getTagsExportFile(courseId, courseName).then(() => {
         setToastMessage(intl.formatMessage(messages.exportTagsSuccessToastMessage));
@@ -136,7 +137,7 @@ const CourseOutline = ({ courseId }) => {
       // Delete `#export-tags` from location
       window.location.href = '#';
     }
-  }, [location]);
+  }, [location, courseId, courseName]);
 
   const [sections, setSections] = useState(sectionsList);
 

--- a/src/header/hooks.js
+++ b/src/header/hooks.js
@@ -90,7 +90,7 @@ export const useToolsMenuItems = courseId => {
     },
     ...(getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true'
       ? [{
-        href: '#export-tags',
+        href: `${studioBaseUrl}/course/${courseId}#export-tags`,
         title: intl.formatMessage(messages['header.links.exportTags']),
       }] : []
     ),


### PR DESCRIPTION
## Description

Fixes the "Export Tags" course menu item so that it works no matter where in the course it's used.

Affects "Course Authors" with tagging enabled.

https://github.com/user-attachments/assets/8e7bae38-ca68-4b72-937a-ede5bb662a10

## Supporting information

See: https://github.com/openedx/frontend-app-authoring/issues/1380
Private-ref: [FAL-3873](https://tasks.opencraft.com/browse/FAL-3873)

## Testing instructions

1. Visit a course page other than the Course Outline in the Authoring MFE (e.g. Advanced Settings, Course Team, Export Course)
2. Click menu item Tools > Export Tags
   Should redirect you to the Course Outline page and download the tags export csv.
3. From the Course Outline page, click menu item Tools > Export Tags
   Will reload the Course Outline page and download the tags export csv.