### PR TITLE
[sumac] fix: TinyMce aux modal issues in text editors [FC-0062] (#1500)

### DIFF
--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -219,7 +219,32 @@ export const setupCustomBehavior = ({
       if (newContent) { updateContent(newContent); }
     });
   }
-  editor.on('ExecCommand', (e) => {
+
+  editor.on('init', /* istanbul ignore next */ () => {
+    // Moving TinyMce aux modal inside the Editor modal
+    // if the editor is on modal mode.
+    // This is to avoid issues using the aux modal:
+    // * Avoid close aux modal when clicking the content inside.
+    // * When the user opens the `Edit Source Code` modal, this adds `data-focus-on-hidden`
+    //   to the TinyMce aux modal, making it unusable.
+    const modalLayer = document.querySelector('.pgn__modal-layer');
+    const tinymceAux = document.querySelector('.tox.tox-tinymce-aux');
+
+    if (modalLayer && tinymceAux) {
+      modalLayer.appendChild(tinymceAux);
+    }
+  });
+
+  editor.on('ExecCommand', /* istanbul ignore next */ (e) => {
+    // Remove `data-focus-on-hidden` and `aria-hidden` on TinyMce aux modal used on emoticons, formulas, etc.
+    // When using the Editor in modal mode, it may happen that the editor modal is rendered
+    // before the TinyMce aux modal, which adds these attributes, making the TinyMce aux modal unusable.
+    const modalElement = document.querySelector('.tox.tox-silver-sink.tox-tinymce-aux');
+    if (modalElement) {
+      modalElement.removeAttribute('data-focus-on-hidden');
+      modalElement.removeAttribute('aria-hidden');
+    }
+
     if (editorType === 'text' && e.command === 'mceFocus') {
       const initialContent = editor.getContent();
       const newContent = module.replaceStaticWithAsset({


### PR DESCRIPTION
Move the aux modal inside the editor modal

(cherry picked from commit https://github.com/openedx/frontend-app-authoring/commit/0365e3809b20251c5f99bd954c5d9c5a8490b725)

Backport of https://github.com/openedx/frontend-app-authoring/pull/1500

Internal ticket: [FAL-3928](https://tasks.opencraft.com/browse/FAL-3928)