### PR TITLE
refactor: Remove unused defaultToAdvanced and getBetaParsedOLXData

### DIFF
--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/hooks.js
@@ -23,7 +23,6 @@ export const onSelect = ({
         attempts_before_showanswer_button: 0,
         show_reset_button: null,
         showanswer: null,
-        defaultToAdvanced: false,
       },
       defaultSettings: snakeCaseKeys(defaultSettings),
     });

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/hooks.test.js
@@ -55,7 +55,6 @@ describe('SelectTypeModal hooks', () => {
           attempts_before_showanswer_button: 0,
           show_reset_button: null,
           showanswer: null,
-          defaultToAdvanced: false,
         },
         defaultSettings: mockDefaultSettings,
       });

--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -746,13 +746,4 @@ export class OLXParser {
       groupFeedbackList,
     };
   }
-
-  getBetaParsedOLXData() {
-    /* TODO: Replace olxParser.getParsedOLXData() with new parser function
-    * and remove console.log()
-    */
-    // eslint-disable-next-line no-console
-    console.log('Should default to the advanced editor');
-    return this.getParsedOLXData();
-  }
 }

--- a/src/editors/data/redux/thunkActions/problem.ts
+++ b/src/editors/data/redux/thunkActions/problem.ts
@@ -34,14 +34,9 @@ export const isBlankProblem = ({ rawOLX }) => {
 export const getDataFromOlx = ({ rawOLX, rawSettings, defaultSettings }) => {
   let olxParser;
   let parsedProblem;
-  const { default_to_advanced: defaultToAdvanced } = rawSettings;
   try {
     olxParser = new OLXParser(rawOLX);
-    if (defaultToAdvanced) {
-      parsedProblem = olxParser.getBetaParsedOLXData();
-    } else {
-      parsedProblem = olxParser.getParsedOLXData();
-    }
+    parsedProblem = olxParser.getParsedOLXData();
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('The Problem Could Not Be Parsed from OLX. redirecting to Advanced editor.', error);


### PR DESCRIPTION
edx-platform would pass a default_to_advanced flag in through the REST API, depending on the value of a waffle flag.
The flag did not actually cause anything to default to advanced. What it actually did was switch from getOLXParser to getBetaOLXParser. However, getBetaOLXParser was never implemented--it just logs a console warning and return getOLXParser.
    
We remove this unused flag and unused function. The underlying default_to_advanced API flag and the backing waffle flag will be removed from edx-platform in a separate PR.

This essentially reverts https://github.com/openedx-unsupported/frontend-lib-content-components/pull/496
