### PR TITLE
fix: link navigation for BrokenLink and GoToBlock

### DIFF
--- a/src/optimizer-page/CourseOptimizerPage.test.js
+++ b/src/optimizer-page/CourseOptimizerPage.test.js
@@ -144,6 +144,13 @@ describe('CourseOptimizerPage', () => {
         expect(getAllByText(scanResultsMessages.brokenLinkStatus.defaultMessage)[0]).toBeInTheDocument();
         expect(queryAllByText(scanResultsMessages.lockedLinkStatus.defaultMessage)[0]).toBeInTheDocument();
         expect(queryAllByText(scanResultsMessages.recommendedManualCheckText.defaultMessage)[0]).toBeInTheDocument();
+        const brokenLinks = getAllByText('https://example.com/broken-link-algo');
+        expect(brokenLinks.length).toBeGreaterThan(0);
+        fireEvent.click(brokenLinks[0]);
+        const lockedLinks = getAllByText('https://example.com/locked-link-algo');
+        expect(lockedLinks.length).toBeGreaterThan(0);
+        fireEvent.click(lockedLinks[0]);
+        fireEvent.click((getAllByText('Go to Block'))[0]);
       });
     });
 

--- a/src/optimizer-page/scan-results/BrokenLinkTable.tsx
+++ b/src/optimizer-page/scan-results/BrokenLinkTable.tsx
@@ -10,22 +10,36 @@ import { Unit } from '../types';
 import messages from './messages';
 import LockedInfoIcon from './LockedInfoIcon';
 
-const BrokenLinkHref: FC<{ href: string }> = ({ href }) => (
-  <div className="broken-link-container">
-    <a href={href} target="_blank" className="broken-link" rel="noreferrer">
-      {href}
-    </a>
-  </div>
-);
+const BrokenLinkHref: FC<{ href: string }> = ({ href }) => {
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    window.open(href, '_blank');
+  };
 
-const GoToBlock: FC<{ block: { url: string } }> = ({ block }) => (
-  <span style={{ display: 'flex', gap: '.5rem' }}>
-    <Icon src={OpenInNew} />
-    <a href={block.url} target="_blank" rel="noreferrer">
-      Go to Block
-    </a>
-  </span>
-);
+  return (
+    <div className="broken-link-container">
+      <a href={href} onClick={handleClick} className="broken-link" rel="noreferrer">
+        {href}
+      </a>
+    </div>
+  );
+};
+
+const GoToBlock: FC<{ block: { url: string } }> = ({ block }) => {
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    window.open(block.url, '_blank');
+  };
+
+  return (
+    <span style={{ display: 'flex', gap: '.5rem' }}>
+      <Icon src={OpenInNew} />
+      <a href={block.url} onClick={handleClick} rel="noreferrer">
+        Go to Block
+      </a>
+    </span>
+  );
+};
 
 const RecommendedManualCheckHeading = () => {
   const intl = useIntl();


### PR DESCRIPTION
Ticket: [TNL-11930](https://2u-internal.atlassian.net/browse/TNL-11930)

In this PR, fix link navigation in BrokenLinkHref and GoToBlock components
- Updated BrokenLinkHref to prevent default anchor behavior and open broken links directly in a new tab.
- Updated GoToBlock to prevent default anchor behavior and open block URLs directly in a new tab.
- Added test coverage for this fix code in `CourseOptimizerPage.test.js`, this was needed to be covered: https://github.com/openedx/frontend-app-authoring/pull/1760/checks?check_run_id=39390124321

Previous Behavior (links were very briefly going to “about: blank” url before directing to the given website):
https://github.com/user-attachments/assets/d18fb773-bb6d-4293-aa62-6925ee966476
![ezgif-12d3834d5c4f7e](https://github.com/user-attachments/assets/71d802c9-ec37-4a81-9753-e92ac99c1bbe)


Current Behavior after fix (It doesn't load `about: blank` for even shorter time now):
https://github.com/user-attachments/assets/93d58069-fc25-436d-8857-3bf26c48b7bf
![ezgif-1a2d3d5e3841f3](https://github.com/user-attachments/assets/cad4d535-74fa-4120-9d7a-06c4703f7e73)


