### PR TITLE
Use defaultValue when item is null or empty

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.test.js
@@ -280,7 +280,7 @@ describe('EditProblemView hooks parseState', () => {
     const lmsEndpointUrl = 'someUrl';
     const editorRef = refMock;
     const expectedSettings = {
-      max_attempts: '',
+      max_attempts: null,
       weight: 1,
       rerandomize: null,
       showanswer: ShowAnswerTypesKeys.AFTER_SOME_NUMBER_OF_ATTEMPTS,
@@ -328,7 +328,7 @@ describe('EditProblemView hooks parseState', () => {
       });
       expect(settings).toEqual({
         max_attempts: '',
-        rerandomize: null,
+        rerandomize: 'never',
         show_reset_button: false,
         showanswer: 'after_attempts',
         attempts_before_showanswer_button: 0,

--- a/src/editors/containers/ProblemEditor/data/SettingsParser.js
+++ b/src/editors/containers/ProblemEditor/data/SettingsParser.js
@@ -5,11 +5,12 @@ import { ShowAnswerTypes, RandomizationTypesKeys } from '../../../data/constants
 export const popuplateItem = (parentObject, itemName, statekey, metadata, defaultValue = null, allowNull = false) => {
   let parent = parentObject;
   const item = _.get(metadata, itemName, null);
-  const equalsDefault = item === defaultValue;
-  if (allowNull) {
-    parent = { ...parentObject, [statekey]: item };
-  } else if (!_.isNil(item) && !equalsDefault) {
-    parent = { ...parentObject, [statekey]: item };
+
+  // if item is null, undefined, or empty string, use defaultValue
+  const finalValue = (!_.isNil(item) && item !== '') ? item : defaultValue;
+
+  if (allowNull || (!_.isNil(finalValue) && finalValue !== defaultValue)) {
+    parent = { ...parentObject, [statekey]: finalValue };
   }
   return parent;
 };

--- a/src/editors/containers/ProblemEditor/data/SettingsParser.js
+++ b/src/editors/containers/ProblemEditor/data/SettingsParser.js
@@ -7,9 +7,9 @@ export const popuplateItem = (parentObject, itemName, statekey, metadata, defaul
   const item = _.get(metadata, itemName, null);
 
   // if item is null, undefined, or empty string, use defaultValue
-  const finalValue = (!_.isNil(item) && item !== '') ? item : defaultValue;
+  const finalValue = (_.isNil(item) || item === '') ? defaultValue : item;
 
-  if (allowNull || (!_.isNil(finalValue) && finalValue !== defaultValue)) {
+  if (!_.isNil(finalValue) || allowNull) {
     parent = { ...parentObject, [statekey]: finalValue };
   }
   return parent;


### PR DESCRIPTION
## Description

**Issue:** The "Show Answer" feature was not appearing in certain problem components because an empty string ("") was being sent to the backend instead of the default value.

**Fix:** The issue was resolved by updating the populateItem function to ensure that when an item's value is null or an empty string (""), it correctly falls back to defaultValue.

## Supporting information
[TNL-11844](https://2u-internal.atlassian.net/browse/TNL-11844?atlOrigin=eyJpIjoiYmZmOGQ5NTQ2ZGQ4NGRiODg5NjY1ZTVlYmQwYmEwMWYiLCJwIjoiaiJ9)

## Testing instructions

- Open the course in Studio.
- Go to Advanced Settings.
- Set the Show Answer default value to "Show answer" and save.
- Open or create a problem in the course.
- Do not manually update the Show Answer field.
- Save the problem and check if the Show Answer field automatically applies the default value.

**Expected behavior:** The field should inherit "Show answer" from Advanced Settings if left unchanged.


