### PR TITLE
fix: add user partition id when update groups

### DIFF
--- a/plugins/course-apps/teams/Settings.jsx
+++ b/plugins/course-apps/teams/Settings.jsx
@@ -26,6 +26,7 @@ const TeamSettings = ({
     description: '',
     type: GroupTypes.OPEN,
     maxTeamSize: null,
+    userPartitionId: null,
     id: null,
     key: uuid(),
   };
@@ -38,6 +39,7 @@ const TeamSettings = ({
       type: group.type,
       description: group.description,
       max_team_size: group.maxTeamSize,
+      user_partition_id: group.userPartitionId,
     }));
     return saveSettings({
       team_sets: groups,


### PR DESCRIPTION
## Description

This PR adds a missing property (`userPartitionId`) when updating the groups config. If this property is not sent, the backend generates a new user partition ID, breaking all previous configurations.

## Supporting information

- https://github.com/openedx/frontend-app-authoring/issues/1719

## Testing instructions

1. Using Tutor, create a mount of this MFE with the changes in this PR's branch.
2. Create a Waffle Flag for your course in `{lms_domain}/admin/waffle_utils/waffleflagcourseoverridemodel/`

    - Waffle Flag: `teams.content_groups_for_teams`
    - Course id: [Your Course ID]
    - Enabled: ✅ 
3. Enables Teams in the platform using the `teams.enable_teams_app` flag.
4. Enable teams for your course in **Studio > [Your Course] > Content > Pages & Resources > Teams > Teams toggle**
5. In the same modal of **Configure teams**, create a few **Groups**.
6. Then, go to the **LMS > [Your Course] > Teams** and create a few **Teams** within those **Groups (topics/team-sets)**
7. In Studio, create a new **Unit**, and configure it to **Restrict access** to some **Team**.
8. Now, create a new **Group**, similar to **step 4**.
9. See again the **Unit** configured. The previous configuration is maintained, and everything works as it should.

[add-user-partition-id-when-update-groups.webm](https://github.com/user-attachments/assets/9e7939b1-995e-4ff7-99c3-461bd9c88bfc)
