### PR TITLE
fix: Adjust course import dropzone height to make course import status visible 

### DIFF
--- a/src/import-page/file-section/FileSection.jsx
+++ b/src/import-page/file-section/FileSection.jsx
@@ -43,6 +43,7 @@ const FileSection = ({ intl, courseId }) => {
               }
               accept={{ 'application/gzip': ['.tar.gz'] }}
               data-testid="dropzone"
+              style={{ height: '200px' }}
             />
           )}
       </Card.Section>


### PR DESCRIPTION
# Adjust course import dropzone height to make course import status visible 

## Description
This PR addresses the issue where the `Dropzone` component was too large, obstructing the view of the course import status. The height of the `Dropzone` has been adjusted to 200 pixels to ensure that users can see more information about the course import status while importing a course.

## Changes Made
- Adjusted the height of the `Dropzone` component to 200 pixels.

## Achievements
- **Improved Visibility**: Users can now see more information about the course import status while importing a course without scrolling.
- **Enhanced User Experience**: The reduced height of the `Dropzone` ensures that important information is not obstructed.

## Testing
- Our UI/UX team member ensured that the course import status is more visible during the import process.

![image](https://github.com/user-attachments/assets/2c631f02-2c25-4f20-a726-3454232f4301)


## Related Issues
- [Issue #1387](https://github.com/openedx/frontend-app-authoring/issues/1387): Course Import - Upload widget hides the import success message

## Additional Notes
- Ensure that the reduced height of the `Dropzone` does not affect other functionalities or components on the page.