### PR TITLE
chore: bump frontend-build, remove exceptions for prefer-default-export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@openedx-plugins/course-app-teams": "file:plugins/course-apps/teams",
         "@openedx-plugins/course-app-wiki": "file:plugins/course-apps/wiki",
         "@openedx-plugins/course-app-xpert_unit_summary": "file:plugins/course-apps/xpert_unit_summary",
-        "@openedx/frontend-build": "^14.0.14",
+        "@openedx/frontend-build": "^14.2.0",
         "@openedx/frontend-plugin-framework": "^1.2.1",
         "@openedx/paragon": "^22.8.1",
         "@redux-devtools/extension": "^3.3.0",
@@ -2136,10 +2136,9 @@
       "license": "AGPL-3.0"
     },
     "node_modules/@edx/eslint-config": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-4.2.0.tgz",
-      "integrity": "sha512-2wuIw49uyj6gRwS74qJ8WhBU+X2FOP4uot40sthIC4YU9qCM7WJOcOuAhkRPP1FvZKd3UQH3gZM7eJ85xzDBqA==",
-      "license": "MIT",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-4.3.0.tgz",
+      "integrity": "sha512-4W9wFG4ALr3xocakCsncgJbK67RHfSmDwHDXKHReFtjxl/FRkxhS6qayz189oChqfANieeV3zRCLaq44bLf+/A==",
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
@@ -3555,10 +3554,9 @@
       "link": true
     },
     "node_modules/@openedx/frontend-build": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-build/-/frontend-build-14.1.4.tgz",
