### PR TITLE
fix: show a more detailed error on Bad Request

### DIFF
--- a/src/library-authoring/add-content/AddContentContainer.test.tsx
+++ b/src/library-authoring/add-content/AddContentContainer.test.tsx
@@ -227,4 +227,21 @@ describe('<AddContentContainer />', () => {
       expect(mockShowToast).toHaveBeenCalledWith(errMsg);
     });
   });
+
+  it('should show validation errors in the toast', async () => {
+    const { axiosMock, mockShowToast } = initializeMocks();
+    const url = getCreateLibraryBlockUrl(libraryId);
+    const errMsg = 'Library cannot have more than 100000 Components';
+    axiosMock.onPost(url).reply(400, [errMsg]);
+
+    render();
+
+    const textButton = screen.getByRole('button', { name: /text/i });
+    fireEvent.click(textButton);
+
+    await waitFor(() => {
+      expect(axiosMock.history.post.length).toEqual(0);
+      expect(mockShowToast).toHaveBeenCalledWith(errMsg);
+    });
+  });
 });

--- a/src/library-authoring/add-content/AddContentContainer.tsx
+++ b/src/library-authoring/add-content/AddContentContainer.tsx
@@ -196,8 +196,14 @@ const AddContentContainer = () => {
         // We can't start editing this right away so just show a toast message:
         showToast(intl.formatMessage(messages.successCreateMessage));
       }
-    }).catch(() => {
-      showToast(intl.formatMessage(messages.errorCreateMessage));
+    }).catch((error) => {
+      // 400 Bad Request error usually means we've reached the library's component count limit
+      if (error.response.status === 400) {
+        const detail = error.response.data.length ? error.response.data.join(', ') : error.response.data;
+        showToast(intl.formatMessage(messages.errorCreateMessageWithDetail, { detail }));
+      } else {
+        showToast(intl.formatMessage(messages.errorCreateMessage));
+      }
     });
   };
 

--- a/src/library-authoring/add-content/AddContentContainer.tsx
+++ b/src/library-authoring/add-content/AddContentContainer.tsx
@@ -197,9 +197,12 @@ const AddContentContainer = () => {
         showToast(intl.formatMessage(messages.successCreateMessage));
       }
     }).catch((error) => {
-      // 400 Bad Request error usually means we've reached the library's component count limit
-      if (error.response.status === 400) {
-        const detail = error.response.data.length ? error.response.data.join(', ') : error.response.data;
+      // 400 usually means we've reached the library's max block limit
+      if (
+        error && error.response && error.response.status === 400
+        && error.response.data && error.response.data.length
+      ) {
+        const detail: string = [].concat(error.response.data).join();
         showToast(intl.formatMessage(messages.errorCreateMessageWithDetail, { detail }));
       } else {
         showToast(intl.formatMessage(messages.errorCreateMessage));

--- a/src/library-authoring/add-content/messages.ts
+++ b/src/library-authoring/add-content/messages.ts
@@ -63,8 +63,16 @@ const messages = defineMessages({
   },
   errorCreateMessage: {
     id: 'course-authoring.library-authoring.add-content.error.text',
-    defaultMessage: 'There was an error creating the content.',
-    description: 'Message when creation of content in library is on error',
+    defaultMessage: 'There was an error creating the content. {detail}',
+    description: 'Message when creation of content in library is on error.',
+  },
+  errorCreateMessageWithDetail: {
+    id: 'course-authoring.library-authoring.add-content.error.text-detail',
+    defaultMessage: 'There was an error creating the content: {detail}',
+    description: (
+      'Message when creation of content in library is on error.'
+      + ' The {detail} text provides more information about the error.'
+    ),
   },
   linkingComponentMessage: {
     id: 'course-authoring.library-authoring.linking-collection-content.progress.text',

--- a/src/library-authoring/add-content/messages.ts
+++ b/src/library-authoring/add-content/messages.ts
@@ -63,7 +63,7 @@ const messages = defineMessages({
   },
   errorCreateMessage: {
     id: 'course-authoring.library-authoring.add-content.error.text',
-    defaultMessage: 'There was an error creating the content. {detail}',
+    defaultMessage: 'There was an error creating the content.',
     description: 'Message when creation of content in library is on error.',
   },
   errorCreateMessageWithDetail: {
@@ -103,6 +103,14 @@ const messages = defineMessages({
     id: 'course-authoring.library-authoring.paste-clipboard.error.text',
     defaultMessage: 'There was an error pasting the content.',
     description: 'Message when pasting clipboard in library errors',
+  },
+  errorPasteClipboardMessageWithDetail: {
+    id: 'course-authoring.library-authoring.paste-clipboard.error.text-detail',
+    defaultMessage: 'There was an error pasting the content: {detail}',
+    description: (
+      'Message when pasting clipboard in library errors.'
+      + ' The {detail} text provides more information about the error.'
+    ),
   },
   pastingClipboardMessage: {
     id: 'course-authoring.library-authoring.paste-clipboard.loading.text',


### PR DESCRIPTION
## Description

Show a detailed error when 400 Bad Request received while adding a component to a library, either a new or pasted component. The most likely error from the backend here is "library can only have {max} components", and since this error is translated already, we can just report it through.

Content Authors using Libraries v2 are affected by this change.

Error shown on paste:

![image](https://github.com/user-attachments/assets/70259f73-83ca-412e-8450-d3a6014bd6d5)

Error shown on create:

![image](https://github.com/user-attachments/assets/3e6c02b7-7b3e-4d6f-bee5-0cb12fd6cef8)

## Supporting information

Relates to: https://github.com/openedx/frontend-app-authoring/issues/1456
Private-ref: [FAL-3873](https://tasks.opencraft.com/browse/FAL-3873)

## Testing instructions

1. Manually decrease `settings.MAX_BLOCKS_PER_CONTENT_LIBRARY` in the backend to a suitable limit for testing.
2. Try to add more than `settings.MAX_BLOCKS_PER_CONTENT_LIBRARY` blocks to a content library
3. Confirm that the updated toast error is legible and helpful.