### PR TITLE
feat!: remove Maintenance header link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@edx/browserslist-config": "1.2.0",
         "@edx/frontend-component-footer": "^14.1.0",
-        "@edx/frontend-component-header": "^5.7.0",
+        "@edx/frontend-component-header": "^5.8.0",
         "@edx/frontend-enterprise-hotjar": "^2.0.0",
         "@edx/frontend-platform": "^8.0.3",
         "@edx/openedx-atlas": "^0.6.0",
@@ -2175,9 +2175,10 @@
       }
     },
     "node_modules/@edx/frontend-component-header": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-5.7.0.tgz",
-      "integrity": "sha512-a7ErsU0m6yaU8VGLN4JYC1Y43W5L/zSCZSmpDZw534LiPK43k4eyU8u5Ep1yxp+8sOvB49qED4huIq+1oVDJsA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-5.8.0.tgz",
+      "integrity": "sha512-AgLgt1y5vrqx6cU3IDr7HKngJImTN48gCIaXdCQ4YhR4PpX3p+ZS9R5Ih0dapWtvnX0Oo2hT2ggUKORV0h90rw==",
+      "license": "AGPL-3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "6.6.0",
         "@fortawesome/free-brands-svg-icons": "6.6.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
     "@edx/browserslist-config": "1.2.0",
     "@edx/frontend-component-footer": "^14.1.0",
-    "@edx/frontend-component-header": "^5.7.0",
+    "@edx/frontend-component-header": "^5.8.0",
     "@edx/frontend-enterprise-hotjar": "^2.0.0",
     "@edx/frontend-platform": "^8.0.3",
     "@edx/openedx-atlas": "^0.6.0",


### PR DESCRIPTION
...by bumping frontend-component-header 5.7.0 -> 5.8.0

Our reasoning is that the two functions of the Studio Maintenance dashboard (Announcements and Maintenance Banner) have been broken for a while.

It's actually version 5.7.2 that removes the link [1] but since 5.8.0 has no breaking changes, it seemed prudent to jump straight to latest.

[1] https://github.com/openedx/frontend-component-header/releases/v5.7.2

Related PR: https://github.com/openedx/edx-platform/pull/35852