### PR TITLE
fix: render proper visibility message on self-paced course type

### DIFF
--- a/src/generic/configure-modal/ConfigureModal.jsx
+++ b/src/generic/configure-modal/ConfigureModal.jsx
@@ -224,6 +224,7 @@ const ConfigureModal = ({
                 category={category}
                 isSubsection={isSubsection}
                 showWarning={visibilityState === VisibilityTypes.STAFF_ONLY}
+                isSelfPaced={isSelfPaced}
               />
             </Tab>
             <Tab eventKey="advanced" title={intl.formatMessage(messages.advancedTabTitle)}>

--- a/src/generic/configure-modal/VisibilityTab.jsx
+++ b/src/generic/configure-modal/VisibilityTab.jsx
@@ -11,6 +11,7 @@ const VisibilityTab = ({
   category,
   showWarning,
   isSubsection,
+  isSelfPaced,
 }) => {
   const intl = useIntl();
   const visibilityTitle = COURSE_BLOCK_NAMES[category]?.name;
@@ -53,6 +54,13 @@ const VisibilityTab = ({
     setFieldValue('showCorrectness', e.target.value);
   };
 
+  const hideDueMessage = {
+    hideContentLabel: isSelfPaced ? messages.hideContentAfterEnd : messages.hideContentAfterDue,
+    hideContentDescription: (
+      isSelfPaced ? messages.hideContentAfterEndDescription : messages.hideContentAfterDueDescription
+    ),
+  };
+
   return (
     <>
       <h5 className="mt-4 text-gray-700">
@@ -72,9 +80,10 @@ const VisibilityTab = ({
               </Form.Radio>
               <Form.Text><FormattedMessage {...messages.showEntireSubsectionDescription} /></Form.Text>
               <Form.Radio value="hideDue">
-                <FormattedMessage {...messages.hideContentAfterDue} />
+                <FormattedMessage {...hideDueMessage.hideContentLabel} />
               </Form.Radio>
-              <Form.Text><FormattedMessage {...messages.hideContentAfterDueDescription} /></Form.Text>
+              <Form.Text><FormattedMessage {...hideDueMessage.hideContentDescription} />
+              </Form.Text>
               <Form.Radio value="hide">
                 <FormattedMessage {...messages.hideEntireSubsection} />
               </Form.Radio>
@@ -130,6 +139,11 @@ VisibilityTab.propTypes = {
   category: PropTypes.string.isRequired,
   showWarning: PropTypes.bool.isRequired,
   isSubsection: PropTypes.bool.isRequired,
+  isSelfPaced: PropTypes.bool,
+};
+
+VisibilityTab.defaultProps = {
+  isSelfPaced: false,
 };
 
 export default injectIntl(VisibilityTab);

--- a/src/generic/configure-modal/messages.js
+++ b/src/generic/configure-modal/messages.js
@@ -143,6 +143,14 @@ const messages = defineMessages({
     id: 'course-authoring.course-outline.configure-modal.visibility-tab.hide-content-after-due-description',
     defaultMessage: 'After the subsection\'s due date has passed, learners can no longer access its content. The subsection is not included in grade calculations.',
   },
+  hideContentAfterEnd: {
+    id: 'course-authoring.course-outline.configure-modal.visibility-tab.hide-content-after-end',
+    defaultMessage: 'Hide content after end date',
+  },
+  hideContentAfterEndDescription: {
+    id: 'course-authoring.course-outline.configure-modal.visibility-tab.hide-content-after-end-description',
+    defaultMessage: 'After the course\'s end date has passed, learners can no longer access its content. The subsection is not included in grade calculations.',
+  },
   hideEntireSubsection: {
     id: 'course-authoring.course-outline.configure-modal.visibility-tab.hide-entire-subsection',
     defaultMessage: 'Hide entire subsection',


### PR DESCRIPTION
## Description

This PR fixes the message displayed in the `Subsection visibility` section of the `Configure` modal within the studio Course Outline when a course is either `isSelfPaced` or not.

## Supporting information

- https://github.com/openedx/frontend-app-authoring/issues/1020
- https://github.com/eduNEXT/consulting-issues-mapping/issues/156

## Testing instructions

- Mount this MFE using this PR's branch
- Access to a course in the Studio
- Go to `Schedule & details`, change the date to a future date, and test changing `Course Pacing` among the two options
- After changing the `Course Pacing` go to the outline, click the three dots of a subsection, click in `Configure` and then in `Visibility`
- You should watch:
``` MD
# `Course Pacing` equal to `Self-Paced`
`Hide content after end date
After the course's end date has passed, learners can no longer access its content. The subsection is not included in grade calculations.`

# `Course Pacing` equal to `Instructor-Paced`
`Hide content after due date
After the subsection's due date has passed, learners can no longer access its content. The subsection is not included in grade calculations.`
```

## Screenshots

![instructor_paced](https://github.com/user-attachments/assets/9547cdef-0c8e-4ab9-b743-3c3a5137f101)
![self-paced](https://github.com/user-attachments/assets/f0db6410-c5a5-496a-9301-55511d3d6a16)

