### PR TITLE
fix: toggle behavior for video & file view

### DIFF
--- a/src/files-and-videos/files-page/factories/mockApiResponses.jsx
+++ b/src/files-and-videos/files-page/factories/mockApiResponses.jsx
@@ -40,6 +40,27 @@ export const initialState = {
       },
     },
   },
+  videos: {
+    videoIds: ['mOckID1'],
+    pageSettings: {},
+    loadingStatus: RequestStatus.SUCCESSFUL,
+    updatingStatus: '',
+    addingStatus: '',
+    deletingStatus: '',
+    usageStatus: '',
+    transcriptStatus: '',
+    errors: {
+      add: [],
+      delete: [],
+      thumbnail: [],
+      download: [],
+      usageMetrics: [],
+      transcript: [],
+      loading: '',
+    },
+    filesCurrentView: 'card',
+    videosCurrentView: 'list',
+  },
 };
 
 export const generateFetchAssetApiResponse = () => ({

--- a/src/files-and-videos/videos-page/data/slice.js
+++ b/src/files-and-videos/videos-page/data/slice.js
@@ -23,10 +23,18 @@ const slice = createSlice({
       transcript: [],
       loading: '',
     },
+    filesCurrentView: 'list',
+    videosCurrentView: 'list',
   },
   reducers: {
     setVideoIds: (state, { payload }) => {
       state.videoIds = payload.videoIds;
+    },
+    setVideosCurrentViewState: (state, { payload }) => {
+      state.videosCurrentView = payload.videosCurrentView;
+    },
+    setFilesCurrentViewState: (state, { payload }) => {
+      state.filesCurrentView = payload.filesCurrentView;
     },
     setPageSettings: (state, { payload }) => {
       state.pageSettings = payload;
@@ -98,6 +106,8 @@ const slice = createSlice({
 
 export const {
   setVideoIds,
+  setVideosCurrentViewState,
+  setFilesCurrentViewState,
   setPageSettings,
   updateLoadingStatus,
   deleteVideoSuccess,

--- a/src/files-and-videos/videos-page/factories/mockApiResponses.jsx
+++ b/src/files-and-videos/videos-page/factories/mockApiResponses.jsx
@@ -84,6 +84,8 @@ export const initialState = {
       transcript: [],
       loading: '',
     },
+    filesCurrentView: 'list',
+    videosCurrentView: 'card',
   },
   models: {
     videos: {


### PR DESCRIPTION
Ticket: [TNL-11637](https://2u-internal.atlassian.net/browse/TNL-11637)
This PR fixes toggle behavior for video and file view.

- Before:
  - The default view was card. And The videos and files both pages were sharing same variable & default view.
  - Whenever user selects list view on videos/files page and redirects to another page, the toggle/view shifts again to default(card) view whenever it returns to videos/files page.

- After:
  - The default view is list now. And The videos and files both pages can have different state & default view.
  - Whenever user selects card view on videos/files page and redirects to another page, the toggle/view remain same whatever user had selected before when it returns to videos/files page.
https://github.com/user-attachments/assets/fd47d24f-35cb-42af-b549-7dd0949e74ad


**Note:** Refreshing a page will use default(list) view.
