### PR TITLE
fix: Height in Advanced Editor [FC-0076]

### DIFF
--- a/src/library-authoring/LibraryBlock/LibraryBlock.tsx
+++ b/src/library-authoring/LibraryBlock/LibraryBlock.tsx
@@ -28,7 +28,8 @@ export const LibraryBlock = ({
   view,
 }: LibraryBlockProps) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  const defaultiFrameHeight = view === 'studio_view' ? 80 : 50;
+  const xblockView = view ?? 'student_view';
+  const defaultiFrameHeight = xblockView === 'studio_view' ? 80 : 50;
 
   const [iFrameHeight, setIFrameHeight] = useState(defaultiFrameHeight);
   const studioBaseUrl = getConfig().STUDIO_BASE_URL;
@@ -78,8 +79,6 @@ export const LibraryBlock = ({
   }, []);
 
   const queryStr = version ? `?version=${version}` : '';
-
-  const xblockView = view ?? 'student_view';
 
   return (
     <div style={{

--- a/src/library-authoring/LibraryBlock/LibraryBlock.tsx
+++ b/src/library-authoring/LibraryBlock/LibraryBlock.tsx
@@ -28,7 +28,9 @@ export const LibraryBlock = ({
   view,
 }: LibraryBlockProps) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [iFrameHeight, setIFrameHeight] = useState(50);
+  const defaultiFrameHeight = view === 'studio_view' ? 80 : 50;
+
+  const [iFrameHeight, setIFrameHeight] = useState(defaultiFrameHeight);
   const studioBaseUrl = getConfig().STUDIO_BASE_URL;
 
   const intl = useIntl();


### PR DESCRIPTION
## Description

- Updates the height of the Advanced Editor.
- Which edX user roles will this change impact? "Course Author"

## Supporting information

- Related to https://github.com/openedx/edx-platform/pull/36221
- Internal ticket: [FAL-4040](https://tasks.opencraft.com/browse/FAL-4040)

## Testing instructions

- Go to a course. Go to Advanced settings
- Add the following in Advanced module list:

```
[
    "done",
    "google-calendar",
    "google-document",
    "pdf",
]
```

- Install the [PDF plugging](https://github.com/open-craft/xblock-pdf.git@v1.1.0#egg=xblock-pdf) 
- Create and copy a completion block 
- Go to the library home of a library. Paste the block.
- Open the Editor. Verify the style, and verify that the text does not overlap with the close button.
- Also verify that the editor has a good size.
- Also verify that the Save and Cancel buttons are on the right side.
- Also verify that the buttons are at the bottom of the modal.
- On the course unit, create and copy a PDF block.
- Go to the library and paste the block.
- Open the Editor. Verify the style of the Save and Cancel buttons.
- Also verify that the Save and Cancel buttons are on the right side.
- Also verify that the buttons are at the bottom of the modal.
- On the course unit, create and copy a Google Document block.
- Go to the library and paste the block.
- Open the Editor. Verify that the Save and Cancel buttons are on the right side and the bottom of the modal.

## Other information

N/A