### PR TITLE
Fix regex mismatch in text block

### DIFF
--- a/src/editors/sharedComponents/TinyMceWidget/utils.js
+++ b/src/editors/sharedComponents/TinyMceWidget/utils.js
@@ -18,7 +18,7 @@ export const parseAssetName = (relativeUrl) => {
   let assetName = '';
   if (relativeUrl.match(/\/asset-v1:\S+[+]\S+[@]\S+[+]\S+\/\w/)?.length >= 1) {
     const assetBlockName = relativeUrl.substring(0, relativeUrl.search(/("|&quot;)/));
-    const dividedSrc = assetBlockName.split(/\/asset-v1:\S+[+]\S+[@]\S+[+]\S+\//);
+    const dividedSrc = assetBlockName.split(/\/asset-v1:\S+[+]\S+[@]\S+[+]\S+[/@]/);
     [, assetName] = dividedSrc;
   } else {
     const assetBlockName = relativeUrl.substring(relativeUrl.indexOf('@') + 1, relativeUrl.search(/("|&quot;)/));


### PR DESCRIPTION
## Description
This PR resolve issue in text components where the save button became unresponsive after making changes. The problem was caused by a mismatch in the regular expressions used to match specific patterns. One pattern, @asset+block/, ended with a /, while the other, @asset+block@, ended with an @. 

## Supporting information

https://2u-internal.atlassian.net/browse/TNL-11741?atlOrigin=eyJpIjoiOWFjZDgwYzhjOWI3NGQ3NDk1MjIyMDgyNmRhNjQ0OTYiLCJwIjoiaiJ9

## Testing instructions

1. Open a course.
2. Add a new Text component.
3. Select the text in popup.
4. Edit the component in the frontend-app-authoring interface.
5. Use the Insert/Edit Link button to add the link `/asset-v1:olaX+abc99+101+type@asset+block@2.2.3.pdf`.
7. Save the component.
8. Verify that the URL is added without any errors.