### PR TITLE
fix: allow user provided value if can auto-create orgs [FC-0076]

### DIFF
--- a/src/library-authoring/create-library/CreateLibrary.test.tsx
+++ b/src/library-authoring/create-library/CreateLibrary.test.tsx
@@ -88,6 +88,12 @@ describe('<CreateLibrary />', () => {
     userEvent.click(titleInput);
     userEvent.type(titleInput, 'Test Library Name');
 
+    // We cannot create a new org, and so we're restricted to the allowed list
+    const orgOptions = screen.getByTestId('autosuggest-iconbutton');
+    userEvent.click(orgOptions);
+    expect(screen.getByText('org1')).toBeInTheDocument();
+    ['org2', 'org3', 'org4', 'org5'].forEach((org) => expect(screen.queryByText(org)).not.toBeInTheDocument());
+
     const orgInput = await screen.findByRole('combobox', { name: /organization/i });
     userEvent.click(orgInput);
     userEvent.type(orgInput, 'NewOrg');
@@ -108,7 +114,6 @@ describe('<CreateLibrary />', () => {
     axiosMock.onGet(getStudioHomeApiUrl()).reply(200, {
       ...studioHomeMock,
       allow_to_create_new_org: true,
-      allowToCreateNewOrg: true,
     });
     axiosMock.onPost(getContentLibraryV2CreateApiUrl()).reply(200, {
       id: 'library-id',
@@ -119,6 +124,11 @@ describe('<CreateLibrary />', () => {
     const titleInput = await screen.findByRole('textbox', { name: /library name/i });
     userEvent.click(titleInput);
     userEvent.type(titleInput, 'Test Library Name');
+
+    // We can create a new org, so we're also allowed to use any existing org
+    const orgOptions = screen.getByTestId('autosuggest-iconbutton');
+    userEvent.click(orgOptions);
+    ['org1', 'org2', 'org3', 'org4', 'org5'].forEach((org) => expect(screen.queryByText(org)).toBeInTheDocument());
 
     const orgInput = await screen.findByRole('combobox', { name: /organization/i });
     userEvent.click(orgInput);

--- a/src/library-authoring/create-library/CreateLibrary.test.tsx
+++ b/src/library-authoring/create-library/CreateLibrary.test.tsx
@@ -3,9 +3,11 @@ import type MockAdapter from 'axios-mock-adapter';
 import userEvent from '@testing-library/user-event';
 
 import {
+  act,
   fireEvent,
   initializeMocks,
   render,
+  screen,
   waitFor,
 } from '../../testUtils';
 import { studioHomeMock } from '../../studio-home/__mocks__';
@@ -49,22 +51,22 @@ describe('<CreateLibrary />', () => {
       id: 'library-id',
     });
 
-    const { getByRole } = render(<CreateLibrary />);
+    render(<CreateLibrary />);
 
-    const titleInput = getByRole('textbox', { name: /library name/i });
+    const titleInput = await screen.findByRole('textbox', { name: /library name/i });
     userEvent.click(titleInput);
     userEvent.type(titleInput, 'Test Library Name');
 
-    const orgInput = getByRole('combobox', { name: /organization/i });
+    const orgInput = await screen.findByRole('combobox', { name: /organization/i });
     userEvent.click(orgInput);
     userEvent.type(orgInput, 'org1');
-    userEvent.tab();
+    act(() => userEvent.tab());
 
-    const slugInput = getByRole('textbox', { name: /library id/i });
+    const slugInput = await screen.findByRole('textbox', { name: /library id/i });
     userEvent.click(slugInput);
     userEvent.type(slugInput, 'test_library_slug');
 
-    fireEvent.click(getByRole('button', { name: /create/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /create/i }));
     await waitFor(() => {
       expect(axiosMock.history.post.length).toBe(1);
       expect(axiosMock.history.post[0].data).toBe(
@@ -80,26 +82,26 @@ describe('<CreateLibrary />', () => {
       id: 'library-id',
     });
 
-    const { getByRole, getByText } = render(<CreateLibrary />);
+    render(<CreateLibrary />);
 
-    const titleInput = getByRole('textbox', { name: /library name/i });
+    const titleInput = await screen.findByRole('textbox', { name: /library name/i });
     userEvent.click(titleInput);
     userEvent.type(titleInput, 'Test Library Name');
 
-    const orgInput = getByRole('combobox', { name: /organization/i });
+    const orgInput = await screen.findByRole('combobox', { name: /organization/i });
     userEvent.click(orgInput);
     userEvent.type(orgInput, 'NewOrg');
-    userEvent.tab();
+    act(() => userEvent.tab());
 
-    const slugInput = getByRole('textbox', { name: /library id/i });
+    const slugInput = await screen.findByRole('textbox', { name: /library id/i });
     userEvent.click(slugInput);
     userEvent.type(slugInput, 'test_library_slug');
 
-    fireEvent.click(getByRole('button', { name: /create/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /create/i }));
     await waitFor(() => {
       expect(axiosMock.history.post.length).toBe(0);
     });
-    expect(getByText('Required field.')).toBeInTheDocument();
+    expect(await screen.findByText('Required field.')).toBeInTheDocument();
   });
 
   test('can create new org if allowed', async () => {
@@ -112,22 +114,22 @@ describe('<CreateLibrary />', () => {
       id: 'library-id',
     });
 
-    const { getByRole } = render(<CreateLibrary />);
+    render(<CreateLibrary />);
 
-    const titleInput = getByRole('textbox', { name: /library name/i });
+    const titleInput = await screen.findByRole('textbox', { name: /library name/i });
     userEvent.click(titleInput);
     userEvent.type(titleInput, 'Test Library Name');
 
-    const orgInput = getByRole('combobox', { name: /organization/i });
+    const orgInput = await screen.findByRole('combobox', { name: /organization/i });
     userEvent.click(orgInput);
     userEvent.type(orgInput, 'NewOrg');
-    userEvent.tab();
+    act(() => userEvent.tab());
 
-    const slugInput = getByRole('textbox', { name: /library id/i });
+    const slugInput = await screen.findByRole('textbox', { name: /library id/i });
     userEvent.click(slugInput);
     userEvent.type(slugInput, 'test_library_slug');
 
-    fireEvent.click(getByRole('button', { name: /create/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /create/i }));
     await waitFor(() => {
       expect(axiosMock.history.post.length).toBe(1);
       expect(axiosMock.history.post[0].data).toBe(
@@ -142,37 +144,37 @@ describe('<CreateLibrary />', () => {
     axiosMock.onPost(getContentLibraryV2CreateApiUrl()).reply(400, {
       field: 'Error message',
     });
-    const { getByRole, getByTestId } = render(<CreateLibrary />);
+    render(<CreateLibrary />);
 
-    const titleInput = getByRole('textbox', { name: /library name/i });
+    const titleInput = await screen.findByRole('textbox', { name: /library name/i });
     userEvent.click(titleInput);
     userEvent.type(titleInput, 'Test Library Name');
 
-    const orgInput = getByTestId('autosuggest-textbox-input');
+    const orgInput = await screen.findByTestId('autosuggest-textbox-input');
     userEvent.click(orgInput);
     userEvent.type(orgInput, 'org1');
-    userEvent.tab();
+    act(() => userEvent.tab());
 
-    const slugInput = getByRole('textbox', { name: /library id/i });
+    const slugInput = await screen.findByRole('textbox', { name: /library id/i });
     userEvent.click(slugInput);
     userEvent.type(slugInput, 'test_library_slug');
 
-    fireEvent.click(getByRole('button', { name: /create/i }));
-    await waitFor(() => {
+    fireEvent.click(await screen.findByRole('button', { name: /create/i }));
+    await waitFor(async () => {
       expect(axiosMock.history.post.length).toBe(1);
       expect(axiosMock.history.post[0].data).toBe(
         '{"description":"","title":"Test Library Name","org":"org1","slug":"test_library_slug"}',
       );
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(getByRole('alert')).toHaveTextContent('Request failed with status code 400');
-      expect(getByRole('alert')).toHaveTextContent('{"field":"Error message"}');
+      expect(await screen.findByRole('alert')).toHaveTextContent('Request failed with status code 400');
+      expect(await screen.findByRole('alert')).toHaveTextContent('{"field":"Error message"}');
     });
   });
 
   test('cancel creating library navigates to libraries page', async () => {
-    const { getByRole } = render(<CreateLibrary />);
+    render(<CreateLibrary />);
 
-    fireEvent.click(getByRole('button', { name: /cancel/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /cancel/i }));
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/libraries');
     });

--- a/src/library-authoring/create-library/CreateLibrary.tsx
+++ b/src/library-authoring/create-library/CreateLibrary.tsx
@@ -39,11 +39,22 @@ const CreateLibrary = () => {
   } = useCreateLibraryV2();
 
   const {
-    data: organizationListData,
+    data: allOrganizations,
     isLoading: isOrganizationListLoading,
   } = useOrganizationListData();
 
-  const { studioHomeData: { allowToCreateNewOrg } } = useStudioHome();
+  const {
+    studioHomeData: {
+      allowedOrganizationsForLibraries,
+      allowToCreateNewOrg,
+    },
+  } = useStudioHome();
+
+  const organizations = (
+    allowToCreateNewOrg
+      ? allOrganizations
+      : allowedOrganizationsForLibraries
+  ) || [];
 
   const handleOnClickCancel = () => {
     navigate('/libraries');
@@ -111,9 +122,9 @@ const CreateLibrary = () => {
                   )}
                   placeholder={intl.formatMessage(messages.orgPlaceholder)}
                 >
-                  {organizationListData ? organizationListData.map((org) => (
+                  {organizations.map((org) => (
                     <Form.AutosuggestOption key={org} id={org}>{org}</Form.AutosuggestOption>
-                  )) : []}
+                  ))}
                 </Form.Autosuggest>
                 <FormikErrorFeedback name="org">
                   <Form.Text>{intl.formatMessage(messages.orgHelp)}</Form.Text>

--- a/src/library-authoring/create-library/CreateLibrary.tsx
+++ b/src/library-authoring/create-library/CreateLibrary.tsx
@@ -19,6 +19,7 @@ import FormikErrorFeedback from '../../generic/FormikErrorFeedback';
 import AlertError from '../../generic/alert-error';
 import { useOrganizationListData } from '../../generic/data/apiHooks';
 import SubHeader from '../../generic/sub-header/SubHeader';
+import { useStudioHome } from '../../studio-home/hooks';
 import { useCreateLibraryV2 } from './data/apiHooks';
 import messages from './messages';
 
@@ -41,6 +42,8 @@ const CreateLibrary = () => {
     data: organizationListData,
     isLoading: isOrganizationListLoading,
   } = useOrganizationListData();
+
+  const { studioHomeData: { allowToCreateNewOrg } } = useStudioHome();
 
   const handleOnClickCancel = () => {
     navigate('/libraries');
@@ -100,7 +103,12 @@ const CreateLibrary = () => {
                 <Form.Autosuggest
                   name="org"
                   isLoading={isOrganizationListLoading}
-                  onChange={(event) => formikProps.setFieldValue('org', event.selectionId)}
+                  onChange={(event) => formikProps.setFieldValue(
+                    'org',
+                    allowToCreateNewOrg
+                      ? (event.selectionId || event.userProvidedText)
+                      : event.selectionId,
+                  )}
                   placeholder={intl.formatMessage(messages.orgPlaceholder)}
                 >
                   {organizationListData ? organizationListData.map((org) => (

--- a/src/studio-home/__mocks__/studioHomeMock.js
+++ b/src/studio-home/__mocks__/studioHomeMock.js
@@ -76,4 +76,5 @@ module.exports = {
   platformName: 'Your Platform Name Here',
   userIsActive: true,
   allowToCreateNewOrg: false,
+  allowedOrganizationsForLibraries: ['org1'],
 };


### PR DESCRIPTION
## Description

Allows Content Authors to auto-create an organization when creating a library, if auto-creating orgs is allowed by the platform.

https://github.com/user-attachments/assets/67e291b9-408b-470c-b194-698869d35552

## Supporting information

Part of: https://github.com/openedx/frontend-app-authoring/issues/1577
Depends on: https://github.com/openedx/edx-platform/pull/36094 <-- this PR must be merged first.

## Testing instructions

0. Install branch from https://github.com/openedx/edx-platform/pull/36094

With cms `settings.ORGANIZATIONS_AUTOCREATE = True` (default):
1. Visit http://apps.local.openedx.io:2001/authoring/library/create
3. Fill in the form using an organization that does not exist in the available list, e.g. `NewOrg`
4. Click "Create"
   Should redirect to the new library's page and auto-create the organization.

With cms `settings.ORGANIZATIONS_AUTOCREATE = False`:
1. Visit http://apps.local.openedx.io:2001/authoring/library/create
3. Fill in the form using an organization that does not exist in the available list, e.g. `NewOrg2`
4. Click "Create"
   Should not allow the library (or organization) to be created, and instead show "Required field" under the Organization field.

Author Notes & Concerns:

1. My [initial approach](https://github.com/openedx/frontend-app-authoring/compare/master...open-craft:frontend-app-authoring:jill/fal-4020-library-org-refactor) refactored [the code used by the "Create Course" form into a shared `OrganizationField`](https://github.com/openedx/frontend-app-authoring/commit/93f8aa05f486130c287985fe9191e13d1f57bcbb). which I then [modified to use `Form.Autosuggest` instead of `Dropdown`](https://github.com/openedx/frontend-app-authoring/commit/a5c36f1238517ddad969b512418bf2502d6be9e9) to preserve "Create Library"'s auto-complete functionality.
  This works fine, but was a bigger change, so I decided against it.