### PR TITLE
feat: block creation in libraries v2

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -39,4 +39,4 @@ INVITE_STUDENTS_EMAIL_TO="someone@domain.com"
 ENABLE_HOME_PAGE_COURSE_API_V2=true
 ENABLE_CHECKLIST_QUALITY=true
 ENABLE_GRADING_METHOD_IN_PROBLEMS=false
-LIBRARY_SUPPORTED_BLOCKS="problem,video,html,drag-and-drop-v2"
+LIBRARY_SUPPORTED_BLOCKS="problem,video,html,drag-and-drop-v2, other"

--- a/.env.test
+++ b/.env.test
@@ -39,4 +39,5 @@ INVITE_STUDENTS_EMAIL_TO="someone@domain.com"
 ENABLE_HOME_PAGE_COURSE_API_V2=true
 ENABLE_CHECKLIST_QUALITY=true
 ENABLE_GRADING_METHOD_IN_PROBLEMS=false
-LIBRARY_SUPPORTED_BLOCKS="problem,video,html,drag-and-drop-v2, other"
+# "other" is used to test the workflow for creating blocks that aren't supported by the built-in editors
+LIBRARY_SUPPORTED_BLOCKS="problem,video,html,drag-and-drop-v2,other"

--- a/src/editors/containers/EditorContainer/hooks.test.jsx
+++ b/src/editors/containers/EditorContainer/hooks.test.jsx
@@ -16,7 +16,7 @@ jest.mock('../../data/redux', () => ({
     app: {
       isInitialized: (state) => ({ isInitialized: state }),
       images: (state) => ({ images: state }),
-      isCreateBlock: (state) => ({ isCreateBlock: state }),
+      shouldCreateBlock: (state) => ({ shouldCreateBlock: state }),
     },
     requests: {
       isFailed: (...args) => ({ requestFailed: args }),
@@ -77,7 +77,7 @@ describe('EditorContainer hooks', () => {
           validateEntry,
         });
       });
-      it('returns callback to createBlock with dispatch and content if isCreateBlock is true', () => {
+      it('returns callback to createBlock with dispatch and content if shouldCreateBlock is true', () => {
         const getContent = () => 'myTestContentValue';
         const setAssetToStaticUrl = () => 'myTestContentValue';
         const validateEntry = () => 'vaLIdAteENTry';

--- a/src/editors/containers/EditorContainer/hooks.test.jsx
+++ b/src/editors/containers/EditorContainer/hooks.test.jsx
@@ -16,6 +16,7 @@ jest.mock('../../data/redux', () => ({
     app: {
       isInitialized: (state) => ({ isInitialized: state }),
       images: (state) => ({ images: state }),
+      isCreateBlock: (state) => ({ isCreateBlock: state }),
     },
     requests: {
       isFailed: (...args) => ({ requestFailed: args }),
@@ -26,6 +27,7 @@ jest.mock('../../hooks', () => ({
   ...jest.requireActual('../../hooks'),
   navigateCallback: jest.fn((args) => ({ navigateCallback: args })),
   saveBlock: jest.fn((args) => ({ saveBlock: args })),
+  createBlock: jest.fn((args) => ({ createBlock: args })),
 }));
 
 const dispatch = jest.fn();
@@ -53,6 +55,8 @@ describe('EditorContainer hooks', () => {
         const getContent = () => 'myTestContentValue';
         const setAssetToStaticUrl = () => 'myTestContentValue';
         const validateEntry = () => 'vaLIdAteENTry';
+        reactRedux.useSelector.mockReturnValue(false);
+
         const output = hooks.handleSaveClicked({
           getContent,
           images: {
@@ -71,6 +75,31 @@ describe('EditorContainer hooks', () => {
           analytics: reactRedux.useSelector(selectors.app.analytics),
           dispatch,
           validateEntry,
+        });
+      });
+      it('returns callback to createBlock with dispatch and content if isCreateBlock is true', () => {
+        const getContent = () => 'myTestContentValue';
+        const setAssetToStaticUrl = () => 'myTestContentValue';
+        const validateEntry = () => 'vaLIdAteENTry';
+        reactRedux.useSelector.mockReturnValue(true);
+
+        const output = hooks.handleSaveClicked({
+          getContent,
+          images: {
+            portableUrl: '/static/sOmEuiMAge.jpeg',
+            displayName: 'sOmEuiMAge',
+          },
+          destination: 'testDEsTURL',
+          analytics: 'soMEanALytics',
+          dispatch,
+          validateEntry,
+        });
+        output();
+        expect(appHooks.createBlock).toHaveBeenCalledWith({
+          content: setAssetToStaticUrl(reactRedux.useSelector(selectors.app.images), getContent),
+          destination: reactRedux.useSelector(selectors.app.returnUrl),
+          analytics: reactRedux.useSelector(selectors.app.analytics),
+          dispatch,
         });
       });
     });

--- a/src/editors/containers/EditorContainer/hooks.ts
+++ b/src/editors/containers/EditorContainer/hooks.ts
@@ -42,7 +42,6 @@ export const handleSaveClicked = ({
       returnFunction,
     });
   }
-
   return () => saveBlock({
     analytics,
     content: getContent({ dispatch }),

--- a/src/editors/containers/EditorContainer/hooks.ts
+++ b/src/editors/containers/EditorContainer/hooks.ts
@@ -30,11 +30,11 @@ export const handleSaveClicked = ({
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const returnUrl = useSelector(selectors.app.returnUrl);
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const isCreateBlock = useSelector(selectors.app.isCreateBlock);
+  const createBlockOnSave = useSelector(selectors.app.shouldCreateBlock);
   const destination = returnFunction ? '' : returnUrl;
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const analytics = useSelector(selectors.app.analytics);
-  if (isCreateBlock) {
+  if (createBlockOnSave) {
     return () => createBlock({
       analytics,
       content: getContent({ dispatch }),

--- a/src/editors/containers/EditorContainer/hooks.ts
+++ b/src/editors/containers/EditorContainer/hooks.ts
@@ -9,6 +9,7 @@ import * as appHooks from '../../hooks';
 
 export const {
   clearSaveError,
+  clearCreateError,
   navigateCallback,
   nullMethod,
   saveBlock,
@@ -90,3 +91,14 @@ export const isInitialized = () => useSelector(selectors.app.isInitialized);
 export const saveFailed = () => useSelector((rootState) => (
   selectors.requests.isFailed(rootState, { requestKey: RequestKeys.saveBlock })
 ));
+
+export const createFailed = () => ({
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  createFailed: useSelector((rootState) => (
+    selectors.requests.isFailed(rootState, { requestKey: RequestKeys.createBlock })
+  )),
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  createFailedError: useSelector((rootState) => (
+    selectors.requests.error(rootState, { requestKey: RequestKeys.createBlock })
+  )),
+});

--- a/src/editors/containers/EditorContainer/hooks.ts
+++ b/src/editors/containers/EditorContainer/hooks.ts
@@ -12,6 +12,7 @@ export const {
   navigateCallback,
   nullMethod,
   saveBlock,
+  createBlock,
 } = appHooks;
 
 export const state = StrictDict({
@@ -27,9 +28,21 @@ export const handleSaveClicked = ({
 }) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const returnUrl = useSelector(selectors.app.returnUrl);
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const isCreateBlock = useSelector(selectors.app.isCreateBlock);
   const destination = returnFunction ? '' : returnUrl;
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const analytics = useSelector(selectors.app.analytics);
+  if (isCreateBlock) {
+    return () => createBlock({
+      analytics,
+      content: getContent({ dispatch }),
+      destination,
+      dispatch,
+      returnFunction,
+      validateEntry,
+    });
+  }
 
   return () => saveBlock({
     analytics,

--- a/src/editors/containers/EditorContainer/hooks.ts
+++ b/src/editors/containers/EditorContainer/hooks.ts
@@ -40,7 +40,6 @@ export const handleSaveClicked = ({
       destination,
       dispatch,
       returnFunction,
-      validateEntry,
     });
   }
 

--- a/src/editors/containers/EditorContainer/index.test.tsx
+++ b/src/editors/containers/EditorContainer/index.test.tsx
@@ -9,6 +9,7 @@ import {
 import editorCmsApi from '../../data/services/cms/api';
 
 import EditorPage from '../../EditorPage';
+import * as hooks from './hooks';
 
 // Mock this plugins component:
 jest.mock('frontend-components-tinymce-advanced-plugins', () => ({ a11ycheckerCss: '' }));
@@ -164,5 +165,15 @@ describe('EditorContainer', () => {
     expect(window.removeEventListener).toHaveBeenCalledWith('beforeunload', expect.any(Function));
     expect(mockEvent.preventDefault).toHaveBeenCalled();
     expect(mockEvent.returnValue).toBe(true);
+  });
+  test('should display an alert when is an error creating a new block', async () => {
+    jest.spyOn(hooks, 'createFailed').mockImplementation(() => ({ createFailed: true, createFailedError: 'error' }));
+    render(<EditorPage {...{ ...defaultPropsHtml, blockId: '' }} />);
+    expect(await screen.findByText(/There was an error creating the content/i)).toBeInTheDocument();
+  });
+  test('should display an alert when is an error saving the changes', async () => {
+    jest.spyOn(hooks, 'saveFailed').mockImplementation(() => true);
+    render(<EditorPage {...defaultPropsHtml} />);
+    expect(await screen.findByText(/Error: Content save failed. Please check recent changes and try again later./i)).toBeInTheDocument();
   });
 });

--- a/src/editors/containers/EditorContainer/index.test.tsx
+++ b/src/editors/containers/EditorContainer/index.test.tsx
@@ -17,17 +17,6 @@ jest.spyOn(editorCmsApi, 'fetchCourseImages').mockImplementation(async () => ( /
   { data: { assets: [], start: 0, end: 0, page: 0, pageSize: 50, totalCount: 0 } }
 ));
 // Mock out the 'get ancestors' API:
-jest.spyOn(editorCmsApi, 'fetchByUnitId').mockImplementation(async () => ({
-  status: 200,
-  data: {
-    ancestors: [{
-      id: 'block-v1:Org+TS100+24+type@vertical+block@parent',
-      display_name: 'You-Knit? The Test Unit',
-      category: 'vertical',
-      has_children: true,
-    }],
-  },
-}));
 
 const isDirtyMock = jest.fn();
 jest.mock('../TextEditor/hooks', () => ({
@@ -60,6 +49,17 @@ describe('EditorContainer', () => {
     jest.spyOn(window, 'removeEventListener');
     jest.spyOn(mockEvent, 'preventDefault');
     Object.defineProperty(mockEvent, 'returnValue', { writable: true });
+    jest.spyOn(editorCmsApi, 'fetchByUnitId').mockImplementation(async () => ({
+      status: 200,
+      data: {
+        ancestors: [{
+          id: 'block-v1:Org+TS100+24+type@vertical+block@parent',
+          display_name: 'You-Knit? The Test Unit',
+          category: 'vertical',
+          has_children: true,
+        }],
+      },
+    }));
   });
 
   afterEach(() => {

--- a/src/editors/containers/EditorContainer/index.tsx
+++ b/src/editors/containers/EditorContainer/index.tsx
@@ -94,6 +94,7 @@ const EditorContainer: React.FC<Props> = ({
   const onSave = () => {
     setSaved(true);
     handleSave();
+    dispatch({ type: 'resetEditor' });
   };
   // Stops user from navigating away if they have unsaved changes.
   usePromptIfDirty(() => {
@@ -109,6 +110,7 @@ const EditorContainer: React.FC<Props> = ({
       openCancelConfirmModal();
     } else {
       handleCancel();
+      dispatch({ type: 'resetEditor' });
     }
   };
   return (
@@ -126,6 +128,7 @@ const EditorContainer: React.FC<Props> = ({
           if (returnFunction) {
             closeCancelConfirmModal();
           }
+          dispatch({ type: 'resetEditor' });
         }}
       />
       <ModalDialog.Header className="shadow-sm zindex-10">

--- a/src/editors/containers/EditorContainer/index.tsx
+++ b/src/editors/containers/EditorContainer/index.tsx
@@ -94,7 +94,6 @@ const EditorContainer: React.FC<Props> = ({
   const onSave = () => {
     setSaved(true);
     handleSave();
-    dispatch({ type: 'resetEditor' });
   };
   // Stops user from navigating away if they have unsaved changes.
   usePromptIfDirty(() => {
@@ -110,7 +109,6 @@ const EditorContainer: React.FC<Props> = ({
       openCancelConfirmModal();
     } else {
       handleCancel();
-      dispatch({ type: 'resetEditor' });
     }
   };
   return (

--- a/src/editors/containers/EditorContainer/index.tsx
+++ b/src/editors/containers/EditorContainer/index.tsx
@@ -18,6 +18,9 @@ import { useEditorContext } from '../../EditorContext';
 import TitleHeader from './components/TitleHeader';
 import * as hooks from './hooks';
 import messages from './messages';
+import { parseErrorMsg } from '../../../library-authoring/add-content/AddContentContainer';
+import libraryMessages from '../../../library-authoring/add-content/messages';
+
 import './index.scss';
 import usePromptIfDirty from '../../../generic/promptIfDirty/usePromptIfDirty';
 import CancelConfirmModal from './components/CancelConfirmModal';
@@ -81,9 +84,12 @@ const EditorContainer: React.FC<Props> = ({
   const isInitialized = hooks.isInitialized();
   const { isCancelConfirmOpen, openCancelConfirmModal, closeCancelConfirmModal } = hooks.cancelConfirmModalToggle();
   const handleCancel = hooks.handleCancel({ onClose, returnFunction });
+  const { createFailed, createFailedError } = hooks.createFailed();
   const disableSave = !isInitialized;
   const saveFailed = hooks.saveFailed();
   const clearSaveFailed = hooks.clearSaveError({ dispatch });
+  const clearCreateFailed = hooks.clearCreateError({ dispatch });
+
   const handleSave = hooks.handleSaveClicked({
     dispatch,
     getContent,
@@ -113,6 +119,16 @@ const EditorContainer: React.FC<Props> = ({
   };
   return (
     <EditorModalWrapper onClose={confirmCancelIfDirty}>
+      {createFailed && (
+        <Toast show onClose={clearCreateFailed}>
+          {parseErrorMsg(
+            intl,
+            createFailedError,
+            libraryMessages.errorCreateMessageWithDetail,
+            libraryMessages.errorCreateMessage,
+          )}
+        </Toast>
+      )}
       {saveFailed && (
         <Toast show onClose={clearSaveFailed}>
           <FormattedMessage {...messages.contentSaveFailed} />

--- a/src/editors/containers/ProblemEditor/index.test.tsx
+++ b/src/editors/containers/ProblemEditor/index.test.tsx
@@ -27,7 +27,7 @@ jest.mock('../../data/redux', () => ({
   selectors: {
     app: {
       blockValue: jest.fn(state => ({ blockValue: state })),
-      isCreateBlock: jest.fn(state => ({ isCreateBlock: state })),
+      shouldCreateBlock: jest.fn(state => ({ shouldCreateBlock: state })),
     },
     problem: {
       problemType: jest.fn(state => ({ problemType: state })),
@@ -106,7 +106,7 @@ describe('ProblemEditor', () => {
       expect(
         mapStateToProps(testState).blockFinished,
       ).toEqual(
-        selectors.app.isCreateBlock(testState)
+        selectors.app.shouldCreateBlock(testState)
         || selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchBlock }),
       );
     });
@@ -114,7 +114,7 @@ describe('ProblemEditor', () => {
       expect(
         mapStateToProps(testState).advancedSettingsFinished,
       ).toEqual(
-        selectors.app.isCreateBlock(testState)
+        selectors.app.shouldCreateBlock(testState)
         || selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchAdvancedSettings }),
       );
     });

--- a/src/editors/containers/ProblemEditor/index.test.tsx
+++ b/src/editors/containers/ProblemEditor/index.test.tsx
@@ -27,6 +27,7 @@ jest.mock('../../data/redux', () => ({
   selectors: {
     app: {
       blockValue: jest.fn(state => ({ blockValue: state })),
+      isCreateBlock: jest.fn(state => ({ isCreateBlock: state })),
     },
     problem: {
       problemType: jest.fn(state => ({ problemType: state })),
@@ -104,12 +105,18 @@ describe('ProblemEditor', () => {
     test('blockFinished from requests.isFinished', () => {
       expect(
         mapStateToProps(testState).blockFinished,
-      ).toEqual(selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchBlock }));
+      ).toEqual(
+        selectors.app.isCreateBlock(testState)
+        || selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchBlock }),
+      );
     });
     test('advancedSettingsFinished from requests.isFinished', () => {
       expect(
         mapStateToProps(testState).advancedSettingsFinished,
-      ).toEqual(selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchAdvancedSettings }));
+      ).toEqual(
+        selectors.app.isCreateBlock(testState)
+        || selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchAdvancedSettings }),
+      );
     });
   });
   describe('mapDispatchToProps', () => {

--- a/src/editors/containers/ProblemEditor/index.tsx
+++ b/src/editors/containers/ProblemEditor/index.tsx
@@ -65,12 +65,12 @@ const ProblemEditor: React.FC<Props> = ({
 };
 
 export const mapStateToProps = (state) => ({
-  blockFinished: selectors.app.isCreateBlock(state)
+  blockFinished: selectors.app.shouldCreateBlock(state)
   || selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchBlock }),
   blockFailed: selectors.requests.isFailed(state, { requestKey: RequestKeys.fetchBlock }),
   problemType: selectors.problem.problemType(state),
   blockValue: selectors.app.blockValue(state),
-  advancedSettingsFinished: selectors.app.isCreateBlock(state)
+  advancedSettingsFinished: selectors.app.shouldCreateBlock(state)
   || selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchAdvancedSettings }),
 });
 

--- a/src/editors/containers/ProblemEditor/index.tsx
+++ b/src/editors/containers/ProblemEditor/index.tsx
@@ -65,11 +65,13 @@ const ProblemEditor: React.FC<Props> = ({
 };
 
 export const mapStateToProps = (state) => ({
-  blockFinished: selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchBlock }),
+  blockFinished: selectors.app.isCreateBlock(state)
+  || selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchBlock }),
   blockFailed: selectors.requests.isFailed(state, { requestKey: RequestKeys.fetchBlock }),
   problemType: selectors.problem.problemType(state),
   blockValue: selectors.app.blockValue(state),
-  advancedSettingsFinished: selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchAdvancedSettings }),
+  advancedSettingsFinished: selectors.app.isCreateBlock(state)
+  || selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchAdvancedSettings }),
 });
 
 export const mapDispatchToProps = {

--- a/src/editors/containers/TextEditor/index.jsx
+++ b/src/editors/containers/TextEditor/index.jsx
@@ -132,7 +132,8 @@ export const mapStateToProps = (state) => ({
   blockFailed: selectors.requests.isFailed(state, { requestKey: RequestKeys.fetchBlock }),
   blockId: selectors.app.blockId(state),
   showRawEditor: selectors.app.showRawEditor(state),
-  blockFinished: selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchBlock }),
+  blockFinished: selectors.app.isCreateBlock(state)
+  || selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchBlock }),
   learningContextId: selectors.app.learningContextId(state),
   images: selectors.app.images(state),
   isLibrary: selectors.app.isLibrary(state),

--- a/src/editors/containers/TextEditor/index.jsx
+++ b/src/editors/containers/TextEditor/index.jsx
@@ -132,7 +132,7 @@ export const mapStateToProps = (state) => ({
   blockFailed: selectors.requests.isFailed(state, { requestKey: RequestKeys.fetchBlock }),
   blockId: selectors.app.blockId(state),
   showRawEditor: selectors.app.showRawEditor(state),
-  blockFinished: selectors.app.isCreateBlock(state)
+  blockFinished: selectors.app.shouldCreateBlock(state)
   || selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchBlock }),
   learningContextId: selectors.app.learningContextId(state),
   images: selectors.app.images(state),

--- a/src/editors/containers/TextEditor/index.test.jsx
+++ b/src/editors/containers/TextEditor/index.test.jsx
@@ -55,7 +55,7 @@ jest.mock('../../data/redux', () => ({
   selectors: {
     app: {
       blockValue: jest.fn(state => ({ blockValue: state })),
-      isCreateBlock: jest.fn(state => ({ isCreateBlock: state })),
+      shouldCreateBlock: jest.fn(state => ({ shouldCreateBlock: state })),
       lmsEndpointUrl: jest.fn(state => ({ lmsEndpointUrl: state })),
       studioEndpointUrl: jest.fn(state => ({ studioEndpointUrl: state })),
       showRawEditor: jest.fn(state => ({ showRawEditor: state })),
@@ -127,7 +127,7 @@ describe('TextEditor', () => {
     test('blockFinished from requests.isFinished', () => {
       expect(
         mapStateToProps(testState).blockFinished,
-      ).toEqual(selectors.app.isCreateBlock(testState)
+      ).toEqual(selectors.app.shouldCreateBlock(testState)
       || selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchBlock }));
     });
     test('learningContextId from app.learningContextId', () => {

--- a/src/editors/containers/TextEditor/index.test.jsx
+++ b/src/editors/containers/TextEditor/index.test.jsx
@@ -55,6 +55,7 @@ jest.mock('../../data/redux', () => ({
   selectors: {
     app: {
       blockValue: jest.fn(state => ({ blockValue: state })),
+      isCreateBlock: jest.fn(state => ({ isCreateBlock: state })),
       lmsEndpointUrl: jest.fn(state => ({ lmsEndpointUrl: state })),
       studioEndpointUrl: jest.fn(state => ({ studioEndpointUrl: state })),
       showRawEditor: jest.fn(state => ({ showRawEditor: state })),
@@ -126,7 +127,8 @@ describe('TextEditor', () => {
     test('blockFinished from requests.isFinished', () => {
       expect(
         mapStateToProps(testState).blockFinished,
-      ).toEqual(selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchBlock }));
+      ).toEqual(selectors.app.isCreateBlock(testState)
+      || selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchBlock }));
     });
     test('learningContextId from app.learningContextId', () => {
       expect(

--- a/src/editors/containers/VideoEditor/index.tsx
+++ b/src/editors/containers/VideoEditor/index.tsx
@@ -23,7 +23,7 @@ const VideoEditor: React.FC<EditorComponent> = ({
     (state) => selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchStudioView }),
   );
   const isLibrary = useSelector(selectors.app.isLibrary) as boolean;
-  const isCreateBlock = useSelector(selectors.app.isCreateBlock) as boolean;
+  const isCreateWorkflow = useSelector(selectors.app.shouldCreateBlock) as boolean;
   const {
     error,
     validateEntry,
@@ -37,7 +37,7 @@ const VideoEditor: React.FC<EditorComponent> = ({
         returnFunction={returnFunction}
         validateEntry={validateEntry}
       >
-        {(isCreateBlock || studioViewFinished) ? (
+        {(isCreateWorkflow || studioViewFinished) ? (
           <div className="video-editor">
             <VideoEditorModal {...{ isLibrary }} />
           </div>

--- a/src/editors/containers/VideoEditor/index.tsx
+++ b/src/editors/containers/VideoEditor/index.tsx
@@ -20,10 +20,10 @@ const VideoEditor: React.FC<EditorComponent> = ({
 }) => {
   const intl = useIntl();
   const studioViewFinished = useSelector(
-    (state) => selectors.app.isCreateBlock(state)
-    || selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchStudioView }),
+    (state) => selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchStudioView }),
   );
   const isLibrary = useSelector(selectors.app.isLibrary) as boolean;
+  const isCreateBlock = useSelector(selectors.app.isCreateBlock) as boolean;
   const {
     error,
     validateEntry,
@@ -37,7 +37,7 @@ const VideoEditor: React.FC<EditorComponent> = ({
         returnFunction={returnFunction}
         validateEntry={validateEntry}
       >
-        {studioViewFinished ? (
+        {(isCreateBlock || studioViewFinished) ? (
           <div className="video-editor">
             <VideoEditorModal {...{ isLibrary }} />
           </div>

--- a/src/editors/containers/VideoEditor/index.tsx
+++ b/src/editors/containers/VideoEditor/index.tsx
@@ -20,7 +20,8 @@ const VideoEditor: React.FC<EditorComponent> = ({
 }) => {
   const intl = useIntl();
   const studioViewFinished = useSelector(
-    (state) => selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchStudioView }),
+    (state) => selectors.app.isCreateBlock(state)
+    || selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchStudioView }),
   );
   const isLibrary = useSelector(selectors.app.isLibrary) as boolean;
   const {

--- a/src/editors/data/constants/problem.ts
+++ b/src/editors/data/constants/problem.ts
@@ -239,3 +239,7 @@ export const ignoredOlxAttributes = [
   '@_url_name',
   '@_x-is-pointer-node',
 ] as const;
+
+// Useful for the block creation workflow.
+export const problemTitles = new Set([...Object.values(ProblemTypes).map((problem) => problem.title),
+  ...Object.values(AdvanceProblems).map((problem) => problem.title)]);

--- a/src/editors/data/constants/requests.ts
+++ b/src/editors/data/constants/requests.ts
@@ -13,7 +13,7 @@ export const RequestKeys = StrictDict({
   fetchImages: 'fetchImages',
   fetchUnit: 'fetchUnit',
   fetchStudioView: 'fetchStudioView',
-  creaateBlock: 'createBlock',
+  createBlock: 'createBlock',
   saveBlock: 'saveBlock',
   uploadVideo: 'uploadVideo',
   allowThumbnailUpload: 'allowThumbnailUpload',

--- a/src/editors/data/constants/requests.ts
+++ b/src/editors/data/constants/requests.ts
@@ -13,6 +13,7 @@ export const RequestKeys = StrictDict({
   fetchImages: 'fetchImages',
   fetchUnit: 'fetchUnit',
   fetchStudioView: 'fetchStudioView',
+  creaateBlock: 'createBlock',
   saveBlock: 'saveBlock',
   uploadVideo: 'uploadVideo',
   allowThumbnailUpload: 'allowThumbnailUpload',

--- a/src/editors/data/constants/requests.ts
+++ b/src/editors/data/constants/requests.ts
@@ -26,6 +26,7 @@ export const RequestKeys = StrictDict({
   checkTranscriptsForImport: 'checkTranscriptsForImport',
   importTranscript: 'importTranscript',
   uploadAsset: 'uploadAsset',
+  batchUploadAssets: 'batchUploadAssets',
   fetchAdvancedSettings: 'fetchAdvancedSettings',
   fetchVideoFeatures: 'fetchVideoFeatures',
   getHandlerUrl: 'getHandlerUrl',

--- a/src/editors/data/redux/app/reducer.ts
+++ b/src/editors/data/redux/app/reducer.ts
@@ -54,7 +54,6 @@ const app = createSlice({
       images: { ...state.images, ...payload.images },
       imageCount: payload.imageCount,
     }),
-    resetImages: (state) => ({ ...state, images: {}, imageCount: 0 }),
     setVideos: (state, { payload }) => ({ ...state, videos: payload }),
     setCourseDetails: (state, { payload }) => ({ ...state, courseDetails: payload }),
     setShowRawEditor: (state, { payload }) => ({

--- a/src/editors/data/redux/app/selectors.test.ts
+++ b/src/editors/data/redux/app/selectors.test.ts
@@ -88,6 +88,7 @@ describe('app selectors unit tests', () => {
         simpleSelectors.unitUrl,
         simpleSelectors.blockValue,
         selectors.isLibrary,
+        selectors.isCreateBlock,
       ]);
     });
     describe('for library blocks', () => {
@@ -115,6 +116,16 @@ describe('app selectors unit tests', () => {
           [[null, truthy.blockValue, false, false] as [any, any, any, any], false] as const,
           [[truthy.unitUrl, null, false, false] as [any, any, any, any], false] as const,
           [[truthy.unitUrl, truthy.blockValue, false, false] as [any, any, any, any], true] as const,
+        ].map(([args, expected]) => expect(cb(...args)).toEqual(expected));
+      });
+    });
+    describe('component creation workflow', () => {
+      it('returns true if is isCreateBlock is truthy', () => {
+        const { resultFunc: cb } = selectors.isInitialized;
+
+        [
+          [[null, null, true, true] as [any, any, any, any], true] as const,
+          [[null, null, true, true] as [any, any, any, any], true] as const,
         ].map(([args, expected]) => expect(cb(...args)).toEqual(expected));
       });
     });
@@ -182,6 +193,11 @@ describe('app selectors unit tests', () => {
       it('should return true when learningContextId a v1 library', () => {
         expect(selectors.isLibrary.resultFunc(learningContextIdLibrary, 'library-v1')).toEqual(true);
       });
+    });
+  });
+  describe('isCreateBlock', () => {
+    it('should return false if the editor is initialized with a blockId', () => {
+      expect(selectors.isCreateBlock.resultFunc('block-v1:', 'text')).toEqual(false);
     });
   });
 });

--- a/src/editors/data/redux/app/selectors.test.ts
+++ b/src/editors/data/redux/app/selectors.test.ts
@@ -98,8 +98,8 @@ describe('app selectors unit tests', () => {
         };
 
         [
-          [[null, truthy.blockValue, true] as [any, any, any], true] as const,
-          [[null, null, true] as [any, any, any], false] as const,
+          [[null, truthy.blockValue, true, false] as [any, any, any, any], true] as const,
+          [[null, null, true, false] as [any, any, any, any], false] as const,
         ].map(([args, expected]) => expect(cb(...args)).toEqual(expected));
       });
     });
@@ -112,9 +112,9 @@ describe('app selectors unit tests', () => {
         };
 
         [
-          [[null, truthy.blockValue, false] as [any, any, any], false] as const,
-          [[truthy.unitUrl, null, false] as [any, any, any], false] as const,
-          [[truthy.unitUrl, truthy.blockValue, false] as [any, any, any], true] as const,
+          [[null, truthy.blockValue, false, false] as [any, any, any, any], false] as const,
+          [[truthy.unitUrl, null, false, false] as [any, any, any, any], false] as const,
+          [[truthy.unitUrl, truthy.blockValue, false, false] as [any, any, any, any], true] as const,
         ].map(([args, expected]) => expect(cb(...args)).toEqual(expected));
       });
     });

--- a/src/editors/data/redux/app/selectors.test.ts
+++ b/src/editors/data/redux/app/selectors.test.ts
@@ -88,7 +88,7 @@ describe('app selectors unit tests', () => {
         simpleSelectors.unitUrl,
         simpleSelectors.blockValue,
         selectors.isLibrary,
-        selectors.isCreateBlock,
+        selectors.shouldCreateBlock,
       ]);
     });
     describe('for library blocks', () => {
@@ -120,7 +120,7 @@ describe('app selectors unit tests', () => {
       });
     });
     describe('component creation workflow', () => {
-      it('returns true if is isCreateBlock is truthy', () => {
+      it('returns true if is shouldCreateBlock is truthy', () => {
         const { resultFunc: cb } = selectors.isInitialized;
 
         [
@@ -195,9 +195,9 @@ describe('app selectors unit tests', () => {
       });
     });
   });
-  describe('isCreateBlock', () => {
+  describe('shouldCreateBlock', () => {
     it('should return false if the editor is initialized with a blockId', () => {
-      expect(selectors.isCreateBlock.resultFunc('block-v1:', 'text')).toEqual(false);
+      expect(selectors.shouldCreateBlock.resultFunc('block-v1:', 'text')).toEqual(false);
     });
   });
 });

--- a/src/editors/data/redux/app/selectors.ts
+++ b/src/editors/data/redux/app/selectors.ts
@@ -54,7 +54,7 @@ export const isLibrary = createSelector(
   },
 );
 
-export const isCreateBlock = createSelector(
+export const shouldCreateBlock = createSelector(
   [simpleSelectors.blockId,
     simpleSelectors.blockType,
   ],
@@ -71,10 +71,10 @@ export const isInitialized = createSelector(
     simpleSelectors.unitUrl,
     simpleSelectors.blockValue,
     isLibrary,
-    isCreateBlock,
+    shouldCreateBlock,
   ],
-  (unitUrl, blockValue, isLibraryBlock, isCreateEditor) => {
-    if (isCreateEditor) {
+  (unitUrl, blockValue, isLibraryBlock, initCreateWorkflow) => {
+    if (initCreateWorkflow) {
       return true;
     }
 
@@ -122,5 +122,5 @@ export default {
   displayTitle,
   analytics,
   isLibrary,
-  isCreateBlock,
+  shouldCreateBlock,
 };

--- a/src/editors/data/redux/app/selectors.ts
+++ b/src/editors/data/redux/app/selectors.ts
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import type { EditorState } from '..';
 import { blockTypes } from '../../constants/app';
-import { isLibraryV1Key } from '../../../../generic/key-utils';
+import { isLibraryKey, isLibraryV1Key } from '../../../../generic/key-utils';
 import * as urls from '../../services/cms/urls';
 
 export const appSelector = (state: EditorState) => state.app;
@@ -47,7 +47,19 @@ export const isLibrary = createSelector(
     if (isLibraryV1Key(learningContextId)) {
       return true;
     }
-    if (blockId && blockId.startsWith('lb:')) {
+    if ((blockId && blockId.startsWith('lb:')) || isLibraryKey(learningContextId)) {
+      return true;
+    }
+    return false;
+  },
+);
+
+export const isCreateBlock = createSelector(
+  [simpleSelectors.blockId,
+    simpleSelectors.blockType,
+  ],
+  (blockId, blockType) => {
+    if (blockId === '' && blockType) {
       return true;
     }
     return false;
@@ -59,8 +71,13 @@ export const isInitialized = createSelector(
     simpleSelectors.unitUrl,
     simpleSelectors.blockValue,
     isLibrary,
+    isCreateBlock,
   ],
-  (unitUrl, blockValue, isLibraryBlock) => {
+  (unitUrl, blockValue, isLibraryBlock, isCreateEditor) => {
+    if (isCreateEditor) {
+      return true;
+    }
+
     if (isLibraryBlock) {
       return !!blockValue;
     }
@@ -105,4 +122,5 @@ export default {
   displayTitle,
   analytics,
   isLibrary,
+  isCreateBlock,
 };

--- a/src/editors/data/redux/index.ts
+++ b/src/editors/data/redux/index.ts
@@ -12,13 +12,21 @@ import { AdvancedProblemType, ProblemType } from '../constants/problem';
 
 export { default as thunkActions } from './thunkActions';
 
-const rootReducer = combineReducers({
+const editorReducer = combineReducers({
   app: app.reducer,
   requests: requests.reducer,
   video: video.reducer,
   problem: problem.reducer,
   game: game.reducer,
 });
+
+const rootReducer = (state: any, action: any) => {
+  if (action.type === 'resetEditor') {
+    return editorReducer(undefined, action);
+  }
+
+  return editorReducer(state, action);
+};
 
 const actions = StrictDict({
   app: app.actions,

--- a/src/editors/data/redux/requests/reducer.js
+++ b/src/editors/data/redux/requests/reducer.js
@@ -8,6 +8,7 @@ const initialState = {
   [RequestKeys.fetchUnit]: { status: RequestStates.inactive },
   [RequestKeys.fetchBlock]: { status: RequestStates.inactive },
   [RequestKeys.fetchStudioView]: { status: RequestStates.inactive },
+  [RequestKeys.createBlock]: { status: RequestStates.inactive },
   [RequestKeys.saveBlock]: { status: RequestStates.inactive },
   [RequestKeys.uploadAsset]: { status: RequestStates.inactive },
   [RequestKeys.allowThumbnailUpload]: { status: RequestStates.inactive },

--- a/src/editors/data/redux/thunkActions/app.js
+++ b/src/editors/data/redux/thunkActions/app.js
@@ -88,6 +88,7 @@ export const fetchCourseDetails = () => (dispatch) => {
  */
 export const initialize = (data) => (dispatch) => {
   const editorType = data.blockType;
+  dispatch({ type: 'resetEditor' });
   dispatch(actions.app.initialize(data));
   if (data.blockId === '' && editorType) {
     dispatch(actions.app.initializeEditor());
@@ -139,6 +140,10 @@ export const createBlock = (content, returnToUnit) => (dispatch) => {
       dispatch(actions.app.setBlockId(response.id));
       dispatch(saveBlock(content, returnToUnit));
     },
+    onFailure: (error) => dispatch(actions.requests.failRequest({
+      requestKey: RequestKeys.createBlock,
+      error,
+    })),
   }));
 };
 

--- a/src/editors/data/redux/thunkActions/app.js
+++ b/src/editors/data/redux/thunkActions/app.js
@@ -8,7 +8,6 @@ import * as module from './app';
 import { actions as appActions, selectors } from '../app';
 import { actions as requestsActions } from '../requests';
 import { RequestKeys } from '../../constants/requests';
-import { addComponentsToCollection } from '../../../../library-authoring/data/api';
 
 // Similar to `import { actions } from '..';` but avoid circular imports:
 const actions = {
@@ -140,13 +139,6 @@ export const createBlock = (content, returnToUnit) => (dispatch, getState) => {
       dispatch(actions.app.setBlockId(response.id));
       const newImages = Object.values(selectors.images(getState())).map((image) => image.file);
 
-      if (selectors.isLibrary(getState())) {
-        const collectionIndex = window.location.pathname.indexOf('collection');
-        const collectionId = collectionIndex !== -1 ? window.location.pathname.substring(collectionIndex).split('/')[1] : null;
-        if (collectionId) {
-          addComponentsToCollection(selectors.learningContextId(getState()), collectionId, [response.id]);
-        }
-      }
       if (newImages.length === 0) {
         dispatch(saveBlock(content, returnToUnit));
         return;

--- a/src/editors/data/redux/thunkActions/app.js
+++ b/src/editors/data/redux/thunkActions/app.js
@@ -89,6 +89,12 @@ export const fetchCourseDetails = () => (dispatch) => {
 export const initialize = (data) => (dispatch) => {
   const editorType = data.blockType;
   dispatch(actions.app.initialize(data));
+
+  if (data.blockId === '' && data.blockType) {
+    dispatch(actions.app.initializeEditor());
+    return;
+  }
+
   dispatch(module.fetchBlock());
   if (data.blockId?.startsWith('block-v1:')) {
     dispatch(module.fetchUnit());
@@ -125,6 +131,18 @@ export const saveBlock = (content, returnToUnit) => (dispatch) => {
   }));
 };
 
+/**
+ * @param {func} onSuccess
+ */
+export const createBlock = (content, returnToUnit) => (dispatch) => {
+  dispatch(requests.createBlock({
+    onSuccess: (response) => {
+      dispatch(actions.app.setBlockId(response.id));
+      dispatch(saveBlock(content, returnToUnit));
+    },
+  }));
+};
+
 export const uploadAsset = ({ file, setSelection }) => (dispatch) => {
   dispatch(requests.uploadAsset({
     asset: file,
@@ -142,4 +160,5 @@ export default StrictDict({
   saveBlock,
   fetchImages,
   uploadAsset,
+  createBlock,
 });

--- a/src/editors/data/redux/thunkActions/app.js
+++ b/src/editors/data/redux/thunkActions/app.js
@@ -89,8 +89,7 @@ export const fetchCourseDetails = () => (dispatch) => {
 export const initialize = (data) => (dispatch) => {
   const editorType = data.blockType;
   dispatch(actions.app.initialize(data));
-
-  if (data.blockId === '' && data.blockType) {
+  if (data.blockId === '' && editorType) {
     dispatch(actions.app.initializeEditor());
     return;
   }

--- a/src/editors/data/redux/thunkActions/app.js
+++ b/src/editors/data/redux/thunkActions/app.js
@@ -169,7 +169,7 @@ export const createBlock = (content, returnToUnit) => (dispatch, getState) => {
 };
 
 export const uploadAsset = ({ file, setSelection }) => (dispatch, getState) => {
-  if (selectors.isCreateBlock(getState())) {
+  if (selectors.shouldCreateBlock(getState())) {
     const tempFileURL = URL.createObjectURL(file);
     const tempImage = {
       displayName: file.name,

--- a/src/editors/data/redux/thunkActions/app.test.js
+++ b/src/editors/data/redux/thunkActions/app.test.js
@@ -382,7 +382,7 @@ describe('app thunkActions', () => {
         error,
       }));
     });
-    test.only('should call batchUploadAssets if the block has images', () => {
+    test('should call batchUploadAssets if the block has images', () => {
       mockImageData.map(image => ({ ...image, file: 'file' }));
       getState.mockReturnValueOnce({ app: { blockId: '', images: mockImageData } });
       const data = { id: 'block-id' };

--- a/src/editors/data/redux/thunkActions/app.test.js
+++ b/src/editors/data/redux/thunkActions/app.test.js
@@ -7,6 +7,7 @@ import * as thunkActions from './app';
 jest.mock('./requests', () => ({
   fetchBlock: (args) => ({ fetchBlock: args }),
   fetchUnit: (args) => ({ fetchUnit: args }),
+  createBlock: (args) => ({ createBlock: args }),
   saveBlock: (args) => ({ saveBlock: args }),
   uploadAsset: (args) => ({ uploadAsset: args }),
   fetchStudioView: (args) => ({ fetchStudioView: args }),
@@ -196,6 +197,21 @@ describe('app thunkActions', () => {
       thunkActions.fetchCourseDetails = fetchCourseDetails;
     });
   });
+  describe('initialize without block id but block type defined', () => {
+    it('dispatches actions.app.initialize, and then fetches both block and unit', () => {
+      const data = {
+        ...testValue,
+        blockType: 'html',
+        blockId: '',
+        learningContextId: 'course-v1:UniversityX+PHYS+1',
+      };
+      thunkActions.initialize(data)(dispatch);
+      expect(dispatch.mock.calls).toEqual([
+        [actions.app.initialize(data)],
+        [actions.app.initializeEditor()],
+      ]);
+    });
+  });
   describe('initialize with block type html', () => {
     it('dispatches actions.app.initialize, and then fetches both block and unit', () => {
       const {
@@ -331,6 +347,26 @@ describe('app thunkActions', () => {
       calls[1][0].saveBlock.onSuccess(response);
       expect(dispatch).toHaveBeenCalledWith(actions.app.setSaveResponse(response));
       expect(returnToUnit).toHaveBeenCalled();
+    });
+  });
+  describe('createBlock', () => {
+    let returnToUnit;
+    beforeEach(() => {
+      returnToUnit = jest.fn();
+      thunkActions.createBlock(testValue, returnToUnit)(dispatch);
+      [[dispatchedAction]] = dispatch.mock.calls;
+    });
+    it('dispatches createBlock', () => {
+      expect(dispatchedAction.createBlock).not.toBe(undefined);
+    });
+    test('onSuccess: calls setBlockId and dispatches saveBlock', () => {
+      const {
+        saveBlock,
+      } = thunkActions;
+      thunkActions.saveBlock = saveBlock;
+
+      dispatchedAction.createBlock.onSuccess({ id: 'library' });
+      expect(dispatch).toHaveBeenCalledWith(actions.app.setBlockId('library'));
     });
   });
   describe('uploadAsset', () => {

--- a/src/editors/data/redux/thunkActions/app.test.js
+++ b/src/editors/data/redux/thunkActions/app.test.js
@@ -186,6 +186,7 @@ describe('app thunkActions', () => {
       thunkActions.fetchCourseDetails = () => 'fetchCourseDetails';
       thunkActions.initialize(testValue)(dispatch);
       expect(dispatch.mock.calls).toEqual([
+        [{ type: 'resetEditor' }],
         [actions.app.initialize(testValue)],
         [thunkActions.fetchBlock()],
       ]);
@@ -207,6 +208,7 @@ describe('app thunkActions', () => {
       };
       thunkActions.initialize(data)(dispatch);
       expect(dispatch.mock.calls).toEqual([
+        [{ type: 'resetEditor' }],
         [actions.app.initialize(data)],
         [actions.app.initializeEditor()],
       ]);
@@ -236,6 +238,7 @@ describe('app thunkActions', () => {
       };
       thunkActions.initialize(data)(dispatch);
       expect(dispatch.mock.calls).toEqual([
+        [{ type: 'resetEditor' }],
         [actions.app.initialize(data)],
         [thunkActions.fetchBlock()],
         [thunkActions.fetchUnit()],
@@ -273,6 +276,7 @@ describe('app thunkActions', () => {
       };
       thunkActions.initialize(data)(dispatch);
       expect(dispatch.mock.calls).toEqual([
+        [{ type: 'resetEditor' }],
         [actions.app.initialize(data)],
         [thunkActions.fetchBlock()],
         [thunkActions.fetchUnit()],
@@ -310,6 +314,7 @@ describe('app thunkActions', () => {
       };
       thunkActions.initialize(data)(dispatch);
       expect(dispatch.mock.calls).toEqual([
+        [{ type: 'resetEditor' }],
         [actions.app.initialize(data)],
         [thunkActions.fetchBlock()],
         [thunkActions.fetchUnit()],

--- a/src/editors/data/redux/thunkActions/problem.ts
+++ b/src/editors/data/redux/thunkActions/problem.ts
@@ -59,6 +59,7 @@ export const getDataFromOlx = ({ rawOLX, rawSettings, defaultSettings }) => {
 };
 
 export const loadProblem = ({ rawOLX, rawSettings, defaultSettings }) => (dispatch) => {
+  console.debug(rawOLX);
   if (isBlankProblem({ rawOLX })) {
     dispatch(actions.problem.setEnableTypeSelection(camelizeKeys(defaultSettings)));
   } else {
@@ -84,7 +85,7 @@ export const fetchAdvancedSettings = ({ rawOLX, rawSettings }) => (dispatch) => 
 };
 
 export const initializeProblem = (blockValue) => (dispatch, getState) => {
-  const rawOLX = _.get(blockValue, 'data.data', {});
+  const rawOLX = _.get(blockValue, 'data.data', '');
   const rawSettings = _.get(blockValue, 'data.metadata', {});
   const learningContextId = selectors.app.learningContextId(getState());
   if (isLibraryKey(learningContextId)) {

--- a/src/editors/data/redux/thunkActions/problem.ts
+++ b/src/editors/data/redux/thunkActions/problem.ts
@@ -59,7 +59,6 @@ export const getDataFromOlx = ({ rawOLX, rawSettings, defaultSettings }) => {
 };
 
 export const loadProblem = ({ rawOLX, rawSettings, defaultSettings }) => (dispatch) => {
-  console.debug(rawOLX);
   if (isBlankProblem({ rawOLX })) {
     dispatch(actions.problem.setEnableTypeSelection(camelizeKeys(defaultSettings)));
   } else {

--- a/src/editors/data/redux/thunkActions/requests.js
+++ b/src/editors/data/redux/thunkActions/requests.js
@@ -128,8 +128,7 @@ export const saveBlock = ({ content, ...rest }) => (dispatch, getState) => {
 };
 
 /**
- * Tracked saveBlock api method.  Tracked to the `saveBlock` request key.
- * @param {string} content
+ * Tracked createBlock api method.  Tracked to the `createBlock` request key.
  * @param {[func]} onSuccess - onSuccess method ((response) => { ... })
  * @param {[func]} onFailure - onFailure method ((error) => { ... })
  */
@@ -139,7 +138,7 @@ export const createBlock = ({ ...rest }) => (dispatch, getState) => {
     : `${uuid4()}`;
 
   dispatch(module.networkRequest({
-    requestKey: RequestKeys.creaateBlock,
+    requestKey: RequestKeys.createBlock,
     promise: createLibraryBlock({
       libraryId: selectors.app.learningContextId(getState()),
       blockType: selectors.app.blockType(getState()),

--- a/src/editors/data/redux/thunkActions/requests.js
+++ b/src/editors/data/redux/thunkActions/requests.js
@@ -144,9 +144,9 @@ export const createBlock = ({ ...rest }) => (dispatch, getState) => {
   if (!cleanTitle || (blockType === blockTypes.problem && problemTitles.has(blockTitle))) {
     definitionId = `${uuid4()}`;
   } else {
-    // add a hash to prevent duplication.
-    const hash = uuid4().split('-')[4];
-    definitionId = `${cleanTitle.replaceAll(/\s+/g, '-')}-${hash}`;
+    // add a short random suffix to prevent conflicting IDs.
+    const suffix = uuid4().split('-')[4];
+    definitionId = `${cleanTitle.replaceAll(/\s+/g, '-')}-${suffix}`;
   }
   dispatch(module.networkRequest({
     requestKey: RequestKeys.createBlock,

--- a/src/editors/data/redux/thunkActions/requests.js
+++ b/src/editors/data/redux/thunkActions/requests.js
@@ -1,3 +1,5 @@
+import { v4 as uuid4 } from 'uuid';
+
 import { StrictDict, parseLibraryImageData, getLibraryImageAssets } from '../../../utils';
 
 import { RequestKeys } from '../../constants/requests';
@@ -12,6 +14,7 @@ import { selectors as videoSelectors } from '../video';
 // eslint-disable-next-line import/no-self-import
 import * as module from './requests';
 import { isLibraryKey } from '../../../../generic/key-utils';
+import { createLibraryBlock } from '../../../../library-authoring/data/api';
 import { acceptedImgKeys } from '../../../sharedComponents/ImageUploadModal/SelectImageModal/utils';
 
 // Similar to `import { actions, selectors } from '..';` but avoid circular imports:
@@ -123,6 +126,29 @@ export const saveBlock = ({ content, ...rest }) => (dispatch, getState) => {
     ...rest,
   }));
 };
+
+/**
+ * Tracked saveBlock api method.  Tracked to the `saveBlock` request key.
+ * @param {string} content
+ * @param {[func]} onSuccess - onSuccess method ((response) => { ... })
+ * @param {[func]} onFailure - onFailure method ((error) => { ... })
+ */
+export const createBlock = ({ ...rest }) => (dispatch, getState) => {
+  const definitionId = selectors.app.blockTitle(getState())
+    ? selectors.app.blockTitle(getState()).toLowerCase().replaceAll(' ', '-')
+    : `${uuid4()}`;
+
+  dispatch(module.networkRequest({
+    requestKey: RequestKeys.creaateBlock,
+    promise: createLibraryBlock({
+      libraryId: selectors.app.learningContextId(getState()),
+      blockType: selectors.app.blockType(getState()),
+      definitionId,
+    }),
+    ...rest,
+  }));
+};
+
 export const uploadAsset = ({ asset, ...rest }) => (dispatch, getState) => {
   const learningContextId = selectors.app.learningContextId(getState());
   dispatch(module.networkRequest({

--- a/src/editors/data/redux/thunkActions/requests.js
+++ b/src/editors/data/redux/thunkActions/requests.js
@@ -449,6 +449,7 @@ export default StrictDict({
   fetchBlock,
   fetchStudioView,
   fetchUnit,
+  createBlock,
   saveBlock,
   fetchImages,
   fetchVideos,

--- a/src/editors/data/redux/thunkActions/requests.test.js
+++ b/src/editors/data/redux/thunkActions/requests.test.js
@@ -439,6 +439,24 @@ describe('requests thunkActions module', () => {
       });
     });
 
+    describe('batchUploadAssets', () => {
+      const assets = [new Blob(['file1']), new Blob(['file2'])];
+      testNetworkRequestAction({
+        action: requests.batchUploadAssets,
+        args: { ...fetchParams, assets },
+        expectedString: 'with upload batch assets promise',
+        expectedData: {
+          ...fetchParams,
+          requestKey: RequestKeys.batchUploadAssets,
+          promise: assets.reduce((acc, asset) => acc.then(() => api.uploadAsset({
+            asset,
+            learningContextId: selectors.app.learningContextId(testState),
+            studioEndpointUrl: selectors.app.studioEndpointUrl(testState),
+          })), Promise.resolve()),
+        },
+      });
+    });
+
     describe('uploadThumbnail', () => {
       const thumbnail = 'SoME tHumbNAil CoNtent As String';
       const videoId = 'SoME VidEOid CoNtent As String';

--- a/src/editors/data/redux/thunkActions/requests.test.js
+++ b/src/editors/data/redux/thunkActions/requests.test.js
@@ -26,6 +26,7 @@ jest.mock('../app/selectors', () => ({
 jest.mock('../video/selectors', () => ({
   transcriptHandlerUrl: () => ('transcriptHandlerUrl'),
   blockTitle: (state) => state.data,
+  blockTitle: (state) => state.some,
 }));
 
 jest.mock('../../services/cms/api', () => ({

--- a/src/editors/data/redux/thunkActions/requests.test.js
+++ b/src/editors/data/redux/thunkActions/requests.test.js
@@ -19,14 +19,12 @@ jest.mock('../app/selectors', () => ({
   blockId: (state) => ({ blockId: state }),
   blockType: (state) => ({ blockType: state }),
   learningContextId: (state) => ({ learningContextId: state }),
-  blockTitle: (state) => ({ title: state }),
+  blockTitle: (state) => state.some,
   isLibrary: (state) => (state.isLibrary),
 }));
 
 jest.mock('../video/selectors', () => ({
   transcriptHandlerUrl: () => ('transcriptHandlerUrl'),
-  blockTitle: (state) => state.data,
-  blockTitle: (state) => state.some,
 }));
 
 jest.mock('../../services/cms/api', () => ({
@@ -476,26 +474,27 @@ describe('requests thunkActions module', () => {
         });
 
         it('should replace the base64 image with the image path in the content', (done) => {
-   /*       const onLoad = jest.fn();
+          /*       const onLoad = jest.fn();
           const readAsDataURLMock = jest.fn(() => {
             this.result = 'data:image/jpeg;base64,TESTBASE64';
             onLoad();
-          });*/
+          }); */
           class FileReaderMock {
             constructor() {
               this.result = '';
               this.onload = null;
             }
+
             addEventListener(event, callback) {
               if (event === 'load') {
-                this.onLoad =callback;
+                this.onLoad = callback;
               }
             }
 
             readAsDataURL() {
               this.result = 'data:image/jpeg;base64,TESTBASE64';
               this.onLoad();
-            };
+            }
           }
           global.FileReader = FileReaderMock;
           global.URL.revokeObjectURL = jest.fn();

--- a/src/editors/data/redux/thunkActions/requests.test.js
+++ b/src/editors/data/redux/thunkActions/requests.test.js
@@ -3,6 +3,7 @@ import { RequestKeys } from '../../constants/requests';
 import api from '../../services/cms/api';
 import * as requests from './requests';
 import { actions, selectors } from '../index';
+import { createLibraryBlock } from '../../../../library-authoring/data/api';
 
 const testState = {
   some: 'data',
@@ -24,6 +25,7 @@ jest.mock('../app/selectors', () => ({
 
 jest.mock('../video/selectors', () => ({
   transcriptHandlerUrl: () => ('transcriptHandlerUrl'),
+  blockTitle: (state) => state.data,
 }));
 
 jest.mock('../../services/cms/api', () => ({
@@ -49,6 +51,10 @@ jest.mock('../../services/cms/api', () => ({
   importTranscript: (args) => args,
   fetchVideoFeatures: (args) => args,
   uploadVideo: (args) => args,
+}));
+
+jest.mock('../../../../library-authoring/data/api', () => ({
+  createLibraryBlock: ({ id, url }) => ({ id, url }),
 }));
 
 jest.mock('../../../utils', () => ({
@@ -356,6 +362,21 @@ describe('requests thunkActions module', () => {
             content,
             studioEndpointUrl: selectors.app.studioEndpointUrl(testState),
             title: selectors.app.blockTitle(testState),
+          }),
+        },
+      });
+    });
+    describe('createBlock', () => {
+      testNetworkRequestAction({
+        action: requests.createBlock,
+        args: { ...fetchParams },
+        expectedString: 'with create promise',
+        expectedData: {
+          ...fetchParams,
+          requestKey: RequestKeys.createBlock,
+          promise: createLibraryBlock({
+            libraryId: selectors.app.learningContextId(testState),
+            blockType: selectors.app.blockType(testState),
           }),
         },
       });

--- a/src/editors/data/redux/thunkActions/video.js
+++ b/src/editors/data/redux/thunkActions/video.js
@@ -17,8 +17,8 @@ const selectors = { app: appSelectors, video: videoSelectors };
 
 export const loadVideoData = (selectedVideoId, selectedVideoUrl) => (dispatch, getState) => {
   const state = getState();
-  const blockValueData = state.app.blockValue.data;
-  let rawVideoData = blockValueData.metadata ? blockValueData.metadata : {};
+  const blockValueData = state.app?.blockValue?.data;
+  let rawVideoData = blockValueData?.metadata ? blockValueData.metadata : {};
   const rawVideos = Object.values(selectors.app.videos(state));
   if (selectedVideoId !== undefined && selectedVideoId !== null) {
     const selectedVideo = _.find(rawVideos, video => {

--- a/src/editors/hooks.test.jsx
+++ b/src/editors/hooks.test.jsx
@@ -25,6 +25,7 @@ jest.mock('./data/redux', () => ({
     app: {
       initialize: (args) => ({ initializeApp: args }),
       saveBlock: (args) => ({ saveBlock: args }),
+      createBlock: (args) => ({ createBlock: args }),
     },
   },
 }));
@@ -165,12 +166,61 @@ describe('hooks', () => {
     });
   });
 
+  describe('createBlock', () => {
+    const navigateCallback = (args) => ({ navigateCallback: args });
+    const dispatch = jest.fn();
+    const destination = 'uRLwhENsAved';
+    const analytics = 'dATAonEveNT';
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.spyOn(hooks, hookKeys.navigateCallback).mockImplementationOnce(navigateCallback);
+    });
+    it('returns null when content is null', () => {
+      const content = null;
+      const expected = hooks.createBlock({
+        content,
+        destination,
+        analytics,
+        dispatch,
+      });
+      expect(expected).toEqual(undefined);
+    });
+    it('dispatches thunkActions.app.createBlock with navigateCallback, and passed content', () => {
+      const content = 'myContent';
+      hooks.createBlock({
+        content,
+        destination,
+        analytics,
+        dispatch,
+      });
+      expect(dispatch).toHaveBeenCalledWith(thunkActions.app.createBlock(
+        content,
+        navigateCallback({
+          destination,
+          analyticsEvent: analyticsEvt.editorSaveClick,
+          analytics,
+        }),
+      ));
+    });
+  });
+
   describe('clearSaveError', () => {
     it('dispatches actions.requests.clearRequest with saveBlock requestKey', () => {
       const dispatch = jest.fn();
       hooks.clearSaveError({ dispatch })();
       expect(dispatch).toHaveBeenCalledWith(actions.requests.clearRequest({
         requestKey: RequestKeys.saveBlock,
+      }));
+    });
+  });
+
+  describe('clearCreateError', () => {
+    it('dispatches actions.requests.clearRequest with createBlock requestKey', () => {
+      const dispatch = jest.fn();
+      hooks.clearCreateError({ dispatch })();
+      expect(dispatch).toHaveBeenCalledWith(actions.requests.clearRequest({
+        requestKey: RequestKeys.createBlock,
       }));
     });
   });

--- a/src/editors/hooks.ts
+++ b/src/editors/hooks.ts
@@ -71,7 +71,6 @@ export const createBlock = ({
   destination,
   dispatch,
   returnFunction,
-  validateEntry,
 }) => {
   if (!content) {
     return;

--- a/src/editors/hooks.ts
+++ b/src/editors/hooks.ts
@@ -65,7 +65,27 @@ export const saveBlock = ({
     ));
   }
 };
-
+export const createBlock = ({
+  analytics,
+  content,
+  destination,
+  dispatch,
+  returnFunction,
+  validateEntry,
+}) => {
+  if (!content) {
+    return;
+  }
+  dispatch(thunkActions.app.createBlock(
+    content,
+    navigateCallback({
+      destination,
+      analyticsEvent: analyticsEvt.editorSaveClick,
+      analytics,
+      returnFunction,
+    }),
+  ));
+};
 export const clearSaveError = ({
   dispatch,
 }) => () => dispatch(actions.requests.clearRequest({ requestKey: RequestKeys.saveBlock }));

--- a/src/editors/hooks.ts
+++ b/src/editors/hooks.ts
@@ -88,3 +88,7 @@ export const createBlock = ({
 export const clearSaveError = ({
   dispatch,
 }) => () => dispatch(actions.requests.clearRequest({ requestKey: RequestKeys.saveBlock }));
+
+export const clearCreateError = ({
+  dispatch,
+}) => () => dispatch(actions.requests.clearRequest({ requestKey: RequestKeys.createBlock }));

--- a/src/editors/sharedComponents/ImageUploadModal/index.jsx
+++ b/src/editors/sharedComponents/ImageUploadModal/index.jsx
@@ -200,7 +200,7 @@ ImageUploadModal.propTypes = {
   images: PropTypes.shape({}).isRequired,
   lmsEndpointUrl: PropTypes.string.isRequired,
   editorType: PropTypes.string,
-  isLibrary: PropTypes.string,
+  isLibrary: PropTypes.bool,
 };
 
 export const ImageUploadModalInternal = ImageUploadModal; // For testing only

--- a/src/library-authoring/add-content/AddContentContainer.test.tsx
+++ b/src/library-authoring/add-content/AddContentContainer.test.tsx
@@ -80,7 +80,7 @@ describe('<AddContentContainer />', () => {
     expect(await screen.findByRole('heading', { name: /Text/ })).toBeInTheDocument();
   });
 
-  it('should create a content when the block is not supported by the editor', async () => {
+  it('should create a component when the block is not supported by the editor', async () => {
     mockClipboardEmpty.applyMock();
     const url = getCreateLibraryBlockUrl(libraryId);
     axiosMock.onPost(url).reply(200);
@@ -128,18 +128,12 @@ describe('<AddContentContainer />', () => {
     jest.spyOn(editorCmsApi, 'fetchCourseImages').mockImplementation(async () => ( // eslint-disable-next-line
       { data: { assets: [], start: 0, end: 0, page: 0, pageSize: 50, totalCount: 0 } }
     ));
-
-    Object.defineProperty(window, 'location', {
-      value: { pathname: `/library/${libraryId}/collection/${collectionId}` },
-      writable: true,
-    });
     axiosMock.onPost(url).reply(200, {
       id: usageKey,
     });
 
-    axiosMock.onPatch(collectionComponentUrl).reply(200);
-
     axiosMock.onPost(updateBlockUrl).reply(200, mockXBlockFields.dataHtml);
+    axiosMock.onPatch(collectionComponentUrl).reply(200);
     render(collectionId);
 
     const textButton = screen.getByRole('button', { name: /text/i });

--- a/src/library-authoring/add-content/AddContentContainer.test.tsx
+++ b/src/library-authoring/add-content/AddContentContainer.test.tsx
@@ -1,5 +1,4 @@
 import MockAdapter from 'axios-mock-adapter/types';
-import { snakeCaseObject } from '@edx/frontend-platform';
 import {
   fireEvent,
   render as baseRender,
@@ -7,9 +6,10 @@ import {
   waitFor,
   initializeMocks,
 } from '../../testUtils';
-import { mockContentLibrary } from '../data/api.mocks';
+import { mockContentLibrary, mockXBlockFields } from '../data/api.mocks';
 import {
   getContentLibraryApiUrl, getCreateLibraryBlockUrl, getLibraryCollectionComponentApiUrl, getLibraryPasteClipboardUrl,
+  getXBlockFieldsApiUrl,
 } from '../data/api';
 import { mockBroadcastChannel, mockClipboardEmpty, mockClipboardHtml } from '../../generic/data/api.mock';
 import { LibraryProvider } from '../common/context/LibraryContext';
@@ -17,8 +17,10 @@ import AddContentContainer from './AddContentContainer';
 import { ComponentEditorModal } from '../components/ComponentEditorModal';
 import editorCmsApi from '../../editors/data/services/cms/api';
 import { ToastActionData } from '../../generic/toast-context';
+import * as textEditorHooks from '../../editors/containers/TextEditor/hooks';
 
 mockBroadcastChannel();
+// mockCreateLibraryBlock.applyMock();
 
 // Mocks for ComponentEditorModal to work in tests.
 jest.mock('frontend-components-tinymce-advanced-plugins', () => ({ a11ycheckerCss: '' }));
@@ -48,6 +50,7 @@ describe('<AddContentContainer />', () => {
     axiosMock = mocks.axiosMock;
     mockShowToast = mocks.mockShowToast;
     axiosMock.onGet(getContentLibraryApiUrl(libraryId)).reply(200, {});
+    jest.spyOn(textEditorHooks, 'getContent').mockImplementation(() => () => '<p>Edited HTML content</p>');
   });
   afterEach(() => {
     jest.restoreAllMocks();
@@ -61,11 +64,11 @@ describe('<AddContentContainer />', () => {
     expect(screen.queryByRole('button', { name: /open reponse/i })).not.toBeInTheDocument(); // Excluded from MVP
     expect(screen.queryByRole('button', { name: /drag drop/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /video/i })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /advanced \/ other/i })).not.toBeInTheDocument(); // Excluded from MVP
+    expect(screen.queryByRole('button', { name: /advanced \/ other/i })).toBeInTheDocument(); // To test not editor supported blocks
     expect(screen.queryByRole('button', { name: /copy from clipboard/i })).not.toBeInTheDocument();
   });
 
-  it('should create a content', async () => {
+  it('should open the editor modal to create a content when the block is supported', async () => {
     mockClipboardEmpty.applyMock();
     const url = getCreateLibraryBlockUrl(libraryId);
     axiosMock.onPost(url).reply(200);
@@ -74,7 +77,16 @@ describe('<AddContentContainer />', () => {
 
     const textButton = screen.getByRole('button', { name: /text/i });
     fireEvent.click(textButton);
+    expect(await screen.findByRole('heading', { name: /Text/ })).toBeInTheDocument();
+  });
 
+  it('should create a content when the block is not supported by the editor', async () => {
+    mockClipboardEmpty.applyMock();
+    const url = getCreateLibraryBlockUrl(libraryId);
+    axiosMock.onPost(url).reply(200);
+    render();
+    const textButton = screen.getByRole('button', { name: /other/i });
+    fireEvent.click(textButton);
     await waitFor(() => expect(axiosMock.history.post[0].url).toEqual(url));
     await waitFor(() => expect(axiosMock.history.patch.length).toEqual(0));
   });
@@ -87,13 +99,14 @@ describe('<AddContentContainer />', () => {
       libraryId,
       collectionId,
     );
-    // having id of block which is not video, html or problem will not trigger editor.
+
     axiosMock.onPost(url).reply(200, { id: 'some-component-id' });
     axiosMock.onPatch(collectionComponentUrl).reply(200);
 
     render(collectionId);
 
-    const textButton = screen.getByRole('button', { name: /text/i });
+    // Select a block that is not supported by the editor should create the component
+    const textButton = screen.getByRole('button', { name: /other/i });
     fireEvent.click(textButton);
 
     await waitFor(() => expect(axiosMock.history.post[0].url).toEqual(url));
@@ -105,6 +118,8 @@ describe('<AddContentContainer />', () => {
     mockClipboardEmpty.applyMock();
     const collectionId = 'some-collection-id';
     const url = getCreateLibraryBlockUrl(libraryId);
+    const usageKey = mockXBlockFields.usageKeyNewHtml;
+    const updateBlockUrl = getXBlockFieldsApiUrl(usageKey);
     const collectionComponentUrl = getLibraryCollectionComponentApiUrl(
       libraryId,
       collectionId,
@@ -113,39 +128,26 @@ describe('<AddContentContainer />', () => {
     jest.spyOn(editorCmsApi, 'fetchCourseImages').mockImplementation(async () => ( // eslint-disable-next-line
       { data: { assets: [], start: 0, end: 0, page: 0, pageSize: 50, totalCount: 0 } }
     ));
-    jest.spyOn(editorCmsApi, 'fetchByUnitId').mockImplementation(async () => ({
-      status: 200,
-      data: {
-        ancestors: [{
-          id: 'block-v1:Org+TS100+24+type@vertical+block@parent',
-          display_name: 'You-Knit? The Test Unit',
-          category: 'vertical',
-          has_children: true,
-        }],
-      },
-    }));
 
-    axiosMock.onPost(url).reply(200, {
-      id: 'lb:OpenedX:CSPROB2:html:1a5efd56-4ee5-4df0-b466-44f08fbbf567',
+    Object.defineProperty(window, 'location', {
+      value: { pathname: `/library/${libraryId}/collection/${collectionId}` },
+      writable: true,
     });
-    const fieldsHtml = {
-      displayName: 'Introduction to Testing',
-      data: '<p>This is a text component which uses <strong>HTML</strong>.</p>',
-      metadata: { displayName: 'Introduction to Testing' },
-    };
-    jest.spyOn(editorCmsApi, 'fetchBlockById').mockImplementationOnce(async () => (
-      { status: 200, data: snakeCaseObject(fieldsHtml) }
-    ));
+    axiosMock.onPost(url).reply(200, {
+      id: usageKey,
+    });
+
     axiosMock.onPatch(collectionComponentUrl).reply(200);
 
+    axiosMock.onPost(updateBlockUrl).reply(200, mockXBlockFields.dataHtml);
     render(collectionId);
 
     const textButton = screen.getByRole('button', { name: /text/i });
     fireEvent.click(textButton);
 
-    // Component should be linked to Collection on closing editor.
-    const closeButton = await screen.findByRole('button', { name: 'Exit the editor' });
-    fireEvent.click(closeButton);
+    // Component should be linked to Collection on saving the changes in the editor.
+    const saveButton = screen.getByLabelText('Save changes and return to learning context');
+    fireEvent.click(saveButton);
     await waitFor(() => expect(axiosMock.history.post[0].url).toEqual(url));
     await waitFor(() => expect(axiosMock.history.patch.length).toEqual(1));
     await waitFor(() => expect(axiosMock.history.patch[0].url).toEqual(collectionComponentUrl));
@@ -258,20 +260,6 @@ describe('<AddContentContainer />', () => {
       mockResponse: ['library cannot have more than 100000 components'],
       expectedError: 'There was an error pasting the content: library cannot have more than 100000 components',
       buttonName: /paste from clipboard/i,
-    },
-    {
-      label: 'should handle failure to create content',
-      mockUrl: getCreateLibraryBlockUrl(libraryId),
-      mockResponse: undefined,
-      expectedError: 'There was an error creating the content.',
-      buttonName: /text/i,
-    },
-    {
-      label: 'should show detailed error in toast on create failure',
-      mockUrl: getCreateLibraryBlockUrl(libraryId),
-      mockResponse: 'library cannot have more than 100000 components',
-      expectedError: 'There was an error creating the content: library cannot have more than 100000 components',
-      buttonName: /text/i,
     },
   ])('$label', async ({
     mockUrl, mockResponse, buttonName, expectedError,

--- a/src/library-authoring/add-content/AddContentContainer.tsx
+++ b/src/library-authoring/add-content/AddContentContainer.tsx
@@ -194,7 +194,7 @@ const AddContentContainer = () => {
     const suportedEditorTypes = Object.values(blockTypes);
     if (suportedEditorTypes.includes(blockType)) {
       // linkComponent on editor close.
-      openComponentEditor('', (data) => linkComponent(data.id), blockType);
+      openComponentEditor('', (data) => data && linkComponent(data.id), blockType);
     } else {
       createBlockMutation.mutateAsync({
         libraryId,

--- a/src/library-authoring/add-content/AddContentContainer.tsx
+++ b/src/library-authoring/add-content/AddContentContainer.tsx
@@ -62,7 +62,23 @@ const AddContentButton = ({ contentType, onCreateContent } : AddContentButtonPro
     </Button>
   );
 };
-
+export const parseErrorMsg = (
+  intl,
+  error: any,
+  detailedMessage: MessageDescriptor,
+  defaultMessage: MessageDescriptor,
+) => {
+  try {
+    const { response: { data } } = error;
+    const detail = data && (Array.isArray(data) ? data.join() : String(data));
+    if (detail) {
+      return intl.formatMessage(detailedMessage, { detail });
+    }
+  } catch (_err) {
+    // ignore
+  }
+  return intl.formatMessage(defaultMessage);
+};
 const AddContentContainer = () => {
   const intl = useIntl();
   const {
@@ -80,23 +96,6 @@ const AddContentContainer = () => {
   const { showPasteXBlock, sharedClipboardData } = useCopyToClipboard(canEdit);
 
   const [isAddLibraryContentModalOpen, showAddLibraryContentModal, closeAddLibraryContentModal] = useToggle();
-
-  const parseErrorMsg = (
-    error: any,
-    detailedMessage: MessageDescriptor,
-    defaultMessage: MessageDescriptor,
-  ) => {
-    try {
-      const { response: { data } } = error;
-      const detail = data && (Array.isArray(data) ? data.join() : String(data));
-      if (detail) {
-        return intl.formatMessage(detailedMessage, { detail });
-      }
-    } catch (_err) {
-      // ignore
-    }
-    return intl.formatMessage(defaultMessage);
-  };
 
   const isBlockTypeEnabled = (blockType: string) => getConfig().LIBRARY_SUPPORTED_BLOCKS.includes(blockType);
 
@@ -184,13 +183,13 @@ const AddContentContainer = () => {
       showToast(intl.formatMessage(messages.successPasteClipboardMessage));
     }).catch((error) => {
       showToast(parseErrorMsg(
+        intl,
         error,
         messages.errorPasteClipboardMessageWithDetail,
         messages.errorPasteClipboardMessage,
       ));
     });
   };
-
   const onCreateBlock = (blockType: string) => {
     const suportedEditorTypes = Object.values(blockTypes);
     if (suportedEditorTypes.includes(blockType)) {
@@ -207,6 +206,7 @@ const AddContentContainer = () => {
         linkComponent(data.id);
       }).catch((error) => {
         showToast(parseErrorMsg(
+          intl,
           error,
           messages.errorCreateMessageWithDetail,
           messages.errorCreateMessage,

--- a/src/library-authoring/add-content/AddContentContainer.tsx
+++ b/src/library-authoring/add-content/AddContentContainer.tsx
@@ -194,7 +194,7 @@ const AddContentContainer = () => {
     const suportedEditorTypes = Object.values(blockTypes);
     if (suportedEditorTypes.includes(blockType)) {
       // linkComponent on editor close.
-      openComponentEditor('', () => {}, blockType);
+      openComponentEditor('', (data) => linkComponent(data.id), blockType);
     } else {
       createBlockMutation.mutateAsync({
         libraryId,

--- a/src/library-authoring/add-content/AddContentWorkflow.test.tsx
+++ b/src/library-authoring/add-content/AddContentWorkflow.test.tsx
@@ -60,20 +60,17 @@ describe('AddContentWorkflow test', () => {
     const newComponentButton = await screen.findByRole('button', { name: /New/ });
     fireEvent.click(newComponentButton);
 
-    // Click "Text" to create a text component
+    // Click "Text" to open the editor in creation mode
     fireEvent.click(await screen.findByRole('button', { name: /Text/ }));
-
-    // Then the editor should open
-    expect(await screen.findByRole('heading', { name: /New Text Component/ })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /Text/ })).toBeInTheDocument();
 
     // Edit the title
     fireEvent.click(screen.getByRole('button', { name: /Edit Title/ }));
     const titleInput = screen.getByPlaceholderText('Title');
     fireEvent.change(titleInput, { target: { value: 'A customized title' } });
     fireEvent.blur(titleInput);
-    await waitFor(() => expect(screen.queryByRole('heading', { name: /New Text Component/ })).not.toBeInTheDocument());
-    expect(screen.getByRole('heading', { name: /A customized title/ }));
-
+    await waitFor(() => expect(screen.queryByRole('heading', { name: /Text/ })).not.toBeInTheDocument());
+    expect(screen.getByRole('heading', { name: /A customized title/ })).toBeInTheDocument();
     // Note that TinyMCE doesn't really load properly in our test environment
     // so we can't really edit the text, but we have getContent() mocked to simulate
     // using TinyMCE to enter some new HTML.
@@ -83,10 +80,12 @@ describe('AddContentWorkflow test', () => {
       status: 200, data: { id: mockXBlockFields.usageKeyNewHtml },
     }));
 
-    // Click Save
+    // Click Save should create the component and then save the content
     const saveButton = screen.getByLabelText('Save changes and return to learning context');
     fireEvent.click(saveButton);
-    expect(saveSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('can create a Problem component', async () => {
@@ -96,10 +95,8 @@ describe('AddContentWorkflow test', () => {
     const newComponentButton = await screen.findByRole('button', { name: /New/ });
     fireEvent.click(newComponentButton);
 
-    // Click "Problem" to create a capa problem component
+    // Click "Problem" to create a capa problem component in the editor
     fireEvent.click(await screen.findByRole('button', { name: /Problem/ }));
-
-    // Then the editor should open
     expect(await screen.findByRole('heading', { name: /Select problem type/ })).toBeInTheDocument();
 
     // Select the type: Numerical Input
@@ -117,10 +114,12 @@ describe('AddContentWorkflow test', () => {
       status: 200, data: { id: mockXBlockFields.usageKeyNewProblem },
     }));
 
-    // Click Save
+    // Click Save should create the component and then save the content
     const saveButton = screen.getByLabelText('Save changes and return to learning context');
     fireEvent.click(saveButton);
-    expect(saveSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('can create a Video component', async () => {
@@ -133,8 +132,8 @@ describe('AddContentWorkflow test', () => {
     // Click "Video" to create a video component
     fireEvent.click(await screen.findByRole('button', { name: /Video/ }));
 
-    // Then the editor should open - this is the default title of a blank video in our mock
-    expect(await screen.findByRole('heading', { name: /New Video/ })).toBeInTheDocument();
+    // Then the editor should open
+    expect(await screen.findByRole('heading', { name: /Video/ })).toBeInTheDocument();
 
     // Enter the video URL
     const urlInput = await screen.findByRole('textbox', { name: 'Video URL' });
@@ -146,9 +145,11 @@ describe('AddContentWorkflow test', () => {
       status: 200, data: { id: mockXBlockFields.usageKeyNewVideo },
     }));
 
-    // Click Save
+    // Click Save should create the component and then save the content
     const saveButton = screen.getByLabelText('Save changes and return to learning context');
     fireEvent.click(saveButton);
-    expect(saveSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/library-authoring/common/context/LibraryContext.tsx
+++ b/src/library-authoring/common/context/LibraryContext.tsx
@@ -15,6 +15,7 @@ import { useComponentPickerContext } from './ComponentPickerContext';
 
 export interface ComponentEditorInfo {
   usageKey: string;
+  blockType?:string
   onClose?: () => void;
 }
 
@@ -38,7 +39,7 @@ export type LibraryContextData = {
   /** If the editor is open and the user is editing some component, this is the component being edited. */
   componentBeingEdited: ComponentEditorInfo | undefined;
   /** If an onClose callback is provided, it will be called when the editor is closed. */
-  openComponentEditor: (usageKey: string, onClose?: () => void) => void;
+  openComponentEditor: (usageKey: string, onClose?: () => void, blockType?:string) => void;
   closeComponentEditor: () => void;
   componentPicker?: typeof ComponentPicker;
 };
@@ -85,8 +86,8 @@ export const LibraryProvider = ({
       return undefined;
     });
   }, []);
-  const openComponentEditor = useCallback((usageKey: string, onClose?: () => void) => {
-    setComponentBeingEdited({ usageKey, onClose });
+  const openComponentEditor = useCallback((usageKey: string, onClose?: () => void, blockType?:string) => {
+    setComponentBeingEdited({ usageKey, onClose, blockType });
   }, []);
 
   const { data: libraryData, isLoading: isLoadingLibraryData } = useContentLibrary(libraryId);

--- a/src/library-authoring/common/context/LibraryContext.tsx
+++ b/src/library-authoring/common/context/LibraryContext.tsx
@@ -16,7 +16,7 @@ import { useComponentPickerContext } from './ComponentPickerContext';
 export interface ComponentEditorInfo {
   usageKey: string;
   blockType?:string
-  onClose?: () => void;
+  onClose?: (data?:any) => void;
 }
 
 export type LibraryContextData = {
@@ -39,8 +39,8 @@ export type LibraryContextData = {
   /** If the editor is open and the user is editing some component, this is the component being edited. */
   componentBeingEdited: ComponentEditorInfo | undefined;
   /** If an onClose callback is provided, it will be called when the editor is closed. */
-  openComponentEditor: (usageKey: string, onClose?: () => void, blockType?:string) => void;
-  closeComponentEditor: () => void;
+  openComponentEditor: (usageKey: string, onClose?: (data?:any) => void, blockType?:string) => void;
+  closeComponentEditor: (data?:any) => void;
   componentPicker?: typeof ComponentPicker;
 };
 
@@ -80,9 +80,9 @@ export const LibraryProvider = ({
 }: LibraryProviderProps) => {
   const [isCreateCollectionModalOpen, openCreateCollectionModal, closeCreateCollectionModal] = useToggle(false);
   const [componentBeingEdited, setComponentBeingEdited] = useState<ComponentEditorInfo | undefined>();
-  const closeComponentEditor = useCallback(() => {
+  const closeComponentEditor = useCallback((data) => {
     setComponentBeingEdited((prev) => {
-      prev?.onClose?.();
+      prev?.onClose?.(data);
       return undefined;
     });
   }, []);

--- a/src/library-authoring/components/ComponentEditorModal.tsx
+++ b/src/library-authoring/components/ComponentEditorModal.tsx
@@ -25,7 +25,7 @@ export const ComponentEditorModal: React.FC<Record<never, never>> = () => {
   if (componentBeingEdited === undefined) {
     return null;
   }
-  const blockType = getBlockType(componentBeingEdited.usageKey);
+  const blockType = componentBeingEdited.blockType || getBlockType(componentBeingEdited.usageKey);
 
   const onClose = () => {
     closeComponentEditor();

--- a/src/library-authoring/components/ComponentEditorModal.tsx
+++ b/src/library-authoring/components/ComponentEditorModal.tsx
@@ -27,8 +27,8 @@ export const ComponentEditorModal: React.FC<Record<never, never>> = () => {
   }
   const blockType = componentBeingEdited.blockType || getBlockType(componentBeingEdited.usageKey);
 
-  const onClose = () => {
-    closeComponentEditor();
+  const onClose = (data?:any) => {
+    closeComponentEditor(data);
     invalidateComponentData(queryClient, libraryId, componentBeingEdited.usageKey);
   };
 
@@ -40,7 +40,7 @@ export const ComponentEditorModal: React.FC<Record<never, never>> = () => {
       studioEndpointUrl={getConfig().STUDIO_BASE_URL}
       lmsEndpointUrl={getConfig().LMS_BASE_URL}
       onClose={onClose}
-      returnFunction={() => { onClose(); return () => {}; }}
+      returnFunction={() => onClose}
       fullScreen={false}
     />
   );


### PR DESCRIPTION
## Description

This PR changes the way components are creating in libraries V2 with the purpose to avoid the creation of a blank component as fist step, behavior that have the following problems:

- The "cancel" action doesn't cancel the addition of the component, which seems like a bug.
- We can't set a https://github.com/openedx/frontend-app-authoring/issues/1384 for the component, because its title is not set at the time of creation.

## Supporting information

This PR is liked to https://github.com/openedx/frontend-app-authoring/issues/1482#issuecomment-2512498837 issue. 

## Testing instructions

- Create a component in libraries V2 supported by the editor `[text, video, problem]` 
- Press the cancel button or the close icon, no new component should appear in the platform. 
- Prove the right creating workflow:
   - Update the title and save it, should be used as `usage_key` block.
   - If the title does not change should create a unique key.
   - The user is enable to update images.
   - Press the save button should create the component and save the content.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

### PR sandbox

UN/PW: openedx / openedx

**Settings**
```yaml
```