### PR TITLE
fix: avoid changing url when removing filters

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -148,7 +148,7 @@ const LibraryAuthoringPage = ({ returnToLibrarySelection }: LibraryAuthoringPage
     } else if (currentPath && currentPath in ContentType) {
       setActiveKey(ContentType[currentPath]);
     }
-  }, [location.pathname]);
+  }, []);
 
   useEffect(() => {
     if (!componentPickerMode) {

--- a/src/search-manager/SearchManager.ts
+++ b/src/search-manager/SearchManager.ts
@@ -147,7 +147,9 @@ export const SearchContextProvider: React.FC<{
     setBlockTypesFilter([]);
     setTagsFilter([]);
     setProblemTypesFilter([]);
-    setUsageKey('');
+    if (usageKey !== '') {
+      setUsageKey('');
+    }
   }, []);
 
   // Initialize a connection to Meilisearch:


### PR DESCRIPTION
## Description

When clearing filters the library authoring page redirects to the first tab that was navigated to. Here's a video for lack of a better explanation:

https://www.loom.com/share/355e907bb767476a8d50c434233bcd23?sid=5349e45e-fe07-4c1d-9d75-f2126cf3fee2

This PR does two things:
- Makes the Active Tab Key independent from the URL, except for the initial load, where the active tab is set from the url.
- Avoids unnecessarily changing SearchParams: Due to a limitation of the useSearchParams react hook, which uses a memoized value for the URL that becomes stale after selecting a tab, it unexpectedly changes the URL value. Unfortunately there's no way to completely avoid this, so if there's a usageKey url param, the hook setter function will be called and the URL will revert to the stale memoized url.

## Supporting information

Issue: https://github.com/openedx/frontend-app-authoring/issues/1524
Private-Ref: https://tasks.opencraft.com/browse/FAL-3971

## Testing instructions

(Follow the video above)
1. Navigate to a library
2. Change the tab to components
3. Filter by type
4. Reset the filters
5. Assert that you are still in the components tab

