### PR TITLE
feat: add last published date to HistoryWidget [FC-0076]

### DIFF
--- a/src/library-authoring/collections/CollectionDetails.tsx
+++ b/src/library-authoring/collections/CollectionDetails.tsx
@@ -166,8 +166,7 @@ const CollectionDetails = () => {
           {intl.formatMessage(messages.detailsTabHistoryTitle)}
         </h3>
         <HistoryWidget
-          created={collection.created ? new Date(collection.created) : null}
-          modified={collection.modified ? new Date(collection.modified) : null}
+          {...collection}
         />
       </div>
     </Stack>

--- a/src/library-authoring/component-info/ComponentDetails.test.tsx
+++ b/src/library-authoring/component-info/ComponentDetails.test.tsx
@@ -53,10 +53,12 @@ describe('<ComponentDetails />', () => {
   });
 
   it('should render the component history', async () => {
-    render(mockLibraryBlockMetadata.usageKeyNeverPublished);
+    render(mockLibraryBlockMetadata.usageKeyPublished);
     // Show created date
     expect(await screen.findByText('June 20, 2024')).toBeInTheDocument();
     // Show modified date
     expect(await screen.findByText('June 21, 2024')).toBeInTheDocument();
+    // Show last published date
+    expect(await screen.findByText('June 22, 2024')).toBeInTheDocument();
   });
 });

--- a/src/library-authoring/component-info/ComponentManagement.test.tsx
+++ b/src/library-authoring/component-info/ComponentManagement.test.tsx
@@ -68,7 +68,7 @@ describe('<ComponentManagement />', () => {
     expect(await screen.findByText('Published')).toBeInTheDocument();
     expect(screen.getByText('Published')).toBeInTheDocument();
     expect(
-      screen.getByText(matchInnerText('SPAN', 'Last published on June 21, 2024 at 24:00 by Luke.')),
+      screen.getByText(matchInnerText('SPAN', 'Last published on June 22, 2024 at 24:00 by Luke.')),
     ).toBeInTheDocument();
   });
 

--- a/src/library-authoring/data/api.mocks.ts
+++ b/src/library-authoring/data/api.mocks.ts
@@ -356,7 +356,7 @@ mockLibraryBlockMetadata.dataPublished = {
   defKey: null,
   blockType: 'html',
   displayName: 'Introduction to Testing 2',
-  lastPublished: '2024-06-21T00:00:00',
+  lastPublished: '2024-06-22T00:00:00',
   publishedBy: 'Luke',
   lastDraftCreated: null,
   lastDraftCreatedBy: '2024-06-20T20:00:00Z',

--- a/src/library-authoring/generic/history-widget/index.tsx
+++ b/src/library-authoring/generic/history-widget/index.tsx
@@ -15,6 +15,7 @@ const CustomFormattedDate = ({ date }: { date: string | Date }) => (
 type HistoryWidgedProps = {
   modified: string | Date | null;
   created: string | Date | null;
+  lastPublished?: string | Date | null;
 };
 
 /**
@@ -32,8 +33,15 @@ type HistoryWidgedProps = {
 const HistoryWidget = ({
   modified,
   created,
+  lastPublished,
 }: HistoryWidgedProps) => (
   <Stack className="history-widget-bar small" gap={3}>
+    {lastPublished && (
+      <div>
+        <div className="text-muted"><FormattedMessage {...messages.lastPublishedTitle} /> </div>
+        <CustomFormattedDate date={lastPublished} />
+      </div>
+    )}
     {modified && (
       <div>
         <div className="text-muted"><FormattedMessage {...messages.lastModifiedTitle} /> </div>

--- a/src/library-authoring/generic/history-widget/messages.ts
+++ b/src/library-authoring/generic/history-widget/messages.ts
@@ -1,6 +1,11 @@
 import { defineMessages } from '@edx/frontend-platform/i18n';
 
 const messages = defineMessages({
+  lastPublishedTitle: {
+    id: 'course-authoring.library-authoring.generic.history-widget.last-published',
+    defaultMessage: 'Last Published',
+    description: 'Title of the last published section in the library authoring sidebar.',
+  },
   lastModifiedTitle: {
     id: 'course-authoring.library-authoring.generic.history-widget.last-modified',
     defaultMessage: 'Last Modified',


### PR DESCRIPTION
## Description

This PR adds the "Last Published" date to the `HistoryWidget`.
![image](https://github.com/user-attachments/assets/80d4d9c0-2401-47e3-8bbd-afe9b5d7daef)

## Addition Information
- https://github.com/openedx/frontend-app-authoring/issues/1354#issuecomment-2526179107

## Testing Instructions
- Open the library component sidebar
- Open the "Details" tab
- Check the new "Last Published" entity 

___
Private ref: [FAL-4015](https://tasks.opencraft.com/browse/FAL-4015)