### PR TITLE
fix: editor flicker after creating xblock

### DIFF
--- a/src/editors/hooks.test.jsx
+++ b/src/editors/hooks.test.jsx
@@ -50,11 +50,19 @@ describe('hooks', () => {
   describe('initializeApp', () => {
     test('calls provided function with provided data as args when useEffect is called', () => {
       const dispatch = jest.fn();
-      const fakeData = { some: 'data' };
+      const fakeData = {
+        blockId: 'blockId',
+        studioEndpointUrl: 'studioEndpointUrl',
+        learningContextId: 'learningContextId',
+      };
       hooks.initializeApp({ dispatch, data: fakeData });
       expect(dispatch).not.toHaveBeenCalledWith(fakeData);
       const [cb, prereqs] = useEffect.mock.calls[0];
-      expect(prereqs).toStrictEqual([fakeData]);
+      expect(prereqs).toStrictEqual([
+        fakeData.blockId,
+        fakeData.studioEndpointUrl,
+        fakeData.learningContextId,
+      ]);
       cb();
       expect(dispatch).toHaveBeenCalledWith(thunkActions.app.initialize(fakeData));
     });

--- a/src/editors/hooks.ts
+++ b/src/editors/hooks.ts
@@ -9,7 +9,7 @@ import { RequestKeys } from './data/constants/requests';
 // eslint-disable-next-line react-hooks/rules-of-hooks
 export const initializeApp = ({ dispatch, data }) => useEffect(
   () => dispatch(thunkActions.app.initialize(data)),
-  [data],
+  [data?.blockId, data?.studioEndpointUrl, data?.learningContextId],
 );
 
 export const navigateTo = (destination: string | URL) => {


### PR DESCRIPTION
Backport of https://github.com/openedx/frontend-app-authoring/pull/1531

## Description

This PR fixes the flicker bug described here: https://github.com/openedx/frontend-app-authoring/pull/1528#issuecomment-2494602511

https://github.com/user-attachments/assets/ac51fac2-831c-4c17-be89-3e40814f2454

## Additional Information

The `data` object is being mutated with the same value, causing the components to re-render. 

**Note**: There is a racing condition involved, so the flicker doesn't happen consistently.

## Testing instructions

1. Try to add a new component using the sidebar and check if the flicker stopped happening.