-      "integrity": "sha512-DMzkitHqemtqwxmDsF8y7zRVAJcW8URPfWcLKtFvXffqJ3WW7fJXXMmiZWKra/vGBw3SRyYRqvdzQG1d2giPAw==",
-      "license": "AGPL-3.0",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-build/-/frontend-build-14.2.0.tgz",
+      "integrity": "sha512-yeBanEnfpYY3gci9vBmPlFZLzTIhbUVjM8DxldPeaHzG7IZzMVR14KNkS470siCpikNxarordg3fGXSDU+QYHA==",
       "dependencies": {
         "@babel/cli": "7.24.8",
         "@babel/core": "7.24.9",
@@ -3568,7 +3566,7 @@
         "@babel/plugin-syntax-dynamic-import": "7.8.3",
         "@babel/preset-env": "7.24.8",
         "@babel/preset-react": "7.24.7",
-        "@edx/eslint-config": "4.2.0",
+        "@edx/eslint-config": "^4.3.0",
         "@edx/new-relic-source-map-webpack-plugin": "2.1.0",
         "@edx/typescript-config": "1.1.0",
         "@formatjs/cli": "^6.0.3",
@@ -5169,7 +5167,8 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -5201,7 +5200,8 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
       "version": "7.6.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5211,7 +5211,8 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.62.0",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -5236,7 +5237,8 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.62.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "@typescript-eslint/visitor-keys": "5.62.0"
@@ -5251,7 +5253,8 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.62.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
       "dependencies": {
         "@typescript-eslint/typescript-estree": "5.62.0",
         "@typescript-eslint/utils": "5.62.0",
@@ -5276,7 +5279,8 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "5.62.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -5287,7 +5291,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.62.0",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "@typescript-eslint/visitor-keys": "5.62.0",
@@ -5312,7 +5317,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.6.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5322,7 +5328,8 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.62.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
@@ -5346,7 +5353,8 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
       "version": "7.6.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5356,7 +5364,8 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.62.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "eslint-visitor-keys": "^3.3.0"
@@ -5371,7 +5380,8 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -5889,7 +5899,8 @@
     },
     "node_modules/array.prototype.tosorted": {
       "version": "1.1.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -5935,7 +5946,8 @@
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag=="
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -6018,8 +6030,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.10.0",
-      "license": "MPL-2.0",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
+      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
       "engines": {
         "node": ">=4"
       }
@@ -6047,7 +6060,8 @@
     },
     "node_modules/axobject-query": {
       "version": "3.2.4",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.4.tgz",
+      "integrity": "sha512-aPTElBrbifBU1krmZxGZOlBkslORe7Ll7+BDnI50Wy4LgOt69luMgevkDfTq1O/ZgprooPCtWpjCwKSZw/iZ4A==",
       "engines": {
         "node": ">= 0.4"
       }
@@ -7003,7 +7017,8 @@
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA=="
     },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
@@ -7413,7 +7428,8 @@
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="
     },
     "node_modules/data-urls": {
       "version": "3.0.2",
@@ -8360,7 +8376,8 @@
     },
     "node_modules/eslint-config-airbnb": {
       "version": "19.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
+      "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
       "dependencies": {
         "eslint-config-airbnb-base": "^15.0.0",
         "object.assign": "^4.1.2",
@@ -8379,7 +8396,8 @@
     },
     "node_modules/eslint-config-airbnb-base": {
       "version": "15.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
+      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
       "dependencies": {
         "confusing-browser-globals": "^1.0.10",
         "object.assign": "^4.1.2",
@@ -8396,7 +8414,8 @@
     },
     "node_modules/eslint-config-airbnb-typescript": {
       "version": "17.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-17.1.0.tgz",
+      "integrity": "sha512-GPxI5URre6dDpJ0CtcthSZVBAfI+Uw7un5OYNVxP2EYi3H81Jw701yFP7AU+/vCE7xBtFmjge7kfhhk4+RAiig==",
       "dependencies": {
         "eslint-config-airbnb-base": "^15.0.0"
       },
@@ -8725,7 +8744,8 @@
     },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.7.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.7.1.tgz",
+      "integrity": "sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==",
       "dependencies": {
         "@babel/runtime": "^7.20.7",
         "aria-query": "^5.1.3",
@@ -8753,11 +8773,13 @@
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.32.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
+      "integrity": "sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==",
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flatmap": "^1.3.1",
@@ -8784,7 +8806,8 @@
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "4.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
       "engines": {
         "node": ">=10"
       },
@@ -8794,7 +8817,8 @@
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
       "version": "2.1.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -8804,7 +8828,8 @@
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
       "version": "2.0.0-next.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -12299,7 +12324,8 @@
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flat": "^1.3.1",
@@ -12352,11 +12378,13 @@
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
-      "license": "CC0-1.0"
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="
     },
     "node_modules/language-tags": {
       "version": "1.0.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
+      "integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
       "dependencies": {
         "language-subtag-registry": "~0.3.2"
       }
@@ -12988,7 +13016,8 @@
     },
     "node_modules/natural-compare-lite": {
       "version": "1.4.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g=="
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -15551,7 +15580,8 @@
     },
     "node_modules/object.entries": {
       "version": "1.1.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.8.tgz",
+      "integrity": "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==",
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -15592,7 +15622,8 @@
     },
     "node_modules/object.hasown": {
       "version": "1.1.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.4.tgz",
+      "integrity": "sha512-FZ9LZt9/RHzGySlBARE3VF+gE26TxR38SdmqOqliuTnl9wrKulaQs+4dee1V+Io8VfxqzAfHu6YuRgUy8OHoTg==",
       "dependencies": {
         "define-properties": "^1.2.1",
         "es-abstract": "^1.23.2",
@@ -18935,7 +18966,8 @@
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.11",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz",
+      "integrity": "sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==",
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -19822,7 +19854,8 @@
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dependencies": {
         "tslib": "^1.8.1"
       },
@@ -19835,7 +19868,8 @@
     },
     "node_modules/tsutils/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@openedx-plugins/course-app-teams": "file:plugins/course-apps/teams",
     "@openedx-plugins/course-app-wiki": "file:plugins/course-apps/wiki",
     "@openedx-plugins/course-app-xpert_unit_summary": "file:plugins/course-apps/xpert_unit_summary",
-    "@openedx/frontend-build": "^14.0.14",
+    "@openedx/frontend-build": "^14.2.0",
     "@openedx/frontend-plugin-framework": "^1.2.1",
     "@openedx/paragon": "^22.8.1",
     "@redux-devtools/extension": "^3.3.0",

--- a/plugins/course-apps/live/data/api.js
+++ b/plugins/course-apps/live/data/api.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import { ensureConfig, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { bbbPlanTypes } from '../constants';

--- a/plugins/course-apps/teams/utils.js
+++ b/plugins/course-apps/teams/utils.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import { getConfig } from '@edx/frontend-platform';
 
 import { GroupTypes } from 'CourseAuthoring/data/constants';

--- a/src/advanced-settings/__mocks__/index.js
+++ b/src/advanced-settings/__mocks__/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as advancedSettingsMock } from './advancedSettings';

--- a/src/advanced-settings/data/api.js
+++ b/src/advanced-settings/data/api.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { convertObjectToSnakeCase } from '../../utils';

--- a/src/advanced-settings/index.js
+++ b/src/advanced-settings/index.js
@@ -1,2 +1,1 @@
-/* eslint-disable import/prefer-default-export */
 export { default as AdvancedSettings } from './AdvancedSettings';

--- a/src/certificates/constants.js
+++ b/src/certificates/constants.js
@@ -1,6 +1,5 @@
 import { v4 as uuid } from 'uuid';
 
-// eslint-disable-next-line import/prefer-default-export
 export const defaultCertificate = {
   courseTitle: '',
   signatories: [{

--- a/src/certificates/data/api.js
+++ b/src/certificates/data/api.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 

--- a/src/certificates/index.js
+++ b/src/certificates/index.js
@@ -1,2 +1,1 @@
-/* eslint-disable import/prefer-default-export */
 export { default as Certificates } from './Certificates';

--- a/src/certificates/layout/certificates-sidebar/utils.jsx
+++ b/src/certificates/layout/certificates-sidebar/utils.jsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export const getSidebarData = ({ messages, intl }) => [
   {
     title: intl.formatMessage(messages.workingWithCertificatesTitle),

--- a/src/certificates/utils.js
+++ b/src/certificates/utils.js
@@ -1,6 +1,5 @@
 import { convertObjectToSnakeCase } from '../utils';
 
-// eslint-disable-next-line import/prefer-default-export
 export const prepareCertificatePayload = (data) => convertObjectToSnakeCase(({
   ...data,
   courseTitle: data.courseTitle,

--- a/src/content-tags-drawer/common/context.js
+++ b/src/content-tags-drawer/common/context.js
@@ -1,5 +1,4 @@
 // @ts-check
-/* eslint-disable import/prefer-default-export */
 import React from 'react';
 
 /** @typedef {import("../data/types.mjs").TagsInTaxonomy} TagsInTaxonomy */

--- a/src/content-tags-drawer/index.ts
+++ b/src/content-tags-drawer/index.ts
@@ -1,4 +1,2 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as ContentTagsDrawer } from './ContentTagsDrawer';
-// eslint-disable-next-line import/prefer-default-export
 export { default as ContentTagsDrawerSheet } from './ContentTagsDrawerSheet';

--- a/src/content-tags-drawer/utils.js
+++ b/src/content-tags-drawer/utils.js
@@ -1,3 +1,2 @@
-// eslint-disable-next-line import/prefer-default-export
 export const extractOrgFromContentId = (contentId) => contentId.split('+')[0].split(':')[1];
 export const languageExportId = 'languages-v1';

--- a/src/course-outline/hooks.jsx
+++ b/src/course-outline/hooks.jsx
@@ -361,5 +361,4 @@ const useCourseOutline = ({ courseId }) => {
   };
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { useCourseOutline };

--- a/src/course-outline/index.js
+++ b/src/course-outline/index.js
@@ -1,2 +1,1 @@
-/* eslint-disable import/prefer-default-export */
 export { default as CourseOutline } from './CourseOutline';

--- a/src/course-outline/outline-sidebar/utils.jsx
+++ b/src/course-outline/outline-sidebar/utils.jsx
@@ -65,5 +65,4 @@ const getFormattedSidebarMessages = (docsLinks, intl) => {
   ];
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { getFormattedSidebarMessages };

--- a/src/course-rerun/hooks.jsx
+++ b/src/course-rerun/hooks.jsx
@@ -56,5 +56,4 @@ const useCourseRerun = (courseId) => {
   };
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { useCourseRerun };

--- a/src/course-team/hooks.jsx
+++ b/src/course-team/hooks.jsx
@@ -136,5 +136,4 @@ const useCourseTeam = ({ courseId }) => {
   };
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { useCourseTeam };

--- a/src/course-team/utils.js
+++ b/src/course-team/utils.js
@@ -49,5 +49,4 @@ const getInfoModalSettings = (modalType, currentEmail, errorMessage, courseName,
   }
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { getInfoModalSettings };

--- a/src/course-unit/clipboard/index.js
+++ b/src/course-unit/clipboard/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as PasteNotificationAlert } from './paste-notification';

--- a/src/course-unit/clipboard/paste-notification/utils.js
+++ b/src/course-unit/clipboard/paste-notification/utils.js
@@ -7,6 +7,5 @@
  * @returns {boolean|null} - The status of the alert. Returns `true` if the fileList has length,
  *                          `false` if it does not, and `null` if fileList is not defined.
  */
-// eslint-disable-next-line import/prefer-default-export
 export const getAlertStatus = (fileList, alertKey, alertState) => (
   fileList?.length ? fileList && alertState[alertKey] : null);

--- a/src/course-unit/data/utils.js
+++ b/src/course-unit/data/utils.js
@@ -3,7 +3,6 @@ import { camelCaseObject } from '@edx/frontend-platform';
 import { NOTIFICATION_MESSAGES } from '../../constants';
 import { PUBLISH_TYPES } from '../constants';
 
-// eslint-disable-next-line import/prefer-default-export
 export function normalizeCourseSectionVerticalData(metadata) {
   const data = camelCaseObject(metadata);
   return {

--- a/src/course-unit/hooks.jsx
+++ b/src/course-unit/hooks.jsx
@@ -29,7 +29,6 @@ import { PUBLISH_TYPES } from './constants';
 
 import { useCopyToClipboard } from '../generic/clipboard';
 
-// eslint-disable-next-line import/prefer-default-export
 export const useCourseUnit = ({ courseId, blockId }) => {
   const dispatch = useDispatch();
   const [searchParams] = useSearchParams();

--- a/src/course-unit/index.js
+++ b/src/course-unit/index.js
@@ -1,2 +1,1 @@
-/* eslint-disable import/prefer-default-export */
 export { default as CourseUnit } from './CourseUnit';

--- a/src/course-updates/constants.ts
+++ b/src/course-updates/constants.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export const REQUEST_TYPES = {
   add_new_update: 'add_new_update',
   edit_update: 'edit_update',

--- a/src/course-updates/course-update/utils.js
+++ b/src/course-updates/course-update/utils.js
@@ -13,5 +13,4 @@ const isDateForUpdateValid = (date) => {
   return parsedDate.isValid() && parsedDate.format(COMMA_SEPARATED_DATE_FORMAT) === date;
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { isDateForUpdateValid };

--- a/src/course-updates/hooks.jsx
+++ b/src/course-updates/hooks.jsx
@@ -112,5 +112,4 @@ const useCourseUpdates = ({ courseId }) => {
   };
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { useCourseUpdates };

--- a/src/course-updates/index.js
+++ b/src/course-updates/index.js
@@ -1,2 +1,1 @@
-/* eslint-disable import/prefer-default-export */
 export { default as CourseUpdates } from './CourseUpdates';

--- a/src/course-updates/update-form/utils.js
+++ b/src/course-updates/update-form/utils.js
@@ -52,5 +52,4 @@ const geUpdateFormSettings = (requestType, courseUpdatesInitialValues, intl) => 
   }
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { geUpdateFormSettings };

--- a/src/course-updates/utils.js
+++ b/src/course-updates/utils.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export const matchesAnyStatus = (statuses, status) => Object.values(statuses).some(s => s === status);

--- a/src/custom-pages/data/api.js
+++ b/src/custom-pages/data/api.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import { camelCaseObject, ensureConfig, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 

--- a/src/custom-pages/data/selectors.js
+++ b/src/custom-pages/data/selectors.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/prefer-default-export */
-
 export const getLoadingStatus = (state) => state.customPages.loadingStatus;
 export const getSavingStatus = (state) => state.customPages.savingStatus;
 export const getCustomPagesApiStatus = (state) => state.customPages.customPagesApiStatus;

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/prefer-default-export */
-
 /**
  * Enum for request status.
  * @readonly

--- a/src/data/selectors.js
+++ b/src/data/selectors.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export const getWaffleFlags = (state) => state.courseDetail?.waffleFlags;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Tolerance/constants.ts
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Tolerance/constants.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import messages from './messages';
 
 export const ToleranceTypes = {
@@ -9,7 +8,6 @@ export const ToleranceTypes = {
   number: {
     type: 'Number',
     message: messages.typesNumber,
-
   },
   none: {
     type: 'None',

--- a/src/editors/containers/ProblemEditor/data/reactStateOLXHelpers.js
+++ b/src/editors/containers/ProblemEditor/data/reactStateOLXHelpers.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/prefer-default-export */
-
 import { flatten } from 'lodash';
 
 /**

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/constants.ts
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/constants.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export const analyticsEvents = {
   socialSharingSettingChanged: 'edx.social.video_sharing_setting.changed',
 };

--- a/src/editors/data/constants/app.ts
+++ b/src/editors/data/constants/app.ts
@@ -1,6 +1,5 @@
 import { StrictDict } from '../../utils';
 
-/* eslint-disable import/prefer-default-export */
 export const blockTypes = StrictDict({
   html: 'html',
   video: 'video',

--- a/src/editors/sharedComponents/Button/hooks.js
+++ b/src/editors/sharedComponents/Button/hooks.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 export const isVariantAdd = (variant) => variant === 'add';
 
 export const getButtonProps = ({ variant, className, Add }) => {

--- a/src/editors/sharedComponents/SelectableBox/constants.ts
+++ b/src/editors/sharedComponents/SelectableBox/constants.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 const FORM_CONTROL_SIZES = {
   SMALL: 'sm',
   LARGE: 'lg',

--- a/src/editors/sharedComponents/SelectableBox/utils.js
+++ b/src/editors/sharedComponents/SelectableBox/utils.js
@@ -3,7 +3,7 @@ import { RadioControl } from './FormRadio';
 import FormRadioSet from './FormRadioSet';
 import FormCheckboxSet from './FormCheckboxSet';
 
-// eslint-disable-next-line import/prefer-default-export,consistent-return
+// eslint-disable-next-line consistent-return
 export const getInputType = (component, type) => {
   if (component === 'SelectableBox') {
     switch (type) {

--- a/src/editors/utils/index.ts
+++ b/src/editors/utils/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 export { default as StrictDict } from './StrictDict';
 export { default as keyStore } from './keyStore';
 export { default as camelizeKeys } from './camelizeKeys';

--- a/src/export-page/__mocks__/index.js
+++ b/src/export-page/__mocks__/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as exportPageMock } from './exportPage';

--- a/src/export-page/data/api.js
+++ b/src/export-page/data/api.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 

--- a/src/files-and-videos/files-page/data/api.js
+++ b/src/files-and-videos/files-page/data/api.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import { camelCaseObject, ensureConfig, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 

--- a/src/files-and-videos/generic/utils.js
+++ b/src/files-and-videos/generic/utils.js
@@ -1,4 +1,4 @@
-export const sortFiles = (files, sortType) => { // eslint-disable-line import/prefer-default-export
+export const sortFiles = (files, sortType) => {
   const [sort, direction] = sortType.split(',');
   let sortedFiles;
   if (sort === 'displayName') {

--- a/src/files-and-videos/index.ts
+++ b/src/files-and-videos/index.ts
@@ -1,3 +1,2 @@
-/* eslint-disable import/prefer-default-export */
 export { default as FilesPage } from './files-page';
 export { default as VideosPage } from './videos-page';

--- a/src/generic/__mocks__/index.js
+++ b/src/generic/__mocks__/index.js
@@ -1,2 +1,1 @@
-/* eslint-disable import/prefer-default-export */
 export { default as contentTagsCountMock } from './contentTagsCount';

--- a/src/generic/clipboard/paste-component/constants.js
+++ b/src/generic/clipboard/paste-component/constants.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 
-/* eslint-disable import/prefer-default-export */
 export const clipboardPropsTypes = {
   sourceEditUrl: PropTypes.string.isRequired,
   content: PropTypes.shape({

--- a/src/generic/create-or-rerun-course/hooks.jsx
+++ b/src/generic/create-or-rerun-course/hooks.jsx
@@ -136,5 +136,4 @@ const useCreateOrRerunCourse = (initialValues) => {
   };
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { useCreateOrRerunCourse };

--- a/src/generic/divider/index.jsx
+++ b/src/generic/divider/index.jsx
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as Divider } from './Divider';

--- a/src/generic/help-sidebar/constants.ts
+++ b/src/generic/help-sidebar/constants.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export const otherLinkURLParams = {
   scheduleAndDetails: 'settings/details',
   grading: 'settings/grading',

--- a/src/generic/hooks/index.tsx
+++ b/src/generic/hooks/index.tsx
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { useEventListener } from './useEventListener';

--- a/src/generic/hooks/useEventListener.tsx
+++ b/src/generic/hooks/useEventListener.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, MutableRefObject } from 'react';
 
-// eslint-disable-next-line import/prefer-default-export
 export function useEventListener<K extends keyof WindowEventMap>(
   type: K,
   handler: (event: WindowEventMap[K]) => void,

--- a/src/generic/processing-notification/data/selectors.js
+++ b/src/generic/processing-notification/data/selectors.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export const getProcessingNotification = (state) => ({
   isShow: state.processingNotification.isShow,
   title: state.processingNotification.title,

--- a/src/generic/saving-error-alert/utils.js
+++ b/src/generic/saving-error-alert/utils.js
@@ -22,5 +22,4 @@ const handleResponseErrors = (error, dispatch, savingStatusFunction) => {
   return false;
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { handleResponseErrors };

--- a/src/grading-settings/data/api.js
+++ b/src/grading-settings/data/api.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 

--- a/src/grading-settings/index.js
+++ b/src/grading-settings/index.js
@@ -1,2 +1,1 @@
-/* eslint-disable import/prefer-default-export */
 export { default as GradingSettings } from './GradingSettings';

--- a/src/group-configurations/experiment-configurations-section/validation.js
+++ b/src/group-configurations/experiment-configurations-section/validation.js
@@ -3,7 +3,6 @@ import * as Yup from 'yup';
 import messages from './messages';
 import { allGroupNamesAreUnique } from './utils';
 
-// eslint-disable-next-line import/prefer-default-export
 export const experimentFormValidationSchema = (formatMessage) => Yup.object().shape({
   id: Yup.number(),
   name: Yup.string()

--- a/src/group-configurations/group-configuration-sidebar/utils.jsx
+++ b/src/group-configurations/group-configuration-sidebar/utils.jsx
@@ -53,5 +53,5 @@ const getSidebarData = ({
   }
   return groups;
 };
-// eslint-disable-next-line import/prefer-default-export
+
 export { getSidebarData };

--- a/src/group-configurations/hooks.jsx
+++ b/src/group-configurations/hooks.jsx
@@ -97,5 +97,4 @@ const useGroupConfigurations = (courseId) => {
   };
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { useGroupConfigurations };

--- a/src/help-urls/__mocks__/index.js
+++ b/src/help-urls/__mocks__/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as helpUrls } from './helpUrls';

--- a/src/help-urls/data/api.js
+++ b/src/help-urls/data/api.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 

--- a/src/help-urls/data/thunks.js
+++ b/src/help-urls/data/thunks.js
@@ -3,7 +3,6 @@ import { RequestStatus } from '../../data/constants';
 import { getHelpUrls } from './api';
 import { updateLoadingHelpUrlsStatus, updatePages } from './slice';
 
-/* eslint-disable import/prefer-default-export */
 export function fetchHelpUrls() {
   return async (dispatch) => {
     dispatch(updateLoadingHelpUrlsStatus({ status: RequestStatus.IN_PROGRESS }));

--- a/src/help-urls/hooks.jsx
+++ b/src/help-urls/hooks.jsx
@@ -18,5 +18,5 @@ const useHelpUrls = (tokenNames) => {
 
   return helpTokens;
 };
-/* eslint-disable-next-line import/prefer-default-export */
+
 export { useHelpUrls };

--- a/src/import-page/utils.js
+++ b/src/import-page/utils.js
@@ -10,7 +10,6 @@ import { LAST_IMPORT_COOKIE_NAME } from './data/constants';
  * @param {string} fileName - File name.
  * @returns {void}
  */
-// eslint-disable-next-line import/prefer-default-export
 export const setImportCookie = (date, completed, fileName) => {
   const cookies = new Cookies();
   cookies.set(LAST_IMPORT_COOKIE_NAME, { date, completed, fileName }, { path: window.location.pathname });

--- a/src/library-authoring/__mocks__/index.ts
+++ b/src/library-authoring/__mocks__/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as libraryComponentsMock } from './libraryComponentsMock';

--- a/src/library-authoring/add-content/PickLibraryContentModal.tsx
+++ b/src/library-authoring/add-content/PickLibraryContentModal.tsx
@@ -30,7 +30,6 @@ interface PickLibraryContentModalProps {
   onClose: () => void;
 }
 
-// eslint-disable-next-line import/prefer-default-export
 export const PickLibraryContentModal: React.FC<PickLibraryContentModalProps> = ({
   isOpen,
   onClose,

--- a/src/library-authoring/add-content/index.ts
+++ b/src/library-authoring/add-content/index.ts
@@ -1,3 +1,2 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as AddContentContainer } from './AddContentContainer';
 export { default as AddContentHeader } from './AddContentHeader';

--- a/src/library-authoring/component-info/ComponentAdvancedAssets.tsx
+++ b/src/library-authoring/component-info/ComponentAdvancedAssets.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-nested-ternary */
-/* eslint-disable import/prefer-default-export */
 import React from 'react';
 import {
   Button,

--- a/src/library-authoring/component-info/ComponentAdvancedInfo.tsx
+++ b/src/library-authoring/component-info/ComponentAdvancedInfo.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-nested-ternary */
-/* eslint-disable import/prefer-default-export */
 import React from 'react';
 import {
   Alert,

--- a/src/library-authoring/component-picker/ComponentPicker.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.tsx
@@ -49,7 +49,6 @@ type ComponentPickerProps = { libraryId?: string, showOnlyPublished?: boolean } 
   }
 );
 
-// eslint-disable-next-line import/prefer-default-export
 export const ComponentPicker: React.FC<ComponentPickerProps> = ({
   /** Restrict the component picker to a specific library */
   libraryId,

--- a/src/library-authoring/component-picker/index.ts
+++ b/src/library-authoring/component-picker/index.ts
@@ -1,2 +1,1 @@
-/* eslint-disable import/prefer-default-export */
 export { ComponentPicker } from './ComponentPicker';

--- a/src/library-authoring/components/ComponentEditorModal.tsx
+++ b/src/library-authoring/components/ComponentEditorModal.tsx
@@ -7,7 +7,6 @@ import { getBlockType } from '../../generic/key-utils';
 import { useLibraryContext } from '../common/context';
 import { invalidateComponentData } from '../data/apiHooks';
 
-/* eslint-disable import/prefer-default-export */
 export function canEditComponent(usageKey: string): boolean {
   let blockType: string;
   try {

--- a/src/library-authoring/create-collection/index.tsx
+++ b/src/library-authoring/create-collection/index.tsx
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as CreateCollectionModal } from './CreateCollectionModal';

--- a/src/library-authoring/create-library/data/apiHooks.ts
+++ b/src/library-authoring/create-library/data/apiHooks.ts
@@ -9,7 +9,6 @@ import { libraryAuthoringQueryKeys } from '../../data/apiHooks';
 /**
  * Hook that provides a "mutation" that can be used to create a new content library.
  */
-// eslint-disable-next-line import/prefer-default-export
 export const useCreateLibraryV2 = () => {
   const queryClient = useQueryClient();
 

--- a/src/library-authoring/create-library/index.ts
+++ b/src/library-authoring/create-library/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as CreateLibrary } from './CreateLibrary';

--- a/src/library-authoring/library-sidebar/index.ts
+++ b/src/library-authoring/library-sidebar/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as LibrarySidebar } from './LibrarySidebar';

--- a/src/library-authoring/library-team/index.tsx
+++ b/src/library-authoring/library-team/index.tsx
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as LibraryTeamModal } from './LibraryTeamModal';

--- a/src/pages-and-resources/data/selectors.js
+++ b/src/pages-and-resources/data/selectors.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/prefer-default-export */
-
 export const getLoadingStatus = (state) => state.pagesAndResources.loadingStatus;
 export const getSavingStatus = (state) => state.pagesAndResources.savingStatus;
 export const getCourseAppsApiStatus = (state) => state.pagesAndResources.courseAppsApiStatus;

--- a/src/pages-and-resources/data/thunks.js
+++ b/src/pages-and-resources/data/thunks.js
@@ -27,7 +27,6 @@ const COURSE_APPS_ORDER = [
   'ora_settings',
 ];
 
-/* eslint-disable import/prefer-default-export */
 export function fetchCourseApps(courseId) {
   return async (dispatch) => {
     dispatch(updateLoadingStatus({ courseId, status: RequestStatus.IN_PROGRESS }));

--- a/src/pages-and-resources/index.js
+++ b/src/pages-and-resources/index.js
@@ -1,2 +1,1 @@
-/* eslint-disable import/prefer-default-export */
 export { default as PagesAndResources } from './PagesAndResources';

--- a/src/pages-and-resources/utils.test.jsx
+++ b/src/pages-and-resources/utils.test.jsx
@@ -45,4 +45,4 @@ function renderWithProviders(
 }
 
 // We may add additional exports to this file over time, so we will not export render as the default.
-export { renderWithProviders as render }; // eslint-disable-line import/prefer-default-export
+export { renderWithProviders as render };

--- a/src/schedule-and-details/basic-section/constants.js
+++ b/src/schedule-and-details/basic-section/constants.js
@@ -1,2 +1,1 @@
-/* eslint-disable-next-line import/prefer-default-export */
 export const INVITE_STUDENTS_LINK_ID = 'invite-students-link';

--- a/src/schedule-and-details/constants.js
+++ b/src/schedule-and-details/constants.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export const defaultEntranceExamMinimumScorePct = '50';

--- a/src/schedule-and-details/data/api.js
+++ b/src/schedule-and-details/data/api.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { convertObjectToSnakeCase } from '../../utils';

--- a/src/schedule-and-details/hooks.jsx
+++ b/src/schedule-and-details/hooks.jsx
@@ -146,5 +146,4 @@ const useSaveValuesPrompt = (
   };
 };
 
-/* eslint-disable-next-line import/prefer-default-export */
 export { useLoadValuesPrompt, useSaveValuesPrompt };

--- a/src/schedule-and-details/license-section/hooks.jsx
+++ b/src/schedule-and-details/license-section/hooks.jsx
@@ -109,5 +109,4 @@ const useLicenseDetails = (license, onChange) => {
   };
 };
 
-/* eslint-disable-next-line import/prefer-default-export */
 export { useLicenseDetails };

--- a/src/schedule-and-details/license-section/utils.js
+++ b/src/schedule-and-details/license-section/utils.js
@@ -13,5 +13,4 @@ const generateLicenseURL = (details) => {
   return `${creativeCommonsLicensesURL}/${detailsString}/${creativeCommonsVersion}`;
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { generateLicenseURL };

--- a/src/search-modal/index.ts
+++ b/src/search-modal/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as SearchModal } from './SearchModal';

--- a/src/studio-home/__mocks__/index.js
+++ b/src/studio-home/__mocks__/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as studioHomeMock } from './studioHomeMock';

--- a/src/studio-home/card-item/utils.ts
+++ b/src/studio-home/card-item/utils.ts
@@ -3,5 +3,4 @@
  * @param {string} str - The string to trim.
  * @returns {string} The trimmed string.
  */
-// eslint-disable-next-line import/prefer-default-export
 export const trimSlashes = (str: string): string => str.replace(/^\/|\/$/g, '');

--- a/src/studio-home/hooks.jsx
+++ b/src/studio-home/hooks.jsx
@@ -105,5 +105,4 @@ const useStudioHome = () => {
   };
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { useStudioHome };

--- a/src/studio-home/index.ts
+++ b/src/studio-home/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as StudioHome } from './StudioHome';

--- a/src/studio-home/tabs-section/utils.js
+++ b/src/studio-home/tabs-section/utils.js
@@ -11,5 +11,4 @@ const sortAlphabeticallyArray = (arr) => [...arr]
     return firstDisplayName.localeCompare(secondDisplayName);
   });
 
-// eslint-disable-next-line import/prefer-default-export
 export { sortAlphabeticallyArray };

--- a/src/taxonomy/__mocks__/index.js
+++ b/src/taxonomy/__mocks__/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as taxonomyListMock } from './taxonomyListMock';

--- a/src/taxonomy/common/context.js
+++ b/src/taxonomy/common/context.js
@@ -1,5 +1,4 @@
 // @ts-check
-/* eslint-disable import/prefer-default-export */
 import React from 'react';
 
 /**

--- a/src/taxonomy/import-tags/index.js
+++ b/src/taxonomy/import-tags/index.js
@@ -1,3 +1,2 @@
 // @ts-check
-// eslint-disable-next-line import/prefer-default-export
 export { default as ImportTagsWizard } from './ImportTagsWizard';

--- a/src/taxonomy/manage-orgs/index.js
+++ b/src/taxonomy/manage-orgs/index.js
@@ -1,1 +1,1 @@
-export { default as ManageOrgsModal } from './ManageOrgsModal'; // eslint-disable-line import/prefer-default-export
+export { default as ManageOrgsModal } from './ManageOrgsModal';

--- a/src/taxonomy/tag-list/index.js
+++ b/src/taxonomy/tag-list/index.js
@@ -1,2 +1,1 @@
-/* eslint-disable import/prefer-default-export */
 export { default as TagListTable } from './TagListTable';

--- a/src/taxonomy/taxonomy-detail/index.js
+++ b/src/taxonomy/taxonomy-detail/index.js
@@ -1,2 +1,2 @@
 // @ts-check
-export { default as TaxonomyDetailPage } from './TaxonomyDetailPage'; // eslint-disable-line import/prefer-default-export
+export { default as TaxonomyDetailPage } from './TaxonomyDetailPage';

--- a/src/taxonomy/taxonomy-menu/index.js
+++ b/src/taxonomy/taxonomy-menu/index.js
@@ -1,2 +1,2 @@
 // @ts-check
-export { default as TaxonomyMenu } from './TaxonomyMenu'; // eslint-disable-line import/prefer-default-export
+export { default as TaxonomyMenu } from './TaxonomyMenu';

--- a/src/textbooks/__mocks__/index.js
+++ b/src/textbooks/__mocks__/index.js
@@ -1,2 +1,1 @@
-/* eslint-disable import/prefer-default-export */
 export { default as textbooksMock } from './textbooksMock';

--- a/src/textbooks/hooks.jsx
+++ b/src/textbooks/hooks.jsx
@@ -92,5 +92,4 @@ const useTextbooks = (courseId, waffleFlags) => {
   };
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { useTextbooks };

--- a/src/textbooks/index.js
+++ b/src/textbooks/index.js
@@ -1,2 +1,1 @@
-/* eslint-disable import/prefer-default-export */
 export { default as Textbooks } from './Textbooks';

--- a/src/textbooks/utils.js
+++ b/src/textbooks/utils.js
@@ -17,6 +17,5 @@ const getTextbookFormInitialValues = (isEditForm = false, textbook = {}) => (isE
   });
 
 export {
-  // eslint-disable-next-line import/prefer-default-export
   getTextbookFormInitialValues,
 };


### PR DESCRIPTION
## Description

This PR bumps `frontend-build` to pull in the eslint config changes from https://github.com/openedx/eslint-config/pull/164 so that default exports are no longer recommended in single-export files. This lets us remove a huge number of exceptions specified in the code, as you can see in the diff.


## Testing instructions

This should only affect linting; no changes to the behavior of the code. Run `npm run lint` or just check the CI output.
