### PR TITLE
Update useRef before dispatching file upload action

### DIFF
--- a/src/files-and-videos/videos-page/VideosPage.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.jsx
@@ -29,6 +29,7 @@ import {
   resetErrors,
   updateVideoOrder,
   cancelAllUploads,
+  newUploadData,
 } from './data/thunks';
 import messages from './messages';
 import VideosPageProvider from './VideosPageProvider';
@@ -124,6 +125,19 @@ const VideosPage = ({
   const handleAddFile = (files) => {
     handleErrorReset({ errorType: 'add' });
     uploadingIdsRef.current.uploadCount = files.length;
+
+    files.forEach((file, idx) => {
+      const name = file?.name || `Video ${idx + 1}`;
+      const progress = 0;
+
+      newUploadData({
+        status: RequestStatus.PENDING,
+        currentData: uploadingIdsRef.current.uploadData,
+        originalValue: { name, progress },
+        key: `video_${idx}`,
+      });
+    });
+
     dispatch(addVideoFile(courseId, files, videoIds, uploadingIdsRef));
   };
   const handleDeleteFile = (id) => dispatch(deleteVideoFile(courseId, id));

--- a/src/files-and-videos/videos-page/data/thunks.js
+++ b/src/files-and-videos/videos-page/data/thunks.js
@@ -280,7 +280,7 @@ const uploadToBucket = async ({
   }
 };
 
-const newUploadData = ({
+export const newUploadData = ({
   status,
   edxVideoId,
   currentData,


### PR DESCRIPTION
##Description

**Issue:**
The video upload modal dialog does not display upload progress when a video is being uploaded.
 
**Before fix:**
![without-fix-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/62873efb-03ca-4ce1-ac42-6ae83eee69ce)

**Fix:**
Refactored handleAddFile to update uploadingIdsRef before dispatching addVideoFile.
![with-fix-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/97017fcf-6bca-4351-9ec8-263ded104ddd)

## Supporting information

[TNL-11940](https://2u-internal.atlassian.net/browse/TNL-11940)

## Testing instructions

1. Navigate to the Videos page.
2. Ensure there are no existing videos.
3. Upload a new video.
4. Verify that the upload progress is now correctly displayed in the modal dialog.
