### PR TITLE
fix: 500 error after saving empty subsection release date

### DIFF
--- a/src/generic/configure-modal/ConfigureModal.jsx
+++ b/src/generic/configure-modal/ConfigureModal.jsx
@@ -140,15 +140,18 @@ const ConfigureModal = ({
     : intl.formatMessage(messages.title, { title: displayName });
 
   const handleSave = (data) => {
+    let { releaseDate } = data;
+    // to prevent passing an empty string to the backend
+    releaseDate = releaseDate || null;
     const groupAccess = {};
     switch (category) {
       case COURSE_BLOCK_NAMES.chapter.id:
-        onConfigureSubmit(data.isVisibleToStaffOnly, data.releaseDate);
+        onConfigureSubmit(data.isVisibleToStaffOnly, releaseDate);
         break;
       case COURSE_BLOCK_NAMES.sequential.id:
         onConfigureSubmit(
           data.isVisibleToStaffOnly,
-          data.releaseDate,
+          releaseDate,
           data.graderType,
           data.dueDate,
           data.isTimeLimited,


### PR DESCRIPTION
## Description

#### Steps to Reproduce:

1. In Studio create course -> on Course outline page add Section and Subsection

2. Click on three dots button for Subsections -> click on Configure

3. Set empty **Release date**, save changes
<img width="760" alt="Знімок екрана 2024-11-01 о 15 55 24" src="https://github.com/user-attachments/assets/dbd0ac28-f1d4-4cca-98fa-65894b0ca644">

4. Watch the CMS logs:
```
2024-11-01 14:03:24,129 ERROR 403 [django.request] [user None] [ip None] log.py:241 - Internal Server Error: /xblock/outline/block-v1:RG+dimilitydiadimiljitydiadifnkffffffffffffffffffjkkkkkhhjllkn+2024+type@chapter+block@d51c801024ba44b8ac784375f6648723
Traceback (most recent call last):
  File "/openedx/venv/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pyenv/versions/3.11.8/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/django/views/decorators/http.py", line 43, in inner
    return func(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/django/contrib/auth/decorators.py", line 23, in _wrapper_view
    return view_func(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/common/djangoapps/util/json_request.py", line 57, in parse_json_into_request
    return view_function(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/cms/djangoapps/contentstore/views/block.py", line 324, in xblock_outline_handler
    create_xblock_info(
  File "/openedx/venv/lib/python3.11/site-packages/edx_django_utils/plugins/pluggable_override.py", line 77, in wrapper
    return prev_fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py", line 982, in create_xblock_info
    child_info = _create_xblock_child_info(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py", line 1520, in _create_xblock_child_info
    child_info["children"] = [
                             ^
  File "/openedx/edx-platform/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py", line 1521, in <listcomp>
    create_xblock_info(
  File "/openedx/venv/lib/python3.11/site-packages/edx_django_utils/plugins/pluggable_override.py", line 77, in wrapper
    return prev_fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py", line 998, in create_xblock_info
    visibility_state = _compute_visibility_state(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py", line 1418, in _compute_visibility_state
    is_live = is_course_self_paced or datetime.now(UTC) > xblock.start
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'datetime.datetime' and 'NoneType'
[01/Nov/2024 14:03:24] "GET /xblock/outline/block-v1:RG+dimilitydiadimiljitydiadifnkffffffffffffffffffjkkkkkhhjllkn+2024+type@chapter+block@d51c801024ba44b8ac784375f6648723 HTTP/1.1" 500 340232
```
5. Comparison with legacy page
<img width="1493" alt="Знімок екрана 2024-11-01 о 16 01 44" src="https://github.com/user-attachments/assets/59fec102-349c-4059-b46d-e2b393ef4518">

<img width="1493" alt="Знімок екрана 2024-11-01 о 16 00 04" src="https://github.com/user-attachments/assets/ced5ed67-eeb1-498a-8518-d356fbc3f367">

Because the string comes to the backend, the [logic does not work correctly](https://github.com/openedx/edx-platform/blob/d6e05281484e1a039100a228782e74e5e3ad89f7/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py#L431).

### After fix:
<img width="1493" alt="Знімок екрана 2024-11-01 о 16 09 42" src="https://github.com/user-attachments/assets/c3e42638-d82b-43d4-a7fc-d19c33158034">


