### PR TITLE
fix: Update error messages when adding user to library [FC-0062]

### DIFF
--- a/src/generic/processing-notification/ProcessingNotification.test.jsx
+++ b/src/generic/processing-notification/ProcessingNotification.test.jsx
@@ -26,7 +26,15 @@ describe('<ProcessingNotification />', () => {
     expect(screen.getByText('Undo')).toBeInTheDocument();
     expect(screen.getByRole('alert').querySelector('.processing-notification-hide-close-button')).not.toBeInTheDocument();
     userEvent.click(screen.getByText('Undo'));
-    expect(mockUndo).toBeCalled();
+    expect(mockUndo).toHaveBeenCalled();
+  });
+
+  it('renders with `disableCapitalize`', () => {
+    const title = 'ThIs IS a Test. OK?';
+    render(<ProcessingNotification {...props} close={() => {}} title={title} disableCapitalize />);
+    expect(screen.getByText(title)).toBeInTheDocument();
+    expect(screen.getByText('Undo')).toBeInTheDocument();
+    expect(screen.getByRole('alert').querySelector('.processing-notification-hide-close-button')).not.toBeInTheDocument();
   });
 
   it('add hide-close-button class if no close action is passed', () => {

--- a/src/generic/processing-notification/ProcessingNotification.test.jsx
+++ b/src/generic/processing-notification/ProcessingNotification.test.jsx
@@ -1,13 +1,11 @@
-import { capitalize } from 'lodash';
 import userEvent from '@testing-library/user-event';
 import { initializeMocks, render, screen } from '../../testUtils';
-import { NOTIFICATION_MESSAGES } from '../../constants';
 import ProcessingNotification from '.';
 
 const mockUndo = jest.fn();
 
 const props = {
-  title: NOTIFICATION_MESSAGES.saving,
+  title: 'ThIs IS a Test. OK?',
   isShow: true,
   action: {
     label: 'Undo',
@@ -22,24 +20,16 @@ describe('<ProcessingNotification />', () => {
 
   it('renders successfully', () => {
     render(<ProcessingNotification {...props} close={() => {}} />);
-    expect(screen.getByText(capitalize(props.title))).toBeInTheDocument();
+    expect(screen.getByText(props.title)).toBeInTheDocument();
     expect(screen.getByText('Undo')).toBeInTheDocument();
     expect(screen.getByRole('alert').querySelector('.processing-notification-hide-close-button')).not.toBeInTheDocument();
     userEvent.click(screen.getByText('Undo'));
     expect(mockUndo).toHaveBeenCalled();
   });
 
-  it('renders with `disableCapitalize`', () => {
-    const title = 'ThIs IS a Test. OK?';
-    render(<ProcessingNotification {...props} close={() => {}} title={title} disableCapitalize />);
-    expect(screen.getByText(title)).toBeInTheDocument();
-    expect(screen.getByText('Undo')).toBeInTheDocument();
-    expect(screen.getByRole('alert').querySelector('.processing-notification-hide-close-button')).not.toBeInTheDocument();
-  });
-
   it('add hide-close-button class if no close action is passed', () => {
     render(<ProcessingNotification {...props} />);
-    expect(screen.getByText(capitalize(props.title))).toBeInTheDocument();
+    expect(screen.getByText(props.title)).toBeInTheDocument();
     expect(screen.getByRole('alert').querySelector('.processing-notification-hide-close-button')).toBeInTheDocument();
   });
 });

--- a/src/generic/processing-notification/index.jsx
+++ b/src/generic/processing-notification/index.jsx
@@ -7,7 +7,7 @@ import { capitalize } from 'lodash';
 import classNames from 'classnames';
 
 const ProcessingNotification = ({
-  isShow, title, action, close,
+  isShow, title, action, close, disableCapitalize,
 }) => (
   <Toast
     className={classNames({ 'processing-notification-hide-close-button': !close })}
@@ -18,13 +18,16 @@ const ProcessingNotification = ({
   >
     <span className="d-flex align-items-center">
       <Icon className="processing-notification-icon mb-0 mr-2" src={IconSettings} />
-      <span className="font-weight-bold h4 mb-0 text-white">{capitalize(title)}</span>
+      <span className="font-weight-bold h4 mb-0 text-white">
+        {!disableCapitalize ? capitalize(title) : title}
+      </span>
     </span>
   </Toast>
 );
 
 ProcessingNotification.defaultProps = {
   close: null,
+  disableCapitalize: false,
 };
 
 ProcessingNotification.propTypes = {
@@ -35,6 +38,7 @@ ProcessingNotification.propTypes = {
     onClick: PropTypes.func,
   }),
   close: PropTypes.func,
+  disableCapitalize: PropTypes.bool,
 };
 
 export default ProcessingNotification;

--- a/src/generic/processing-notification/index.jsx
+++ b/src/generic/processing-notification/index.jsx
@@ -3,11 +3,10 @@ import {
   Icon, Toast,
 } from '@openedx/paragon';
 import { Settings as IconSettings } from '@openedx/paragon/icons';
-import { capitalize } from 'lodash';
 import classNames from 'classnames';
 
 const ProcessingNotification = ({
-  isShow, title, action, close, disableCapitalize,
+  isShow, title, action, close,
 }) => (
   <Toast
     className={classNames({ 'processing-notification-hide-close-button': !close })}
@@ -18,16 +17,13 @@ const ProcessingNotification = ({
   >
     <span className="d-flex align-items-center">
       <Icon className="processing-notification-icon mb-0 mr-2" src={IconSettings} />
-      <span className="font-weight-bold h4 mb-0 text-white">
-        {!disableCapitalize ? capitalize(title) : title}
-      </span>
+      <span className="font-weight-bold h4 mb-0 text-white">{title}</span>
     </span>
   </Toast>
 );
 
 ProcessingNotification.defaultProps = {
   close: null,
-  disableCapitalize: false,
 };
 
 ProcessingNotification.propTypes = {
@@ -38,7 +34,6 @@ ProcessingNotification.propTypes = {
     onClick: PropTypes.func,
   }),
   close: PropTypes.func,
-  disableCapitalize: PropTypes.bool,
 };
 
 export default ProcessingNotification;

--- a/src/generic/toast-context/index.test.tsx
+++ b/src/generic/toast-context/index.test.tsx
@@ -10,11 +10,11 @@ export interface WraperProps {
 }
 
 // eslint-disable-next-line react/prop-types
-const TestComponentToShow = ({ capitilize = false }) => {
+const TestComponentToShow = () => {
   const { showToast } = React.useContext(ToastContext);
 
   React.useEffect(() => {
-    showToast('This is the Toast!', undefined, capitilize);
+    showToast('This is the Toast!');
   }, [showToast]);
 
   return <div>Content</div>;
@@ -61,11 +61,6 @@ describe('<ToastProvider />', () => {
   it('should show toast', async () => {
     render(<RootWrapper><TestComponentToShow /></RootWrapper>);
     expect(await screen.findByText('This is the Toast!')).toBeInTheDocument();
-  });
-
-  it('should capitilize toast', async () => {
-    render(<RootWrapper><TestComponentToShow capitilize /></RootWrapper>);
-    expect(await screen.findByText('This is the toast!')).toBeInTheDocument();
   });
 
   it('should close toast after 5000ms', async () => {

--- a/src/generic/toast-context/index.test.tsx
+++ b/src/generic/toast-context/index.test.tsx
@@ -9,7 +9,6 @@ export interface WraperProps {
   children: React.ReactNode;
 }
 
-// eslint-disable-next-line react/prop-types
 const TestComponentToShow = () => {
   const { showToast } = React.useContext(ToastContext);
 

--- a/src/generic/toast-context/index.test.tsx
+++ b/src/generic/toast-context/index.test.tsx
@@ -9,11 +9,12 @@ export interface WraperProps {
   children: React.ReactNode;
 }
 
-const TestComponentToShow = () => {
+// eslint-disable-next-line react/prop-types
+const TestComponentToShow = ({ capitilize = false }) => {
   const { showToast } = React.useContext(ToastContext);
 
   React.useEffect(() => {
-    showToast('This is the toast!');
+    showToast('This is the Toast!', undefined, capitilize);
   }, [showToast]);
 
   return <div>Content</div>;
@@ -23,7 +24,7 @@ const TestComponentToClose = () => {
   const { showToast, closeToast } = React.useContext(ToastContext);
 
   React.useEffect(() => {
-    showToast('This is the toast!');
+    showToast('This is the Toast!');
     closeToast();
   }, [showToast]);
 
@@ -59,19 +60,24 @@ describe('<ToastProvider />', () => {
 
   it('should show toast', async () => {
     render(<RootWrapper><TestComponentToShow /></RootWrapper>);
+    expect(await screen.findByText('This is the Toast!')).toBeInTheDocument();
+  });
+
+  it('should capitilize toast', async () => {
+    render(<RootWrapper><TestComponentToShow capitilize /></RootWrapper>);
     expect(await screen.findByText('This is the toast!')).toBeInTheDocument();
   });
 
   it('should close toast after 5000ms', async () => {
     render(<RootWrapper><TestComponentToShow /></RootWrapper>);
-    expect(await screen.findByText('This is the toast!')).toBeInTheDocument();
+    expect(await screen.findByText('This is the Toast!')).toBeInTheDocument();
     jest.advanceTimersByTime(6000);
-    expect(screen.queryByText('This is the toast!')).not.toBeInTheDocument();
+    expect(screen.queryByText('This is the Toast!')).not.toBeInTheDocument();
   });
 
   it('should close toast', async () => {
     render(<RootWrapper><TestComponentToClose /></RootWrapper>);
     expect(await screen.findByText('Content')).toBeInTheDocument();
-    expect(screen.queryByText('This is the toast!')).not.toBeInTheDocument();
+    expect(screen.queryByText('This is the Toast!')).not.toBeInTheDocument();
   });
 });

--- a/src/generic/toast-context/index.tsx
+++ b/src/generic/toast-context/index.tsx
@@ -10,7 +10,8 @@ export interface ToastActionData {
 export interface ToastContextData {
   toastMessage: string | null;
   toastAction?: ToastActionData;
-  showToast: (message: string, action?: ToastActionData) => void;
+  capitilize?: boolean;
+  showToast: (message: string, action?: ToastActionData, capitilize?: boolean) => void;
   closeToast: () => void;
 }
 
@@ -25,6 +26,7 @@ export interface ToastProviderProps {
 export const ToastContext = React.createContext<ToastContextData>({
   toastMessage: null,
   toastAction: undefined,
+  capitilize: false,
   showToast: () => {},
   closeToast: () => {},
 });
@@ -38,10 +40,12 @@ export const ToastProvider = (props: ToastProviderProps) => {
 
   const [toastMessage, setToastMessage] = React.useState<string | null>(null);
   const [toastAction, setToastAction] = React.useState<ToastActionData | undefined>(undefined);
+  const [capitilize, setCapitilize] = React.useState<boolean>(false);
 
   const resetState = React.useCallback(() => {
     setToastMessage(null);
     setToastAction(undefined);
+    setCapitilize(false);
   }, []);
 
   React.useEffect(() => () => {
@@ -49,18 +53,20 @@ export const ToastProvider = (props: ToastProviderProps) => {
     resetState();
   }, []);
 
-  const showToast = React.useCallback((message, action?: ToastActionData) => {
+  const showToast = React.useCallback((message, action?: ToastActionData, isCapitilize?: boolean) => {
     setToastMessage(message);
     setToastAction(action);
+    setCapitilize(isCapitilize ?? false);
   }, [setToastMessage, setToastAction]);
-  const closeToast = React.useCallback(() => resetState(), [setToastMessage, setToastAction]);
+  const closeToast = React.useCallback(() => resetState(), [setToastMessage, setToastAction, setCapitilize]);
 
   const context = React.useMemo(() => ({
     toastMessage,
     toastAction,
+    capitilize,
     showToast,
     closeToast,
-  }), [toastMessage, toastAction, showToast, closeToast]);
+  }), [toastMessage, toastAction, capitilize, showToast, closeToast]);
 
   return (
     <ToastContext.Provider value={context}>
@@ -71,6 +77,7 @@ export const ToastProvider = (props: ToastProviderProps) => {
           title={toastMessage}
           action={toastAction}
           close={closeToast}
+          disableCapitalize={!capitilize}
         />
       )}
     </ToastContext.Provider>

--- a/src/generic/toast-context/index.tsx
+++ b/src/generic/toast-context/index.tsx
@@ -10,8 +10,7 @@ export interface ToastActionData {
 export interface ToastContextData {
   toastMessage: string | null;
   toastAction?: ToastActionData;
-  capitilize?: boolean;
-  showToast: (message: string, action?: ToastActionData, capitilize?: boolean) => void;
+  showToast: (message: string, action?: ToastActionData) => void;
   closeToast: () => void;
 }
 
@@ -26,7 +25,6 @@ export interface ToastProviderProps {
 export const ToastContext = React.createContext<ToastContextData>({
   toastMessage: null,
   toastAction: undefined,
-  capitilize: false,
   showToast: () => {},
   closeToast: () => {},
 });
@@ -40,12 +38,10 @@ export const ToastProvider = (props: ToastProviderProps) => {
 
   const [toastMessage, setToastMessage] = React.useState<string | null>(null);
   const [toastAction, setToastAction] = React.useState<ToastActionData | undefined>(undefined);
-  const [capitilize, setCapitilize] = React.useState<boolean>(false);
 
   const resetState = React.useCallback(() => {
     setToastMessage(null);
     setToastAction(undefined);
-    setCapitilize(false);
   }, []);
 
   React.useEffect(() => () => {
@@ -53,20 +49,18 @@ export const ToastProvider = (props: ToastProviderProps) => {
     resetState();
   }, []);
 
-  const showToast = React.useCallback((message, action?: ToastActionData, isCapitilize?: boolean) => {
+  const showToast = React.useCallback((message, action?: ToastActionData) => {
     setToastMessage(message);
     setToastAction(action);
-    setCapitilize(isCapitilize ?? false);
   }, [setToastMessage, setToastAction]);
-  const closeToast = React.useCallback(() => resetState(), [setToastMessage, setToastAction, setCapitilize]);
+  const closeToast = React.useCallback(() => resetState(), [setToastMessage, setToastAction]);
 
   const context = React.useMemo(() => ({
     toastMessage,
     toastAction,
-    capitilize,
     showToast,
     closeToast,
-  }), [toastMessage, toastAction, capitilize, showToast, closeToast]);
+  }), [toastMessage, toastAction, showToast, closeToast]);
 
   return (
     <ToastContext.Provider value={context}>
@@ -77,7 +71,6 @@ export const ToastProvider = (props: ToastProviderProps) => {
           title={toastMessage}
           action={toastAction}
           close={closeToast}
-          disableCapitalize={!capitilize}
         />
       )}
     </ToastContext.Provider>

--- a/src/library-authoring/library-team/LibraryTeam.test.tsx
+++ b/src/library-authoring/library-team/LibraryTeam.test.tsx
@@ -211,7 +211,7 @@ describe('<LibraryTeam />', () => {
   it('shows error', async () => {
     const url = getLibraryTeamApiUrl(libraryId);
     const axiosMock = new MockAdapter(getAuthenticatedHttpClient());
-    axiosMock.onPost(url).reply(400, { error: 'Error' });
+    axiosMock.onPost(url).reply(400, {});
 
     await renderLibraryTeam();
 

--- a/src/library-authoring/library-team/LibraryTeam.test.tsx
+++ b/src/library-authoring/library-team/LibraryTeam.test.tsx
@@ -179,6 +179,8 @@ describe('<LibraryTeam />', () => {
         `{"library_id":"${libraryId}","email":"another@user.tld","access_level":"read"}`,
       );
     });
+
+    expect(await screen.findByText('Team Member added')).toBeInTheDocument();
   });
 
   it('shows error when user do not exist', async () => {
@@ -202,7 +204,7 @@ describe('<LibraryTeam />', () => {
     });
 
     expect(await screen.findByText(
-      'Error adding team member. please verify that the email is correct and belongs to a registered user.',
+      'Error adding Team Member. Please verify that the email is correct and belongs to a registered user.',
     )).toBeInTheDocument();
   });
 
@@ -226,7 +228,7 @@ describe('<LibraryTeam />', () => {
       expect(axiosMock.history.post.length).toEqual(1);
     });
 
-    expect(await screen.findByText('Error adding team member')).toBeInTheDocument();
+    expect(await screen.findByText('Error adding Team Member')).toBeInTheDocument();
   });
 
   it('allows library team member roles to be changed', async () => {

--- a/src/library-authoring/library-team/LibraryTeam.test.tsx
+++ b/src/library-authoring/library-team/LibraryTeam.test.tsx
@@ -206,6 +206,29 @@ describe('<LibraryTeam />', () => {
     )).toBeInTheDocument();
   });
 
+  it('shows error', async () => {
+    const url = getLibraryTeamApiUrl(libraryId);
+    const axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    axiosMock.onPost(url).reply(400, { error: 'Error' });
+
+    await renderLibraryTeam();
+
+    const addButton = screen.getByRole('button', { name: 'New team member' });
+    userEvent.click(addButton);
+    const emailInput = screen.getByRole('textbox', { name: 'User\'s email address' });
+    userEvent.click(emailInput);
+    userEvent.type(emailInput, 'another@user.tld');
+
+    const saveButton = screen.getByRole('button', { name: /add member/i });
+    userEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(axiosMock.history.post.length).toEqual(1);
+    });
+
+    expect(await screen.findByText('Error adding team member')).toBeInTheDocument();
+  });
+
   it('allows library team member roles to be changed', async () => {
     const { username } = mockGetLibraryTeam.readerMember;
     const url = getLibraryTeamMemberApiUrl(libraryId, username);

--- a/src/library-authoring/library-team/LibraryTeam.test.tsx
+++ b/src/library-authoring/library-team/LibraryTeam.test.tsx
@@ -15,6 +15,7 @@ import {
   getLibraryTeamMemberApiUrl,
 } from '../data/api';
 import { LibraryProvider } from '../common/context';
+import { ToastProvider } from '../../generic/toast-context';
 import LibraryTeam from './LibraryTeam';
 
 mockContentLibrary.applyMock();
@@ -28,9 +29,11 @@ describe('<LibraryTeam />', () => {
   const { libraryId } = mockContentLibrary;
   const renderLibraryTeam = async () => {
     render(
-      <LibraryProvider libraryId={libraryId}>
-        <LibraryTeam />
-      </LibraryProvider>,
+      <ToastProvider>
+        <LibraryProvider libraryId={libraryId}>
+          <LibraryTeam />
+        </LibraryProvider>
+      </ToastProvider>,
     );
 
     await waitFor(() => {
@@ -176,6 +179,31 @@ describe('<LibraryTeam />', () => {
         `{"library_id":"${libraryId}","email":"another@user.tld","access_level":"read"}`,
       );
     });
+  });
+
+  it('shows error when user do not exist', async () => {
+    const url = getLibraryTeamApiUrl(libraryId);
+    const axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    axiosMock.onPost(url).reply(400, { email: 'Error' });
+
+    await renderLibraryTeam();
+
+    const addButton = screen.getByRole('button', { name: 'New team member' });
+    userEvent.click(addButton);
+    const emailInput = screen.getByRole('textbox', { name: 'User\'s email address' });
+    userEvent.click(emailInput);
+    userEvent.type(emailInput, 'another@user.tld');
+
+    const saveButton = screen.getByRole('button', { name: /add member/i });
+    userEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(axiosMock.history.post.length).toEqual(1);
+    });
+
+    expect(await screen.findByText(
+      'Error adding team member. please verify that the email is correct and belongs to a registered user.',
+    )).toBeInTheDocument();
   });
 
   it('allows library team member roles to be changed', async () => {

--- a/src/library-authoring/library-team/LibraryTeam.tsx
+++ b/src/library-authoring/library-team/LibraryTeam.tsx
@@ -66,8 +66,8 @@ const LibraryTeam: React.FC<Record<never, never>> = () => {
       }).then(() => {
         showToast(intl.formatMessage(messages.addMemberSuccess));
       }).catch((addMemberError) => {
-        const errorData = addMemberError.response.data;
-        if ('email' in errorData) {
+        const errorData = typeof addMemberError === 'object' ? addMemberError.response?.data : undefined;
+        if (errorData && 'email' in errorData) {
           showToast(intl.formatMessage(messages.addMemberEmailError));
         } else {
           showToast(intl.formatMessage(messages.addMemberError));

--- a/src/library-authoring/library-team/LibraryTeam.tsx
+++ b/src/library-authoring/library-team/LibraryTeam.tsx
@@ -65,8 +65,13 @@ const LibraryTeam: React.FC<Record<never, never>> = () => {
         accessLevel: LibraryRole.Reader.toString() as LibraryAccessLevel,
       }).then(() => {
         showToast(intl.formatMessage(messages.addMemberSuccess));
-      }).catch(() => {
-        showToast(intl.formatMessage(messages.addMemberError));
+      }).catch((addMemberError) => {
+        const errorData = addMemberError.response.data;
+        if ('email' in errorData) {
+          showToast(intl.formatMessage(messages.addMemberEmailError));
+        } else {
+          showToast(intl.formatMessage(messages.addMemberError));
+        }
       });
       closeAddLibraryTeamMember();
     },

--- a/src/library-authoring/library-team/messages.ts
+++ b/src/library-authoring/library-team/messages.ts
@@ -124,6 +124,11 @@ const messages = defineMessages({
     defaultMessage: 'Error adding Team Member',
     description: 'Message shown when an error occurs while adding a Library Team member',
   },
+  addMemberEmailError: {
+    id: 'course-authoring.library-authoring.library-team.add-member-email-error',
+    defaultMessage: 'Error adding team member. Please verify that the email is correct and belongs to a registered user.',
+    description: 'Message shown when an error occurs with email while adding a Library Team member.',
+  },
   deleteMemberSuccess: {
     id: 'course-authoring.library-authoring.library-team.delete-member-success',
     defaultMessage: 'Team Member deleted',

--- a/src/library-authoring/library-team/messages.ts
+++ b/src/library-authoring/library-team/messages.ts
@@ -126,7 +126,7 @@ const messages = defineMessages({
   },
   addMemberEmailError: {
     id: 'course-authoring.library-authoring.library-team.add-member-email-error',
-    defaultMessage: 'Error adding team member. Please verify that the email is correct and belongs to a registered user.',
+    defaultMessage: 'Error adding Team Member. Please verify that the email is correct and belongs to a registered user.',
     description: 'Message shown when an error occurs with email while adding a Library Team member.',
   },
   deleteMemberSuccess: {


### PR DESCRIPTION
## Description

- Updates the message error when the user doesn't exist when adding a new team member to a library.
- Which edX user roles will this change impact? "Course Author"

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/1342#issuecomment-2491666441
- Internal ticket: [FAL-3978](https://tasks.opencraft.com/browse/FAL-3978)

## Testing instructions

- Select a library from the list of v2 Libraries, and open the Library Info sidebar. You need to use a user with Admin access.
- Click on `Manage Access`, and add a user that doesn't exist.
- Verify the new error message.