### PR TITLE
[sumac] fix: Library Preview Expand button covers dropdown

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.scss
+++ b/src/library-authoring/LibraryAuthoringPage.scss
@@ -12,13 +12,17 @@
 }
 
 .library-authoring-sidebar {
-  z-index: 1001; // to appear over header
+  z-index: 1000; // same as header
   flex: 450px 0 0;
   position: sticky;
   top: 0;
   right: 0;
   height: 100vh;
   overflow-y: auto;
+}
+
+.dropdown-menu {
+  z-index: 1001; // over the sidebar
 }
 
 // Reduce breadcrumb bottom margin

--- a/src/library-authoring/component-info/ComponentPreview.tsx
+++ b/src/library-authoring/component-info/ComponentPreview.tsx
@@ -55,7 +55,7 @@ const ComponentPreview = () => {
           variant="light"
           iconBefore={OpenInFull}
           onClick={openModal}
-          className="position-absolute right-0 zindex-10 m-1"
+          className="position-absolute right-0 zindex-1 m-1"
         >
           {intl.formatMessage(messages.previewExpandButtonTitle)}
         </Button>


### PR DESCRIPTION
Fix this issue: https://github.com/openedx/frontend-app-authoring/issues/1390

Backported for sumac (cherry picked from commit https://github.com/openedx/frontend-app-authoring/commit/cff1177ae93db0f63377ef387fca232b24e47c0b)

See https://github.com/openedx/frontend-app-authoring/pull/1438 for full details and testing instructions.