### PR TITLE
fix: paste button on unit outline

### DIFF
--- a/src/course-unit/CourseUnit.jsx
+++ b/src/course-unit/CourseUnit.jsx
@@ -201,7 +201,9 @@ const CourseUnit = ({ courseId }) => {
               {showPasteXBlock && canPasteComponent && isUnitVerticalType && (
                 <PasteComponent
                   clipboardData={sharedClipboardData}
-                  onClick={handleCreateNewCourseXBlock}
+                  onClick={
+                    () => handleCreateNewCourseXBlock({ stagedContent: 'clipboard', parentLocator: blockId })
+                  }
                   text={intl.formatMessage(messages.pasteButtonText)}
                 />
               )}

--- a/src/generic/clipboard/paste-component/index.tsx
+++ b/src/generic/clipboard/paste-component/index.tsx
@@ -17,9 +17,9 @@ const PasteComponent = ({
   const [showPopover, togglePopover] = useState(false);
   const popoverElementRef = useRef(null);
 
-  const handlePopoverToggle = (isOpen) => togglePopover(isOpen);
+  const handlePopoverToggle = (isOpen: boolean) => togglePopover(isOpen);
 
-  const renderPopover = () => (
+  const renderPopover = (props) => (
     <div role="link" ref={popoverElementRef} tabIndex={0}>
       <Popover
         className="clipboard-popover"
@@ -28,6 +28,7 @@ const PasteComponent = ({
         onMouseLeave={() => handlePopoverToggle(false)}
         onFocus={() => handlePopoverToggle(true)}
         onBlur={() => handlePopoverToggle(false)}
+        {...props}
       >
         <PopoverContent clipboardData={clipboardData} />
       </Popover>


### PR DESCRIPTION
## Description

#1700 included a bug that broke the "Paste Component" feature on the new Unit Outline (and the positioning of the "What is on the clipboard" popover).
This PR fixes it.

## Testing Instructions
- Open a Unit
- Copy a Component
- Paste this component and check the results