### PR TITLE
perf: add staleTime to queryClient to avoid excessive calls [sumac]

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -35,7 +35,13 @@ import { ToastProvider } from './generic/toast-context';
 import 'react-datepicker/dist/react-datepicker.css';
 import './index.scss';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 60_000, // If cache is up to one hour old, no need to re-fetch
+    },
+  },
+});
 
 const App = () => {
   useEffect(() => {


### PR DESCRIPTION
## Description

This backports the `staleTime` parameter to avoid excessive backend calls.

## Additional information
- More info here (https://github.com/openedx/frontend-app-authoring/pull/1723#issuecomment-2719156375)

## Testing Instruction
- Open a Course Outline
- Check that we have one (and only one) call to http://studio.local.openedx.io:8001/api/content-staging/v1/clipboard/
- Open and close some sections (exposing the Unit card)
- Check that no additional calls to the endpoint are made