### PR TITLE
fix: Numeric input with variables conversion to StringResponse

### DIFF
--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
@@ -426,14 +426,14 @@ class ReactStateOLXParser {
     // If contain variables, generate as stringresponse instead of numericalresponse
     if (mainAnswer && this.containsVariables(mainAnswer)) {
       // Create a stringresponse type
-      let answerObject = {
+      const answerObject = {
         ':@': {
           '@_answer': mainAnswer,
           '@_type': 'ci',
         },
-        [ProblemTypeKeys.TEXTINPUT]: []
+        [ProblemTypeKeys.TEXTINPUT]: [],
       };
-      let firstCorrectAnswerParsed = true;
+      const firstCorrectAnswerParsed = true;
 
       answers.forEach((answer) => {
         const correcthint = this.getAnswerHints(selectedFeedback?.[answer.id]);
@@ -442,15 +442,13 @@ class ReactStateOLXParser {
           if (correcthint.length > 0) {
             answerObject[ProblemTypeKeys.TEXTINPUT].push(...correcthint);
           }
-        }
-        else if (answer.correct && firstCorrectAnswerParsed) {
+        } else if (answer.correct && firstCorrectAnswerParsed) {
           answerObject[ProblemTypeKeys.TEXTINPUT].push({
             ':@': { '@_answer': answer.title },
             additional_answer: [...correcthint],
           });
-        }
         // Wrong answers as stringequalhint (if exists)
-        else if (!answer.correct) {
+        } else if (!answer.correct) {
           const wronghint = correcthint[0]?.correcthint;
           if (wronghint) {
             answerObject[ProblemTypeKeys.TEXTINPUT].push({


### PR DESCRIPTION
## Description

This PR adds support for numeric inputs containing variables by converting them to string response format when needed. The current implementation detects when a numeric input answer contains variables (letters other than 'e', which is used in scientific notation) and properly converts it to a string response format that can handle algebraic expressions.


Changes

- Added a flag `convertedToStringResponse` to track when a numeric problem has been converted to string response

- Implemented logic in `buildNumericalResponse` to detect variables in answers and generate string response format instead

- Extended `buildNumericInput` to check this flag and render the appropriate OLX output


## Discussion 

This solution detects whether, when creating a problem with Numerical Input, the problem's solution contains variables. If so, it converts the solution to stringResponse so that the OLX is properly constructed for the backend to process it as a string.

The issue with this solution is that the equation previewer provided by numericalResponse with its formulaequationinput stops working because the OLX has been modified to stringResponse. The main idea was to adapt a logic similar to the legacy editor, but the difference is that the legacy code handles these cases with a different structure in JavaScript.

In conclusion, the solution implemented in this PR ensures that problems containing variables work correctly, preventing the "undefined variables" error. However, as a consequence, the equation previewer no longer functions when entering a response.

## Testing instructions

- Create a new problem with numerical input where the answer is a math expression like m*c^2:
 
![image](https://github.com/user-attachments/assets/9da78a02-fe69-4bd6-8df6-45ece8bb2ed6)

The OLX will have an structure like this: 
![image](https://github.com/user-attachments/assets/27b059f1-88dc-40dc-985c-5ee81e33204a)

## Related issues:
 [Numerical Input Component Incorrectly Handles Formulas as numericalresponse](https://github.com/openedx/frontend-app-authoring/issues/1680)

[[Test failure] TC_AUTHOR_50: Numerical input component generates an error with the formula shown in the usage example. ](https://github.com/openedx/wg-build-test-release/issues/420)