### PR TITLE
fix: broken re-run notification dismiss

### DIFF
--- a/src/course-outline/hooks.jsx
+++ b/src/course-outline/hooks.jsx
@@ -242,7 +242,7 @@ const useCourseOutline = ({ courseId }) => {
   };
 
   const handleDismissNotification = () => {
-    dispatch(dismissNotificationQuery(notificationDismissUrl));
+    dispatch(dismissNotificationQuery(`${getConfig().STUDIO_BASE_URL}${notificationDismissUrl}`));
   };
 
   const handleSectionDragAndDrop = (


### PR DESCRIPTION
## Description

When you re-run a course:
![image](https://github.com/user-attachments/assets/25a53a02-5433-4a3e-804a-596967b0704a)

You see this notification:
![image](https://github.com/user-attachments/assets/fc5908a0-b349-44d5-bd75-9e2addc9aad3)

If you click the "Dismiss" button, in the "Network" tab of your browser dev tools you can see this:
![image](https://github.com/user-attachments/assets/c02a426c-9af8-49f5-828b-3e8ff4a6fe44)
 
This `DELETE` request has no effect, because needs to be sent to Studio instead. If you re-load the page - the notification will still be there.

This PR fixes this by prefixing [notification_dismiss_url](https://github.com/openedx/edx-platform/blob/838977a8f3981be491a7fa2441724e4e6e92d895/cms/djangoapps/contentstore/utils.py#L1916-L1922) that we get from the backend with the Studio base URL. 

## Testing instructions

A dismissed notification shouldn't re-appear after page reload.

[internal reference](https://tasks.opencraft.com/browse/BB-9234)