### PR TITLE
fix: fixed Configure modal for Course Unit page

### DIFF
--- a/src/course-unit/CourseUnit.test.jsx
+++ b/src/course-unit/CourseUnit.test.jsx
@@ -1020,7 +1020,7 @@ describe('<CourseUnit />', () => {
     axiosMock
       .onPost(getXBlockBaseApiUrl(courseUnitIndexMock.id), {
         publish: null,
-        metadata: { visible_to_staff_only: true, group_access: { 50: [2] } },
+        metadata: { visible_to_staff_only: true, group_access: { 50: [2] }, discussion_enabled: true },
       })
       .reply(200, { dummy: 'value' });
     axiosMock

--- a/src/course-unit/data/api.js
+++ b/src/course-unit/data/api.js
@@ -91,13 +91,14 @@ export async function createCourseXblock({
  * @param {boolean} groupAccess - Access group key set.
  * @returns {Promise<any>} A promise that resolves with the response data.
  */
-export async function handleCourseUnitVisibilityAndData(unitId, type, isVisible, groupAccess) {
+export async function handleCourseUnitVisibilityAndData(unitId, type, isVisible, groupAccess, isDiscussionEnabled) {
   const body = {
     publish: groupAccess ? null : type,
     ...(type === PUBLISH_TYPES.republish ? {
       metadata: {
         visible_to_staff_only: isVisible ? true : null,
         group_access: groupAccess || null,
+        discussion_enabled: isDiscussionEnabled,
       },
     } : {}),
   };

--- a/src/course-unit/data/thunk.js
+++ b/src/course-unit/data/thunk.js
@@ -119,15 +119,28 @@ export function editCourseItemQuery(itemId, displayName, sequenceId) {
   };
 }
 
-export function editCourseUnitVisibilityAndData(itemId, type, isVisible, groupAccess, isModalView, blockId = itemId) {
+export function editCourseUnitVisibilityAndData(
+  itemId,
+  type,
+  isVisible,
+  groupAccess,
+  isDiscussionEnabled,
+  blockId = itemId,
+) {
   return async (dispatch) => {
     dispatch(updateSavingStatus({ status: RequestStatus.PENDING }));
     dispatch(updateQueryPendingStatus(true));
-    const notification = getNotificationMessage(type, isVisible, isModalView);
+    const notification = getNotificationMessage(type, isVisible, true);
     dispatch(showProcessingNotification(notification));
 
     try {
-      await handleCourseUnitVisibilityAndData(itemId, type, isVisible, groupAccess).then(async (result) => {
+      await handleCourseUnitVisibilityAndData(
+        itemId,
+        type,
+        isVisible,
+        groupAccess,
+        isDiscussionEnabled,
+      ).then(async (result) => {
         if (result) {
           const courseUnit = await getCourseUnitData(blockId);
           dispatch(fetchCourseItemSuccess(courseUnit));

--- a/src/course-unit/hooks.jsx
+++ b/src/course-unit/hooks.jsx
@@ -66,8 +66,15 @@ export const useCourseUnit = ({ courseId, blockId }) => {
     dispatch(changeEditTitleFormOpen(!isTitleEditFormOpen));
   };
 
-  const handleConfigureSubmit = (id, isVisible, groupAccess, closeModalFn) => {
-    dispatch(editCourseUnitVisibilityAndData(id, PUBLISH_TYPES.republish, isVisible, groupAccess, true, blockId));
+  const handleConfigureSubmit = (id, isVisible, groupAccess, isDiscussionEnabled, closeModalFn) => {
+    dispatch(editCourseUnitVisibilityAndData(
+      id,
+      PUBLISH_TYPES.republish,
+      isVisible,
+      groupAccess,
+      isDiscussionEnabled,
+      blockId,
+    ));
     closeModalFn();
   };
 

--- a/src/generic/configure-modal/ConfigureModal.test.jsx
+++ b/src/generic/configure-modal/ConfigureModal.test.jsx
@@ -221,6 +221,10 @@ describe('<ConfigureModal /> for Unit', () => {
 
     expect(getByRole('button', { name: messages.cancelButton.defaultMessage })).toBeInTheDocument();
     expect(getByRole('button', { name: messages.saveButton.defaultMessage })).toBeInTheDocument();
+
+    expect(queryByText(messages.discussionEnabledSectionTitle.defaultMessage)).toBeInTheDocument();
+    expect(queryByText(messages.discussionEnabledCheckbox.defaultMessage)).toBeInTheDocument();
+    expect(queryByText(messages.discussionEnabledDescription.defaultMessage)).toBeInTheDocument();
   });
 });
 
@@ -278,5 +282,9 @@ describe('<ConfigureModal /> for XBlock', () => {
 
     expect(getByRole('button', { name: messages.cancelButton.defaultMessage })).toBeInTheDocument();
     expect(getByRole('button', { name: messages.saveButton.defaultMessage })).toBeInTheDocument();
+
+    expect(queryByText(messages.discussionEnabledSectionTitle.defaultMessage)).not.toBeInTheDocument();
+    expect(queryByText(messages.discussionEnabledCheckbox.defaultMessage)).not.toBeInTheDocument();
+    expect(queryByText(messages.discussionEnabledDescription.defaultMessage)).not.toBeInTheDocument();
   });
 });

--- a/src/generic/configure-modal/UnitTab.jsx
+++ b/src/generic/configure-modal/UnitTab.jsx
@@ -130,12 +130,16 @@ const UnitTab = ({
           )}
         </Form.Group>
       )}
-      <h4 className="mt-4"><FormattedMessage {...messages.discussionEnabledSectionTitle} /></h4>
-      <hr />
-      <Form.Checkbox checked={discussionEnabled} onChange={handleDiscussionChange}>
-        <FormattedMessage {...messages.discussionEnabledCheckbox} />
-      </Form.Checkbox>
-      <p className="x-small font-weight-bold"><FormattedMessage {...messages.discussionEnabledDescription} /></p>
+      {!isXBlockComponent && (
+        <>
+          <h4 className="mt-4"><FormattedMessage {...messages.discussionEnabledSectionTitle} /></h4>
+          <hr />
+          <Form.Checkbox checked={discussionEnabled} onChange={handleDiscussionChange}>
+            <FormattedMessage {...messages.discussionEnabledCheckbox} />
+          </Form.Checkbox>
+          <p className="x-small font-weight-bold"><FormattedMessage {...messages.discussionEnabledDescription} /></p>
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Description

Fixed behavior of the configuration modal window on the course unit page

Issue: https://github.com/openedx/frontend-app-authoring/issues/1429

## Testing instructions

1.	Open the new Course unit page.
2.	Open the configuration modal for the unit/XBlock.
3.	After saving, the configuration modal is closed.
4.	For XBlock configuration modal, the Discussions checkbox is hidden.
5.	For the unit configuration modal, the Discussions checkbox is visible and can be saved.

https://github.com/user-attachments/assets/d0c048be-7e16-462e-98c5-39638afb9b11