### PR TITLE
feat: Add cancel confirmation modal to Advanced editors in libraries [FC-0076]

### DIFF
--- a/src/editors/AdvancedEditor.test.tsx
+++ b/src/editors/AdvancedEditor.test.tsx
@@ -4,6 +4,9 @@ import {
   render,
   initializeMocks,
   waitFor,
+  screen,
+  act,
+  fireEvent,
 } from '../testUtils';
 import AdvancedEditor from './AdvancedEditor';
 
@@ -17,7 +20,7 @@ describe('AdvancedEditor', () => {
     initializeMocks();
   });
 
-  it('should call onClose when receiving "cancel-clicked" message', () => {
+  it('should call onClose when receiving "cancel-clicked" message', async () => {
     render(<AdvancedEditor usageKey="test" onClose={onCloseMock} />);
 
     const messageEvent = new MessageEvent('message', {
@@ -28,8 +31,17 @@ describe('AdvancedEditor', () => {
       origin: getConfig().STUDIO_BASE_URL,
     });
 
-    window.dispatchEvent(messageEvent);
+    act(() => {
+      // Send cancel event
+      window.dispatchEvent(messageEvent);
+    });
 
+    // Expect open cancel confimation modal
+    expect(await screen.findByText(/Are you sure you want to exit the editor/)).toBeInTheDocument();
+    // Click on "OK"
+    const confirmButton = await screen.findByRole('button', { name: 'OK' });
+    fireEvent.click(confirmButton);
+    // Should call `onClose`
     expect(onCloseMock).toHaveBeenCalled();
   });
 

--- a/src/editors/containers/EditorContainer/components/CancelConfirmModal.tsx
+++ b/src/editors/containers/EditorContainer/components/CancelConfirmModal.tsx
@@ -21,11 +21,7 @@ const CancelConfirmModal = ({
       confirmAction={(
         <Button
           variant="primary"
-          onClick={() => {
-            if (onCloseEditor) {
-              onCloseEditor();
-            }
-          }}
+          onClick={() => onCloseEditor?.()}
         >
           <FormattedMessage {...messages.okButtonLabel} />
         </Button>

--- a/src/editors/containers/EditorContainer/components/CancelConfirmModal.tsx
+++ b/src/editors/containers/EditorContainer/components/CancelConfirmModal.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@openedx/paragon';
+import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
+import BaseModal from '../../../sharedComponents/BaseModal';
+import messages from '../messages';
+
+interface CancelConfirmModalProps {
+  isOpen: boolean,
+  closeCancelConfirmModal: () => void,
+  onCloseEditor: (() => void) | null,
+}
+
+const CancelConfirmModal = ({
+  isOpen,
+  closeCancelConfirmModal,
+  onCloseEditor,
+}: CancelConfirmModalProps) => {
+  const intl = useIntl();
+  return (
+    <BaseModal
+      size="md"
+      confirmAction={(
+        <Button
+          variant="primary"
+          onClick={() => {
+            if (onCloseEditor) {
+              onCloseEditor();
+            }
+          }}
+        >
+          <FormattedMessage {...messages.okButtonLabel} />
+        </Button>
+      )}
+      isOpen={isOpen}
+      close={closeCancelConfirmModal}
+      title={intl.formatMessage(messages.cancelConfirmTitle)}
+    >
+      <FormattedMessage {...messages.cancelConfirmDescription} />
+    </BaseModal>
+  );
+};
+
+export default CancelConfirmModal;

--- a/src/editors/containers/EditorContainer/index.tsx
+++ b/src/editors/containers/EditorContainer/index.tsx
@@ -15,12 +15,12 @@ import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import { EditorComponent } from '../../EditorComponent';
 import { useEditorContext } from '../../EditorContext';
-import BaseModal from '../../sharedComponents/BaseModal';
 import TitleHeader from './components/TitleHeader';
 import * as hooks from './hooks';
 import messages from './messages';
 import './index.scss';
 import usePromptIfDirty from '../../../generic/promptIfDirty/usePromptIfDirty';
+import CancelConfirmModal from './components/CancelConfirmModal';
 
 interface WrapperProps {
   children: React.ReactNode;
@@ -118,29 +118,16 @@ const EditorContainer: React.FC<Props> = ({
           <FormattedMessage {...messages.contentSaveFailed} />
         </Toast>
       )}
-      <BaseModal
-        size="md"
-        confirmAction={(
-          <Button
-            variant="primary"
-            onClick={() => {
-              handleCancel();
-              if (returnFunction) {
-                closeCancelConfirmModal();
-              }
-            }}
-          >
-            <FormattedMessage {...messages.okButtonLabel} />
-          </Button>
-        )}
+      <CancelConfirmModal
         isOpen={isCancelConfirmOpen}
-        close={() => {
-          closeCancelConfirmModal();
+        closeCancelConfirmModal={closeCancelConfirmModal}
+        onCloseEditor={() => {
+          handleCancel();
+          if (returnFunction) {
+            closeCancelConfirmModal();
+          }
         }}
-        title={intl.formatMessage(messages.cancelConfirmTitle)}
-      >
-        <FormattedMessage {...messages.cancelConfirmDescription} />
-      </BaseModal>
+      />
       <ModalDialog.Header className="shadow-sm zindex-10">
         <div className="d-flex flex-row justify-content-between">
           <h2 className="h3 col pl-0">


### PR DESCRIPTION
## Description

- Extracts the cancel confirmation modal as a new component.
- Adds the cancel confirmation modal to the Advanced editors in libraries.
- Which edX user roles will this change impact? Common user roles are "Course Author"

![image](https://github.com/user-attachments/assets/0bd5db7c-e02b-491b-b71e-6904b693de02)


## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/1669
- Internal ticket: [FAL-4091](https://tasks.opencraft.com/browse/FAL-4091)

## Testing instructions

- Go to the library home of a library.
- Create a new Drag an drop block.
- Open the editor.
- Click on cancel or outside of the modal. Verify that the cancel confirmation modals appear.
- Follow the testing instructions of https://github.com/openedx/frontend-app-authoring/pull/1649#issue-2831593180 to enable more blocks to tests.


## Other information

N/A