### PR TITLE
feat: Show never published as disabled in library component picker [FC-0076]

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -140,7 +140,6 @@ const LibraryAuthoringPage = ({ returnToLibrarySelection }: LibraryAuthoringPage
     libraryId,
     libraryData,
     isLoadingLibraryData,
-    showOnlyPublished,
     componentId,
     collectionId,
   } = useLibraryContext();
@@ -210,9 +209,6 @@ const LibraryAuthoringPage = ({ returnToLibrarySelection }: LibraryAuthoringPage
   ) : undefined;
 
   const extraFilter = [`context_key = "${libraryId}"`];
-  if (showOnlyPublished) {
-    extraFilter.push('last_published IS NOT NULL');
-  }
 
   const activeTypeFilters = {
     components: 'NOT type = "collection"',

--- a/src/library-authoring/__mocks__/library-search.json
+++ b/src/library-authoring/__mocks__/library-search.json
@@ -22,6 +22,7 @@
           "created": 1721857069.042984,
           "modified": 1725878053.420395,
           "last_published": 1725035862.450613,
+          "publish_status": "published",
           "usage_key": "lb:Axim:TEST:html:571fe018-f3ce-45c9-8f53-5dafcb422fdd",
           "block_type": "html",
           "context_key": "lib:Axim:TEST",
@@ -241,6 +242,7 @@
           "created": 1724879593.066427,
           "modified": 1725034981.663482,
           "last_published": 1725035862.450613,
+          "publish_status": "published",
           "usage_key": "lb:Axim:TEST:html:73a22298-bcd9-4f4c-ae34-0bc2b0612480",
           "block_type": "html",
           "context_key": "lib:Axim:TEST",
@@ -268,6 +270,7 @@
           "created": 1721857034.455737,
           "modified": 1722551300.377488,
           "last_published": 1724879092.002222,
+          "publish_status": "published",
           "usage_key": "lb:Axim:TEST:html:be5b5db9-26ba-4fac-86af-654538c70b5e",
           "block_type": "html",
           "context_key": "lib:Axim:TEST",
@@ -295,6 +298,7 @@
           "created": 1720774228.49832,
           "modified": 1720774228.49832,
           "last_published": 1724879092.002222,
+          "publish_status": "published",
           "usage_key": "lb:Axim:TEST:html:e59e8c73-4056-4894-bca4-062781fb3f68",
           "block_type": "html",
           "context_key": "lib:Axim:TEST",
@@ -322,6 +326,7 @@
           "created": 1724725821.973896,
           "modified": 1724725821.973896,
           "last_published": 1724879092.002222,
+          "publish_status": "published",
           "usage_key": "lb:Axim:TEST:problem:f16116c9-516e-4bb9-b99e-103599f62417",
           "block_type": "problem",
           "context_key": "lib:Axim:TEST",
@@ -352,6 +357,7 @@
           "created": 1720774232.76135,
           "modified": 1720774232.76135,
           "last_published": 1724879092.002222,
+          "publish_status": "published",
           "usage_key": "lb:Axim:TEST:problem:2ace6b9b-6620-413c-a66f-19c797527f34",
           "block_type": "problem",
           "context_key": "lib:Axim:TEST",
@@ -382,6 +388,7 @@
           "created": 1720774232.76135,
           "modified": 1720774232.76135,
           "last_published": 1724879092.002222,
+          "publish_status": "published",
           "usage_key": "lb:Axim:TEST:problem:7d7e98ba-3ac9-4aa8-8946-159129b39a28",
           "block_type": "problem",
           "context_key": "lib:Axim:TEST",
@@ -412,6 +419,7 @@
           "created": 1720774232.76135,
           "modified": 1720774232.76135,
           "last_published": 1724879092.002222,
+          "publish_status": "published",
           "usage_key": "lb:Axim:TEST:problem:4e1a72f9-ac93-42aa-a61c-ab5f9698c398",
           "block_type": "problem",
           "context_key": "lib:Axim:TEST",
@@ -442,6 +450,7 @@
           "created": 1720774232.76135,
           "modified": 1720774232.76135,
           "last_published": 1724879092.002222,
+          "publish_status": "published",
           "usage_key": "lb:Axim:TEST:problem:ad483625-ade2-4712-88d8-c9743abbd291",
           "block_type": "problem",
           "context_key": "lib:Axim:TEST",
@@ -472,6 +481,7 @@
           "created": 1720774232.76135,
           "modified": 1720774232.76135,
           "last_published": 1724879092.002222,
+          "publish_status": "published",
           "usage_key": "lb:Axim:TEST:problem:b4c859cb-de70-421a-917b-e6e01ce44bd8",
           "block_type": "problem",
           "context_key": "lib:Axim:TEST",
@@ -481,6 +491,30 @@
             "display_name": "String Response Problem",
             "description": "Problem"
           }
+        },
+        {
+          "id": "lbaximtesthtml571fe018-f3ce-45c9-8f53-5dafcb422fdv-273ebd51",
+          "display_name": "Never published component",
+          "block_id": "571fe018-f3ce-45c9-8f53-5dafcb422fdv",
+          "content": {
+            "html_content": "This is a text component which uses HTML."
+          },
+          "tags": {},
+          "type": "library_block",
+          "breadcrumbs": [
+            {
+              "display_name": "Test Library"
+            }
+          ],
+          "created": 1721857069.042984,
+          "modified": 1725878053.420395,
+          "last_published": null,
+          "publish_status": "never",
+          "usage_key": "lb:Axim:TEST:html:571fe018-f3ce-45c9-8f53-5dafcb422fdv",
+          "block_type": "html",
+          "context_key": "lib:Axim:TEST",
+          "org": "Axim",
+          "access_id": 15
         }
       ],
       "query": "",

