### PR TITLE
fix: change ComponentPreview modal size to xl [FC-0076]

### DIFF
--- a/src/library-authoring/component-info/ComponentPreview.tsx
+++ b/src/library-authoring/component-info/ComponentPreview.tsx
@@ -24,6 +24,7 @@ const ModalComponentPreview = ({ isOpen, close, usageKey }: ModalComponentPrevie
       isOpen={isOpen}
       onClose={close}
       isOverflowVisible={false}
+      size="xl"
       className="component-preview-modal"
     >
       <LibraryBlock


### PR DESCRIPTION
## Description

This PR changes the `PreviewComponent` modal size from the default `"md"` to `"xl"`.

### Preview
![image](https://github.com/user-attachments/assets/e43b34f4-f73e-490c-aaad-d7ef82371fbf)

### After
![image](https://github.com/user-attachments/assets/c8e54e18-185e-423c-91bc-f7461a49dbff)


## Supporting information

Related to https://github.com/openedx/frontend-app-authoring/issues/1343

## Testing instructions

Open the component preview modal using the "Expand" button on the component sidebar and check the width before and after this PR.

**Settings**

```yaml
TUTOR_GROVE_ADDITIONAL_DOMAINS:
 - domain: meilisearch.{{ LMS_HOST }}
```

___
Private ref: [FAL-3991](https://tasks.opencraft.com/browse/FAL-3991)