### PR TITLE
feat: [FC-0070] Manage Tags interoperation

### DIFF
--- a/src/CourseAuthoringRoutes.jsx
+++ b/src/CourseAuthoringRoutes.jsx
@@ -51,7 +51,7 @@ const CourseAuthoringRoutes = () => {
       <Routes>
         <Route
           path="/"
-          element={<PageWrap><CourseOutline courseId={courseId} /></PageWrap>}
+          element={<PageWrap><IframeProvider><CourseOutline courseId={courseId} /></IframeProvider></PageWrap>}
         />
         <Route
           path="course_info"

--- a/src/CourseAuthoringRoutes.jsx
+++ b/src/CourseAuthoringRoutes.jsx
@@ -51,7 +51,7 @@ const CourseAuthoringRoutes = () => {
       <Routes>
         <Route
           path="/"
-          element={<PageWrap><IframeProvider><CourseOutline courseId={courseId} /></IframeProvider></PageWrap>}
+          element={<PageWrap><CourseOutline courseId={courseId} /></PageWrap>}
         />
         <Route
           path="course_info"

--- a/src/content-tags-drawer/data/apiHooks.jsx
+++ b/src/content-tags-drawer/data/apiHooks.jsx
@@ -14,6 +14,7 @@ import {
   updateContentTaxonomyTags,
   getContentTaxonomyTagsCount,
 } from './api';
+import { useIframe } from '../../course-unit/context/hooks';
 import { libraryQueryPredicate, xblockQueryKeys } from '../../library-authoring/data/apiHooks';
 import { getLibraryId } from '../../generic/key-utils';
 
@@ -126,6 +127,7 @@ export const useContentData = (contentId) => (
  */
 export const useContentTaxonomyTagsUpdater = (contentId) => {
   const queryClient = useQueryClient();
+  const iframeContext = useIframe();
 
   return useMutation({
     /**
@@ -173,8 +175,9 @@ export const useContentTaxonomyTagsUpdater = (contentId) => {
             contentId,
             ...data,
           };
+          iframeContext?.sendMessageToIframe('authoring.events.tags.updated', { ...contentData });
           window.top?.postMessage(
-            { type: 'authoring.events.tags.updated', data: contentData },
+            { type: 'authoring.events.tags.updated', payload: { ...contentData } },
             getConfig().STUDIO_BASE_URL,
           );
         });
@@ -185,8 +188,9 @@ export const useContentTaxonomyTagsUpdater = (contentId) => {
             contentId,
             count: data,
           };
+          iframeContext?.sendMessageToIframe('authoring.events.tags.count.updated', { ...contentData });
           window.top?.postMessage(
-            { type: 'authoring.events.tags.count.updated', data: contentData },
+            { type: 'authoring.events.tags.count.updated', payload: { ...contentData } },
             getConfig().STUDIO_BASE_URL,
           );
         });

--- a/src/content-tags-drawer/data/apiHooks.jsx
+++ b/src/content-tags-drawer/data/apiHooks.jsx
@@ -126,7 +126,7 @@ export const useContentData = (contentId) => (
  */
 export const useContentTaxonomyTagsUpdater = (contentId) => {
   const queryClient = useQueryClient();
-  const unitIframe = window.frames[0];
+  const unitIframe = window.frames['xblock-iframe'];
 
   return useMutation({
     /**

--- a/src/content-tags-drawer/data/apiHooks.jsx
+++ b/src/content-tags-drawer/data/apiHooks.jsx
@@ -161,7 +161,8 @@ export const useContentTaxonomyTagsUpdater = (contentId) => {
     onSuccess: /* istanbul ignore next */ () => {
       /* istanbul ignore next */
       if (window.top != null) {
-        // This send messages to the parent page if the drawer is called from a iframe.
+        // Sends messages to the parent page if the drawer was opened
+        // from an iframe or the unit iframe within the course.
         // Is used on Studio to update tags data and counts.
         // In the future, when the Course Outline Page and Unit Page are integrated into this MFE,
         // they should just use React Query to load the tag counts, and React Query will automatically

--- a/src/course-unit/CourseUnit.jsx
+++ b/src/course-unit/CourseUnit.jsx
@@ -28,7 +28,7 @@ import Breadcrumbs from './breadcrumbs/Breadcrumbs';
 import HeaderNavigations from './header-navigations/HeaderNavigations';
 import Sequence from './course-sequence';
 import Sidebar from './sidebar';
-import { useCourseUnit, useLayoutGrid } from './hooks';
+import { useCourseUnit, useLayoutGrid, useScrollToLastPosition } from './hooks';
 import messages from './messages';
 import PublishControls from './sidebar/PublishControls';
 import LocationInfo from './sidebar/LocationInfo';
@@ -78,6 +78,8 @@ const CourseUnit = ({ courseId }) => {
   useEffect(() => {
     document.title = getPageHeadTitle('', unitTitle);
   }, [unitTitle]);
+
+  useScrollToLastPosition();
 
   const {
     isShow: isShowProcessingNotification,

--- a/src/course-unit/CourseUnit.test.jsx
+++ b/src/course-unit/CourseUnit.test.jsx
@@ -93,6 +93,9 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('@tanstack/react-query', () => ({
   useQuery: jest.fn(({ queryKey }) => {
+    const taxonomyApiHooksModule = jest.requireActual('../taxonomy/data/apiHooks');
+    const actualQueryKeys = taxonomyApiHooksModule.taxonomyQueryKeys;
+
     if (queryKey[0] === 'contentTaxonomyTags') {
       return {
         data: {
@@ -106,7 +109,7 @@ jest.mock('@tanstack/react-query', () => ({
         isSuccess: true,
       };
     }
-    if (queryKey[0] === 'taxonomies') {
+    if (actualQueryKeys.all.includes(queryKey[0])) {
       return {
         data: {
           results: [],

--- a/src/course-unit/add-component/AddComponent.jsx
+++ b/src/course-unit/add-component/AddComponent.jsx
@@ -61,7 +61,7 @@ const AddComponent = ({ blockId, handleCreateNewCourseXBlock }) => {
       case COMPONENT_TYPES.problem:
       case COMPONENT_TYPES.video:
         handleCreateNewCourseXBlock({ type, parentLocator: blockId }, ({ courseKey, locator }) => {
-          localStorage.setItem('modalEditLastYPosition', window.scrollY);
+          localStorage.setItem('createXBlockLastYPosition', window.scrollY);
           navigate(`/course/${courseKey}/editor/${type}/${locator}`);
         });
         break;
@@ -92,6 +92,7 @@ const AddComponent = ({ blockId, handleCreateNewCourseXBlock }) => {
           boilerplate: moduleName,
           parentLocator: blockId,
         }, ({ courseKey, locator }) => {
+          localStorage.setItem('createXBlockLastYPosition', window.scrollY);
           navigate(`/course/${courseKey}/editor/html/${locator}`);
         });
         break;

--- a/src/course-unit/constants.js
+++ b/src/course-unit/constants.js
@@ -75,4 +75,5 @@ export const messageTypes = {
   completeXBlockEditing: 'completeXBlockEditing',
   studioAjaxError: 'studioAjaxError',
   refreshPositions: 'refreshPositions',
+  openManageTags: 'openManageTags',
 };

--- a/src/course-unit/context/hooks.tsx
+++ b/src/course-unit/context/hooks.tsx
@@ -2,11 +2,11 @@ import { useContext } from 'react';
 
 import { IframeContext, IframeContextType } from './iFrameContext';
 
-// eslint-disable-next-line import/prefer-default-export
 export const useIframe = (): IframeContextType => {
   const context = useContext(IframeContext);
   if (!context) {
-    throw new Error('useIframe must be used within an IframeProvider');
+    // eslint-disable-next-line no-console
+    console.error('useIframe must be used within an IframeProvider');
   }
-  return context;
+  return context as IframeContextType;
 };

--- a/src/course-unit/context/hooks.tsx
+++ b/src/course-unit/context/hooks.tsx
@@ -5,8 +5,7 @@ import { IframeContext, IframeContextType } from './iFrameContext';
 export const useIframe = (): IframeContextType => {
   const context = useContext(IframeContext);
   if (!context) {
-    // eslint-disable-next-line no-console
-    console.error('useIframe must be used within an IframeProvider');
+    throw new Error('useIframe must be used within an IframeProvider');
   }
-  return context as IframeContextType;
+  return context;
 };

--- a/src/course-unit/hooks.test.jsx
+++ b/src/course-unit/hooks.test.jsx
@@ -1,0 +1,122 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useScrollToLastPosition, useLayoutGrid } from './hooks';
+import { messageTypes } from './constants';
+
+jest.useFakeTimers();
+
+describe('useLayoutGrid', () => {
+  it('returns fullWidth layout when isUnitLibraryType is true', () => {
+    const { result } = renderHook(() => useLayoutGrid('someCategory', true));
+
+    expect(result.current).toEqual({
+      lg: [{ span: 12 }, { span: 0 }],
+      md: [{ span: 12 }, { span: 0 }],
+      sm: [{ span: 12 }, { span: 0 }],
+      xs: [{ span: 12 }, { span: 0 }],
+      xl: [{ span: 12 }, { span: 0 }],
+    });
+  });
+
+  it('returns default layout when isUnitLibraryType is false', () => {
+    const { result } = renderHook(() => useLayoutGrid('someCategory', false));
+
+    expect(result.current).toEqual({
+      lg: [{ span: 8 }, { span: 4 }],
+      md: [{ span: 8 }, { span: 4 }],
+      sm: [{ span: 8 }, { span: 3 }],
+      xs: [{ span: 9 }, { span: 3 }],
+      xl: [{ span: 9 }, { span: 3 }],
+    });
+  });
+
+  it('does not recompute layout if unitCategory remains the same', () => {
+    const { result, rerender } = renderHook(
+      ({ unitCategory, isUnitLibraryType }) => useLayoutGrid(unitCategory, isUnitLibraryType),
+      { initialProps: { unitCategory: 'category1', isUnitLibraryType: false } },
+    );
+
+    const firstResult = result.current;
+
+    rerender({ unitCategory: 'category1', isUnitLibraryType: false });
+
+    expect(result.current).toBe(firstResult);
+  });
+
+  it('recomputes layout when unitCategory changes', () => {
+    const { result, rerender } = renderHook(
+      ({ unitCategory, isUnitLibraryType }) => useLayoutGrid(unitCategory, isUnitLibraryType),
+      { initialProps: { unitCategory: 'category1', isUnitLibraryType: false } },
+    );
+
+    const firstResult = result.current;
+
+    rerender({ unitCategory: 'category2', isUnitLibraryType: false });
+
+    expect(result.current).not.toBe(firstResult);
+  });
+});
+
+describe('useScrollToLastPosition', () => {
+  const storageKey = 'createXBlockLastYPosition';
+  let scrollToSpy;
+
+  beforeEach(() => {
+    localStorage.clear();
+    scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    scrollToSpy.mockRestore();
+  });
+
+  it('should not add event listener if no lastYPosition is in localStorage', () => {
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+
+    renderHook(() => useScrollToLastPosition(storageKey));
+
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith('message', expect.any(Function));
+
+    addEventListenerSpy.mockRestore();
+  });
+
+  it('should add event listener if lastYPosition exists in localStorage', () => {
+    localStorage.setItem(storageKey, '500');
+
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+
+    renderHook(() => useScrollToLastPosition(storageKey));
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
+
+    addEventListenerSpy.mockRestore();
+  });
+
+  it('should scroll to saved position on message event', () => {
+    localStorage.setItem(storageKey, '500');
+
+    const { unmount } = renderHook(() => useScrollToLastPosition(storageKey));
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', { data: { type: messageTypes.resize } }));
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 500, behavior: 'smooth' });
+    expect(localStorage.getItem(storageKey)).toBeNull();
+
+    unmount();
+  });
+
+  it('should clear timeout and remove event listener on unmount', () => {
+    localStorage.setItem(storageKey, '500');
+
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useScrollToLastPosition(storageKey));
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
+  });
+});

--- a/src/course-unit/xblock-container-iframe/hooks/types.ts
+++ b/src/course-unit/xblock-container-iframe/hooks/types.ts
@@ -11,6 +11,7 @@ export type UseMessageHandlersTypes = {
   handleCloseLegacyEditorXBlockModal: () => void;
   handleSaveEditedXBlockData: () => void;
   handleFinishXBlockDragging: () => void;
+  handleOpenManageTagsModal: (id: string) => void;
 };
 
 export type MessageHandlersTypes = Record<string, (payload: any) => void>;

--- a/src/course-unit/xblock-container-iframe/hooks/useMessageHandlers.tsx
+++ b/src/course-unit/xblock-container-iframe/hooks/useMessageHandlers.tsx
@@ -26,6 +26,7 @@ export const useMessageHandlers = ({
   handleCloseLegacyEditorXBlockModal,
   handleSaveEditedXBlockData,
   handleFinishXBlockDragging,
+  handleOpenManageTagsModal,
 }: UseMessageHandlersTypes): MessageHandlersTypes => useMemo(() => ({
   [messageTypes.copyXBlock]: ({ usageId }) => dispatch(copyToClipboard(usageId)),
   [messageTypes.deleteXBlock]: ({ usageId }) => handleDeleteXBlock(usageId),
@@ -41,6 +42,7 @@ export const useMessageHandlers = ({
   [messageTypes.saveEditedXBlockData]: handleSaveEditedXBlockData,
   [messageTypes.studioAjaxError]: ({ error }) => handleResponseErrors(error, dispatch, updateSavingStatus),
   [messageTypes.refreshPositions]: handleFinishXBlockDragging,
+  [messageTypes.openManageTags]: (payload) => handleOpenManageTagsModal(payload.contentId),
 }), [
   courseId,
   handleDeleteXBlock,

--- a/src/course-unit/xblock-container-iframe/index.tsx
+++ b/src/course-unit/xblock-container-iframe/index.tsx
@@ -2,7 +2,7 @@ import {
   useRef, FC, useEffect, useState, useMemo, useCallback,
 } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { useToggle } from '@openedx/paragon';
+import { useToggle, Sheet } from '@openedx/paragon';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
@@ -10,6 +10,7 @@ import DeleteModal from '../../generic/delete-modal/DeleteModal';
 import ConfigureModal from '../../generic/configure-modal/ConfigureModal';
 import ModalIframe from '../../generic/modal-iframe';
 import { IFRAME_FEATURE_POLICY } from '../../constants';
+import ContentTagsDrawer from '../../content-tags-drawer/ContentTagsDrawer';
 import supportedEditors from '../../editors/supportedEditors';
 import { useIframe } from '../context/hooks';
 import { updateCourseUnitSidebar } from '../data/thunk';
@@ -43,6 +44,7 @@ const XBlockContainerIframe: FC<XBlockContainerIframeProps> = ({
   const [deleteXBlockId, setDeleteXBlockId] = useState<string | null>(null);
   const [configureXBlockId, setConfigureXBlockId] = useState<string | null>(null);
   const [showLegacyEditModal, setShowLegacyEditModal] = useState<boolean>(false);
+  const [isManageTagsOpen, openManageTagsModal, closeManageTagsModal] = useToggle(false);
 
   const iframeUrl = useMemo(() => getIframeUrl(blockId), [blockId]);
   const legacyEditModalUrl = useMemo(() => getLegacyEditModalUrl(configureXBlockId), [configureXBlockId]);
@@ -120,6 +122,11 @@ const XBlockContainerIframe: FC<XBlockContainerIframeProps> = ({
     dispatch(updateCourseUnitSidebar(blockId));
   };
 
+  const handleOpenManageTagsModal = (id: string) => {
+    setConfigureXBlockId(id);
+    openManageTagsModal();
+  };
+
   const messageHandlers = useMessageHandlers({
     courseId,
     navigate,
@@ -133,6 +140,7 @@ const XBlockContainerIframe: FC<XBlockContainerIframeProps> = ({
     handleCloseLegacyEditorXBlockModal,
     handleSaveEditedXBlockData,
     handleFinishXBlockDragging,
+    handleOpenManageTagsModal,
   });
 
   useIframeMessages(messageHandlers);
@@ -177,6 +185,15 @@ const XBlockContainerIframe: FC<XBlockContainerIframeProps> = ({
         referrerPolicy="origin"
         aria-label={intl.formatMessage(messages.xblockIframeLabel, { xblockCount: courseVerticalChildren.length })}
       />
+      {configureXBlockId && (
+        <Sheet
+          position="right"
+          show={isManageTagsOpen}
+          onClose={closeManageTagsModal}
+        >
+          <ContentTagsDrawer id={configureXBlockId} onClose={closeManageTagsModal} />
+        </Sheet>
+      )}
     </>
   );
 };

--- a/src/course-unit/xblock-container-iframe/index.tsx
+++ b/src/course-unit/xblock-container-iframe/index.tsx
@@ -175,6 +175,7 @@ const XBlockContainerIframe: FC<XBlockContainerIframeProps> = ({
       <iframe
         ref={iframeRef}
         title={intl.formatMessage(messages.xblockIframeTitle)}
+        name="xblock-iframe"
         src={iframeUrl}
         frameBorder="0"
         allow={IFRAME_FEATURE_POLICY}
@@ -190,6 +191,7 @@ const XBlockContainerIframe: FC<XBlockContainerIframeProps> = ({
           position="right"
           show={isManageTagsOpen}
           onClose={closeManageTagsModal}
+          blocking
         >
           <ContentTagsDrawer id={configureXBlockId} onClose={closeManageTagsModal} />
         </Sheet>


### PR DESCRIPTION
🚨 **Dependencies:**
- 🔗 [edx-plarform PR](https://github.com/openedx/edx-platform/pull/35751)

## Description

Added interaction between MFE and Legacy tagging functionality for xblocks on the Course unit page.

Useful information to include:
- fixed problem with scrolling after creating a new xblock with a new editor (https://github.com/openedx/edx-platform/pull/35777#pullrequestreview-2631007078)

## Testing instructions

https://github.com/user-attachments/assets/a2db1457-24d6-4d3f-8c84-22c8f50dfecd

## Other information

**Settings**
```yaml
EDX_PLATFORM_REPOSITORY: https://github.com/raccoongang/edx-platform.git
EDX_PLATFORM_VERSION: Peter_Kulko/manage-tags-interoperation-between-mfe-and-Studio-xBlock-View

TUTOR_GROVE_NEW_MFES:
  authoring:
    port: 18000
    repository: https://github.com/raccoongang/frontend-app-course-authoring.git
    version: Peter_Kulko/manage-tags-interoperation-between-mfe-and-Studio-xBlock-View

TUTOR_GROVE_WAFFLE_FLAGS:
  - name: contentstore.new_studio_mfe.use_new_unit_page
    everyone: true

TUTOR_GROVE_MFE_LMS_COMMON_SETTINGS:
  MFE_CONFIG:
    ENABLE_UNIT_PAGE: true
```