### PR TITLE
Hide / error on Libraries v2 pages if !librariesV2Enabled

### DIFF
--- a/src/studio-home/StudioHome.tsx
+++ b/src/studio-home/StudioHome.tsx
@@ -47,7 +47,7 @@ const StudioHome = () => {
     setShowNewCourseContainer,
     librariesV1Enabled,
     librariesV2Enabled,
-  } = useStudioHome(isPaginationCoursesEnabled);
+  } = useStudioHome();
 
   const v1LibraryTab = librariesV1Enabled && location?.pathname.split('/').pop() === 'libraries-v1';
   const showV2LibraryURL = librariesV2Enabled && !v1LibraryTab;

--- a/src/studio-home/hooks.jsx
+++ b/src/studio-home/hooks.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
+import { getConfig } from '@edx/frontend-platform';
 
 import { RequestStatus } from '../data/constants';
 import { COURSE_CREATOR_STATES } from '../constants';
@@ -14,9 +15,10 @@ import {
 } from './data/selectors';
 import { updateSavingStatuses } from './data/slice';
 
-const useStudioHome = (isPaginated = false) => {
+const useStudioHome = () => {
   const location = useLocation();
   const dispatch = useDispatch();
+  const isPaginated = getConfig().ENABLE_HOME_PAGE_COURSE_API_V2;
   const studioHomeData = useSelector(getStudioHomeData);
   const studioHomeCoursesParams = useSelector(getStudioHomeCoursesParams);
   const { isFiltered } = studioHomeCoursesParams;


### PR DESCRIPTION
## Description

Show an error message if the user tries to view a v2 Library while Libraries V2 are disabled in the platform.

![image](https://github.com/user-attachments/assets/bbebd5a8-c789-485f-8922-48b8734306fe)

## Supporting information

Relates to: https://github.com/openedx/frontend-app-authoring/issues/1448
Private-ref: [FAL-3873](https://tasks.opencraft.com/browse/FAL-3873)

## Testing instructions

1. In Django Admin, enable the `contentstore.new_studio_mfe.disable_new_libraries` flag to disable Libraries V2.
2. Load a library's home page in the Authoring MFE.
3. Verify that the error message is shown instead of the library content.
4. In Django Admin, disable the `contentstore.new_studio_mfe.disable_new_libraries` flag to enable Libraries V2.
5. Refresh the library's home page
6. Verify that the error message is no longer shown.