### PR TITLE
fix: advanced-settings.api always return exactly what it receives

### DIFF
--- a/src/advanced-settings/data/api.js
+++ b/src/advanced-settings/data/api.js
@@ -1,8 +1,10 @@
 /* eslint-disable import/prefer-default-export */
 import {
+  camelCaseObject,
   getConfig,
 } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { camelCase } from 'lodash';
 import { convertObjectToSnakeCase } from '../../utils';
 
 const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
@@ -17,7 +19,19 @@ const getProctoringErrorsApiUrl = () => `${getApiBaseUrl()}/api/contentstore/v1/
 export async function getCourseAdvancedSettings(courseId) {
   const { data } = await getAuthenticatedHttpClient()
     .get(`${getCourseAdvancedSettingsApiUrl(courseId)}?fetch_all=0`);
-  return data;
+  const keepValues = {};
+  Object.keys(data).forEach((key) => {
+    keepValues[camelCase(key)] = { value: data[key].value };
+  });
+  const formattedData = {};
+  const formattedCamelCaseData = camelCaseObject(data);
+  Object.keys(formattedCamelCaseData).forEach((key) => {
+    formattedData[key] = {
+      ...formattedCamelCaseData[key],
+      value: keepValues[key]?.value,
+    };
+  });
+  return formattedData;
 }
 
 /**
@@ -29,7 +43,19 @@ export async function getCourseAdvancedSettings(courseId) {
 export async function updateCourseAdvancedSettings(courseId, settings) {
   const { data } = await getAuthenticatedHttpClient()
     .patch(`${getCourseAdvancedSettingsApiUrl(courseId)}`, convertObjectToSnakeCase(settings));
-  return data;
+  const keepValues = {};
+  Object.keys(data).forEach((key) => {
+    keepValues[camelCase(key)] = { value: data[key].value };
+  });
+  const formattedData = {};
+  const formattedCamelCaseData = camelCaseObject(data);
+  Object.keys(formattedCamelCaseData).forEach((key) => {
+    formattedData[key] = {
+      ...formattedCamelCaseData[key],
+      value: keepValues[key]?.value,
+    };
+  });
+  return formattedData;
 }
 
 /**
@@ -39,5 +65,17 @@ export async function updateCourseAdvancedSettings(courseId, settings) {
  */
 export async function getProctoringExamErrors(courseId) {
   const { data } = await getAuthenticatedHttpClient().get(`${getProctoringErrorsApiUrl()}${courseId}`);
-  return data;
+  const keepValues = {};
+  Object.keys(data).forEach((key) => {
+    keepValues[camelCase(key)] = { value: data[key].value };
+  });
+  const formattedData = {};
+  const formattedCamelCaseData = camelCaseObject(data);
+  Object.keys(formattedCamelCaseData).forEach((key) => {
+    formattedData[key] = {
+      ...formattedCamelCaseData[key],
+      value: keepValues[key]?.value,
+    };
+  });
+  return formattedData;
 }

--- a/src/advanced-settings/data/api.js
+++ b/src/advanced-settings/data/api.js
@@ -19,7 +19,9 @@ const getProctoringErrorsApiUrl = () => `${getApiBaseUrl()}/api/contentstore/v1/
 export async function getCourseAdvancedSettings(courseId) {
   const { data } = await getAuthenticatedHttpClient()
     .get(`${getCourseAdvancedSettingsApiUrl(courseId)}?fetch_all=0`);
+  // we start with: { camelCaseField: { value: { shouldBeSnakeCase: '123' } }, ... }
   const objectFormatted = camelCaseObject(data);
+  // we want: { camelCaseField: { value: { should_be_snake_case: '123' } }, ... }
   Object.keys(objectFormatted).forEach((key) => {
     if (objectFormatted[key]?.value) {
       objectFormatted[key].value = snakeCaseObject(objectFormatted[key].value);
@@ -37,7 +39,9 @@ export async function getCourseAdvancedSettings(courseId) {
 export async function updateCourseAdvancedSettings(courseId, settings) {
   const { data } = await getAuthenticatedHttpClient()
     .patch(`${getCourseAdvancedSettingsApiUrl(courseId)}`, convertObjectToSnakeCase(settings));
+  // we start with: { camelCaseField: { value: { shouldBeSnakeCase: '123' } }, ... }
   const objectFormatted = camelCaseObject(data);
+  // we want: { camelCaseField: { value: { should_be_snake_case: '123' } }, ... }
   Object.keys(objectFormatted).forEach((key) => {
     if (objectFormatted[key]?.value) {
       objectFormatted[key].value = snakeCaseObject(objectFormatted[key].value);

--- a/src/advanced-settings/data/api.js
+++ b/src/advanced-settings/data/api.js
@@ -5,7 +5,6 @@ import {
 } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { camelCase } from 'lodash';
-import { convertObjectToSnakeCase } from '../../utils';
 
 const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
 export const getCourseAdvancedSettingsApiUrl = (courseId) => `${getApiBaseUrl()}/api/contentstore/v0/advanced_settings/${courseId}`;
@@ -42,7 +41,7 @@ export async function getCourseAdvancedSettings(courseId) {
  */
 export async function updateCourseAdvancedSettings(courseId, settings) {
   const { data } = await getAuthenticatedHttpClient()
-    .patch(`${getCourseAdvancedSettingsApiUrl(courseId)}`, convertObjectToSnakeCase(settings));
+    .patch(`${getCourseAdvancedSettingsApiUrl(courseId)}`, settings);
   const keepValues = {};
   Object.keys(data).forEach((key) => {
     keepValues[camelCase(key)] = { value: data[key].value };

--- a/src/advanced-settings/data/api.js
+++ b/src/advanced-settings/data/api.js
@@ -1,8 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import {
-  camelCaseObject,
   getConfig,
-  snakeCaseObject,
 } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { convertObjectToSnakeCase } from '../../utils';
@@ -19,15 +17,7 @@ const getProctoringErrorsApiUrl = () => `${getApiBaseUrl()}/api/contentstore/v1/
 export async function getCourseAdvancedSettings(courseId) {
   const { data } = await getAuthenticatedHttpClient()
     .get(`${getCourseAdvancedSettingsApiUrl(courseId)}?fetch_all=0`);
-  // we start with: { camelCaseField: { value: { shouldBeSnakeCase: '123' } }, ... }
-  const objectFormatted = camelCaseObject(data);
-  // we want: { camelCaseField: { value: { should_be_snake_case: '123' } }, ... }
-  Object.keys(objectFormatted).forEach((key) => {
-    if (objectFormatted[key]?.value) {
-      objectFormatted[key].value = snakeCaseObject(objectFormatted[key].value);
-    }
-  });
-  return objectFormatted;
+  return data;
 }
 
 /**
@@ -39,15 +29,7 @@ export async function getCourseAdvancedSettings(courseId) {
 export async function updateCourseAdvancedSettings(courseId, settings) {
   const { data } = await getAuthenticatedHttpClient()
     .patch(`${getCourseAdvancedSettingsApiUrl(courseId)}`, convertObjectToSnakeCase(settings));
-  // we start with: { camelCaseField: { value: { shouldBeSnakeCase: '123' } }, ... }
-  const objectFormatted = camelCaseObject(data);
-  // we want: { camelCaseField: { value: { should_be_snake_case: '123' } }, ... }
-  Object.keys(objectFormatted).forEach((key) => {
-    if (objectFormatted[key]?.value) {
-      objectFormatted[key].value = snakeCaseObject(objectFormatted[key].value);
-    }
-  });
-  return objectFormatted;
+  return data;
 }
 
 /**
@@ -57,5 +39,5 @@ export async function updateCourseAdvancedSettings(courseId, settings) {
  */
 export async function getProctoringExamErrors(courseId) {
   const { data } = await getAuthenticatedHttpClient().get(`${getProctoringErrorsApiUrl()}${courseId}`);
-  return camelCaseObject(data);
+  return data;
 }

--- a/src/advanced-settings/data/api.js
+++ b/src/advanced-settings/data/api.js
@@ -1,4 +1,10 @@
-import { camelCaseObject, getConfig } from '@edx/frontend-platform';
+/* eslint-disable import/prefer-default-export */
+import {
+  camelCaseObject,
+  getConfig,
+  modifyObjectKeys,
+  snakeCaseObject,
+} from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { convertObjectToSnakeCase } from '../../utils';
 
@@ -14,7 +20,13 @@ const getProctoringErrorsApiUrl = () => `${getApiBaseUrl()}/api/contentstore/v1/
 export async function getCourseAdvancedSettings(courseId) {
   const { data } = await getAuthenticatedHttpClient()
     .get(`${getCourseAdvancedSettingsApiUrl(courseId)}?fetch_all=0`);
-  return camelCaseObject(data);
+  const objectFormatted = camelCaseObject(data);
+  return modifyObjectKeys(objectFormatted, (key) => {
+    if (objectFormatted[key]?.value) {
+      objectFormatted[key].value = snakeCaseObject(objectFormatted[key].value);
+    }
+    return key;
+  });
 }
 
 /**
@@ -26,7 +38,13 @@ export async function getCourseAdvancedSettings(courseId) {
 export async function updateCourseAdvancedSettings(courseId, settings) {
   const { data } = await getAuthenticatedHttpClient()
     .patch(`${getCourseAdvancedSettingsApiUrl(courseId)}`, convertObjectToSnakeCase(settings));
-  return camelCaseObject(data);
+  const objectFormatted = camelCaseObject(data);
+  return modifyObjectKeys(objectFormatted, (key) => {
+    if (objectFormatted[key]?.value) {
+      objectFormatted[key].value = snakeCaseObject(objectFormatted[key].value);
+    }
+    return key;
+  });
 }
 
 /**

--- a/src/advanced-settings/data/api.js
+++ b/src/advanced-settings/data/api.js
@@ -2,7 +2,6 @@
 import {
   camelCaseObject,
   getConfig,
-  modifyObjectKeys,
   snakeCaseObject,
 } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
@@ -21,12 +20,12 @@ export async function getCourseAdvancedSettings(courseId) {
   const { data } = await getAuthenticatedHttpClient()
     .get(`${getCourseAdvancedSettingsApiUrl(courseId)}?fetch_all=0`);
   const objectFormatted = camelCaseObject(data);
-  return modifyObjectKeys(objectFormatted, (key) => {
+  Object.keys(objectFormatted).forEach((key) => {
     if (objectFormatted[key]?.value) {
       objectFormatted[key].value = snakeCaseObject(objectFormatted[key].value);
     }
-    return key;
   });
+  return objectFormatted;
 }
 
 /**
@@ -39,12 +38,12 @@ export async function updateCourseAdvancedSettings(courseId, settings) {
   const { data } = await getAuthenticatedHttpClient()
     .patch(`${getCourseAdvancedSettingsApiUrl(courseId)}`, convertObjectToSnakeCase(settings));
   const objectFormatted = camelCaseObject(data);
-  return modifyObjectKeys(objectFormatted, (key) => {
+  Object.keys(objectFormatted).forEach((key) => {
     if (objectFormatted[key]?.value) {
       objectFormatted[key].value = snakeCaseObject(objectFormatted[key].value);
     }
-    return key;
   });
+  return objectFormatted;
 }
 
 /**

--- a/src/advanced-settings/data/api.test.js
+++ b/src/advanced-settings/data/api.test.js
@@ -23,7 +23,24 @@ describe('courseSettings API', () => {
   describe('getCourseAdvancedSettings', () => {
     it('should fetch and unformat course advanced settings', async () => {
       const fakeData = {
-        keyCamelCase: {
+        key_snake_case: {
+          display_name: 'To come camelCase',
+          testCamelCase: 'This key must not be formatted',
+          PascalCase: 'To come camelCase',
+          'kebab-case': 'To come camelCase',
+          UPPER_CASE: 'To come camelCase',
+          lowercase: 'This key must not be formatted',
+          UPPERCASE: 'To come lowercase',
+          'Title Case': 'To come camelCase',
+          'dot.case': 'To come camelCase',
+          SCREAMING_SNAKE_CASE: 'To come camelCase',
+          MixedCase: 'To come camelCase',
+          'Train-Case': 'To come camelCase',
+          nestedOption: {
+            anotherOption: 'To come camelCase',
+          },
+          // value is an object with various cases
+          // this contain must not be formatted to camelCase
           value: {
             snake_case: 'snake_case',
             camelCase: 'camelCase',
@@ -43,6 +60,26 @@ describe('courseSettings API', () => {
           },
         },
       };
+      const expected = {
+        keySnakeCase: {
+          displayName: 'To come camelCase',
+          testCamelCase: 'This key must not be formatted',
+          pascalCase: 'To come camelCase',
+          kebabCase: 'To come camelCase',
+          upperCase: 'To come camelCase',
+          lowercase: 'This key must not be formatted',
+          uppercase: 'To come lowercase',
+          titleCase: 'To come camelCase',
+          dotCase: 'To come camelCase',
+          screamingSnakeCase: 'To come camelCase',
+          mixedCase: 'To come camelCase',
+          trainCase: 'To come camelCase',
+          nestedOption: {
+            anotherOption: 'To come camelCase',
+          },
+          value: fakeData.key_snake_case.value,
+        },
+      };
 
       mockHttpClient.get.mockResolvedValue({ data: fakeData });
 
@@ -50,14 +87,31 @@ describe('courseSettings API', () => {
       expect(mockHttpClient.get).toHaveBeenCalledWith(
         `${process.env.STUDIO_BASE_URL}/api/contentstore/v0/advanced_settings/course-v1:Test+T101+2024?fetch_all=0`,
       );
-      expect(result).toEqual(fakeData);
+      expect(result).toEqual(expected);
     });
   });
 
   describe('updateCourseAdvancedSettings', () => {
     it('should update and unformat course advanced settings', async () => {
       const fakeData = {
-        keyCamelCase: {
+        key_snake_case: {
+          display_name: 'To come camelCase',
+          testCamelCase: 'This key must not be formatted', // because already be camelCase
+          PascalCase: 'To come camelCase',
+          'kebab-case': 'To come camelCase',
+          UPPER_CASE: 'To come camelCase',
+          lowercase: 'This key must not be formatted', // because camelCase in lowercase not formatted
+          UPPERCASE: 'To come lowercase', // because camelCase in UPPERCASE format to lowercase
+          'Title Case': 'To come camelCase',
+          'dot.case': 'To come camelCase',
+          SCREAMING_SNAKE_CASE: 'To come camelCase',
+          MixedCase: 'To come camelCase',
+          'Train-Case': 'To come camelCase',
+          nestedOption: {
+            anotherOption: 'To come camelCase',
+          },
+          // value is an object with various cases
+          // this contain must not be formatted to camelCase
           value: {
             snake_case: 'snake_case',
             camelCase: 'camelCase',
@@ -75,6 +129,26 @@ describe('courseSettings API', () => {
               anotherOption: 'nestedContent',
             },
           },
+        },
+      };
+      const expected = {
+        keySnakeCase: {
+          displayName: 'To come camelCase',
+          testCamelCase: 'This key must not be formatted',
+          pascalCase: 'To come camelCase',
+          kebabCase: 'To come camelCase',
+          upperCase: 'To come camelCase',
+          lowercase: 'This key must not be formatted',
+          uppercase: 'To come lowercase',
+          titleCase: 'To come camelCase',
+          dotCase: 'To come camelCase',
+          screamingSnakeCase: 'To come camelCase',
+          mixedCase: 'To come camelCase',
+          trainCase: 'To come camelCase',
+          nestedOption: {
+            anotherOption: 'To come camelCase',
+          },
+          value: fakeData.key_snake_case.value,
         },
       };
 
@@ -85,14 +159,31 @@ describe('courseSettings API', () => {
         `${process.env.STUDIO_BASE_URL}/api/contentstore/v0/advanced_settings/course-v1:Test+T101+2024`,
         {},
       );
-      expect(result).toEqual(fakeData);
+      expect(result).toEqual(expected);
     });
   });
 
   describe('getProctoringExamErrors', () => {
     it('should fetch proctoring errors and return unformat object', async () => {
       const fakeData = {
-        keyCamelCase: {
+        key_snake_case: {
+          display_name: 'To come camelCase',
+          testCamelCase: 'This key must not be formatted',
+          PascalCase: 'To come camelCase',
+          'kebab-case': 'To come camelCase',
+          UPPER_CASE: 'To come camelCase',
+          lowercase: 'This key must not be formatted',
+          UPPERCASE: 'To come lowercase',
+          'Title Case': 'To come camelCase',
+          'dot.case': 'To come camelCase',
+          SCREAMING_SNAKE_CASE: 'To come camelCase',
+          MixedCase: 'To come camelCase',
+          'Train-Case': 'To come camelCase',
+          nestedOption: {
+            anotherOption: 'To come camelCase',
+          },
+          // value is an object with various cases
+          // this contain must not be formatted to camelCase
           value: {
             snake_case: 'snake_case',
             camelCase: 'camelCase',
@@ -112,6 +203,26 @@ describe('courseSettings API', () => {
           },
         },
       };
+      const expected = {
+        keySnakeCase: {
+          displayName: 'To come camelCase',
+          testCamelCase: 'This key must not be formatted',
+          pascalCase: 'To come camelCase',
+          kebabCase: 'To come camelCase',
+          upperCase: 'To come camelCase',
+          lowercase: 'This key must not be formatted',
+          uppercase: 'To come lowercase',
+          titleCase: 'To come camelCase',
+          dotCase: 'To come camelCase',
+          screamingSnakeCase: 'To come camelCase',
+          mixedCase: 'To come camelCase',
+          trainCase: 'To come camelCase',
+          nestedOption: {
+            anotherOption: 'To come camelCase',
+          },
+          value: fakeData.key_snake_case.value,
+        },
+      };
 
       mockHttpClient.get.mockResolvedValue({ data: fakeData });
 
@@ -119,7 +230,7 @@ describe('courseSettings API', () => {
       expect(mockHttpClient.get).toHaveBeenCalledWith(
         `${process.env.STUDIO_BASE_URL}/api/contentstore/v1/proctoring_errors/course-v1:Test+T101+2024`,
       );
-      expect(result).toEqual(fakeData);
+      expect(result).toEqual(expected);
     });
   });
 });

--- a/src/advanced-settings/data/api.test.js
+++ b/src/advanced-settings/data/api.test.js
@@ -1,20 +1,10 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import {
-  getConfig, camelCaseObject, modifyObjectKeys, snakeCaseObject,
-} from '@edx/frontend-platform';
-import {
   getCourseAdvancedSettings,
   updateCourseAdvancedSettings,
   getProctoringExamErrors,
 } from './api';
 import { convertObjectToSnakeCase } from '../../utils';
-
-jest.mock('@edx/frontend-platform', () => ({
-  getConfig: jest.fn(),
-  camelCaseObject: jest.fn(),
-  modifyObjectKeys: jest.fn(),
-  snakeCaseObject: jest.fn(),
-}));
 
 jest.mock('@edx/frontend-platform/auth', () => ({
   getAuthenticatedHttpClient: jest.fn(),
@@ -33,70 +23,112 @@ describe('courseSettings API', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     getAuthenticatedHttpClient.mockReturnValue(mockHttpClient);
-    getConfig.mockReturnValue({ STUDIO_BASE_URL: 'http://studio.test' });
   });
 
   describe('getCourseAdvancedSettings', () => {
     it('should fetch and format course advanced settings', async () => {
-      const fakeData = { key: { value: 'some_value' } };
-      const camelCased = { key: { value: 'some_value' } };
-      const modified = { key: { value: 'some_value_snake' } };
+      const fakeData = {
+        keyCamelCase: {
+          value: {
+            oneOption: 'content-1',
+            two_option: 'content-2',
+            threeOption: 'threeContent',
+            nestedOption: {
+              anotherOption: 'nestedContent',
+            },
+          },
+        },
+      };
+      const expected = {
+        keyCamelCase: {
+          value: {
+            one_option: 'content-1',
+            two_option: 'content-2',
+            three_option: 'threeContent',
+            nested_option: {
+              another_option: 'nestedContent',
+            },
+          },
+        },
+      };
 
       mockHttpClient.get.mockResolvedValue({ data: fakeData });
-      camelCaseObject.mockReturnValue(camelCased);
-      snakeCaseObject.mockReturnValue('some_value_snake');
-      modifyObjectKeys.mockImplementation((obj, fn) => {
-        Object.keys(obj).forEach(fn);
-        return modified;
-      });
 
       const result = await getCourseAdvancedSettings('course-v1:Test+T101+2024');
       expect(mockHttpClient.get).toHaveBeenCalledWith(
-        'http://studio.test/api/contentstore/v0/advanced_settings/course-v1:Test+T101+2024?fetch_all=0',
+        `${process.env.STUDIO_BASE_URL}/api/contentstore/v0/advanced_settings/course-v1:Test+T101+2024?fetch_all=0`,
       );
-      expect(result).toEqual(modified);
+      expect(result).toEqual(expected);
     });
   });
 
   describe('updateCourseAdvancedSettings', () => {
     it('should update and format course advanced settings', async () => {
-      const input = { key: 'value' };
-      const snakeInput = { key: 'snake_value' };
-      const serverData = { key: { value: 'server_value' } };
-      const camelCased = { key: { value: 'server_value' } };
-      const modified = { key: { value: 'formatted_value' } };
+      const fakeData = {
+        keyCamelCase: {
+          value: {
+            oneOption: 'content-1',
+            two_option: 'content-2',
+            threeOption: 'threeContent',
+            nestedOption: {
+              anotherOption: 'nestedContent',
+            },
+          },
+        },
+      };
+      const expected = {
+        keyCamelCase: {
+          value: {
+            one_option: 'content-1',
+            two_option: 'content-2',
+            three_option: 'threeContent',
+            nested_option: {
+              another_option: 'nestedContent',
+            },
+          },
+        },
+      };
 
-      convertObjectToSnakeCase.mockReturnValue(snakeInput);
-      mockHttpClient.patch.mockResolvedValue({ data: serverData });
-      camelCaseObject.mockReturnValue(camelCased);
-      snakeCaseObject.mockReturnValue('formatted_value');
-      modifyObjectKeys.mockImplementation((obj, fn) => {
-        Object.keys(obj).forEach(fn);
-        return modified;
-      });
+      convertObjectToSnakeCase.mockReturnValue({});
+      mockHttpClient.patch.mockResolvedValue({ data: fakeData });
 
-      const result = await updateCourseAdvancedSettings('course-v1:Test+T101+2024', input);
+      const result = await updateCourseAdvancedSettings('course-v1:Test+T101+2024', {});
       expect(mockHttpClient.patch).toHaveBeenCalledWith(
-        'http://studio.test/api/contentstore/v0/advanced_settings/course-v1:Test+T101+2024',
-        snakeInput,
+        `${process.env.STUDIO_BASE_URL}/api/contentstore/v0/advanced_settings/course-v1:Test+T101+2024`,
+        {},
       );
-      expect(result).toEqual(modified);
+      expect(result).toEqual(expected);
     });
   });
 
   describe('getProctoringExamErrors', () => {
     it('should fetch proctoring errors and return camelCase object', async () => {
-      const fakeErrors = { errors: [] };
-      const camelCased = { errors: [] };
+      const fakeData = {
+        keyCamelCase: {
+          value: {
+            oneOption: 'content-1',
+            two_option: 'content-2',
+            threeOption: 'threeContent',
+          },
+        },
+      };
+      const expected = {
+        keyCamelCase: {
+          value: {
+            oneOption: 'content-1',
+            twoOption: 'content-2',
+            threeOption: 'threeContent',
+          },
+        },
+      };
 
-      mockHttpClient.get.mockResolvedValue({ data: fakeErrors });
-      camelCaseObject.mockReturnValue(camelCased);
+      mockHttpClient.get.mockResolvedValue({ data: fakeData });
 
       const result = await getProctoringExamErrors('course-v1:Test+T101+2024');
       expect(mockHttpClient.get).toHaveBeenCalledWith(
-        'http://studio.test/api/contentstore/v1/proctoring_errors/course-v1:Test+T101+2024',
+        `${process.env.STUDIO_BASE_URL}/api/contentstore/v1/proctoring_errors/course-v1:Test+T101+2024`,
       );
-      expect(result).toEqual(camelCased);
+      expect(result).toEqual(expected);
     });
   });
 });

--- a/src/advanced-settings/data/api.test.js
+++ b/src/advanced-settings/data/api.test.js
@@ -1,0 +1,102 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import {
+  getConfig, camelCaseObject, modifyObjectKeys, snakeCaseObject,
+} from '@edx/frontend-platform';
+import {
+  getCourseAdvancedSettings,
+  updateCourseAdvancedSettings,
+  getProctoringExamErrors,
+} from './api';
+import { convertObjectToSnakeCase } from '../../utils';
+
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(),
+  camelCaseObject: jest.fn(),
+  modifyObjectKeys: jest.fn(),
+  snakeCaseObject: jest.fn(),
+}));
+
+jest.mock('@edx/frontend-platform/auth', () => ({
+  getAuthenticatedHttpClient: jest.fn(),
+}));
+
+jest.mock('../../utils', () => ({
+  convertObjectToSnakeCase: jest.fn(),
+}));
+
+describe('courseSettings API', () => {
+  const mockHttpClient = {
+    get: jest.fn(),
+    patch: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getAuthenticatedHttpClient.mockReturnValue(mockHttpClient);
+    getConfig.mockReturnValue({ STUDIO_BASE_URL: 'http://studio.test' });
+  });
+
+  describe('getCourseAdvancedSettings', () => {
+    it('should fetch and format course advanced settings', async () => {
+      const fakeData = { key: { value: 'some_value' } };
+      const camelCased = { key: { value: 'some_value' } };
+      const modified = { key: { value: 'some_value_snake' } };
+
+      mockHttpClient.get.mockResolvedValue({ data: fakeData });
+      camelCaseObject.mockReturnValue(camelCased);
+      snakeCaseObject.mockReturnValue('some_value_snake');
+      modifyObjectKeys.mockImplementation((obj, fn) => {
+        Object.keys(obj).forEach(fn);
+        return modified;
+      });
+
+      const result = await getCourseAdvancedSettings('course-v1:Test+T101+2024');
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'http://studio.test/api/contentstore/v0/advanced_settings/course-v1:Test+T101+2024?fetch_all=0',
+      );
+      expect(result).toEqual(modified);
+    });
+  });
+
+  describe('updateCourseAdvancedSettings', () => {
+    it('should update and format course advanced settings', async () => {
+      const input = { key: 'value' };
+      const snakeInput = { key: 'snake_value' };
+      const serverData = { key: { value: 'server_value' } };
+      const camelCased = { key: { value: 'server_value' } };
+      const modified = { key: { value: 'formatted_value' } };
+
+      convertObjectToSnakeCase.mockReturnValue(snakeInput);
+      mockHttpClient.patch.mockResolvedValue({ data: serverData });
+      camelCaseObject.mockReturnValue(camelCased);
+      snakeCaseObject.mockReturnValue('formatted_value');
+      modifyObjectKeys.mockImplementation((obj, fn) => {
+        Object.keys(obj).forEach(fn);
+        return modified;
+      });
+
+      const result = await updateCourseAdvancedSettings('course-v1:Test+T101+2024', input);
+      expect(mockHttpClient.patch).toHaveBeenCalledWith(
+        'http://studio.test/api/contentstore/v0/advanced_settings/course-v1:Test+T101+2024',
+        snakeInput,
+      );
+      expect(result).toEqual(modified);
+    });
+  });
+
+  describe('getProctoringExamErrors', () => {
+    it('should fetch proctoring errors and return camelCase object', async () => {
+      const fakeErrors = { errors: [] };
+      const camelCased = { errors: [] };
+
+      mockHttpClient.get.mockResolvedValue({ data: fakeErrors });
+      camelCaseObject.mockReturnValue(camelCased);
+
+      const result = await getProctoringExamErrors('course-v1:Test+T101+2024');
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'http://studio.test/api/contentstore/v1/proctoring_errors/course-v1:Test+T101+2024',
+      );
+      expect(result).toEqual(camelCased);
+    });
+  });
+});

--- a/src/advanced-settings/data/api.test.js
+++ b/src/advanced-settings/data/api.test.js
@@ -26,27 +26,24 @@ describe('courseSettings API', () => {
   });
 
   describe('getCourseAdvancedSettings', () => {
-    it('should fetch and format course advanced settings', async () => {
+    it('should fetch and unformat course advanced settings', async () => {
       const fakeData = {
         keyCamelCase: {
           value: {
-            oneOption: 'content-1',
-            two_option: 'content-2',
-            threeOption: 'threeContent',
+            snake_case: 'snake_case',
+            camelCase: 'camelCase',
+            PascalCase: 'PascalCase',
+            'kebab-case': 'kebab-case',
+            UPPER_CASE: 'UPPER_CASE',
+            lowercase: 'lowercase',
+            UPPERCASE: 'UPPERCASE',
+            'Title Case': 'Title Case',
+            'dot.case': 'dot.case',
+            SCREAMING_SNAKE_CASE: 'SCREAMING_SNAKE_CASE',
+            MixedCase: 'MixedCase',
+            'Train-Case': 'Train-Case',
             nestedOption: {
               anotherOption: 'nestedContent',
-            },
-          },
-        },
-      };
-      const expected = {
-        keyCamelCase: {
-          value: {
-            one_option: 'content-1',
-            two_option: 'content-2',
-            three_option: 'threeContent',
-            nested_option: {
-              another_option: 'nestedContent',
             },
           },
         },
@@ -58,32 +55,29 @@ describe('courseSettings API', () => {
       expect(mockHttpClient.get).toHaveBeenCalledWith(
         `${process.env.STUDIO_BASE_URL}/api/contentstore/v0/advanced_settings/course-v1:Test+T101+2024?fetch_all=0`,
       );
-      expect(result).toEqual(expected);
+      expect(result).toEqual(fakeData);
     });
   });
 
   describe('updateCourseAdvancedSettings', () => {
-    it('should update and format course advanced settings', async () => {
+    it('should update and unformat course advanced settings', async () => {
       const fakeData = {
         keyCamelCase: {
           value: {
-            oneOption: 'content-1',
-            two_option: 'content-2',
-            threeOption: 'threeContent',
+            snake_case: 'snake_case',
+            camelCase: 'camelCase',
+            PascalCase: 'PascalCase',
+            'kebab-case': 'kebab-case',
+            UPPER_CASE: 'UPPER_CASE',
+            lowercase: 'lowercase',
+            UPPERCASE: 'UPPERCASE',
+            'Title Case': 'Title Case',
+            'dot.case': 'dot.case',
+            SCREAMING_SNAKE_CASE: 'SCREAMING_SNAKE_CASE',
+            MixedCase: 'MixedCase',
+            'Train-Case': 'Train-Case',
             nestedOption: {
               anotherOption: 'nestedContent',
-            },
-          },
-        },
-      };
-      const expected = {
-        keyCamelCase: {
-          value: {
-            one_option: 'content-1',
-            two_option: 'content-2',
-            three_option: 'threeContent',
-            nested_option: {
-              another_option: 'nestedContent',
             },
           },
         },
@@ -97,27 +91,30 @@ describe('courseSettings API', () => {
         `${process.env.STUDIO_BASE_URL}/api/contentstore/v0/advanced_settings/course-v1:Test+T101+2024`,
         {},
       );
-      expect(result).toEqual(expected);
+      expect(result).toEqual(fakeData);
     });
   });
 
   describe('getProctoringExamErrors', () => {
-    it('should fetch proctoring errors and return camelCase object', async () => {
+    it('should fetch proctoring errors and return unformat object', async () => {
       const fakeData = {
         keyCamelCase: {
           value: {
-            oneOption: 'content-1',
-            two_option: 'content-2',
-            threeOption: 'threeContent',
-          },
-        },
-      };
-      const expected = {
-        keyCamelCase: {
-          value: {
-            oneOption: 'content-1',
-            twoOption: 'content-2',
-            threeOption: 'threeContent',
+            snake_case: 'snake_case',
+            camelCase: 'camelCase',
+            PascalCase: 'PascalCase',
+            'kebab-case': 'kebab-case',
+            UPPER_CASE: 'UPPER_CASE',
+            lowercase: 'lowercase',
+            UPPERCASE: 'UPPERCASE',
+            'Title Case': 'Title Case',
+            'dot.case': 'dot.case',
+            SCREAMING_SNAKE_CASE: 'SCREAMING_SNAKE_CASE',
+            MixedCase: 'MixedCase',
+            'Train-Case': 'Train-Case',
+            nestedOption: {
+              anotherOption: 'nestedContent',
+            },
           },
         },
       };
@@ -128,7 +125,7 @@ describe('courseSettings API', () => {
       expect(mockHttpClient.get).toHaveBeenCalledWith(
         `${process.env.STUDIO_BASE_URL}/api/contentstore/v1/proctoring_errors/course-v1:Test+T101+2024`,
       );
-      expect(result).toEqual(expected);
+      expect(result).toEqual(fakeData);
     });
   });
 });

--- a/src/advanced-settings/data/api.test.js
+++ b/src/advanced-settings/data/api.test.js
@@ -4,14 +4,9 @@ import {
   updateCourseAdvancedSettings,
   getProctoringExamErrors,
 } from './api';
-import { convertObjectToSnakeCase } from '../../utils';
 
 jest.mock('@edx/frontend-platform/auth', () => ({
   getAuthenticatedHttpClient: jest.fn(),
-}));
-
-jest.mock('../../utils', () => ({
-  convertObjectToSnakeCase: jest.fn(),
 }));
 
 describe('courseSettings API', () => {
@@ -83,7 +78,6 @@ describe('courseSettings API', () => {
         },
       };
 
-      convertObjectToSnakeCase.mockReturnValue({});
       mockHttpClient.patch.mockResolvedValue({ data: fakeData });
 
       const result = await updateCourseAdvancedSettings('course-v1:Test+T101+2024', {});


### PR DESCRIPTION
## Description

This PR fixes this [bug](https://github.com/openedx/frontend-app-authoring/issues/1243#issue-2496098982) and this [bug](https://github.com/eduNEXT/hosting-heimdall/issues/25).

## Testing instructions

* Deploy your local environment or go to your preferred remote environment (REDWOOD).
* Go to studio > settings > advanced settings.
* "Certificate html override" and "other course settings" are showing dictionary keys in `camelCase` (Review any field whose value is an object with configuration keys).

**BEFORE**
![Captura de pantalla de 2024-12-30 19-41-49](https://github.com/user-attachments/assets/b8eea80d-d69d-4468-b516-be337d5a0345)
![Captura de pantalla de 2024-12-30 19-41-41](https://github.com/user-attachments/assets/bc992f49-79a7-4241-a344-4cd75cade8a7)

**AFTER**
![Captura de pantalla de 2025-06-09 14-42-41](https://github.com/user-attachments/assets/b90e6fc4-f524-4a59-b2c0-e741297dac2c)