--- a/src/library-authoring/component-picker/ComponentPicker.test.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.test.tsx
@@ -274,6 +274,6 @@ describe('<ComponentPicker />', () => {
     fireEvent.click(screen.getByDisplayValue(/lib:sampletaxonomyorg1:tl1/i));
 
     // Wait for the content library to load
-    await screen.findByText(/Only published content is visible and available for reuse./i);
+    await screen.findByText(/Only published content is available for reuse./i);
   });
 });

--- a/src/library-authoring/component-picker/ComponentPicker.test.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.test.tsx
@@ -276,4 +276,18 @@ describe('<ComponentPicker />', () => {
     // Wait for the content library to load
     await screen.findByText(/Only published content is available for reuse./i);
   });
+
+  it('should render never published components as disabled', async () => {
+    render(<ComponentPicker />);
+
+    expect(await screen.findByText('Test Library 1')).toBeInTheDocument();
+    fireEvent.click(screen.getByDisplayValue(/lib:sampletaxonomyorg1:tl1/i));
+
+    // Wait for the content library to load
+    await screen.findByText(/Change Library/i);
+    expect(await screen.findByText('Test Library 1')).toBeInTheDocument();
+
+    // Verify that render the never published component as disabled
+    expect(await screen.findByTestId('card-disabled')).toBeInTheDocument();
+  });
 });

--- a/src/library-authoring/component-picker/messages.ts
+++ b/src/library-authoring/component-picker/messages.ts
@@ -44,7 +44,7 @@ const messages = defineMessages({
   },
   pickerInfoBanner: {
     id: 'course-authoring.library-authoring.pick-components.component-picker.information-alert',
-    defaultMessage: 'Only published content is visible and available for reuse.',
+    defaultMessage: 'Only published content is available for reuse.',
     description: 'The alert text on top of component-picker if only published content is visible.',
   },
 });

--- a/src/library-authoring/components/BaseComponentCard.tsx
+++ b/src/library-authoring/components/BaseComponentCard.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import classNames from 'classnames';
 import {
   Badge,
   Card,
@@ -20,6 +21,7 @@ type BaseComponentCardProps = {
   tags: ContentHitTags;
   actions: React.ReactNode;
   hasUnpublishedChanges?: boolean;
+  disabled?: boolean;
   onSelect: () => void
 };
 
@@ -31,6 +33,7 @@ const BaseComponentCard = ({
   tags,
   actions,
   onSelect,
+  disabled,
   ...props
 } : BaseComponentCardProps) => {
   const tagCount = useMemo(() => {
@@ -43,9 +46,15 @@ const BaseComponentCard = ({
 
   const componentIcon = getItemIcon(componentType);
   const intl = useIntl();
-
   return (
-    <Container className="library-component-card">
+    <Container
+      className={classNames(
+        'library-component-card',
+        {
+          'disabled-card': disabled,
+        },
+      )}
+    >
       <Card
         isClickable
         onClick={onSelect}

--- a/src/library-authoring/components/BaseComponentCard.tsx
+++ b/src/library-authoring/components/BaseComponentCard.tsx
@@ -63,6 +63,7 @@ const BaseComponentCard = ({
             onSelect();
           }
         }}
+        data-testid={disabled ? 'card-disabled' : 'card-enabled'}
       >
         <Card.Header
           className={`library-component-header ${getComponentStyleColor(componentType)}`}

--- a/src/library-authoring/components/ComponentCard.scss
+++ b/src/library-authoring/components/ComponentCard.scss
@@ -1,6 +1,13 @@
 .library-component-card {
   .pgn__card {
-    height: 100%
+    height: 100%;
+  }
+
+  &.disabled-card {
+    .pgn__card {
+      opacity: .6;
+      pointer-events: none;
+    }
   }
 
   .library-component-header {

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -199,11 +199,12 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
     usageKey,
     publishStatus,
   } = contentHit;
+  const isNeverPublished = publishStatus === PublishStatus.NeverPublished;
   const componentDescription: string = (
-    showOnlyPublished ? formatted.published?.description : formatted.description
+    (showOnlyPublished && !isNeverPublished) ? formatted.published?.description : formatted.description
   ) ?? '';
   const displayName: string = (
-    showOnlyPublished ? formatted.published?.displayName : formatted.displayName
+    (showOnlyPublished && !isNeverPublished) ? formatted.published?.displayName : formatted.displayName
   ) ?? '';
 
   const { navigateTo } = useLibraryRoutes();
@@ -215,13 +216,15 @@ const ComponentCard = ({ contentHit }: ComponentCardProps) => {
     }
   }, [usageKey, navigateTo, openComponentInfoSidebar]);
 
+  const isDisabled = showOnlyPublished && isNeverPublished;
   return (
     <BaseComponentCard
       componentType={blockType}
       displayName={displayName}
       description={componentDescription}
       tags={tags}
-      actions={(
+      disabled={isDisabled}
+      actions={!isDisabled && (
         <ActionRow>
           {componentPickerMode ? (
             <AddComponentWidget usageKey={usageKey} blockType={blockType} />


### PR DESCRIPTION
## Description

- Allow the never-published components to be shown in the library component picker.
- Show never-published components as disabled in the library component picker.

![image](https://github.com/user-attachments/assets/42a4d276-0ea8-435b-a10a-718f622af681)

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/1517
- Internal ticket: [FAL-3985](https://tasks.opencraft.com/browse/FAL-3985)

## Testing instructions

- Go to the library home of a library.
- Create a component and publish it.
- Create a component without publishing it.
- Go to a unit in a course. Add a library component to open the library component picker.
- Choose you library
- Verify that the never-published component is disabled.

## Other information

N/A