### PR TITLE
revert: refactor: remove pointless maintenance link message

### DIFF
--- a/src/header/messages.js
+++ b/src/header/messages.js
@@ -116,6 +116,11 @@ const messages = defineMessages({
     defaultMessage: 'Studio Home',
     description: 'Link to Studio Home',
   },
+  'header.user.menu.maintenance': {
+    id: 'header.user.menu.maintenance',
+    defaultMessage: 'Maintenance',
+    description: 'Link to the Studio maintenance page',
+  },
   'header.user.menu.logout': {
     id: 'header.user.menu.logout',
     defaultMessage: 'Logout',


### PR DESCRIPTION
Reverts openedx/frontend-app-authoring#1503

Temporarily reverting, as the Maintenance Announcements tool is still in use, as discussed on: https://github.com/openedx/edx-platform/pull/35852