### PR TITLE
[sumac] fix: add component to collection on paste [FC-0062] (#1450)

### DIFF
--- a/src/library-authoring/add-content/AddContentContainer.tsx
+++ b/src/library-authoring/add-content/AddContentContainer.tsx
@@ -158,6 +158,14 @@ const AddContentContainer = () => {
     contentTypes.push(pasteButton);
   }
 
+  const linkComponent = (usageKey: string) => {
+    updateComponentsMutation.mutateAsync([usageKey]).then(() => {
+      showToast(intl.formatMessage(messages.successAssociateComponentMessage));
+    }).catch(() => {
+      showToast(intl.formatMessage(messages.errorAssociateComponentMessage));
+    });
+  };
+
   const onPaste = () => {
     if (!isBlockTypeEnabled(sharedClipboardData.content?.blockType)) {
       showToast(intl.formatMessage(messages.unsupportedBlockPasteClipboardMessage));
@@ -166,7 +174,8 @@ const AddContentContainer = () => {
     pasteClipboardMutation.mutateAsync({
       libraryId,
       blockId: `${uuid4()}`,
-    }).then(() => {
+    }).then((data) => {
+      linkComponent(data.id);
       showToast(intl.formatMessage(messages.successPasteClipboardMessage));
     }).catch((error) => {
       showToast(parsePasteErrorMsg(error));
@@ -179,10 +188,8 @@ const AddContentContainer = () => {
       blockType,
       definitionId: `${uuid4()}`,
     }).then((data) => {
+      linkComponent(data.id);
       const hasEditor = canEditComponent(data.id);
-      updateComponentsMutation.mutateAsync([data.id]).catch(() => {
-        showToast(intl.formatMessage(messages.errorAssociateComponentMessage));
-      });
       if (hasEditor) {
         openComponentEditor(data.id);
       } else {
@@ -208,6 +215,10 @@ const AddContentContainer = () => {
 
   if (pasteClipboardMutation.isLoading) {
     showToast(intl.formatMessage(messages.pastingClipboardMessage));
+  }
+
+  if (updateComponentsMutation.isLoading) {
+    showToast(intl.formatMessage(messages.linkingComponentMessage));
   }
 
   return (

--- a/src/library-authoring/add-content/messages.ts
+++ b/src/library-authoring/add-content/messages.ts
@@ -66,6 +66,11 @@ const messages = defineMessages({
     defaultMessage: 'There was an error creating the content.',
     description: 'Message when creation of content in library is on error',
   },
+  linkingComponentMessage: {
+    id: 'course-authoring.library-authoring.linking-collection-content.progress.text',
+    defaultMessage: 'Adding component to collection...',
+    description: 'Message when component is being linked to collection in library',
+  },
   successAssociateComponentMessage: {
     id: 'course-authoring.library-authoring.associate-collection-content.success.text',
     defaultMessage: 'Content linked successfully.',


### PR DESCRIPTION
Link component to collection if pasted in a collection page. Fixes: https://github.com/openedx/frontend-app-authoring/issues/1435

(cherry picked from commit 549dbaa0fa5df9451b649cf148adbd8f9137c30f)

Backport of https://github.com/openedx/frontend-app-authoring/pull/1450