### PR TITLE
fix: include plugins in i18n extraction script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@openedx-plugins/course-app-teams": "file:plugins/course-apps/teams",
         "@openedx-plugins/course-app-wiki": "file:plugins/course-apps/wiki",
         "@openedx-plugins/course-app-xpert_unit_summary": "file:plugins/course-apps/xpert_unit_summary",
-        "@openedx/frontend-build": "^14.3.3",
+        "@openedx/frontend-build": "^14.5.0",
         "@openedx/frontend-plugin-framework": "^1.7.0",
         "@openedx/paragon": "^22.16.0",
         "@redux-devtools/extension": "^3.3.0",
@@ -4041,9 +4041,9 @@
       "link": true
     },
     "node_modules/@openedx/frontend-build": {
-      "version": "14.4.0",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-build/-/frontend-build-14.4.0.tgz",
-      "integrity": "sha512-9TrJ2x9n7VkMymah2e1+6cRhC0kpNdFDv63s2RbPdCHjfoFBvaelqfrwMw1KXfudnc6EO3M7scQTw2z3vfNrpA==",
+      "version": "14.5.0",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-build/-/frontend-build-14.5.0.tgz",
+      "integrity": "sha512-HY0PdXvXBxrvJHj8HsRA+VNCHDePENFhqOIvbSz9Ke7HDwHpfDjg2CeKk41aU/8iTyj3eESfPwKQr5fTE0A3Ww==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@babel/cli": "7.24.8",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@openedx-plugins/course-app-teams": "file:plugins/course-apps/teams",
     "@openedx-plugins/course-app-wiki": "file:plugins/course-apps/wiki",
     "@openedx-plugins/course-app-xpert_unit_summary": "file:plugins/course-apps/xpert_unit_summary",
-    "@openedx/frontend-build": "^14.3.3",
+    "@openedx/frontend-build": "^14.5.0",
     "@openedx/frontend-plugin-framework": "^1.7.0",
     "@openedx/paragon": "^22.16.0",
     "@redux-devtools/extension": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build": "fedx-scripts webpack",
-    "i18n_extract": "fedx-scripts formatjs extract",
+    "i18n_extract": "fedx-scripts formatjs extract --include=plugins",
     "stylelint": "stylelint \"plugins/**/*.scss\" \"src/**/*.scss\" \"scss/**/*.scss\" --config .stylelintrc.json",
     "lint": "npm run stylelint && fedx-scripts eslint --ext .js --ext .jsx --ext .ts --ext .tsx .",
     "lint:fix": "npm run stylelint -- --fix && fedx-scripts eslint --fix --ext .js --ext .jsx --ext .ts --ext .tsx .",


### PR DESCRIPTION
## Description
This PR extract more translations to be translated from the exiting source code, when translated those new strings, it will improve localization.

1. Upgrades the `frontend-build` to the `v14.5.0`, with the support for additional source folders.
2. Configure the `plugins` folder to be used as source folder for i18n extraction.


Executing this command before and after this PR, and the prerequisites. You will see an increase of the extracted strings to be translated.

```bash
npm run i18n_extract && grep '"id"' temp/babel-plugin-formatjs/Default.messages.json | wc -l
```

From 1730 before to 2471 after.

## Depends on / prerequisites

Any.

1. https://github.com/openedx/frontend-build/pull/650 has already been merged. :heavy_check_mark: 
2. A frontend-build upgrade - this PR also upgrades this package :heavy_check_mark: 


## Testing instructions

Run
```bash
make pull_translations
```

Manually translate some new extracted strings to be translated, for example for `pt_PT` locale add the next json lines to the file `src/i18n/messages/frontend-app-course-authoring/pt_PT.json`:
```json
  "authoring.problemEditor.selectType.title": "Selecionar o tipo de problema",
  "authoring.problemeditor.selecttype.cancelButton.label": "Cancelar",
  "authoring.problemeditor.selecttype.selectButton.label": "Selecionar",
```

So when editing a "problem", URL: http://apps.local.openedx.io:2001/authoring/course/course-v1:OpenedX+DemoX+DemoCourse/editor/problem/block-v1:OpenedX+DemoX+DemoCourse+type@problem+block@59c24f8a4d5c46af8bfb5fc9cd4bb611

The modal title and action buttons will be translated/localized, view screenshot: 
![image](https://github.com/user-attachments/assets/0088beaa-94de-4d63-bf06-63a207a942ba)


Related to:
- https://github.com/openedx/frontend-app-authoring/pull/1801
- https://github.com/openedx/frontend-build/pull/650
