### PR TITLE
feat: create unit on libraries workflow [FC-0083]

### DIFF
--- a/src/generic/block-type-utils/constants.ts
+++ b/src/generic/block-type-utils/constants.ts
@@ -3,9 +3,10 @@ import {
   BackHand as BackHandIcon,
   BookOpen as BookOpenIcon,
   Casino as ProblemBankIcon,
+  ContentPaste as ContentPasteIcon,
   Edit as EditIcon,
   EditNote as EditNoteIcon,
-  FormatListBulleted as FormatListBulletedIcon,
+  CalendarViewDay,
   HelpOutline as HelpOutlineIcon,
   LibraryAdd as LibraryIcon,
   Lock as LockIcon,
@@ -35,7 +36,7 @@ export const COMPONENT_TYPES = {
 export const UNIT_TYPE_ICONS_MAP: Record<string, React.ComponentType> = {
   video: VideoCameraIcon,
   other: BookOpenIcon,
-  vertical: FormatListBulletedIcon,
+  vertical: CalendarViewDay,
   problem: EditIcon,
   lock: LockIcon,
 };
@@ -58,6 +59,8 @@ export const STRUCTURAL_TYPE_ICONS: Record<string, React.ComponentType> = {
   sequential: Folder,
   chapter: Folder,
   collection: Folder,
+  libraryContent: Folder,
+  paste: ContentPasteIcon,
 };
 
 export const COMPONENT_TYPE_STYLE_COLOR_MAP = {

--- a/src/generic/key-utils.test.ts
+++ b/src/generic/key-utils.test.ts
@@ -32,6 +32,8 @@ describe('component utils', () => {
       ['lb:Axim:beta:problem:571fe018-f3ce-45c9-8f53-5dafcb422fdd', 'lib:Axim:beta'],
       ['lib-collection:org:lib:coll', 'lib:org:lib'],
       ['lib-collection:OpenCraftX:ALPHA:coll', 'lib:OpenCraftX:ALPHA'],
+      ['lct:org:lib:unit:my-unit-9284e2', 'lib:org:lib'],
+      ['lct:OpenCraftX:ALPHA:my-unit-a3223f', 'lib:OpenCraftX:ALPHA'],
     ]) {
       it(`returns '${expected}' for usage key '${input}'`, () => {
         expect(getLibraryId(input)).toStrictEqual(expected);

--- a/src/generic/key-utils.ts
+++ b/src/generic/key-utils.ts
@@ -19,12 +19,10 @@ export function getBlockType(usageKey: string): string {
  * @returns The library key, e.g. `lib:org:lib`
  */
 export function getLibraryId(usageKey: string): string {
-  if (usageKey && (usageKey.startsWith('lb:') || usageKey.startsWith('lib-collection:'))) {
-    const org = usageKey.split(':')[1];
-    const lib = usageKey.split(':')[2];
-    if (org && lib) {
-      return `lib:${org}:${lib}`;
-    }
+  const [blockType, org, lib] = usageKey?.split(':') || [];
+
+  if (['lb', 'lib-collection', 'lct'].includes(blockType) && org && lib) {
+    return `lib:${org}:${lib}`;
   }
   throw new Error(`Invalid usageKey: ${usageKey}`);
 }

--- a/src/generic/loading-button/LoadingButton.test.tsx
+++ b/src/generic/loading-button/LoadingButton.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   act,
   fireEvent,
@@ -9,7 +8,7 @@ import LoadingButton from '.';
 
 const buttonTitle = 'Button Title';
 
-const RootWrapper = (onClick) => (
+const RootWrapper = (onClick?: () => (Promise<void> | void)) => (
   <LoadingButton label={buttonTitle} onClick={onClick} />
 );
 
@@ -31,8 +30,8 @@ describe('<LoadingButton />', () => {
   });
 
   it('renders the spinner correctly', async () => {
-    let resolver;
-    const longFunction = () => new Promise((resolve) => {
+    let resolver: () => void;
+    const longFunction = () => new Promise<void>((resolve) => {
       resolver = resolve;
     });
     const { container, getByRole, getByText } = render(RootWrapper(longFunction));
@@ -51,8 +50,8 @@ describe('<LoadingButton />', () => {
   });
 
   it('renders the spinner correctly even with error', async () => {
-    let rejecter;
-    const longFunction = () => new Promise((_resolve, reject) => {
+    let rejecter: (err: Error) => void;
+    const longFunction = () => new Promise<void>((_resolve, reject) => {
       rejecter = reject;
     });
     const { container, getByRole, getByText } = render(RootWrapper(longFunction));

--- a/src/generic/loading-button/index.tsx
+++ b/src/generic/loading-button/index.tsx
@@ -1,4 +1,3 @@
-// @ts-check
 import React, {
   useCallback,
   useEffect,
@@ -8,20 +7,20 @@ import React, {
 import {
   StatefulButton,
 } from '@openedx/paragon';
-import PropTypes from 'prop-types';
+
+interface LoadingButtonProps {
+  label: string;
+  onClick?: (e: any) => (Promise<void> | void);
+  disabled?: boolean;
+  size?: string;
+  variant?: string;
+  className?: string;
+}
 
 /**
-  * A button that shows a loading spinner when clicked.
-  * @param {object} props
-  * @param {string} props.label
-  * @param {function=} props.onClick
-  * @param {boolean=} props.disabled
-  * @param {string=} props.size
-  * @param {string=} props.variant
-  * @param {string=} props.className
-  * @returns {JSX.Element}
+  * A button that shows a loading spinner when clicked, if the onClick function returns a Promise.
   */
-const LoadingButton = ({
+const LoadingButton: React.FC<LoadingButtonProps> = ({
   label,
   onClick,
   disabled,
@@ -37,7 +36,7 @@ const LoadingButton = ({
     componentMounted.current = false;
   }, []);
 
-  const loadingOnClick = useCallback(async (e) => {
+  const loadingOnClick = useCallback(async (e: any) => {
     if (!onClick) {
       return;
     }
@@ -65,23 +64,6 @@ const LoadingButton = ({
       className={className}
     />
   );
-};
-
-LoadingButton.propTypes = {
-  label: PropTypes.string.isRequired,
-  onClick: PropTypes.func,
-  disabled: PropTypes.bool,
-  size: PropTypes.string,
-  variant: PropTypes.string,
-  className: PropTypes.string,
-};
-
-LoadingButton.defaultProps = {
-  onClick: undefined,
-  disabled: undefined,
-  size: undefined,
-  variant: '',
-  className: '',
 };
 
 export default LoadingButton;

--- a/src/library-authoring/LibraryLayout.tsx
+++ b/src/library-authoring/LibraryLayout.tsx
@@ -12,6 +12,7 @@ import LibraryAuthoringPage from './LibraryAuthoringPage';
 import { LibraryProvider } from './common/context/LibraryContext';
 import { SidebarProvider } from './common/context/SidebarContext';
 import { CreateCollectionModal } from './create-collection';
+import { CreateUnitModal } from './create-unit';
 import LibraryCollectionPage from './collections/LibraryCollectionPage';
 import { ComponentPicker } from './component-picker';
 import { ComponentEditorModal } from './components/ComponentEditorModal';
@@ -44,6 +45,7 @@ const LibraryLayout = () => {
         <>
           {childPage}
           <CreateCollectionModal />
+          <CreateUnitModal />
           <ComponentEditorModal />
         </>
       </SidebarProvider>

--- a/src/library-authoring/add-content/messages.ts
+++ b/src/library-authoring/add-content/messages.ts
@@ -6,6 +6,11 @@ const messages = defineMessages({
     defaultMessage: 'Collection',
     description: 'Content of button to create a Collection.',
   },
+  unitButton: {
+    id: 'course-authoring.library-authoring.add-content.buttons.unit',
+    defaultMessage: 'Unit',
+    description: 'Content of button to create a Unit.',
+  },
   libraryContentButton: {
     id: 'course-authoring.library-authoring.add-content.buttons.library-content',
     defaultMessage: 'Existing Library Content',

--- a/src/library-authoring/common/context/LibraryContext.tsx
+++ b/src/library-authoring/common/context/LibraryContext.tsx
@@ -35,6 +35,10 @@ export type LibraryContextData = {
   isCreateCollectionModalOpen: boolean;
   openCreateCollectionModal: () => void;
   closeCreateCollectionModal: () => void;
+  // "Create New Unit" modal
+  isCreateUnitModalOpen: boolean;
+  openCreateUnitModal: () => void;
+  closeCreateUnitModal: () => void;
   // Editor modal - for editing some component
   /** If the editor is open and the user is editing some component, this is the component being edited. */
   componentBeingEdited: ComponentEditorInfo | undefined;
@@ -80,6 +84,7 @@ export const LibraryProvider = ({
   componentPicker,
 }: LibraryProviderProps) => {
   const [isCreateCollectionModalOpen, openCreateCollectionModal, closeCreateCollectionModal] = useToggle(false);
+  const [isCreateUnitModalOpen, openCreateUnitModal, closeCreateUnitModal] = useToggle(false);
   const [componentBeingEdited, setComponentBeingEdited] = useState<ComponentEditorInfo | undefined>();
   const closeComponentEditor = useCallback((data) => {
     setComponentBeingEdited((prev) => {
@@ -122,6 +127,9 @@ export const LibraryProvider = ({
       isCreateCollectionModalOpen,
       openCreateCollectionModal,
       closeCreateCollectionModal,
+      isCreateUnitModalOpen,
+      openCreateUnitModal,
+      closeCreateUnitModal,
       componentBeingEdited,
       openComponentEditor,
       closeComponentEditor,
@@ -142,6 +150,9 @@ export const LibraryProvider = ({
     isCreateCollectionModalOpen,
     openCreateCollectionModal,
     closeCreateCollectionModal,
+    isCreateUnitModalOpen,
+    openCreateUnitModal,
+    closeCreateUnitModal,
     componentBeingEdited,
     openComponentEditor,
     closeComponentEditor,

--- a/src/library-authoring/create-collection/messages.ts
+++ b/src/library-authoring/create-collection/messages.ts
@@ -1,8 +1,4 @@
-import { defineMessages as _defineMessages } from '@edx/frontend-platform/i18n';
-import type { defineMessages as defineMessagesType } from 'react-intl';
-
-// frontend-platform currently doesn't provide types... do it ourselves.
-const defineMessages = _defineMessages as typeof defineMessagesType;
+import { defineMessages } from '@edx/frontend-platform/i18n';
 
 const messages = defineMessages({
   createCollectionModalTitle: {

--- a/src/library-authoring/create-library/CreateLibrary.tsx
+++ b/src/library-authoring/create-library/CreateLibrary.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { StudioFooter } from '@edx/frontend-component-footer';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {

--- a/src/library-authoring/create-unit/CreateUnitModal.tsx
+++ b/src/library-authoring/create-unit/CreateUnitModal.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import {
+  ActionRow,
+  Form,
+  ModalDialog,
+} from '@openedx/paragon';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Formik } from 'formik';
+import * as Yup from 'yup';
+import FormikControl from '../../generic/FormikControl';
+import { useLibraryContext } from '../common/context/LibraryContext';
+import messages from './messages';
+import { useCreateLibraryContainer } from '../data/apiHooks';
+import { ToastContext } from '../../generic/toast-context';
+import LoadingButton from '../../generic/loading-button';
+
+const CreateUnitModal = () => {
+  const intl = useIntl();
+  const {
+    libraryId,
+    isCreateUnitModalOpen,
+    closeCreateUnitModal,
+  } = useLibraryContext();
+  const create = useCreateLibraryContainer(libraryId);
+  const { showToast } = React.useContext(ToastContext);
+
+  const handleCreate = React.useCallback(async (values) => {
+    try {
+      await create.mutateAsync({
+        containerType: 'unit',
+        ...values,
+      });
+      // TODO: Navigate to the new unit
+      // navigate(`/library/${libraryId}/units/${data.key}`);
+      showToast(intl.formatMessage(messages.createUnitSuccess));
+    } catch (error) {
+      showToast(intl.formatMessage(messages.createUnitError));
+    } finally {
+      closeCreateUnitModal();
+    }
+  }, []);
+
+  return (
+    <ModalDialog
+      title={intl.formatMessage(messages.createUnitModalTitle)}
+      isOpen={isCreateUnitModalOpen}
+      onClose={closeCreateUnitModal}
+      hasCloseButton
+      isFullscreenOnMobile
+      isOverflowVisible={false}
+    >
+      <ModalDialog.Header>
+        <ModalDialog.Title>
+          {intl.formatMessage(messages.createUnitModalTitle)}
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+
+      <Formik
+        initialValues={{
+          displayName: '',
+        }}
+        validationSchema={
+          Yup.object().shape({
+            displayName: Yup.string()
+              .required(intl.formatMessage(messages.createUnitModalNameInvalid)),
+          })
+        }
+        onSubmit={handleCreate}
+      >
+        {(formikProps) => (
+          <>
+            <ModalDialog.Body className="mw-sm">
+              <Form onSubmit={formikProps.handleSubmit}>
+                <FormikControl
+                  name="displayName"
+                  label={(
+                    <Form.Label className="font-weight-bold h3">
+                      {intl.formatMessage(messages.createUnitModalNameLabel)}
+                    </Form.Label>
+                  )}
+                  value={formikProps.values.displayName}
+                  placeholder={intl.formatMessage(messages.createUnitModalNamePlaceholder)}
+                  controlClasses="pb-2"
+                />
+              </Form>
+            </ModalDialog.Body>
+            <ModalDialog.Footer>
+              <ActionRow>
+                <ModalDialog.CloseButton variant="tertiary">
+                  {intl.formatMessage(messages.createUnitModalCancel)}
+                </ModalDialog.CloseButton>
+                <LoadingButton
+                  variant="primary"
+                  onClick={formikProps.submitForm}
+                  disabled={!formikProps.isValid || !formikProps.dirty}
+                  label={intl.formatMessage(messages.createUnitModalCreate)}
+                />
+              </ActionRow>
+            </ModalDialog.Footer>
+          </>
+        )}
+      </Formik>
+    </ModalDialog>
+  );
+};
+
+export default CreateUnitModal;

--- a/src/library-authoring/create-unit/index.tsx
+++ b/src/library-authoring/create-unit/index.tsx
@@ -1,0 +1,1 @@
+export { default as CreateUnitModal } from './CreateUnitModal';

--- a/src/library-authoring/create-unit/messages.ts
+++ b/src/library-authoring/create-unit/messages.ts
@@ -1,0 +1,46 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  createUnitModalTitle: {
+    id: 'course-authoring.library-authoring.modals.create-unit.title',
+    defaultMessage: 'New Unit',
+    description: 'Title of the Create Unit modal',
+  },
+  createUnitModalCancel: {
+    id: 'course-authoring.library-authoring.modals.create-unit.cancel',
+    defaultMessage: 'Cancel',
+    description: 'Label of the Cancel button of the Create Unit modal',
+  },
+  createUnitModalCreate: {
+    id: 'course-authoring.library-authoring.modals.create-unit.create',
+    defaultMessage: 'Create',
+    description: 'Label of the Create button of the Create Unit modal',
+  },
+  createUnitModalNameLabel: {
+    id: 'course-authoring.library-authoring.modals.create-unit.form.name',
+    defaultMessage: 'Name your unit',
+    description: 'Label of the Name field of the Create Unit modal form',
+  },
+  createUnitModalNamePlaceholder: {
+    id: 'course-authoring.library-authoring.modals.create-unit.form.name.placeholder',
+    defaultMessage: 'Give a descriptive title',
+    description: 'Placeholder of the Name field of the Create Unit modal form',
+  },
+  createUnitModalNameInvalid: {
+    id: 'course-authoring.library-authoring.modals.create-unit.form.name.invalid',
+    defaultMessage: 'Unit name is required',
+    description: 'Message when the Name field of the Create Unit modal form is invalid',
+  },
+  createUnitSuccess: {
+    id: 'course-authoring.library-authoring.modals.create-unit.success',
+    defaultMessage: 'Unit created successfully',
+    description: 'Success message when creating a library unit',
+  },
+  createUnitError: {
+    id: 'course-authoring.library-authoring.modals.create-unit.error',
+    defaultMessage: 'There is an error when creating the library unit',
+    description: 'Error message when creating a library unit',
+  },
+});
+
+export default messages;

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -103,6 +103,10 @@ export const getXBlockBaseApiUrl = () => `${getApiBaseUrl()}/xblock/`;
  * Get the URL for the content store api.
  */
 export const getContentStoreApiUrl = () => `${getApiBaseUrl()}/api/contentstore/v2/`;
+/**
+ * Get the URL for the library container api.
+ */
+export const getLibraryContainersApiUrl = (libraryId: string) => `${getApiBaseUrl()}/api/libraries/v2/${libraryId}/containers/`;
 
 export interface ContentLibrary {
   id: string;
@@ -556,4 +560,17 @@ export async function updateComponentCollections(usageKey: string, collectionKey
   await getAuthenticatedHttpClient().patch(getLibraryBlockCollectionsUrl(usageKey), {
     collection_keys: collectionKeys,
   });
+}
+
+export interface CreateLibraryContainerDataRequest {
+  title: string;
+  containerType: string;
+}
+
+/**
+ * Create a library container
+ */
+export async function createLibraryContainer(libraryId: string, containerData: CreateLibraryContainerDataRequest) {
+  const client = getAuthenticatedHttpClient();
+  await client.post(getLibraryContainersApiUrl(libraryId), snakeCaseObject(containerData));
 }

--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -46,6 +46,8 @@ import {
   deleteXBlockAsset,
   restoreLibraryBlock,
   getBlockTypes,
+  createLibraryContainer,
+  type CreateLibraryContainerDataRequest,
 } from './api';
 import { VersionSpec } from '../LibraryBlock';
 
@@ -556,6 +558,19 @@ export const useUpdateComponentCollections = (libraryId: string, usageKey: strin
     mutationFn: async (collectionKeys: string[]) => updateComponentCollections(usageKey, collectionKeys),
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: xblockQueryKeys.componentMetadata(usageKey) });
+      queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, libraryId) });
+    },
+  });
+};
+
+/**
+ * Use this mutation to create a library container
+ */
+export const useCreateLibraryContainer = (libraryId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateLibraryContainerDataRequest) => createLibraryContainer(libraryId, data),
+    onSettled: () => {
       queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, libraryId) });
     },
   });


### PR DESCRIPTION
## Description

This PR implements the basic workflow to create a Unit in a Library.

![image](https://github.com/user-attachments/assets/4261e0d9-b0d7-49fc-97e5-ffb7b6d4cf3d)

## Supporting information

- Implements https://github.com/openedx/frontend-app-authoring/issues/1595
- Depends on: https://github.com/openedx/edx-platform/pull/36371

## Testing instructions

1. Make sure you are using this PR with openedx/edx-platform#36371
2. Open a library
3. Click on the "+ New" button on the Library Header
4. Select "Unit"
5. . You should see the new Unit in the component list

*Note*: The card view for the Unit has not been implemented yet, so interacting with this new Unit card will raise many errors as it is being handled as an ordinary Library Component.

___
Private ref: [FAL-4056](https://tasks.opencraft.com/browse/FAL-4056)