### PR TITLE
[TNL-11864] fix: Prevent Alt Text from Being Truncated Due to Double Quotation Marks

### DIFF
--- a/src/editors/sharedComponents/ImageUploadModal/ImageSettingsModal/hooks.js
+++ b/src/editors/sharedComponents/ImageUploadModal/ImageSettingsModal/hooks.js
@@ -331,8 +331,12 @@ export const onSaveClick = ({
   })) {
     altText.error.dismiss();
     altText.validation.dismiss();
+    let altTextValue = altText.value;
+    if (altTextValue.includes('"')){
+      altTextValue = altTextValue.replace(/"/g, '&quot;');
+    }
     saveToEditor({
-      altText: altText.value,
+      altText: altTextValue,
       dimensions,
       isDecorative,
     });

--- a/src/editors/sharedComponents/ImageUploadModal/ImageSettingsModal/hooks.js
+++ b/src/editors/sharedComponents/ImageUploadModal/ImageSettingsModal/hooks.js
@@ -331,7 +331,7 @@ export const onSaveClick = ({
   })) {
     altText.error.dismiss();
     altText.validation.dismiss();
-    // Replaces double quotes with &quot; to prevent the alt text from being truncated  
+    // Replaces double quotes with &quot; to prevent the alt text from being truncated
     // or breaking the image tag structure.
     const altTextValue = altText.value.replace(/"/g, '&quot;');
     saveToEditor({

--- a/src/editors/sharedComponents/ImageUploadModal/ImageSettingsModal/hooks.js
+++ b/src/editors/sharedComponents/ImageUploadModal/ImageSettingsModal/hooks.js
@@ -331,10 +331,9 @@ export const onSaveClick = ({
   })) {
     altText.error.dismiss();
     altText.validation.dismiss();
-    let altTextValue = altText.value;
-    if (altTextValue.includes('"')) {
-      altTextValue = altTextValue.replace(/"/g, '&quot;');
-    }
+    // Replaces double quotes with &quot; to prevent the alt text from being truncated  
+    // or breaking the image tag structure.
+    const altTextValue = altText.value.replace(/"/g, '&quot;');
     saveToEditor({
       altText: altTextValue,
       dimensions,

--- a/src/editors/sharedComponents/ImageUploadModal/ImageSettingsModal/hooks.js
+++ b/src/editors/sharedComponents/ImageUploadModal/ImageSettingsModal/hooks.js
@@ -332,7 +332,7 @@ export const onSaveClick = ({
     altText.error.dismiss();
     altText.validation.dismiss();
     let altTextValue = altText.value;
-    if (altTextValue.includes('"')){
+    if (altTextValue.includes('"')) {
       altTextValue = altTextValue.replace(/"/g, '&quot;');
     }
     saveToEditor({

--- a/src/editors/sharedComponents/ImageUploadModal/ImageSettingsModal/hooks.test.js
+++ b/src/editors/sharedComponents/ImageUploadModal/ImageSettingsModal/hooks.test.js
@@ -360,6 +360,30 @@ describe('ImageSettingsModal hooks', () => {
         isDecorative: props.isDecorative,
       });
     });
+    it('replaces double quotes with &quot; before saving to editor', () => {
+      props.altText.value = 'The "Submit For Grading" button';
+      jest.spyOn(hooks, hookKeys.checkFormValidation).mockReturnValueOnce(true);
+
+      hooks.onSaveClick({ ...props })();
+
+      expect(props.saveToEditor).toHaveBeenCalledWith({
+        altText: 'The &quot;Submit For Grading&quot; button',
+        dimensions: props.dimensions,
+        isDecorative: props.isDecorative,
+      });
+    });
+    it('does not modify altText if there are no double quotes', () => {
+      props.altText.value = 'The Submit For Grading button';
+      jest.spyOn(hooks, hookKeys.checkFormValidation).mockReturnValueOnce(true);
+
+      hooks.onSaveClick({ ...props })();
+
+      expect(props.saveToEditor).toHaveBeenCalledWith({
+        altText: 'The Submit For Grading button',
+        dimensions: props.dimensions,
+        isDecorative: props.isDecorative,
+      });
+    });
     it('calls dismissError and sets showAltTextSubmissionError to false when checkFormValidation is true', () => {
       jest.spyOn(hooks, hookKeys.checkFormValidation).mockReturnValueOnce(true);
       hooks.onSaveClick({ ...props })();


### PR DESCRIPTION
## Description

When content creators include double quotation marks (") in the Alt Text field using the Visual Editor, the text is truncated at the first occurrence of a double quote.

For example, inserting: `The “Submit For Grading” button is located on the right side of the bar.`

Results in: `The` as alt text

Although the text appears correct after saving, reopening the Edit Image Settings reveals that the Alt Text was actually cut off. Upon inspecting the HTML source, the <img> tag is rendered incorrectly:
```
<img src="/assets/courseware/v1/id/asset-v1:my-course/lab_instruction_1.png" 
     alt="The " submit="" for="" grading="" icon="" is="" located="" on="" the="" right="" side="" of="" bar="" 
     width="595" height="90">
```
This PR resolves the above mentioned issue.

- [JIRA Link](https://2u-internal.atlassian.net/browse/TNL-11864)

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author"
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).

#### Before

<img width="1781" alt="image" src="https://github.com/user-attachments/assets/387d6c73-12d3-4649-b42a-254cd3a75a33" />

#### After

<img width="1781" alt="image" src="https://github.com/user-attachments/assets/07c917ff-b0a3-4494-89ed-a9ee74eaa3c5" />


## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere? No
- Any special concerns or limitations? No