### PR TITLE
fix: hidden remove button

### DIFF
--- a/src/grading-settings/grading-scale/GradingScale.scss
+++ b/src/grading-settings/grading-scale/GradingScale.scss
@@ -72,7 +72,7 @@
       .grading-scale-segment-btn-remove {
         font-size: x-small;
         display: none;
-        margin: -2px -4px 0px 0px;
+        margin: -2px -4px 0 0;
       }
 
       .grading-scale-segment-content {

--- a/src/grading-settings/grading-scale/GradingScale.scss
+++ b/src/grading-settings/grading-scale/GradingScale.scss
@@ -6,7 +6,7 @@
 
   .grading-scale-segments-and-ticks {
     display: inline-block;
-    height: 3.125rem;
+    height: 3.5rem;
     width: 100%;
     border: 1px solid $black;
     overflow: hidden;
@@ -70,13 +70,9 @@
       }
 
       .grading-scale-segment-btn-remove {
-        font: normal $font-weight-normal .6875rem/1 $font-family-base;
+        font-size: x-small;
         display: none;
-        position: absolute;
-        top: -1.5625rem;
-        right: -.375rem;
-        padding: .375rem;
-        text-decoration: none;
+        margin: -2px -4px 0px 0px;
       }
 
       .grading-scale-segment-content {

--- a/src/grading-settings/grading-scale/components/GradingScaleSegment.tsx
+++ b/src/grading-settings/grading-scale/components/GradingScaleSegment.tsx
@@ -66,19 +66,19 @@ const GradingScaleSegment = ({
         <span data-testid="grading-scale-segment-number" className="grading-scale-segment-content-number m-0">
           {gradingSegments[idx === 0 ? 0 : idx - 1]?.previous} - {value === 100 ? value : value - 1}
         </span>
+        {idx !== gradingSegments.length && idx - 1 !== 0 && (
+          <Button
+            variant="link"
+            size="inline"
+            className="grading-scale-segment-btn-remove"
+            data-testid="grading-scale-btn-remove"
+            type="button"
+            onClick={() => removeGradingSegment(idx)}
+          >
+            {intl.formatMessage(messages.removeSegmentButtonText)}
+          </Button>
+        )}
       </div>
-      {idx !== gradingSegments.length && idx - 1 !== 0 && (
-        <Button
-          variant="link"
-          size="inline"
-          className="grading-scale-segment-btn-remove"
-          data-testid="grading-scale-btn-remove"
-          type="button"
-          onClick={() => removeGradingSegment(idx)}
-        >
-          {intl.formatMessage(messages.removeSegmentButtonText)}
-        </Button>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## Description

This PR fixes the visibility of the "Remove" button for grade segments. Previously, the button would appear on hover above the segment. But the styling of the button blocked it from being visible. Now, the button appears on hover under the grade range. This change impacts Course Authors.

### Before
<img width="709" alt="Screenshot 2025-01-21 at 2 08 39 PM" src="https://github.com/user-attachments/assets/d8f19138-fbc9-4628-bc57-a32f0b66f119" />

### After
<img width="709" alt="Screenshot 2025-01-21 at 2 08 49 PM" src="https://github.com/user-attachments/assets/465ed60b-5af3-4128-868e-0771e728f807" />

## Testing instructions

1. Open a course
2. Navigate to the grading page
3. Add a new grade
4. Hover over new grade
5. Confirm that "Remove" is visible
6. Click "Remove"
7. Confirm that the segment is removed
