### PR TITLE
fix: enable publish button on library after component edit [sumac] [FC-0062]

### DIFF
--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -137,6 +137,7 @@ export const useCreateLibraryBlock = () => {
   return useMutation({
     mutationFn: createLibraryBlock,
     onSettled: (_data, _error, variables) => {
+      queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibrary(variables.libraryId) });
       queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, variables.libraryId) });
     },
   });


### PR DESCRIPTION
Backport of https://github.com/openedx/frontend-app-authoring/pull/1446

## Description

This PR fixes the following bug:
> After publishing a library then editing a component, the "Publish" button in Library Info doesn't become enabled until you refresh

## Additional information
Related to:
- https://github.com/openedx/frontend-app-authoring/issues/1455

## Testing information

- Open the library home for a library
- Open the library sidebar and publish the library
- Make sure the "Publish" button is disabled
- Click on a component and open the component's sidebar
- Edit the name of the component
- Open the library sidebar again and check if the "Publish" button is ENABLED
- Publish the library again to reset the status, and make sure the "Publish" button is disabled
- Click on the three-dot menu on a component card and click on edit to open the component editor modal
- Change the component content
- Open the library sidebar again and check if the "Publish" button is ENABLED

___
Private ref: [FAL-3923](https://tasks.opencraft.com/browse/FAL-3923)
