### PR TITLE
fix: legacy library link

### DIFF
--- a/src/studio-home/card-item/index.tsx
+++ b/src/studio-home/card-item/index.tsx
@@ -64,7 +64,7 @@ const CardItem: React.FC<Props> = ({
   const waffleFlags = useSelector(getWaffleFlags);
 
   const destinationUrl: string = path ?? (
-    waffleFlags.useNewCourseOutlinePage
+    waffleFlags.useNewCourseOutlinePage && !isLibraries
       ? url
       : new URL(url, getConfig().STUDIO_BASE_URL).toString()
   );


### PR DESCRIPTION
## Description

This PR fixes the link from the cards on the legacy libraries list page.

## Testing instructions

1. Open the legacy libraries list
![image](https://github.com/user-attachments/assets/2202286d-592b-4a01-990e-d59b5a0ef0d9)
2. Click on one library and check if you got redirected