### PR TITLE
fix: disable filter by block on collections tab [FC-0076]

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -258,7 +258,7 @@ const LibraryAuthoringPage = ({ returnToLibrarySelection }: LibraryAuthoringPage
             <ActionRow className="my-3">
               <SearchKeywordsField className="mr-3" />
               <FilterByTags />
-              <FilterByBlockType />
+              <FilterByBlockType disabled={activeKey === ContentType.collections} />
               <ClearFiltersButton />
               <ActionRow.Spacer />
               <SearchSortWidget />

--- a/src/search-manager/FilterByBlockType.tsx
+++ b/src/search-manager/FilterByBlockType.tsx
@@ -229,8 +229,7 @@ const FilterByBlockType: React.FC<FilterByBlockTypeProps> = ({ disabled = false 
       // Clear filters when disabled
       const selectedBlockTypesFilter = blockTypesFilter;
       const selectedProblemTypesFilter = problemTypesFilter;
-      setBlockTypesFilter([]);
-      setProblemTypesFilter([]);
+      clearFilters();
 
       return () => {
         // Restore filters when re-enabled

--- a/src/search-manager/FilterByBlockType.tsx
+++ b/src/search-manager/FilterByBlockType.tsx
@@ -224,6 +224,11 @@ const FilterByBlockType: React.FC<FilterByBlockTypeProps> = ({ disabled = false 
     setProblemTypesFilter,
   } = useSearchContext();
 
+  const clearFilters = useCallback(/* istanbul ignore next */ () => {
+    setBlockTypesFilter([]);
+    setProblemTypesFilter([]);
+  }, []);
+
   useEffect(() => {
     if (disabled) {
       // Clear filters when disabled
@@ -239,11 +244,6 @@ const FilterByBlockType: React.FC<FilterByBlockTypeProps> = ({ disabled = false 
     }
     return () => {};
   }, [disabled]);
-
-  const clearFilters = useCallback(/* istanbul ignore next */ () => {
-    setBlockTypesFilter([]);
-    setProblemTypesFilter([]);
-  }, []);
 
   // Sort blocktypes in order of hierarchy followed by alphabetically for components
   const sortedBlockTypeKeys = Object.keys(blockTypes).sort((a, b) => {


### PR DESCRIPTION
## Description

This PR adds the `disabled` prop for `FilterByBlockType` component and uses it on the Library Collection tab.

## More Information
- Related to https://github.com/openedx/frontend-app-authoring/issues/1486

## Testing Instruction
- Open a Library
- Select some block type on the `FilterByBlockType` component
- Navigate to the Collection tab and check if the collections are shown
- Return to the "All Content" tab and check if the previous filter persists

___
Private ref: [FAL-3981](https://tasks.opencraft.com/browse/FAL-3981)