### PR TITLE
refactor: Separate Publish order sort from publish filter [FC-0076]

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.test.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.test.tsx
@@ -341,7 +341,7 @@ describe('<LibraryAuthoringPage />', () => {
     await testSortOption('Newest', 'created:desc', false);
     await testSortOption('Oldest', 'created:asc', false);
 
-    // Sorting by Recently Published also excludes unpublished components
+    // Sorting by Recently Published also sorts unpublished components by recently modified
     await testSortOption('Recently Published', ['last_published:desc', 'modified:desc'], false);
 
     // Re-selecting the previous sort option resets sort to default "Recently Modified"

--- a/src/library-authoring/LibraryAuthoringPage.test.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.test.tsx
@@ -311,8 +311,13 @@ describe('<LibraryAuthoringPage />', () => {
       expect(options.length).toBeGreaterThan(0);
       fireEvent.click(options[options.length - 1]);
 
+      let bodyText;
       // Did the search happen with the expected sort option?
-      const bodyText = sortBy ? `"sort":["${sortBy}"]` : '"sort":[]';
+      if (Array.isArray(sortBy)) {
+        bodyText = `"sort":[${sortBy.map(item => `"${item}"`).join(',')}]`;
+      } else {
+        bodyText = sortBy ? `"sort":["${sortBy}"]` : '"sort":[]';
+      }
       await waitFor(() => {
         expect(fetchMock).toHaveBeenLastCalledWith(searchEndpoint, {
           body: expect.stringContaining(bodyText),
@@ -337,14 +342,7 @@ describe('<LibraryAuthoringPage />', () => {
     await testSortOption('Oldest', 'created:asc', false);
 
     // Sorting by Recently Published also excludes unpublished components
-    await testSortOption('Recently Published', 'last_published:desc', false);
-    await waitFor(() => {
-      expect(fetchMock).toHaveBeenLastCalledWith(searchEndpoint, {
-        body: expect.stringContaining('last_published IS NOT NULL'),
-        method: 'POST',
-        headers: expect.anything(),
-      });
-    });
+    await testSortOption('Recently Published', ['last_published:desc', 'modified:desc'], false);
 
     // Re-selecting the previous sort option resets sort to default "Recently Modified"
     await testSortOption('Recently Published', 'modified:desc', true);

--- a/src/library-authoring/collections/LibraryCollectionPage.test.tsx
+++ b/src/library-authoring/collections/LibraryCollectionPage.test.tsx
@@ -268,8 +268,13 @@ describe('<LibraryCollectionPage />', () => {
       expect(options.length).toBeGreaterThan(0);
       fireEvent.click(options[options.length - 1]);
 
+      let bodyText;
       // Did the search happen with the expected sort option?
-      const bodyText = sortBy ? `"sort":["${sortBy}"]` : '"sort":[]';
+      if (Array.isArray(sortBy)) {
+        bodyText = `"sort":[${sortBy.map(item => `"${item}"`).join(',')}]`;
+      } else {
+        bodyText = sortBy ? `"sort":["${sortBy}"]` : '"sort":[]';
+      }
       await waitFor(() => {
         expect(fetchMock).toHaveBeenLastCalledWith(searchEndpoint, {
           body: expect.stringContaining(bodyText),
@@ -293,15 +298,8 @@ describe('<LibraryCollectionPage />', () => {
     await testSortOption('Newest', 'created:desc', false);
     await testSortOption('Oldest', 'created:asc', false);
 
-    // Sorting by Recently Published also excludes unpublished components
-    await testSortOption('Recently Published', 'last_published:desc', false);
-    await waitFor(() => {
-      expect(fetchMock).toHaveBeenLastCalledWith(searchEndpoint, {
-        body: expect.stringContaining('last_published IS NOT NULL'),
-        method: 'POST',
-        headers: expect.anything(),
-      });
-    });
+    // Sorting by Recently Published also sorts unpublished components by recently modified
+    await testSortOption('Recently Published', ['last_published:desc', 'modified:desc'], false);
 
     // Re-selecting the previous sort option resets sort to default "Recently Modified"
     await testSortOption('Recently Published', 'modified:desc', true);

--- a/src/search-manager/FilterByPublished.tsx
+++ b/src/search-manager/FilterByPublished.tsx
@@ -10,33 +10,22 @@ import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import messages from './messages';
 import SearchFilterWidget from './SearchFilterWidget';
 import { useSearchContext } from './SearchManager';
-import { PublishStatus, SearchSortOption } from './data/api';
+import { PublishStatus } from './data/api';
 
 /**
  * A button with a dropdown that allows filtering the current search by publish status
  */
 const FilterByPublished: React.FC<Record<never, never>> = () => {
-  const [onlyPublished, setOnlyPublished] = React.useState(false);
   const intl = useIntl();
   const {
     publishStatus,
     publishStatusFilter,
     setPublishStatusFilter,
-    searchSortOrder,
   } = useSearchContext();
 
   const clearFilters = React.useCallback(() => {
     setPublishStatusFilter([]);
   }, []);
-
-  React.useEffect(() => {
-    if (searchSortOrder === SearchSortOption.RECENTLY_PUBLISHED) {
-      setPublishStatusFilter([PublishStatus.Published, PublishStatus.Modified]);
-      setOnlyPublished(true);
-    } else {
-      setOnlyPublished(false);
-    }
-  }, [searchSortOrder]);
 
   const toggleFilterMode = React.useCallback((mode: PublishStatus) => {
     setPublishStatusFilter(oldList => {
@@ -90,7 +79,6 @@ const FilterByPublished: React.FC<Record<never, never>> = () => {
               as={Form.Checkbox}
               value={PublishStatus.NeverPublished}
               onChange={() => { toggleFilterMode(PublishStatus.NeverPublished); }}
-              disabled={onlyPublished}
             >
               <div>
                 {intl.formatMessage(messages.publishStatusNeverPublished)}

--- a/src/search-manager/SearchManager.ts
+++ b/src/search-manager/SearchManager.ts
@@ -149,10 +149,13 @@ export const SearchContextProvider: React.FC<{
   // SearchSortOption.RELEVANCE is special, it means "no custom sorting", so we
   // send it to useContentSearchResults as an empty array.
   const searchSortOrderToUse = overrideSearchSortOrder ?? searchSortOrder;
-  const sort: SearchSortOption[] = (searchSortOrderToUse === SearchSortOption.RELEVANCE ? [] : [searchSortOrderToUse]);
-  // Selecting SearchSortOption.RECENTLY_PUBLISHED also excludes unpublished components.
+  let sort: SearchSortOption[] = (searchSortOrderToUse === SearchSortOption.RELEVANCE ? [] : [searchSortOrderToUse]);
+  // Adding `SearchSortOption.RECENTLY_MODIFIED` as second sort when
+  // selecting `SearchSortOption.RECENTLY_PUBLISHED`.
+  // This is to sort the never published components by recently modified that
+  // appears in the end after all published components.
   if (searchSortOrderToUse === SearchSortOption.RECENTLY_PUBLISHED) {
-    extraFilter = union(extraFilter, ['last_published IS NOT NULL']);
+    sort = union(sort, [SearchSortOption.RECENTLY_MODIFIED]);
   }
 
   const canClearFilters = (


### PR DESCRIPTION
## Description

This is a fix for https://github.com/openedx/frontend-app-authoring/issues/1484#issuecomment-2654634014
- Which edX user roles will this change impact? Common user roles are "Course Author".

## Supporting information

GitHub issue: https://github.com/openedx/frontend-app-authoring/issues/1484
Internal link: [FAL-4100](https://tasks.opencraft.com/browse/FAL-4100)

## Testing instructions

- Go to the library home of a library
- Create two components and publish both (published)
- Create two components and publish both and make changes to both (published with changes)
- Create four components, avoid publishing (never published)
- Change `Sory By` to `Recently Published`. 
- Verify that the `Publish status` filter doesn't change.
- Verify that the published and published with changes components are ordered by published date. Verify that the never-published components are at the end of the list and are ordered by `recently modified`

## Other information

N/A