### PR TITLE
fix: ignore altText to avoid replace &quot; with "

### DIFF
--- a/src/editors/sharedComponents/CodeEditor/index.test.jsx
+++ b/src/editors/sharedComponents/CodeEditor/index.test.jsx
@@ -64,9 +64,16 @@ describe('CodeEditor', () => {
     describe('cleanHTML', () => {
       const dirtyText = `&${Object.keys(alphanumericMap).join('; , &')};`;
       const cleanText = `${Object.values(alphanumericMap).join(' , ')}`;
+      const dirtyTextWithAlt = '<img src="image.png" alt="Description &le; and &ge; &quot;do not convert these to double quotes&quot; 1" /> and &le; and &ge;';
+      const cleanTextWithAlt = '<img src="image.png" alt="Description ≤ and ≥ &quot;do not convert these to double quotes&quot; 1" /> and ≤ and ≥';
 
       it('escapes alphanumerics and sets them to be literals', () => {
         expect(hooks.cleanHTML({ initialText: dirtyText })).toEqual(cleanText);
+      });
+
+      it('replaces alt attributes with placeholders and restores them', () => {
+        const result = hooks.cleanHTML({ initialText: dirtyTextWithAlt });
+        expect(result).toEqual(cleanTextWithAlt);
       });
     });
 


### PR DESCRIPTION
Ticket: [TNL-11920](https://2u-internal.atlassian.net/browse/TNL-11920)
- Ignore altText to avoid replacing &quot; with "(double quotes) in alt text value.
- Modify unit tests to cover the new code.

**Before:**
<img width="1790" alt="Screenshot 2025-04-07 at 6 14 56 PM" src="https://github.com/user-attachments/assets/9da9fecb-0cb9-454c-bc7a-5843b180be87" />

After saving the text in source code editor:
<img width="1790" alt="Screenshot 2025-04-07 at 6 15 37 PM" src="https://github.com/user-attachments/assets/f55562a3-2ea6-45f6-ada3-d4bdcd0c3b96" />
<img width="1790" alt="Screenshot 2025-04-07 at 6 20 58 PM" src="https://github.com/user-attachments/assets/63f4037e-d27c-45cf-ae4b-48cfa130bfaa" />


**After:**
<img width="1790" alt="Screenshot 2025-04-07 at 6 17 42 PM" src="https://github.com/user-attachments/assets/c1bd9f1f-187d-4031-963e-e07a20242843" />

After saving the text in source code editor(It will remain same, but it will look like in below pic and keep showing the `&quot;` in source code editor):
<img width="1790" alt="Screenshot 2025-04-07 at 6 18 13 PM" src="https://github.com/user-attachments/assets/f19bb12b-1951-4bd9-8eaf-6746f6250acb" />
e code editor:
