### PR TITLE
refactor: Update message for Scan completion in Course Optimizer page

### DIFF
--- a/src/optimizer-page/messages.js
+++ b/src/optimizer-page/messages.js
@@ -15,7 +15,7 @@ const messages = defineMessages({
   },
   description1: {
     id: 'course-authoring.course-optimizer.description1',
-    defaultMessage: `This tool will scan your the published version of your course for broken links.
+    defaultMessage: `This tool will scan the published version of your course for broken links.
     Unpublished changes will not be included in the scan.
     Note that this process will take more time for larger courses.
     To update the scan after you have published new changes to your course,


### PR DESCRIPTION
### [TNL-11884](https://2u-internal.atlassian.net/browse/TNL-11884)

### Description

Update display string for Course Optimizer Scanning Step


#### Before

<img width="1150" alt="Screenshot 2025-02-06 at 5 40 02 PM" src="https://github.com/user-attachments/assets/f7edbbc9-9ae7-4f7a-850a-fb72c55c5023" />

#### After


![Screenshot 2025-02-19 at 7 00 40 PM](https://github.com/user-attachments/assets/ab804d5e-48c8-4590-a47d-792b78d5e6f3)
