### PR TITLE
[TNL-11886] Fix: Resolve Course Optimizer Scanning Bug

### DIFF
--- a/src/optimizer-page/data/constants.ts
+++ b/src/optimizer-page/data/constants.ts
@@ -2,7 +2,7 @@ export const LAST_EXPORT_COOKIE_NAME = 'lastexport';
 export const LINK_CHECK_STATUSES = {
   UNINITIATED: 'Uninitiated',
   PENDING: 'Pending',
-  IN_PROGRESS: 'In-Progress',
+  IN_PROGRESS: 'In Progress',
   SUCCEEDED: 'Succeeded',
   FAILED: 'Failed',
   CANCELED: 'Canceled',
@@ -11,7 +11,7 @@ export const LINK_CHECK_STATUSES = {
 export enum LinkCheckStatusTypes {
   UNINITIATED = 'Uninitiated',
   PENDING = 'Pending',
-  IN_PROGRESS = 'In-Progress',
+  IN_PROGRESS = 'In Progress',
   SUCCEEDED = 'Succeeded',
   FAILED = 'Failed',
   CANCELED = 'Canceled',


### PR DESCRIPTION
- [TNL-11886](https://2u-internal.atlassian.net/browse/TNL-11886)

- Corrected LINK_CHECK_STATUSES.IN_PROGRESS value that is sent by backend. As aligned with backend, it should be [this](https://github.com/openedx/django-user-tasks/blob/13182d5ff3c6165f7f3e7955c58cdfdd7e2d6444/user_tasks/models.py#L43).