### PR TITLE
fix: fetch proper courses when keyword searching with applied filters

### DIFF
--- a/src/studio-home/tabs-section/courses-tab/courses-filters/index.jsx
+++ b/src/studio-home/tabs-section/courses-tab/courses-filters/index.jsx
@@ -95,7 +95,7 @@ const CoursesFilters = ({
 
   const handleSearchCoursesDebounced = useCallback(
     debounce((value) => handleSearchCourses(value), 400),
-    [],
+    [activeOnly, archivedOnly, order, inputSearchValue],
   );
 
   return (


### PR DESCRIPTION
## Description

This PR makes the Studio Home search bar work as expected. When active/archived filters were on or there was selected any order filter, the search skipped these values and just returned the courses list without the respective filters. Additionally, when a search keyword was applied and a filter was selected, the keyword stayed stuck and the search list returned was not the appropriate

- [courses-filters/index.jsx](https://github.com/openedx/frontend-app-authoring/pull/1497/files#diff-f970504b9f0fcd613b8df290917964121b7b09712cae9760ff41c4646833470e): It was added the filter states to the `useCallback` dependencies so if any of this filters changes, they are applied properly and retrieved the proper data

## Supporting information

GitHub Issue: https://github.com/openedx/frontend-app-authoring/issues/1477

## Testing instructions

Make sure you count on at least one course and do the following:

1. Mount this branch on the `frontend-app-authoring` MFE to test it
2. Go to the [Studio Home](http://apps.local.openedx.io:2001/authoring/home), you'll watch all your courses
3. Now apply the filter `Archived` in the dropdown beside the search bar 
4. Try to look for a course you know is active, but if everything goes well, you shouldn't be able to find it
5. The same must happen if you have activated the filter `Active` and try to look for an archived course
6. Ensure you are shown the message "We could not find any results."

### Screenshots
1. Archive/active filter is taken into account
![image](https://github.com/user-attachments/assets/de8a7842-4e8a-458b-8ad0-6575e7ad9d6d)

2. The sorting filter is applied despite changing the other filters
![image](https://github.com/user-attachments/assets/4af9d1df-e1f8-40a7-903b-049a4f536b4d)

3. The search stayed stuck due to a specific keyword was preserved when a filter was applied:
  - Before
    ![image](https://github.com/user-attachments/assets/88b7d3bd-e8d3-4aed-a517-4d3f030742ea)
  - After
    ![image](https://github.com/user-attachments/assets/d00bacf3-1b2b-423b-bc29-f511388fbc0d)
