### PR TITLE
[sumac] fix: add spacing to searchbar and simplify render conditions [FC-0062]

### DIFF
--- a/src/library-authoring/component-picker/SelectLibrary.tsx
+++ b/src/library-authoring/component-picker/SelectLibrary.tsx
@@ -83,44 +83,44 @@ const SelectLibrary = ({ selectedLibrary, setSelectedLibrary }: SelectLibraryPro
         value={searchQuery}
         placeholder={intl.formatMessage(messages.selectLibrarySearchPlaceholder)}
       />
-      <div>
-        {data.results.length === 0 && (<EmptyState hasSearchQuery={!!searchQuery} />)}
-        <Form.RadioSet
-          name="selected-library"
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSelectedLibrary(e.target.value)}
-          value={selectedLibrary}
-        >
-          {data.results.map((library) => (
-            <Card
-              key={library.id}
-              isClickable
-              onClick={() => setSelectedLibrary(library.id)}
-              className="card-item"
-            >
-              <Card.Header
-                size="sm"
-                title={<span className="card-item-title">{library.title}</span>}
-                subtitle={`${library.org} / ${library.slug}`}
-                actions={(
-                  <Form.Radio value={library.id} name={`select-library-${library.id}`}>{' '}</Form.Radio>
-                )}
-              />
-              <Card.Body>
-                <p>{library.description}</p>
-              </Card.Body>
-            </Card>
-          ))}
-        </Form.RadioSet>
-      </div>
-      {data.results.length !== 0 && (
-        <Pagination
-          paginationLabel={intl.formatMessage(messages.selectLibraryPaginationLabel)}
-          pageCount={data!.numPages}
-          currentPage={data!.currentPage}
-          onPageSelect={(page: number) => setCurrentPage(page)}
-          variant="secondary"
-          className="align-self-center"
-        />
+      {data.results.length === 0 ? (<EmptyState hasSearchQuery={!!searchQuery} />) : (
+        <>
+          <Form.RadioSet
+            name="selected-library"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSelectedLibrary(e.target.value)}
+            value={selectedLibrary}
+            className="mt-4"
+          >
+            {data.results.map((library) => (
+              <Card
+                key={library.id}
+                isClickable
+                onClick={() => setSelectedLibrary(library.id)}
+                className="card-item"
+              >
+                <Card.Header
+                  size="sm"
+                  title={<span className="card-item-title">{library.title}</span>}
+                  subtitle={`${library.org} / ${library.slug}`}
+                  actions={(
+                    <Form.Radio value={library.id} name={`select-library-${library.id}`}>{' '}</Form.Radio>
+                  )}
+                />
+                <Card.Body>
+                  <p>{library.description}</p>
+                </Card.Body>
+              </Card>
+            ))}
+          </Form.RadioSet>
+          <Pagination
+            paginationLabel={intl.formatMessage(messages.selectLibraryPaginationLabel)}
+            pageCount={data!.numPages}
+            currentPage={data!.currentPage}
+            onPageSelect={setCurrentPage}
+            variant="secondary"
+            className="align-self-center"
+          />
+        </>
       )}
     </Stack>
   );


### PR DESCRIPTION
Backport of https://github.com/openedx/frontend-app-authoring/pull/1461

## Description
This PR adds padding between the search bar and the library list.

Also, the render method was refactored to be a bit simpler.

### Before
![image](https://github.com/user-attachments/assets/4e63c4b6-5f82-43ed-88b4-0f7331ffeb11)

### After
![image](https://github.com/user-attachments/assets/53e53147-56f2-4170-9874-585079e3e4fb)


## Additional Information
- Part of:
  - https://github.com/openedx/frontend-app-authoring/issues/1337#issuecomment-2425279039

## Testing instructions
-  Open http://apps.local.edly.io:2001/course-authoring/component-picker
- Check the spacing between the search bar and the library list

___
Private ref: [FAL-3931](https://tasks.opencraft.com/browse/FAL-3931)