### PR TITLE
feat: fixed height for prerequisite course dropdown list

### DIFF
--- a/src/schedule-and-details/requirements-section/RequirementsSection.scss
+++ b/src/schedule-and-details/requirements-section/RequirementsSection.scss
@@ -2,4 +2,11 @@
   .form-group-custom:not(:last-child) {
     margin-bottom: 2rem;
   }
+
+  .dropdown-prerequisite {
+    .dropdown-menu {
+      overflow: auto;
+      height: 20rem;
+    }
+  }
 }


### PR DESCRIPTION
Backport: https://github.com/openedx/frontend-app-authoring/pull/1154 (original PR to master)
Related PR: https://github.com/openedx/frontend-app-authoring/pull/1555 (backport to redwood branch)

## Description
made fixed height for the prerequisite course dropdown list.
Note: same height is set for the course language dropdown list.

## Steps to reproduce

1. add waffle flag `contentstore.new_studio_mfe.use_new_grading_page` (in /admin/waffle/flag);
2. go to `studio -> Settings -> Schedule & details`;
3. scroll page till the end and click on Prerequisite course drop-down

## BEFORE
Drop-down list goes beyond footer
![1](https://github.com/user-attachments/assets/67f54f05-6521-434f-9cc4-32009e1f8dff)

## AFTER
Drop-down list has the same height as Course language
<img width="1314" alt="2" src="https://github.com/user-attachments/assets/d8076c02-2415-4ed2-a4a2-7e6c86a99b93">
**Course language example**
![3](https://github.com/user-attachments/assets/db92b368-0a39-42b8-8b85-0b7a86d2b23c)
