### PR TITLE
feat: add existing components to unit [FC-0083]

### DIFF
--- a/src/library-authoring/add-content/AddContent.tsx
+++ b/src/library-authoring/add-content/AddContent.tsx
@@ -116,25 +116,25 @@ const AddContentView = ({
 
   return (
     <>
-      {upstreamContainerType !== ContainerType.Unit && (
+      {(collectionId || unitId) && componentPicker && (
+        /// Show the "Add Library Content" button for units and collections
         <>
-          {collectionId ? (
-            componentPicker && (
-              <>
-                <AddContentButton contentType={libraryContentButtonData} onCreateContent={onCreateContent} />
-                <PickLibraryContentModal
-                  isOpen={isAddLibraryContentModalOpen}
-                  onClose={closeAddLibraryContentModal}
-                />
-              </>
-            )
-          ) : (
-            <AddContentButton contentType={collectionButtonData} onCreateContent={onCreateContent} />
-          )}
-          <AddContentButton contentType={unitButtonData} onCreateContent={onCreateContent} />
-          <hr className="w-100 bg-gray-500" />
+          <AddContentButton contentType={libraryContentButtonData} onCreateContent={onCreateContent} />
+          <PickLibraryContentModal
+            isOpen={isAddLibraryContentModalOpen}
+            onClose={closeAddLibraryContentModal}
+          />
         </>
       )}
+      {!collectionId && !unitId && (
+        // Doesn't show the "Collection" button if we are in a unit or collection
+        <AddContentButton contentType={collectionButtonData} onCreateContent={onCreateContent} />
+      )}
+      {upstreamContainerType !== ContainerType.Unit && (
+        // Doesn't show the "Unit" button if we are in a unit
+        <AddContentButton contentType={unitButtonData} onCreateContent={onCreateContent} />
+      )}
+      <hr className="w-100 bg-gray-500" />
       {/* Note: for MVP we are hiding the unuspported types, not just disabling them. */}
       {contentTypes.filter(ct => !ct.disabled).map((contentType) => (
         <AddContentButton

--- a/src/library-authoring/add-content/PickLibraryContentModal.test.tsx
+++ b/src/library-authoring/add-content/PickLibraryContentModal.test.tsx
@@ -28,9 +28,20 @@ const { libraryId } = mockContentLibrary;
 const onClose = jest.fn();
 let mockShowToast: (message: string) => void;
 
-const render = () => baseRender(<PickLibraryContentModal isOpen onClose={onClose} />, {
-  path: '/library/:libraryId/collection/:collectionId/*',
-  params: { libraryId, collectionId: 'collectionId' },
+const mockAddItemsToCollection = jest.fn();
+const mockAddComponentsToContainer = jest.fn();
+jest.spyOn(api, 'addItemsToCollection').mockImplementation(mockAddItemsToCollection);
+jest.spyOn(api, 'addComponentsToContainer').mockImplementation(mockAddComponentsToContainer);
+
+const render = (context: 'collection' | 'unit') => baseRender(<PickLibraryContentModal isOpen onClose={onClose} />, {
+  path: context === 'collection'
+    ? '/library/:libraryId/collection/:collectionId/*'
+    : '/library/:libraryId/container/:unitId/*',
+  params: {
+    libraryId,
+    ...(context === 'collection' && { collectionId: 'collectionId' }),
+    ...(context === 'unit' && { unitId: 'unitId' }),
+  },
   extraWrapper: ({ children }) => (
     <LibraryProvider
       libraryId={libraryId}
@@ -46,62 +57,80 @@ describe('<PickLibraryContentModal />', () => {
     const mocks = initializeMocks();
     mockShowToast = mocks.mockShowToast;
     mocks.axiosMock.onGet(getStudioHomeApiUrl()).reply(200, studioHomeMock);
+    jest.clearAllMocks();
   });
 
-  it('can pick components from the modal', async () => {
-    const mockAddItemsToCollection = jest.fn();
-    jest.spyOn(api, 'addItemsToCollection').mockImplementation(mockAddItemsToCollection);
+  ['collection' as const, 'unit' as const].forEach((context) => {
+    it(`can pick components from the modal (${context})`, async () => {
+      render(context);
 
-    render();
+      // Wait for the content library to load
+      await waitFor(() => {
+        expect(screen.getByText('Test Library')).toBeInTheDocument();
+        expect(screen.queryAllByText('Introduction to Testing')[0]).toBeInTheDocument();
+      });
 
-    // Wait for the content library to load
-    await waitFor(() => {
-      expect(screen.getByText('Test Library')).toBeInTheDocument();
-      expect(screen.queryAllByText('Introduction to Testing')[0]).toBeInTheDocument();
-    });
+      // Select the first component
+      fireEvent.click(screen.queryAllByRole('button', { name: 'Select' })[0]);
+      expect(await screen.findByText('1 Selected Component')).toBeInTheDocument();
 
-    // Select the first component
-    fireEvent.click(screen.queryAllByRole('button', { name: 'Select' })[0]);
-    expect(await screen.findByText('1 Selected Component')).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: /add to .*/i }));
 
-    fireEvent.click(screen.queryAllByRole('button', { name: 'Add to Collection' })[0]);
-
-    await waitFor(() => {
-      expect(mockAddItemsToCollection).toHaveBeenCalledWith(
-        libraryId,
-        'collectionId',
-        ['lb:Axim:TEST:html:571fe018-f3ce-45c9-8f53-5dafcb422fdd'],
-      );
+      await waitFor(() => {
+        if (context === 'collection') {
+          expect(mockAddItemsToCollection).toHaveBeenCalledWith(
+            libraryId,
+            'collectionId',
+            ['lb:Axim:TEST:html:571fe018-f3ce-45c9-8f53-5dafcb422fdd'],
+          );
+        } else {
+          expect(mockAddComponentsToContainer).toHaveBeenCalledWith(
+            'unitId',
+            ['lb:Axim:TEST:html:571fe018-f3ce-45c9-8f53-5dafcb422fdd'],
+          );
+        }
+      });
       expect(onClose).toHaveBeenCalled();
       expect(mockShowToast).toHaveBeenCalledWith('Content linked successfully.');
     });
-  });
 
-  it('show error when api call fails', async () => {
-    const mockAddItemsToCollection = jest.fn().mockRejectedValue(new Error('Failed to add components'));
-    jest.spyOn(api, 'addItemsToCollection').mockImplementation(mockAddItemsToCollection);
-    render();
+    it(`show error when api call fails (${context})`, async () => {
+      if (context === 'collection') {
+        mockAddItemsToCollection.mockRejectedValueOnce(new Error('Error'));
+      } else {
+        mockAddComponentsToContainer.mockRejectedValueOnce(new Error('Error'));
+      }
+      render(context);
 
-    // Wait for the content library to load
-    await waitFor(() => {
-      expect(screen.getByText('Test Library')).toBeInTheDocument();
-      expect(screen.queryAllByText('Introduction to Testing')[0]).toBeInTheDocument();
-    });
+      // Wait for the content library to load
+      await waitFor(() => {
+        expect(screen.getByText('Test Library')).toBeInTheDocument();
+        expect(screen.queryAllByText('Introduction to Testing')[0]).toBeInTheDocument();
+      });
 
-    // Select the first component
-    fireEvent.click(screen.queryAllByRole('button', { name: 'Select' })[0]);
-    expect(await screen.findByText('1 Selected Component')).toBeInTheDocument();
+      // Select the first component
+      fireEvent.click(screen.queryAllByRole('button', { name: 'Select' })[0]);
+      expect(await screen.findByText('1 Selected Component')).toBeInTheDocument();
 
-    fireEvent.click(screen.queryAllByRole('button', { name: 'Add to Collection' })[0]);
+      fireEvent.click(screen.getByRole('button', { name: /add to .*/i }));
 
-    await waitFor(() => {
-      expect(mockAddItemsToCollection).toHaveBeenCalledWith(
-        libraryId,
-        'collectionId',
-        ['lb:Axim:TEST:html:571fe018-f3ce-45c9-8f53-5dafcb422fdd'],
-      );
+      await waitFor(() => {
+        if (context === 'collection') {
+          expect(mockAddItemsToCollection).toHaveBeenCalledWith(
+            libraryId,
+            'collectionId',
+            ['lb:Axim:TEST:html:571fe018-f3ce-45c9-8f53-5dafcb422fdd'],
+          );
+        } else {
+          expect(mockAddComponentsToContainer).toHaveBeenCalledWith(
+            'unitId',
+            ['lb:Axim:TEST:html:571fe018-f3ce-45c9-8f53-5dafcb422fdd'],
+          );
+        }
+      });
       expect(onClose).toHaveBeenCalled();
-      expect(mockShowToast).toHaveBeenCalledWith('There was an error linking the content to this collection.');
+      const name = context === 'collection' ? 'collection' : 'container';
+      expect(mockShowToast).toHaveBeenCalledWith(`There was an error linking the content to this ${name}.`);
     });
   });
 });

--- a/src/library-authoring/add-content/index.ts
+++ b/src/library-authoring/add-content/index.ts
@@ -1,2 +1,3 @@
 export { default as AddContent } from './AddContent';
 export { default as AddContentHeader } from './AddContentHeader';
+export { PickLibraryContentModal } from './PickLibraryContentModal';

--- a/src/library-authoring/add-content/messages.ts
+++ b/src/library-authoring/add-content/messages.ts
@@ -21,6 +21,11 @@ const messages = defineMessages({
     defaultMessage: 'Add to Collection',
     description: 'Button to add library content to a collection.',
   },
+  addToUnitButton: {
+    id: 'course-authoring.library-authoring.add-content.buttons.library-content.add-to-unit',
+    defaultMessage: 'Add to Unit',
+    description: 'Button to add library content to a unit.',
+  },
   selectedComponents: {
     id: 'course-authoring.library-authoring.add-content.selected-components',
     defaultMessage: '{count, plural, one {# Selected Component} other {# Selected Components}}',

--- a/src/library-authoring/containers/UnitInfo.tsx
+++ b/src/library-authoring/containers/UnitInfo.tsx
@@ -147,7 +147,7 @@ const UnitInfo = () => {
         activeKey={tab}
         onSelect={setSidebarTab}
       >
-        {renderTab(UNIT_INFO_TABS.Preview, <LibraryUnitBlocks />, intl.formatMessage(messages.previewTabTitle))}
+        {renderTab(UNIT_INFO_TABS.Preview, <LibraryUnitBlocks preview />, intl.formatMessage(messages.previewTabTitle))}
         {renderTab(UNIT_INFO_TABS.Organize, <ContainerOrganize />, intl.formatMessage(messages.organizeTabTitle))}
         {renderTab(UNIT_INFO_TABS.Settings, 'Unit Settings', intl.formatMessage(messages.settingsTabTitle))}
       </Tabs>

--- a/src/library-authoring/containers/UnitInfo.tsx
+++ b/src/library-authoring/containers/UnitInfo.tsx
@@ -10,6 +10,7 @@ import {
   useToggle,
 } from '@openedx/paragon';
 import { useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import { MoreVert } from '@openedx/paragon/icons';
 
 import { useComponentPickerContext } from '../common/context/ComponentPickerContext';
@@ -70,7 +71,7 @@ const UnitMenu = ({ containerId, displayName }: ContainerMenuProps) => {
 const UnitInfo = () => {
   const intl = useIntl();
 
-  const { setUnitId } = useLibraryContext();
+  const { libraryId } = useLibraryContext();
   const { componentPickerMode } = useComponentPickerContext();
   const {
     defaultTab,
@@ -81,7 +82,7 @@ const UnitInfo = () => {
     sidebarAction,
   } = useSidebarContext();
   const jumpToCollections = sidebarAction === SidebarActions.JumpToAddCollections;
-  const { insideUnit, navigateTo } = useLibraryRoutes();
+  const { insideUnit } = useLibraryRoutes();
 
   const tab: UnitInfoTab = (
     sidebarTab && isUnitInfoTab(sidebarTab)
@@ -90,15 +91,7 @@ const UnitInfo = () => {
   const unitId = sidebarComponentInfo?.id;
   const { data: container } = useContainer(unitId);
 
-  const handleOpenUnit = useCallback(() => {
-    if (componentPickerMode) {
-      setUnitId(unitId);
-    } else {
-      navigateTo({ unitId });
-    }
-  }, [componentPickerMode, navigateTo, unitId]);
-
-  const showOpenUnitButton = !insideUnit || componentPickerMode;
+  const showOpenUnitButton = !insideUnit && !componentPickerMode;
 
   const renderTab = useCallback((infoTab: UnitInfoTab, component: React.ReactNode, title: string) => {
     if (hiddenTabs.includes(infoTab)) {
@@ -130,7 +123,8 @@ const UnitInfo = () => {
           <Button
             variant="outline-primary"
             className="m-1 text-nowrap flex-grow-1"
-            onClick={handleOpenUnit}
+            as={Link}
+            to={`/library/${libraryId}/unit/${unitId}`}
           >
             {intl.formatMessage(messages.openUnitButton)}
           </Button>

--- a/src/library-authoring/units/LibraryUnitBlocks.tsx
+++ b/src/library-authoring/units/LibraryUnitBlocks.tsx
@@ -17,6 +17,7 @@ import { IframeProvider } from '../../generic/hooks/context/iFrameContext';
 import Loading from '../../generic/Loading';
 import TagCount from '../../generic/tag-count';
 import { useLibraryContext } from '../common/context/LibraryContext';
+import { PickLibraryContentModal } from '../add-content';
 import ComponentMenu from '../components';
 import { LibraryBlockMetadata } from '../data/api';
 import { libraryAuthoringQueryKeys, useContainerChildren } from '../data/apiHooks';
@@ -38,6 +39,8 @@ export const LibraryUnitBlocks = () => {
   const intl = useIntl();
   const [orderedBlocks, setOrderedBlocks] = useState<LibraryBlockMetadata[]>([]);
   const [isManageTagsDrawerOpen, openManageTagsDrawer, closeManageTagsDrawer] = useToggle(false);
+  const [isAddLibraryContentModalOpen, showAddLibraryContentModal, closeAddLibraryContentModal] = useToggle();
+
   const { navigateTo } = useLibraryRoutes();
 
   const {
@@ -148,6 +151,7 @@ export const LibraryUnitBlocks = () => {
     </IframeProvider>
   ));
 
+
   return (
     <div className="library-unit-page">
       <DraggableList itemList={orderedBlocks} setState={setOrderedBlocks} updateOrder={handleReorder}>
@@ -171,11 +175,17 @@ export const LibraryUnitBlocks = () => {
             className="ml-2"
             iconBefore={Add}
             variant="outline-primary rounded-0"
-            disabled
+            disabled={readOnly}
+            onClick={showAddLibraryContentModal}
             block
           >
             {intl.formatMessage(messages.addExistingContentButton)}
           </Button>
+          <PickLibraryContentModal
+            isOpen={isAddLibraryContentModalOpen}
+            onClose={closeAddLibraryContentModal}
+            extraFilter={['NOT block_type = "unit"']}
+          />
         </div>
       </div>
       <ContentTagsDrawerSheet

--- a/src/library-authoring/units/LibraryUnitBlocks.tsx
+++ b/src/library-authoring/units/LibraryUnitBlocks.tsx
@@ -35,7 +35,11 @@ const LARGE_COMPONENTS = [
   'lti_consumer',
 ];
 
-export const LibraryUnitBlocks = () => {
+interface LibraryUnitBlocksProps {
+  preview?: boolean;
+}
+
+export const LibraryUnitBlocks = ({ preview = false }: LibraryUnitBlocksProps) => {
   const intl = useIntl();
   const [orderedBlocks, setOrderedBlocks] = useState<LibraryBlockMetadata[]>([]);
   const [isManageTagsDrawerOpen, openManageTagsDrawer, closeManageTagsDrawer] = useToggle(false);
@@ -151,43 +155,44 @@ export const LibraryUnitBlocks = () => {
     </IframeProvider>
   ));
 
-
   return (
     <div className="library-unit-page">
       <DraggableList itemList={orderedBlocks} setState={setOrderedBlocks} updateOrder={handleReorder}>
         {renderedBlocks}
       </DraggableList>
-      <div className="d-flex">
-        <div className="w-100 mr-2">
-          <Button
-            className="ml-2"
-            iconBefore={Add}
-            variant="outline-primary rounded-0"
-            disabled={readOnly}
-            onClick={openAddContentSidebar}
-            block
-          >
-            {intl.formatMessage(messages.newContentButton)}
-          </Button>
+      { !preview && (
+        <div className="d-flex">
+          <div className="w-100 mr-2">
+            <Button
+              className="ml-2"
+              iconBefore={Add}
+              variant="outline-primary rounded-0"
+              disabled={readOnly}
+              onClick={openAddContentSidebar}
+              block
+            >
+              {intl.formatMessage(messages.newContentButton)}
+            </Button>
+          </div>
+          <div className="w-100 ml-2">
+            <Button
+              className="ml-2"
+              iconBefore={Add}
+              variant="outline-primary rounded-0"
+              disabled={readOnly}
+              onClick={showAddLibraryContentModal}
+              block
+            >
+              {intl.formatMessage(messages.addExistingContentButton)}
+            </Button>
+            <PickLibraryContentModal
+              isOpen={isAddLibraryContentModalOpen}
+              onClose={closeAddLibraryContentModal}
+              extraFilter={['NOT block_type = "unit"']}
+            />
+          </div>
         </div>
-        <div className="w-100 ml-2">
-          <Button
-            className="ml-2"
-            iconBefore={Add}
-            variant="outline-primary rounded-0"
-            disabled={readOnly}
-            onClick={showAddLibraryContentModal}
-            block
-          >
-            {intl.formatMessage(messages.addExistingContentButton)}
-          </Button>
-          <PickLibraryContentModal
-            isOpen={isAddLibraryContentModalOpen}
-            onClose={closeAddLibraryContentModal}
-            extraFilter={['NOT block_type = "unit"']}
-          />
-        </div>
-      </div>
+      )}
       <ContentTagsDrawerSheet
         id={componentId}
         onClose={onTagSidebarClose}

--- a/src/library-authoring/units/LibraryUnitPage.tsx
+++ b/src/library-authoring/units/LibraryUnitPage.tsx
@@ -1,5 +1,9 @@
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { Breadcrumb, Button, Container } from '@openedx/paragon';
+import {
+  Breadcrumb,
+  Button,
+  Container,
+} from '@openedx/paragon';
 import { Add, InfoOutline } from '@openedx/paragon/icons';
 import { useCallback, useEffect } from 'react';
 import { Helmet } from 'react-helmet';


### PR DESCRIPTION
## Description

This PR allows adding existing components to units

![image](https://github.com/user-attachments/assets/2126cc23-762f-46b0-a6ef-f87760d356ac)

## Additional Information
- Implements https://github.com/openedx/frontend-app-authoring/issues/1620
- Depends on https://github.com/openedx/frontend-app-authoring/pull/1784

## Testing instructions

- Go to the library home of a library.
- Create a Unit.
- Open the Unit page of the new unit.
- Click on Add content button.
- Click on "Existing Library Content"
- Select some components and click on "Add to Unit"
-  Verify that the blocks are added to the unit

Note: Before merging https://github.com/openedx/frontend-app-authoring/pull/1797 you may see another Units on the component picker
___
Private ref: [FAL-4059](https://tasks.opencraft.com/browse/FAL-4059)