### PR TITLE
fix: auto-focus the search keyword input when in search modal only [FC-0076]

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.test.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.test.tsx
@@ -111,6 +111,10 @@ describe('<LibraryAuthoringPage />', () => {
     expect(screen.getAllByText('Recently Modified').length).toEqual(1);
     expect((await screen.findAllByText('Introduction to Testing'))[0]).toBeInTheDocument();
 
+    // Search box should not have focus on page load
+    const searchBox = screen.getByRole('searchbox');
+    expect(searchBox).not.toHaveFocus();
+
     // Navigate to the components tab
     fireEvent.click(screen.getByRole('tab', { name: 'Components' }));
     // "Recently Modified" default sort shown

--- a/src/search-manager/SearchKeywordsField.tsx
+++ b/src/search-manager/SearchKeywordsField.tsx
@@ -7,7 +7,11 @@ import { useSearchContext } from './SearchManager';
 /**
  * The "main" input field where users type in search keywords. The search happens as they type (no need to press enter).
  */
-const SearchKeywordsField: React.FC<{ className?: string, placeholder?: string }> = (props) => {
+const SearchKeywordsField: React.FC<{
+  className?: string,
+  placeholder?: string,
+  autoFocus?: boolean,
+}> = (props) => {
   const intl = useIntl();
   const { searchKeywords, setSearchKeywords, usageKey } = useSearchContext();
   const defaultPlaceholder = usageKey ? messages.clearUsageKeyToSearch : messages.inputPlaceholder;
@@ -24,7 +28,7 @@ const SearchKeywordsField: React.FC<{ className?: string, placeholder?: string }
     >
       <SearchField.Label />
       <SearchField.Input
-        autoFocus
+        autoFocus={Boolean(props.autoFocus)}
         placeholder={placeholder}
       />
       <SearchField.ClearButton />

--- a/src/search-modal/SearchModal.test.tsx
+++ b/src/search-modal/SearchModal.test.tsx
@@ -73,4 +73,14 @@ describe('<SearchModal />', () => {
     const { findByText } = render(<RootWrapper />);
     expect(await findByText('An error occurred. Unable to load search results.')).toBeInTheDocument();
   });
+
+  it('should set focus on the search input box when loaded in the modal', async () => {
+    axiosMock.onGet(getContentSearchConfigUrl()).replyOnce(200, {
+      url: 'https://meilisearch.example.com',
+      index: 'test-index',
+      apiKey: 'test-api-key',
+    });
+    const { getByRole } = render(<RootWrapper />);
+    expect(getByRole('searchbox')).toHaveFocus();
+  });
 });

--- a/src/search-modal/SearchModal.tsx
+++ b/src/search-modal/SearchModal.tsx
@@ -21,7 +21,11 @@ const SearchModal: React.FC<{ courseId?: string, isOpen: boolean, onClose: () =>
       isFullscreenOnMobile
       className="courseware-search-modal"
     >
-      <SearchUI courseId={courseId} closeSearchModal={props.onClose} />
+      <SearchUI
+        courseId={courseId}
+        closeSearchModal={props.onClose}
+        autoFocus
+      />
     </ModalDialog>
   );
 };

--- a/src/search-modal/SearchUI.tsx
+++ b/src/search-modal/SearchUI.tsx
@@ -19,7 +19,11 @@ import EmptyStates from './EmptyStates';
 import SearchResults from './SearchResults';
 import messages from './messages';
 
-const SearchUI: React.FC<{ courseId?: string, closeSearchModal?: () => void }> = (props) => {
+const SearchUI: React.FC<{
+  courseId?: string,
+  autoFocus?: boolean,
+  closeSearchModal?: () => void,
+}> = (props) => {
   const hasCourseId = Boolean(props.courseId);
   const [searchThisCourseEnabled, setSearchThisCourse] = React.useState(hasCourseId);
   const switchToThisCourse = React.useCallback(() => setSearchThisCourse(true), []);
@@ -39,7 +43,10 @@ const SearchUI: React.FC<{ courseId?: string, closeSearchModal?: () => void }> =
       <ModalDialog.Header style={{ zIndex: 9 }} className="border-bottom">
         <ModalDialog.Title><FormattedMessage {...messages.title} /></ModalDialog.Title>
         <div className="d-flex mt-3">
-          <SearchKeywordsField className="flex-grow-1 mr-2" />
+          <SearchKeywordsField
+            className="flex-grow-1 mr-2"
+            autoFocus={props.autoFocus}
+          />
           <SelectMenu variant="primary">
             <MenuItem
               onClick={switchToThisCourse}


### PR DESCRIPTION
## Description

This PR fixes an a11y issue for Library Authors introduced by https://github.com/openedx/frontend-app-authoring/pull/1575.

When navigating between the various Library Authoring pages, the search keyword box should _not_ be auto-focused, so focus will follow the user's click/tab events and keep that continuity.

The course content search modal behavior is unchanged -- loading this modal auto-focuses the search input box as one would expect.

Current behavior: see https://github.com/openedx/frontend-app-authoring/issues/1499#issuecomment-2593606624

Fixed behavior: https://github.com/user-attachments/assets/539aad1b-13ae-48da-a5f1-6f15cb6f2e4e

## Supporting information

See https://github.com/openedx/frontend-app-authoring/issues/1499#issuecomment-2593606624
Private-ref: [FAL-3984](https://tasks.opencraft.com/browse/FAL-3984)

## Testing instructions

1. View a library with multiple components and/or collections in it.
2. Click through the different components/collection cards.
    Note that the search input box does not capture focus anymore.
3. View a course, and click the "Search" icon to load the search modal
   Note that the search input box has the initial focus, so you can start typing keywords immediately.