### PR TITLE
fix: use modifyObjectKeys and snakeCaseObject on api data advanced settings to format values

### DIFF
--- a/src/advanced-settings/data/api.js
+++ b/src/advanced-settings/data/api.js
@@ -1,4 +1,5 @@
-import { camelCaseObject, getConfig } from '@edx/frontend-platform';
+/* eslint-disable import/prefer-default-export */
+import { camelCaseObject, getConfig, modifyObjectKeys, snakeCaseObject } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { convertObjectToSnakeCase } from '../../utils';
 
@@ -14,7 +15,13 @@ const getProctoringErrorsApiUrl = () => `${getApiBaseUrl()}/api/contentstore/v1/
 export async function getCourseAdvancedSettings(courseId) {
   const { data } = await getAuthenticatedHttpClient()
     .get(`${getCourseAdvancedSettingsApiUrl(courseId)}?fetch_all=0`);
-  return camelCaseObject(data);
+  const objectFormatted = camelCaseObject(data);
+  return modifyObjectKeys(objectFormatted, (key) => {
+    if (objectFormatted[key]) {
+      objectFormatted[key]['value'] = snakeCaseObject(objectFormatted[key]['value'])
+    }
+    return key;
+  });
 }
 
 /**
@@ -26,7 +33,13 @@ export async function getCourseAdvancedSettings(courseId) {
 export async function updateCourseAdvancedSettings(courseId, settings) {
   const { data } = await getAuthenticatedHttpClient()
     .patch(`${getCourseAdvancedSettingsApiUrl(courseId)}`, convertObjectToSnakeCase(settings));
-  return camelCaseObject(data);
+  const objectFormatted = camelCaseObject(data);
+  return modifyObjectKeys(objectFormatted, (key) => {
+    if (objectFormatted[key]) {
+      objectFormatted[key]['value'] = snakeCaseObject(objectFormatted[key]['value'])
+    }
+    return key;
+  });
 }
 
 /**


### PR DESCRIPTION
## Description

This PR fixes this [bug](https://github.com/openedx/frontend-app-authoring/issues/1243#issue-2496098982).

## Testing instructions

* Deploy your local environment or go to your preferred remote environment (REDWOOD).
* Go to studio > settings > advanced settings.
* "Certificate html override" and "other course settings" are showing dictionary keys in `camelCase` (Review any field whose value is an object with configuration keys).

BEFORE
![Captura de pantalla de 2024-12-30 19-41-49](https://github.com/user-attachments/assets/b8eea80d-d69d-4468-b516-be337d5a0345)
![Captura de pantalla de 2024-12-30 19-41-41](https://github.com/user-attachments/assets/bc992f49-79a7-4241-a344-4cd75cade8a7)

AFTER
![Captura de pantalla de 2024-12-30 19-41-10](https://github.com/user-attachments/assets/a2d10c7d-122c-4d5f-abad-1cc826b81008)
