### PR TITLE
[sumac] fix: bugs with ExpandableTextArea toolbars & modals in problem editor [FC-0076]

### DIFF
--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -148,6 +148,40 @@ export const getImageResizeHandler = ({ editor, imagesRef, setImage }) => () => 
   });
 };
 
+/**
+ * Fix TinyMCE editors used in Paragon modals, by re-parenting their modal <div>
+ * from the body to the Paragon modal container.
+ *
+ * This fixes a problem where clicking on any modal/popup within TinyMCE (e.g.
+ * the emoji inserter, the link inserter, the floating format toolbar -
+ * quickbars, etc.) would cause the parent Paragon modal to close, because
+ * Paragon sees it as a "click outside" event. Also fixes some hover effects by
+ * ensuring the layering of the divs is correct.
+ *
+ * This could potentially cause problems if there are TinyMCE editors being used
+ * both on the parent page and inside a Paragon modal popup, but I don't think
+ * we have that situation.
+ *
+ * Note: we can't just do this on init, because the quickbars plugin used by
+ * ExpandableTextEditors creates its modal DIVs later. Ideally we could listen
+ * for some kind of "modal open" event, but I haven't been able to find anything
+ * like that so for now we do this quite frequently, every time there is a
+ * "selectionchange" event (which is pretty often).
+ */
+export const reparentTinyMceModals = /* istanbul ignore next */ () => {
+  const modalLayer = document.querySelector('.pgn__modal-layer');
+  if (!modalLayer) {
+    return;
+  }
+  const tinymceAuxDivs = document.querySelectorAll('.tox.tox-tinymce-aux');
+  for (const tinymceAux of tinymceAuxDivs) {
+    if (tinymceAux.parentElement !== modalLayer) {
+      // Move this tinyMCE modal div into the paragon modal layer.
+      modalLayer.appendChild(tinymceAux);
+    }
+  }
+};
+
 export const setupCustomBehavior = ({
   updateContent,
   openImgModal,
@@ -221,30 +255,17 @@ export const setupCustomBehavior = ({
   }
 
   editor.on('init', /* istanbul ignore next */ () => {
-    // Moving TinyMce aux modal inside the Editor modal
-    // if the editor is on modal mode.
-    // This is to avoid issues using the aux modal:
-    // * Avoid close aux modal when clicking the content inside.
-    // * When the user opens the `Edit Source Code` modal, this adds `data-focus-on-hidden`
-    //   to the TinyMce aux modal, making it unusable.
-    const modalLayer = document.querySelector('.pgn__modal-layer');
-    const tinymceAux = document.querySelector('.tox.tox-tinymce-aux');
-
-    if (modalLayer && tinymceAux) {
-      modalLayer.appendChild(tinymceAux);
+    // Check if this editor is inside a (Paragon) modal.
+    // The way we get the editor's root <div> depends on whether or not this particular editor is using an iframe:
+    const editorDiv = editor.bodyElement ?? editor.container;
+    if (editorDiv?.closest('.pgn__modal')) {
+      // This editor is inside a Paragon modal. Use this hack to avoid interference with TinyMCE's own modal popups:
+      reparentTinyMceModals();
+      editor.on('selectionchange', reparentTinyMceModals);
     }
   });
 
   editor.on('ExecCommand', /* istanbul ignore next */ (e) => {
-    // Remove `data-focus-on-hidden` and `aria-hidden` on TinyMce aux modal used on emoticons, formulas, etc.
-    // When using the Editor in modal mode, it may happen that the editor modal is rendered
-    // before the TinyMce aux modal, which adds these attributes, making the TinyMce aux modal unusable.
-    const modalElement = document.querySelector('.tox.tox-silver-sink.tox-tinymce-aux');
-    if (modalElement) {
-      modalElement.removeAttribute('data-focus-on-hidden');
-      modalElement.removeAttribute('aria-hidden');
-    }
-
     if (editorType === 'text' && e.command === 'mceFocus') {
       const initialContent = editor.getContent();
       const newContent = module.replaceStaticWithAsset({

--- a/src/editors/sharedComponents/TinyMceWidget/pluginConfig.js
+++ b/src/editors/sharedComponents/TinyMceWidget/pluginConfig.js
@@ -64,16 +64,9 @@ const pluginConfig = ({ isLibrary, placeholder, editorType }) => {
         [editImageSettings],
       ]),
       quickbarsInsertToolbar: toolbar ? false : mapToolbars([
-        [buttons.undo, buttons.redo],
-        [buttons.formatSelect],
-        [buttons.bold, buttons.italic, buttons.underline, buttons.foreColor],
-        [
-          buttons.align.justify,
-          buttons.bullist,
-          buttons.numlist,
-        ],
-        [imageUploadButton, buttons.blockQuote, buttons.codeBlock],
-        [buttons.table, buttons.emoticons, buttons.charmap, buttons.removeFormat, buttons.a11ycheck],
+        // To keep from blocking the whole text input field when it's empty, this "insert" toolbar
+        // used with ExpandableTextArea is kept as minimal as we can.
+        [imageUploadButton, buttons.table],
       ]),
       quickbarsSelectionToolbar: toolbar ? false : mapToolbars([
         [buttons.undo, buttons.redo],


### PR DESCRIPTION
## Description

Backports the bugfixes from https://github.com/openedx/frontend-app-authoring/pull/1646 to Sumac.

## Supporting information

* Backports fixes for https://github.com/openedx/frontend-app-authoring/issues/1637 + 
  https://github.com/openedx/frontend-app-authoring/issues/1636
* Private-ref: [FAL-4085](https://tasks.opencraft.com/browse/FAL-4085)

## Testing instructions

* Run this branch in your sumac tutor devstack.
* Follow instructions on https://github.com/openedx/frontend-app-authoring/pull/1646 to test these changes.
  See notes below.

## Other information
1. [Sumac doesn't support adding images to content library blocks](https://github.com/openedx/frontend-app-authoring/blob/open-release/sumac.master/src/editors/sharedComponents/TinyMceWidget/pluginConfig.js#L9), and so the tinymce `image` button will not show in any of the editors.
   Partial support for library block assets is in Sumac, but adding full support requires backporting these feature PRs: https://github.com/openedx/frontend-app-authoring/pull/1458, https://github.com/openedx/frontend-app-authoring/pull/1516, https://github.com/openedx/frontend-app-authoring/pull/1527 (and more)
2. The library header bug [fixed here](https://github.com/openedx/frontend-app-authoring/pull/1646/files#diff-1c1e7c5912d6ff798a72899cde884c54211549e22fec1f469c8a5a4a854819e1) was not needed for Sumac, so this change was omitted from this PR.