### PR TITLE
Fix problem input [FC-0076]

### DIFF
--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -168,7 +168,7 @@ export const getImageResizeHandler = ({ editor, imagesRef, setImage }) => () => 
  * like that so for now we do this quite frequently, every time there is a
  * "selectionchange" event (which is pretty often).
  */
-export const reparentTinyMceModals = () => {
+export const reparentTinyMceModals = /* istanbul ignore next */ () => {
   const modalLayer = document.querySelector('.pgn__modal-layer');
   if (!modalLayer) {
     return;

--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -255,7 +255,10 @@ export const setupCustomBehavior = ({
   }
 
   editor.on('init', /* istanbul ignore next */ () => {
-    if (editor.bodyElement?.closest('.pgn__modal')) {
+    // Check if this editor is inside a (Paragon) modal.
+    // The way we get the editor's root <div> depends on whether or not this particular editor is using an iframe:
+    const editorDiv = editor.bodyElement ?? editor.container;
+    if (editorDiv?.closest('.pgn__modal')) {
       // This editor is inside a Paragon modal. Use this hack to avoid interference with TinyMCE's own modal popups:
       reparentTinyMceModals();
       editor.on('selectionchange', reparentTinyMceModals);

--- a/src/editors/sharedComponents/TinyMceWidget/pluginConfig.js
+++ b/src/editors/sharedComponents/TinyMceWidget/pluginConfig.js
@@ -64,16 +64,9 @@ const pluginConfig = ({ placeholder, editorType, enableImageUpload }) => {
         [editImageSettings],
       ]),
       quickbarsInsertToolbar: toolbar ? false : mapToolbars([
-        [buttons.undo, buttons.redo],
-        [buttons.formatSelect],
-        [buttons.bold, buttons.italic, buttons.underline, buttons.foreColor],
-        [
-          buttons.align.justify,
-          buttons.bullist,
-          buttons.numlist,
-        ],
-        [imageUploadButton, buttons.blockQuote, buttons.codeBlock],
-        [buttons.table, buttons.emoticons, buttons.charmap, buttons.removeFormat, buttons.a11ycheck],
+        // To keep from blocking the whole text input field when it's empty, this "insert" toolbar
+        // used with ExpandableTextArea is kept as minimal as we can.
+        [imageUploadButton, buttons.table],
       ]),
       quickbarsSelectionToolbar: toolbar ? false : mapToolbars([
         [buttons.undo, buttons.redo],

--- a/src/header/Header.tsx
+++ b/src/header/Header.tsx
@@ -3,7 +3,6 @@ import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { StudioHeader } from '@edx/frontend-component-header';
 import { type Container, useToggle } from '@openedx/paragon';
-import { generatePath, useHref } from 'react-router-dom';
 
 import { getWaffleFlags } from '../data/selectors';
 import { SearchModal } from '../search-modal';
@@ -32,7 +31,6 @@ const Header = ({
   containerProps = {},
 }: HeaderProps) => {
   const intl = useIntl();
-  const libraryHref = useHref('/library/:libraryId');
   const waffleFlags = useSelector(getWaffleFlags);
 
   const [isShowSearchModalOpen, openSearchModal, closeSearchModal] = useToggle(false);
@@ -63,7 +61,7 @@ const Header = ({
 
   const getOutlineLink = () => {
     if (isLibrary) {
-      return generatePath(libraryHref, { libraryId: contextId });
+      return `/library/${contextId}`;
     }
     return waffleFlags.useNewCourseOutlinePage ? `/course/${contextId}` : `${studioBaseUrl}/course/${contextId}`;
   };


### PR DESCRIPTION
## Description

Fixes https://github.com/openedx/frontend-app-authoring/issues/1637 so that clicking editor toolbars doesn't try to close the modal.

Partially fixes https://github.com/openedx/frontend-app-authoring/issues/1636


Before:
![Screenshot](https://github.com/user-attachments/assets/b7981fdd-b794-420a-a106-d854f73516ea)


After:
![Screenshot](https://github.com/user-attachments/assets/ab8df1a9-508b-4f33-8847-95f5bc41e2f8)


## Supporting information

This "Insert" toolbar is shown in the "Expandable" text fields like Answer, Feedback, and Hint (all in the Problem editor), when you click on an empty line (or when the whole input is empty). Most people seemed fine with removing/shortening it, but I was asked on Slack to keep the "image" and "table" insertion tools. Which are also the ones in the [official plugin docs](https://www.tiny.cloud/docs/tinymce/latest/quickbars/) for this floating toolbar plugin.

## Testing instructions

Open a Problem component, both in a library and in a course. Set answers, feedback, and hints. Check that the formatting toolbars (bold/italic/etc. when you have text selected) and other editor modals (insert emoji, insert image, etc.) are clickable and working.

I also fixed a bug in the Studio header. Verify that clicking on the library name will take you back to the library home page:
![Screenshot 2025-02-04 at 10 00 08 AM](https://github.com/user-attachments/assets/42220e84-d43e-4f01-88fe-8133f64cf8a9)

Private ref: FAL-4037