### PR TITLE
fix: TinyMce aux modal issues in text editors [FC-0062]

### DIFF
--- a/src/editors/containers/EditorContainer/index.tsx
+++ b/src/editors/containers/EditorContainer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useDispatch } from 'react-redux';
 
 import {

--- a/src/editors/containers/EditorContainer/index.tsx
+++ b/src/editors/containers/EditorContainer/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 import {
@@ -41,7 +41,7 @@ export const EditorModalWrapper: React.FC<WrapperProps & { onClose: () => void }
   }
   const title = intl.formatMessage(messages.modalTitle);
   return (
-    <ModalDialog isBlocking isOpen size="xl" isOverflowVisible={false} onClose={onClose} title={title}>{children}</ModalDialog>
+    <ModalDialog isOpen size="xl" isOverflowVisible={false} onClose={onClose} title={title}>{children}</ModalDialog>
   );
 };
 

--- a/src/editors/containers/EditorContainer/index.tsx
+++ b/src/editors/containers/EditorContainer/index.tsx
@@ -41,7 +41,7 @@ export const EditorModalWrapper: React.FC<WrapperProps & { onClose: () => void }
   }
   const title = intl.formatMessage(messages.modalTitle);
   return (
-    <ModalDialog isOpen size="xl" isOverflowVisible={false} onClose={onClose} title={title}>{children}</ModalDialog>
+    <ModalDialog isBlocking isOpen size="xl" isOverflowVisible={false} onClose={onClose} title={title}>{children}</ModalDialog>
   );
 };
 

--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -220,12 +220,12 @@ export const setupCustomBehavior = ({
     });
   }
 
