### PR TITLE
fix: fetch only studio home data without courses

### DIFF
--- a/src/CourseAuthoringPage.jsx
+++ b/src/CourseAuthoringPage.jsx
@@ -11,7 +11,7 @@ import { fetchCourseDetail, fetchWaffleFlags } from './data/thunks';
 import { useModel } from './generic/model-store';
 import NotFoundAlert from './generic/NotFoundAlert';
 import PermissionDeniedAlert from './generic/PermissionDeniedAlert';
-import { fetchStudioHomeData } from './studio-home/data/thunks';
+import { fetchOnlyStudioHomeData } from './studio-home/data/thunks';
 import { getCourseAppsApiStatus } from './pages-and-resources/data/selectors';
 import { RequestStatus } from './data/constants';
 import Loading from './generic/Loading';
@@ -25,7 +25,7 @@ const CourseAuthoringPage = ({ courseId, children }) => {
   }, [courseId]);
 
   useEffect(() => {
-    dispatch(fetchStudioHomeData());
+    dispatch(fetchOnlyStudioHomeData());
   }, []);
 
   const courseDetail = useModel('courseDetails', courseId);

--- a/src/studio-home/data/thunks.js
+++ b/src/studio-home/data/thunks.js
@@ -16,10 +16,15 @@ import {
   fetchCourseDataSuccessV2,
 } from './slice';
 
-function fetchStudioHomeData(search, hasHomeData, requestParams = {}, isPaginationEnabled = false) {
+function fetchStudioHomeData(
+  search,
+  hasHomeData,
+  requestParams = {},
+  isPaginationEnabled = false,
+  shouldFetchCourses = true,
+) {
   return async (dispatch) => {
     dispatch(updateLoadingStatuses({ studioHomeLoadingStatus: RequestStatus.IN_PROGRESS }));
-    dispatch(updateLoadingStatuses({ courseLoadingStatus: RequestStatus.IN_PROGRESS }));
 
     if (!hasHomeData) {
       try {
@@ -31,20 +36,28 @@ function fetchStudioHomeData(search, hasHomeData, requestParams = {}, isPaginati
         return;
       }
     }
-    try {
-      if (isPaginationEnabled) {
-        const coursesData = await getStudioHomeCoursesV2(search || '', requestParams);
-        dispatch(fetchCourseDataSuccessV2(coursesData));
-      } else {
-        const coursesData = await getStudioHomeCourses(search || '');
-        dispatch(fetchCourseDataSuccess(coursesData));
-      }
+    if (shouldFetchCourses) {
+      dispatch(updateLoadingStatuses({ courseLoadingStatus: RequestStatus.IN_PROGRESS }));
+      try {
+        if (isPaginationEnabled) {
+          const coursesData = await getStudioHomeCoursesV2(search || '', requestParams);
+          dispatch(fetchCourseDataSuccessV2(coursesData));
+        } else {
+          const coursesData = await getStudioHomeCourses(search || '');
+          dispatch(fetchCourseDataSuccess(coursesData));
+        }
 
-      dispatch(updateLoadingStatuses({ courseLoadingStatus: RequestStatus.SUCCESSFUL }));
-    } catch (error) {
-      dispatch(updateLoadingStatuses({ courseLoadingStatus: RequestStatus.FAILED }));
+        dispatch(updateLoadingStatuses({ courseLoadingStatus: RequestStatus.SUCCESSFUL }));
+      } catch (error) {
+        dispatch(updateLoadingStatuses({ courseLoadingStatus: RequestStatus.FAILED }));
+      }
     }
   };
+}
+
+function fetchOnlyStudioHomeData() {
+  // Wrapper function to fetch only studio home data (without fetching courses)
+  return fetchStudioHomeData('', false, {}, false, false);
 }
 
 function fetchLibraryData() {
@@ -91,6 +104,7 @@ function requestCourseCreatorQuery() {
 
 export {
   fetchStudioHomeData,
+  fetchOnlyStudioHomeData,
   fetchLibraryData,
   requestCourseCreatorQuery,
   handleDeleteNotificationQuery,


### PR DESCRIPTION
## Description

This PR introduces a wrapper function, fetchOnlyStudioHomeData(), to fetch only studio home data without retrieving courses.

## Supporting information

[Related ticket](https://github.com/openedx/frontend-app-authoring/issues/1655)

## Testing instructions

**Before the Change:**

- Open the Course Outline page.
- In the Network tab (Dev Console), observe a request to:
`/api/contentstore/v1/home/courses`

**After the Change:**

- Open the Course Outline page.
- Expected: No request to `/api/contentstore/v1/home/courses`, but other Course Outline data loads correctly.
