### PR TITLE
fix(i18n): extract translations on `plugins` folder 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build": "fedx-scripts webpack",
-    "i18n_extract": "fedx-scripts formatjs extract",
+    "i18n_extract": "formatjs extract --format node_modules/@openedx/frontend-build/lib/formatter.js --ignore {src,plugins}/**/*.json --out-file ./temp/babel-plugin-formatjs/Default.messages.json -- {src,plugins}/**/*.js* {src,plugins}/**/messages.ts",
     "stylelint": "stylelint \"plugins/**/*.scss\" \"src/**/*.scss\" \"scss/**/*.scss\" --config .stylelintrc.json",
     "lint": "npm run stylelint && fedx-scripts eslint --ext .js --ext .jsx --ext .ts --ext .tsx .",
     "lint:fix": "npm run stylelint -- --fix && fedx-scripts eslint --fix --ext .js --ext .jsx --ext .ts --ext .tsx .",


### PR DESCRIPTION
fixes #1588

## Description

This pull request fixes the extract translations process for the `plugins` folder.
This increases the messages that are going to be extracted, making it possible to translate more of this application.

This PR is useful for "Operators" that use Studio and Course authoring MFE on a different language than English.

## Testing instructions

Run the extract_translations on master and on this PR:

```bash
make extract_translations
wc -l temp/babel-plugin-formatjs/Default.messages.json
```
