### PR TITLE
chore: hide transcripts in video preview for library

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoPreviewWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoPreviewWidget/index.jsx
@@ -16,6 +16,7 @@ const VideoPreviewWidget = ({
   videoSource,
   transcripts,
   blockTitle,
+  isLibrary,
   intl,
 }) => {
   const imgRef = React.useRef();
@@ -45,7 +46,9 @@ const VideoPreviewWidget = ({
           />
           <Stack gap={1} className="justify-content-center">
             <h4 className="text-primary mb-0">{blockTitle}</h4>
-            <LanguageNamesWidget transcripts={transcripts} />
+            {!isLibrary && (
+              <LanguageNamesWidget transcripts={transcripts} />
+            )}
             {videoType && (
               <Hyperlink
                 className="text-primary x-small"
@@ -69,6 +72,7 @@ VideoPreviewWidget.propTypes = {
   thumbnail: PropTypes.string.isRequired,
   transcripts: PropTypes.arrayOf(PropTypes.string).isRequired,
   blockTitle: PropTypes.string.isRequired,
+  isLibrary: PropTypes.bool.isRequired,
 };
 
 export const mapStateToProps = (state) => ({
@@ -76,6 +80,7 @@ export const mapStateToProps = (state) => ({
   videoSource: selectors.video.videoSource(state),
   thumbnail: selectors.video.thumbnail(state),
   blockTitle: selectors.app.blockTitle(state),
+  isLibrary: selectors.app.isLibrary(state),
 });
 
 export default injectIntl(connect(mapStateToProps)(VideoPreviewWidget));

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoPreviewWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoPreviewWidget/index.jsx
@@ -11,7 +11,8 @@ import hooks from './hooks';
 import LanguageNamesWidget from './LanguageNamesWidget';
 import videoThumbnail from '../../../../../../data/images/videoThumbnail.svg';
 
-const VideoPreviewWidget = ({
+// Exporting to test this component separately
+export const VideoPreviewWidget = ({
   thumbnail,
   videoSource,
   transcripts,
@@ -47,6 +48,7 @@ const VideoPreviewWidget = ({
           <Stack gap={1} className="justify-content-center">
             <h4 className="text-primary mb-0">{blockTitle}</h4>
             {!isLibrary && (
+              // Since content libraries v2 don't support static assets yet, we can't include transcripts.
               <LanguageNamesWidget transcripts={transcripts} />
             )}
             {videoType && (

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoPreviewWidget/index.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoPreviewWidget/index.test.jsx
@@ -1,0 +1,47 @@
+import {
+  initializeMocks,
+  render,
+  screen,
+} from '../../../../../../../testUtils';
+
+import { VideoPreviewWidget } from '.';
+
+describe('VideoPreviewWidget', () => {
+  const mockIntl = {
+    formatMessage: (message) => message.defaultMessage,
+  };
+
+  beforeEach(() => {
+    initializeMocks();
+  });
+
+  describe('render', () => {
+    test('renders transcripts section in preview for courses', () => {
+      render(
+        <VideoPreviewWidget
+          videoSource="some-source"
+          isLibrary={false}
+          intl={mockIntl}
+          transcripts={[]}
+          blockTitle="some title"
+          thumbnail=""
+        />,
+      );
+      expect(screen.queryByText('No transcripts added')).toBeInTheDocument();
+    });
+
+    test('hides transcripts section in preview for libraries', () => {
+      render(
+        <VideoPreviewWidget
+          videoSource="some-source"
+          isLibrary
+          intl={mockIntl}
+          transcripts={[]}
+          blockTitle="some title"
+          thumbnail=""
+        />,
+      );
+      expect(screen.queryByText('No transcripts added')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.tsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.tsx
@@ -11,7 +11,8 @@ import LicenseWidget from './components/LicenseWidget';
 import ThumbnailWidget from './components/ThumbnailWidget';
 import TranscriptWidget from './components/TranscriptWidget';
 import VideoSourceWidget from './components/VideoSourceWidget';
-import VideoPreviewWidget from './components/VideoPreviewWidget';
+// Using default import to get selectors connected VideoSourceWidget
+import ConnectedVideoPreviewWidget from './components/VideoPreviewWidget';
 import './index.scss';
 import SocialShareWidget from './components/SocialShareWidget';
 import messages from '../../messages';
@@ -42,7 +43,7 @@ const VideoSettingsModal: React.FC<Props> = ({
       </Button>
     )}
     <ErrorSummary />
-    <VideoPreviewWidget />
+    <ConnectedVideoPreviewWidget />
     <VideoSourceWidget />
     {!isLibrary && (
       <SocialShareWidget />


### PR DESCRIPTION
## Description

Fixes: https://github.com/openedx/frontend-app-authoring/issues/1453

## Supporting information

* `Private-ref`: [FAL-3873](https://tasks.opencraft.com/browse/FAL-3873)
* https://github.com/openedx/frontend-app-authoring/issues/1453

## Testing instructions

* Check transcripts in video editor preview in both course and libraries.
* The transcripts part in preview should only be visible for courses.
