### PR TITLE
feat: preserve library sidebar tab while switching items

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.test.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.test.tsx
@@ -409,8 +409,8 @@ describe('<LibraryAuthoringPage />', () => {
   it('should open and close the collection sidebar', async () => {
     await renderLibraryPage();
 
-    // Click on the first component. It could appear twice, in both "Recently Modified" and "Collections"
-    fireEvent.click((await screen.findAllByText('Collection 1'))[0]);
+    // Click on the first collection
+    fireEvent.click((await screen.findByText('Collection 1')));
 
     const sidebar = screen.getByTestId('library-sidebar');
 
@@ -423,6 +423,35 @@ describe('<LibraryAuthoringPage />', () => {
     fireEvent.click(closeButton);
 
     await waitFor(() => expect(screen.queryByTestId('library-sidebar')).not.toBeInTheDocument());
+  });
+
+  it('should preserve the tab while switching from a component to a collection', async () => {
+    await renderLibraryPage();
+
+    // Click on the first collection
+    fireEvent.click((await screen.findByText('Collection 1')));
+
+    const sidebar = screen.getByTestId('library-sidebar');
+
+    const { getByRole } = within(sidebar);
+
+    // Click on the Details tab
+    fireEvent.click(getByRole('tab', { name: 'Details' }));
+
+    // Change to a component
+    fireEvent.click((await screen.findAllByText('Introduction to Testing'))[0]);
+
+    // Check that the Details tab is still selected
+    expect(getByRole('tab', { name: 'Details' })).toHaveAttribute('aria-selected', 'true');
+
+    // Click on the Previews tab
+    fireEvent.click(getByRole('tab', { name: 'Preview' }));
+
+    // Switch back to the collection
+    fireEvent.click((await screen.findByText('Collection 1')));
+
+    // The Manage (default) tab should be selected because the collection does not have a Preview tab
+    expect(getByRole('tab', { name: 'Manage' })).toHaveAttribute('aria-selected', 'true');
   });
 
   it('can filter by capa problem type', async () => {

--- a/src/library-authoring/collections/CollectionInfo.tsx
+++ b/src/library-authoring/collections/CollectionInfo.tsx
@@ -8,7 +8,13 @@ import {
 import { useCallback } from 'react';
 import { useNavigate, useMatch } from 'react-router-dom';
 
-import { useLibraryContext } from '../common/context';
+import {
+  useLibraryContext,
+  type CollectionInfoTab,
+  COLLECTION_INFO_TABS,
+  isCollectionInfoTab,
+  COMPONENT_INFO_TABS,
+} from '../common/context';
 import CollectionDetails from './CollectionDetails';
 import messages from './messages';
 import { ContentTagsDrawer } from '../../content-tags-drawer';
@@ -24,7 +30,12 @@ const CollectionInfo = () => {
     setCollectionId,
     sidebarComponentInfo,
     componentPickerMode,
+    setSidebarCurrentTab,
   } = useLibraryContext();
+
+  const tab: CollectionInfoTab = (
+    sidebarComponentInfo?.currentTab && isCollectionInfoTab(sidebarComponentInfo.currentTab)
+  ) ? sidebarComponentInfo?.currentTab : COLLECTION_INFO_TABS.Manage;
 
   const sidebarCollectionId = sidebarComponentInfo?.id;
   // istanbul ignore if: this should never happen
@@ -63,15 +74,17 @@ const CollectionInfo = () => {
       <Tabs
         variant="tabs"
         className="my-3 d-flex justify-content-around"
-        defaultActiveKey="manage"
+        defaultActiveKey={COMPONENT_INFO_TABS.Manage}
+        activeKey={tab}
+        onSelect={setSidebarCurrentTab}
       >
-        <Tab eventKey="manage" title={intl.formatMessage(messages.manageTabTitle)}>
+        <Tab eventKey={COMPONENT_INFO_TABS.Manage} title={intl.formatMessage(messages.manageTabTitle)}>
           <ContentTagsDrawer
             id={collectionUsageKey}
             variant="component"
           />
         </Tab>
-        <Tab eventKey="details" title={intl.formatMessage(messages.detailsTabTitle)}>
+        <Tab eventKey={COMPONENT_INFO_TABS.Details} title={intl.formatMessage(messages.detailsTabTitle)}>
           <CollectionDetails />
         </Tab>
       </Tabs>

--- a/src/library-authoring/component-info/ComponentInfo.tsx
+++ b/src/library-authoring/component-info/ComponentInfo.tsx
@@ -11,7 +11,13 @@ import {
   CheckBoxOutlineBlank,
 } from '@openedx/paragon/icons';
 
-import { SidebarAdditionalActions, useLibraryContext } from '../common/context';
+import {
+  SidebarAdditionalActions,
+  useLibraryContext,
+  COMPONENT_INFO_TABS,
+  ComponentInfoTab,
+  isComponentInfoTab,
+} from '../common/context';
 import ComponentMenu from '../components';
 import { canEditComponent } from '../components/ComponentEditorModal';
 import ComponentDetails from './ComponentDetails';
@@ -96,20 +102,25 @@ const ComponentInfo = () => {
     readOnly,
     openComponentEditor,
     resetSidebarAdditionalActions,
+    setSidebarCurrentTab,
   } = useLibraryContext();
 
   const jumpToCollections = sidebarComponentInfo?.additionalAction === SidebarAdditionalActions.JumpToAddCollections;
-  // Show Manage tab if JumpToAddCollections action is set in sidebarComponentInfo
-  const [tab, setTab] = React.useState(jumpToCollections ? 'manage' : 'preview');
+
+  const tab: ComponentInfoTab = (
+    sidebarComponentInfo?.currentTab && isComponentInfoTab(sidebarComponentInfo.currentTab)
+  ) ? sidebarComponentInfo?.currentTab : COMPONENT_INFO_TABS.Preview;
+
   useEffect(() => {
+    // Show Manage tab if JumpToAddCollections action is set in sidebarComponentInfo
     if (jumpToCollections) {
-      setTab('manage');
+      setSidebarCurrentTab(COMPONENT_INFO_TABS.Manage);
     }
   }, [jumpToCollections]);
 
   useEffect(() => {
     // This is required to redo actions.
-    if (tab !== 'manage') {
+    if (tab !== COMPONENT_INFO_TABS.Manage) {
       resetSidebarAdditionalActions();
     }
   }, [tab]);
@@ -158,16 +169,17 @@ const ComponentInfo = () => {
       <Tabs
         variant="tabs"
         className="my-3 d-flex justify-content-around"
+        defaultActiveKey={COMPONENT_INFO_TABS.Preview}
         activeKey={tab}
-        onSelect={(k: string) => setTab(k)}
+        onSelect={setSidebarCurrentTab}
       >
-        <Tab eventKey="preview" title={intl.formatMessage(messages.previewTabTitle)}>
+        <Tab eventKey={COMPONENT_INFO_TABS.Preview} title={intl.formatMessage(messages.previewTabTitle)}>
           <ComponentPreview />
         </Tab>
-        <Tab eventKey="manage" title={intl.formatMessage(messages.manageTabTitle)}>
+        <Tab eventKey={COMPONENT_INFO_TABS.Manage} title={intl.formatMessage(messages.manageTabTitle)}>
           <ComponentManagement />
         </Tab>
-        <Tab eventKey="details" title={intl.formatMessage(messages.detailsTabTitle)}>
+        <Tab eventKey={COMPONENT_INFO_TABS.Details} title={intl.formatMessage(messages.detailsTabTitle)}>
           <ComponentDetails />
         </Tab>
       </Tabs>


### PR DESCRIPTION
## Description

This PR makes the selected tab on the sidebar persist while selecting Components or Collections.

![persist-tabs](https://github.com/user-attachments/assets/b0a2f54a-dc1e-4f2a-a2eb-02382cf3e120)

## More information
- Related to https://github.com/openedx/frontend-app-authoring/issues/1538

## Testing instruction
- Open the library authoring page, click on Components/Collections, and check the results
- Note that if you click on a Collection (the default "Manage" tab is shown) and switch to a Component, the "Preview" tab will be shown (it will not persist). This is intended.
___
Private ref: [FAL-3980](https://tasks.opencraft.com/browse/FAL-3980)