### PR TITLE
fix: Show published count component in library content picker [FC-0062]

### DIFF
--- a/src/library-authoring/components/CollectionCard.test.tsx
+++ b/src/library-authoring/components/CollectionCard.test.tsx
@@ -27,14 +27,24 @@ const CollectionHitSample: CollectionHit = {
   created: 1722434322294,
   modified: 1722434322294,
   numChildren: 2,
+  published: {
+    numChildren: 1,
+  },
   tags: {},
 };
 
 let axiosMock: MockAdapter;
 let mockShowToast;
 
-const render = (ui: React.ReactElement) => baseRender(ui, {
-  extraWrapper: ({ children }) => <LibraryProvider libraryId="lib:Axim:TEST">{ children }</LibraryProvider>,
+const render = (ui: React.ReactElement, showOnlyPublished: boolean = false) => baseRender(ui, {
+  extraWrapper: ({ children }) => (
+    <LibraryProvider
+      libraryId="lib:Axim:TEST"
+      showOnlyPublished={showOnlyPublished}
+    >
+      { children }
+    </LibraryProvider>
+  ),
 });
 
 describe('<CollectionCard />', () => {
@@ -50,6 +60,14 @@ describe('<CollectionCard />', () => {
     expect(screen.queryByText('Collection Display Formated Name')).toBeInTheDocument();
     expect(screen.queryByText('Collection description')).toBeInTheDocument();
     expect(screen.queryByText('Collection (2)')).toBeInTheDocument();
+  });
+
+  it('should render published content', () => {
+    render(<CollectionCard collectionHit={CollectionHitSample} />, true);
+
+    expect(screen.queryByText('Collection Display Formated Name')).toBeInTheDocument();
+    expect(screen.queryByText('Collection description')).toBeInTheDocument();
+    expect(screen.queryByText('Collection (1)')).toBeInTheDocument();
   });
 
   it('should navigate to the collection if the open menu clicked', async () => {

--- a/src/library-authoring/components/CollectionCard.tsx
+++ b/src/library-authoring/components/CollectionCard.tsx
@@ -111,6 +111,7 @@ const CollectionCard = ({ collectionHit } : CollectionCardProps) => {
   const {
     openCollectionInfoSidebar,
     componentPickerMode,
+    showOnlyPublished,
   } = useLibraryContext();
 
   const {
@@ -118,7 +119,13 @@ const CollectionCard = ({ collectionHit } : CollectionCardProps) => {
     formatted,
     tags,
     numChildren,
+    published,
   } = collectionHit;
+
+  const numChildrenCount = showOnlyPublished ? (
+    published?.numChildren || 0
+  ) : numChildren;
+
   const { displayName = '', description = '' } = formatted;
 
   return (
@@ -127,7 +134,7 @@ const CollectionCard = ({ collectionHit } : CollectionCardProps) => {
       displayName={displayName}
       description={description}
       tags={tags}
-      numChildren={numChildren}
+      numChildren={numChildrenCount}
       actions={!componentPickerMode && (
         <ActionRow>
           <CollectionMenu collectionHit={collectionHit} />

--- a/src/search-manager/data/api.ts
+++ b/src/search-manager/data/api.ts
@@ -142,6 +142,7 @@ export interface ContentHit extends BaseContentHit {
 export interface ContentPublishedData {
   description?: string,
   displayName?: string,
+  numChildren?: number,
 }
 
 /**
@@ -151,6 +152,7 @@ export interface ContentPublishedData {
 export interface CollectionHit extends BaseContentHit {
   description: string;
   numChildren?: number;
+  published?: ContentPublishedData;
 }
 
 /**


### PR DESCRIPTION
## Description

When using the library component picker, show the correct number on component count (published components) in collection cards.

- Which edX user roles will this change impact?  "Course Author"

## Supporting information

Github issue: https://github.com/openedx/modular-learning/issues/234
Internal ticket: [FAL-3921](https://tasks.opencraft.com/browse/FAL-3921)
Depends on: https://github.com/openedx/edx-platform/pull/35734

## Testing instructions

- Use this branch of edx-paltform: https://github.com/openedx/edx-platform/pull/35734
- Go library home page of a library
- Create or use a collection
- Create components in the collection
- Publish the library
- Create new components, but not publish the library
- Go to a unit in a course and add a "Library content", using the legacy UI
- Select your library and search your collection
- Check that in the collection card, the component count shows only the published components
