### PR TITLE
fix: Upgrade header, temporarily re-introducing Maintenance link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@edx/browserslist-config": "1.2.0",
         "@edx/frontend-component-footer": "^14.1.0",
-        "@edx/frontend-component-header": "^5.8.0",
+        "@edx/frontend-component-header": "^5.8.3",
         "@edx/frontend-enterprise-hotjar": "^2.0.0",
         "@edx/frontend-platform": "^8.0.3",
         "@edx/openedx-atlas": "^0.6.0",
@@ -2175,9 +2175,9 @@
       }
     },
     "node_modules/@edx/frontend-component-header": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-5.8.0.tgz",
-      "integrity": "sha512-AgLgt1y5vrqx6cU3IDr7HKngJImTN48gCIaXdCQ4YhR4PpX3p+ZS9R5Ih0dapWtvnX0Oo2hT2ggUKORV0h90rw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-5.8.3.tgz",
+      "integrity": "sha512-cPenGEirOE7sQwyjakK9Vy/oyvBy4gzhCkf5pxiYYuOhTe0uK/iLnnThJh7R0XdkGdxMMOvUBJVmV4TGC1BHJQ==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "6.6.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
     "@edx/browserslist-config": "1.2.0",
     "@edx/frontend-component-footer": "^14.1.0",
-    "@edx/frontend-component-header": "^5.8.0",
+    "@edx/frontend-component-header": "^5.8.3",
     "@edx/frontend-enterprise-hotjar": "^2.0.0",
     "@edx/frontend-platform": "^8.0.3",
     "@edx/openedx-atlas": "^0.6.0",


### PR DESCRIPTION
## Description

We are temporarily re-introducing the Maintenance link, as the Maintenance Announcements tool is still in use, as discussed on: openedx/edx-platform#35852

There are no other significant changes in this version bump: https://github.com/openedx/frontend-component-header/compare/v5.8.0...v5.8.3

## Supporting information

![image](https://github.com/user-attachments/assets/97cf5b2b-dc4e-49eb-b7ba-bb494d2ad72b)

## Other information

Related PRs:
* https://github.com/openedx/frontend-component-header/pull/565
* https://github.com/openedx/edx-platform/pull/36107

This will be reversed (that is: we will re-remove the Maintenance link) before Ulmo, via:
* https://github.com/openedx/edx-platform/issues/36263