### PR TITLE
refactor: remove pointless maintenance link message

### DIFF
--- a/src/header/messages.js
+++ b/src/header/messages.js
@@ -111,11 +111,6 @@ const messages = defineMessages({
     defaultMessage: 'Studio Home',
     description: 'Link to Studio Home',
   },
-  'header.user.menu.maintenance': {
-    id: 'header.user.menu.maintenance',
-    defaultMessage: 'Maintenance',
-    description: 'Link to the Studio maintenance page',
-  },
   'header.user.menu.logout': {
     id: 'header.user.menu.logout',
     defaultMessage: 'Logout',


### PR DESCRIPTION
This link is defined in frontend-component-header, so the message shouldn't be here. Anyway, we are [deleting the link from frontend-component-header too](https://github.com/openedx/frontend-component-header/pull/553), as [the app is being removed from edx-platform](https://github.com/openedx/edx-platform/pull/35852).