-  editor.on('init', () => {
+  editor.on('init', /* istanbul ignore next */ () => {
     // Moving TinyMce aux modal inside the Editor modal
     // if the editor is on modal mode.
     // This is to avoid issues using the aux modal:
-    // * Avoid close aux modal when clicking the content.
-    // * When the user opens the `Edit Source Code`, this modal adds `data-focus-on-hidden`
+    // * Avoid close aux modal when clicking the content inside.
+    // * When the user opens the `Edit Source Code` modal, this adds `data-focus-on-hidden`
     //   to the TinyMce aux modal, making it unusable.
     const modalLayer = document.querySelector('.pgn__modal-layer');
     const tinymceAux = document.querySelector('.tox.tox-tinymce-aux');
@@ -235,10 +235,10 @@ export const setupCustomBehavior = ({
     }
   });
 
-  editor.on('ExecCommand', (e) => {
+  editor.on('ExecCommand', /* istanbul ignore next */ (e) => {
     // Remove `data-focus-on-hidden` and `area-hidden` on TinyMce aux modal used on emoticons, formulas, etc.
-    // When using the editor in modal mode, it may happen that the modal is rendered before the TinyMce aux modal,
-    // which adds these attributes, making the modal unusable.
+    // When using the Editor in modal mode, it may happen that the editor modal is rendered before the TinyMce aux modal,
+    // which adds these attributes, making the TinyMce aux modal unusable.
     const modalElement = document.querySelector('.tox.tox-silver-sink.tox-tinymce-aux');
     if (modalElement) {
       modalElement.removeAttribute('data-focus-on-hidden');

--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -222,14 +222,31 @@ export const setupCustomBehavior = ({
       if (newContent) { updateContent(newContent); }
     });
   }
+
+  editor.on('init', () => {
+    // Moving TinyMce aux modal inside the Editor modal
+    // if the editor is on modal mode.
+    // This is to avoid issues using the aux modal:
+    // * Avoid close aux modal when clicking the content.
+    // * When the user opens the `Edit Source Code`, this modal adds `data-focus-on-hidden`
+    //   to the TinyMce aux modal, making it unusable.
+    const modalLayer = document.querySelector('.pgn__modal-layer');
+    const tinymceAux = document.querySelector('.tox.tox-tinymce-aux');
+  
+    if (modalLayer && tinymceAux) {
+        modalLayer.appendChild(tinymceAux);
+    }
+  });
+
   editor.on('ExecCommand', (e) => {
 
-    // Remove `data-focus-on-hidden` on TinyMce aux modal used on emoticons, formulas, etc.
-    // Use case: When the user opens the `Edit Source Code`, this modal adds `data-focus-on-hidden`
-    // to the TinyMce aux modal, making it unusable.
-    var modalElement = document.querySelector('.tox-tinymce-aux');
+    // Remove `data-focus-on-hidden` and `area-hidden` on TinyMce aux modal used on emoticons, formulas, etc.
+    // When using the editor in modal mode, it may happen that the modal is rendered before the TinyMce aux modal,
+    // which adds these attributes, making the modal unusable.
+    const modalElement = document.querySelector('.tox.tox-silver-sink.tox-tinymce-aux');
     if (modalElement) {
       modalElement.removeAttribute('data-focus-on-hidden');
+      modalElement.removeAttribute('aria-hidden');
     }
 
     if (editorType === 'text' && e.command === 'mceFocus') {

--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -178,6 +178,8 @@ export const setupCustomBehavior = ({
     tooltip: 'Source code',
     onAction: openSourceCodeModal,
   });
+  
+
   // add a custom simple inline code block formatter.
   const setupCodeFormatting = (api) => {
     editor.formatter.formatChanged(
@@ -185,6 +187,7 @@ export const setupCustomBehavior = ({
       (active) => api.setActive(active),
     );
   };
+
   const toggleCodeFormatting = () => {
     editor.formatter.toggle('code');
     editor.undoManager.add();
@@ -220,6 +223,15 @@ export const setupCustomBehavior = ({
     });
   }
   editor.on('ExecCommand', (e) => {
+
+    // Remove `data-focus-on-hidden` on TinyMce aux modal used on emoticons, formulas, etc.
+    // Use case: When the user opens the `Edit Source Code`, this modal adds `data-focus-on-hidden`
+    // to the TinyMce aux modal, making it unusable.
+    var modalElement = document.querySelector('.tox-tinymce-aux');
+    if (modalElement) {
+      modalElement.removeAttribute('data-focus-on-hidden');
+    }
+
     if (editorType === 'text' && e.command === 'mceFocus') {
       const initialContent = editor.getContent();
       const newContent = module.replaceStaticWithAsset({

--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -237,8 +237,8 @@ export const setupCustomBehavior = ({
 
   editor.on('ExecCommand', /* istanbul ignore next */ (e) => {
     // Remove `data-focus-on-hidden` and `area-hidden` on TinyMce aux modal used on emoticons, formulas, etc.
-    // When using the Editor in modal mode, it may happen that the editor modal is rendered before the TinyMce aux modal,
-    // which adds these attributes, making the TinyMce aux modal unusable.
+    // When using the Editor in modal mode, it may happen that the editor modal is rendered
+    // before the TinyMce aux modal, which adds these attributes, making the TinyMce aux modal unusable.
     const modalElement = document.querySelector('.tox.tox-silver-sink.tox-tinymce-aux');
     if (modalElement) {
       modalElement.removeAttribute('data-focus-on-hidden');

--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -178,8 +178,6 @@ export const setupCustomBehavior = ({
     tooltip: 'Source code',
     onAction: openSourceCodeModal,
   });
-  
-
   // add a custom simple inline code block formatter.
   const setupCodeFormatting = (api) => {
     editor.formatter.formatChanged(
@@ -187,7 +185,6 @@ export const setupCustomBehavior = ({
       (active) => api.setActive(active),
     );
   };
-
   const toggleCodeFormatting = () => {
     editor.formatter.toggle('code');
     editor.undoManager.add();
@@ -232,14 +229,13 @@ export const setupCustomBehavior = ({
     //   to the TinyMce aux modal, making it unusable.
     const modalLayer = document.querySelector('.pgn__modal-layer');
     const tinymceAux = document.querySelector('.tox.tox-tinymce-aux');
-  
+
     if (modalLayer && tinymceAux) {
-        modalLayer.appendChild(tinymceAux);
+      modalLayer.appendChild(tinymceAux);
     }
   });
 
   editor.on('ExecCommand', (e) => {
-
     // Remove `data-focus-on-hidden` and `area-hidden` on TinyMce aux modal used on emoticons, formulas, etc.
     // When using the editor in modal mode, it may happen that the modal is rendered before the TinyMce aux modal,
     // which adds these attributes, making the modal unusable.

--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -236,7 +236,7 @@ export const setupCustomBehavior = ({
   });
 
   editor.on('ExecCommand', /* istanbul ignore next */ (e) => {
-    // Remove `data-focus-on-hidden` and `area-hidden` on TinyMce aux modal used on emoticons, formulas, etc.
+    // Remove `data-focus-on-hidden` and `aria-hidden` on TinyMce aux modal used on emoticons, formulas, etc.
     // When using the Editor in modal mode, it may happen that the editor modal is rendered
     // before the TinyMce aux modal, which adds these attributes, making the TinyMce aux modal unusable.
     const modalElement = document.querySelector('.tox.tox-silver-sink.tox-tinymce-aux');


### PR DESCRIPTION
## Description

Fixes https://github.com/openedx/frontend-app-authoring/issues/1426

The following bugs were found with the TinyMCE aux modal (used in emoticons, formulas and embed iframe):

- The TinyMCE aux modal and the Editor modal close when clicking on any content in the aux modal.
- When the user opens the `Edit Source Code` modal, this adds `data-focus-on-hidden` to the TinyMce aux modal, making it unusable (not clickable).
- Since they are two separate modals, the focus remains on the editor modal, making it impossible to use scrolling or inputs from the modal aux.

**Solution:** Move the aux modal inside the editor modal.

One discarded solution: Block the modal editor from closing when interacting with the modal aux. The modal editor still retained focus.


![image](https://github.com/user-attachments/assets/7711eafb-7120-447a-92b1-a3eba9241f3e)

- Which edX user roles will this change impact? "Course Author"

## Supporting information

Github issue: https://github.com/openedx/frontend-app-authoring/issues/1426
Internal ticket: [FAL-3928](https://tasks.opencraft.com/browse/FAL-3928)

## Testing instructions

- Go to library home of a library.
- Adds a new Text component.
- On the text editor, open the emoticons modal. Test it.
- On the text editor, open the formulas modal. Test it.
- On the text editor, open the Embed iframe modal. Test it.
- On the text editor, open the HTML modal, close it, and open another aux modal.
- Testing above using a problem component.
- Go to unit page using the MFE UI. (Enabling `contentstore.new_studio_mfe.use_new_unit_page`)
- Test the editor with text and problem components.
- Go to unit page using the Legacy UI. (Disabling `contentstore.new_studio_mfe.use_new_unit_page`)
- Test the editor with text and problem components.
