### PR TITLE
refactor: open review tab in course libraries if out of sync [FC-0076]

### DIFF
--- a/src/course-libraries/CourseLibraries.test.tsx
+++ b/src/course-libraries/CourseLibraries.test.tsx
@@ -76,11 +76,16 @@ describe('<CourseLibraries />', () => {
 
   it('shows alert when out of sync components are present', async () => {
     await renderCourseLibrariesPage(mockGetEntityLinks.courseKey);
+    const allTab = await screen.findByRole('tab', { name: 'Libraries' });
+    const reviewTab = await screen.findByRole('tab', { name: 'Review Content Updates 5' });
+    // review tab should be open by default as outOfSyncCount is greater than 0
+    expect(reviewTab).toHaveAttribute('aria-selected', 'true');
+
+    userEvent.click(allTab);
     const alert = await screen.findByRole('alert');
     expect(await within(alert).findByText(
       '5 library components are out of sync. Review updates to accept or ignore changes',
     )).toBeInTheDocument();
-    const allTab = await screen.findByRole('tab', { name: 'Libraries' });
     expect(allTab).toHaveAttribute('aria-selected', 'true');
 
     const reviewBtn = await screen.findByRole('button', { name: 'Review' });
@@ -104,16 +109,21 @@ describe('<CourseLibraries />', () => {
 
   it('hide alert on dismiss', async () => {
     await renderCourseLibrariesPage(mockGetEntityLinks.courseKey);
+    const reviewTab = await screen.findByRole('tab', { name: 'Review Content Updates 5' });
+    // review tab should be open by default as outOfSyncCount is greater than 0
+    expect(reviewTab).toHaveAttribute('aria-selected', 'true');
+    const allTab = await screen.findByRole('tab', { name: 'Libraries' });
+    userEvent.click(allTab);
+    expect(allTab).toHaveAttribute('aria-selected', 'true');
+
     const alert = await screen.findByRole('alert');
     expect(await within(alert).findByText(
       '5 library components are out of sync. Review updates to accept or ignore changes',
     )).toBeInTheDocument();
     const dismissBtn = await screen.findByRole('button', { name: 'Dismiss' });
     userEvent.click(dismissBtn);
-    const allTab = await screen.findByRole('tab', { name: 'Libraries' });
     expect(allTab).toHaveAttribute('aria-selected', 'true');
-
-    expect(alert).not.toBeInTheDocument();
+    waitFor(() => expect(alert).not.toBeInTheDocument());
   });
 });
 

--- a/src/course-libraries/CourseLibraries.tsx
+++ b/src/course-libraries/CourseLibraries.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useCallback, useMemo, useState,
+  useCallback, useEffect, useMemo, useState,
 } from 'react';
 import { Helmet } from 'react-helmet';
 import { getConfig } from '@edx/frontend-platform';
@@ -105,7 +105,7 @@ export const CourseLibraries: React.FC<Props> = ({ courseId }) => {
   const courseDetails = useModel('courseDetails', courseId);
   const [searchParams] = useSearchParams();
   const [tabKey, setTabKey] = useState<CourseLibraryTabs>(
-    () => searchParams.get('tab') as CourseLibraryTabs || CourseLibraryTabs.all,
+    () => searchParams.get('tab') as CourseLibraryTabs,
   );
   const [showReviewAlert, setShowReviewAlert] = useState(false);
   const { data: libraries, isLoading } = useEntityLinksSummaryByDownstreamContext(courseId);
@@ -123,6 +123,19 @@ export const CourseLibraries: React.FC<Props> = ({ courseId }) => {
   const tabChange = useCallback((selectedTab: CourseLibraryTabs) => {
     setTabKey(selectedTab);
   }, []);
+
+  useEffect(() => {
+    setTabKey((prev) => {
+      if (outOfSyncCount > 0) {
+        return CourseLibraryTabs.review;
+      }
+      if (prev) {
+        return prev;
+      }
+      /* istanbul ignore next */
+      return CourseLibraryTabs.all;
+    });
+  }, [outOfSyncCount]);
 
   const renderLibrariesTabContent = useCallback(() => {
     if (isLoading) {


### PR DESCRIPTION

**Description**: Open review tab in course libraries page of any component is out of sync.

**Related to:** https://github.com/openedx/frontend-app-authoring/issues/1565#issuecomment-2731000745

`Private-ref`: [FAL-4006](https://tasks.opencraft.com/browse/FAL-4006)

**Test instructions**: Open `Libraries` page in any course and verify that the review tab is selected by default if components are out of sync