### PR TITLE
fix: content libraries permission [sumac]

### DIFF
--- a/src/studio-home/StudioHome.tsx
+++ b/src/studio-home/StudioHome.tsx
@@ -57,6 +57,7 @@ const StudioHome = () => {
     studioShortName,
     studioRequestEmail,
     showNewLibraryButton,
+    showNewLibraryV2Button,
   } = studioHomeData;
 
   const getHeaderButtons = useCallback(() => {
@@ -86,7 +87,7 @@ const StudioHome = () => {
       );
     }
 
-    if (showNewLibraryButton || showV2LibraryURL) {
+    if ((showNewLibraryButton && !showV2LibraryURL) || (showV2LibraryURL && showNewLibraryV2Button)) {
       const newLibraryClick = () => {
         if (showV2LibraryURL) {
           navigate('/library/create');
@@ -101,7 +102,6 @@ const StudioHome = () => {
           variant="outline-primary"
           iconBefore={AddIcon}
           size="sm"
-          disabled={showNewCourseContainer}
           onClick={newLibraryClick}
           data-testid="new-library-button"
         >

--- a/src/studio-home/__mocks__/studioHomeMock.js
+++ b/src/studio-home/__mocks__/studioHomeMock.js
@@ -67,6 +67,7 @@ module.exports = {
   requestCourseCreatorUrl: '/request_course_creator',
   rerunCreatorStatus: true,
   showNewLibraryButton: true,
+  showNewLibraryV2Button: true,
   splitStudioHome: false,
   studioName: 'Studio',
   studioShortName: 'Studio',

--- a/src/studio-home/factories/mockApiResponses.jsx
+++ b/src/studio-home/factories/mockApiResponses.jsx
@@ -37,6 +37,7 @@ export const generateGetStudioHomeDataApiResponse = () => ({
   requestCourseCreatorUrl: '/request_course_creator',
   rerunCreatorStatus: true,
   showNewLibraryButton: true,
+  showNewLibraryV2Button: true,
   splitStudioHome: false,
   studioName: 'Studio',
   studioShortName: 'Studio',


### PR DESCRIPTION
Backport of https://github.com/openedx/frontend-app-authoring/pull/1545

## Description

This PR fixes the `+ Add Library` button display according to the new permissions.

## Addition information

- Depends on https://github.com/openedx/edx-platform/pull/35953
- Part of https://github.com/openedx/edx-platform/issues/35943

## Testing instructions

- Open the course authoring mfe with a Global Staff
- Check if the `+ Add Library` button at the `Courses` and `Libraries [beta]` tabs show the new library form in the mfe (v2 libraries)
- Check if the `+ Add Library` button at the `Legacy Libraries` tab opens a new tab redirecting to the library page on Legacy Studio
- Open the course authoring mfe with a user without permissions
- Check if the `+ Add Library` button at the `Courses` and `Libraries [beta]` tabs is not show
- Check if the `+ Add Library` button at the `Legacy Libraries` tab opens a new tab redirecting to the library page on Legacy Studio

___
Private ref: [FAL-3987](https://tasks.opencraft.com/browse/FAL-3987)