### PR TITLE
fix: sort Advanced Blocks by default display name [FC-0076]

### DIFF
--- a/src/library-authoring/add-content/AddContent.tsx
+++ b/src/library-authoring/add-content/AddContent.tsx
@@ -154,6 +154,10 @@ const AddAdvancedContentView = ({
   isBlockTypeEnabled,
 }: AddAdvancedContentViewProps) => {
   const intl = useIntl();
+  // Sort block types alphabetically by default display name
+  const sortedBlockTypes = Object.keys(advancedBlocks).sort((typeA, typeB) => (
+    advancedBlocks[typeA].displayName.localeCompare(advancedBlocks[typeB].displayName)
+  ));
   return (
     <>
       <div className="d-flex">
@@ -161,7 +165,7 @@ const AddAdvancedContentView = ({
           {intl.formatMessage(messages.backToAddContentListButton)}
         </Button>
       </div>
-      {Object.keys(advancedBlocks).map((blockType) => (
+      {sortedBlockTypes.map((blockType) => (
         isBlockTypeEnabled(blockType) ? (
           <AddContentButton
             key={`add-content-${blockType}`}


### PR DESCRIPTION
## Description

Alphabetically sorts the blocks listed under "Advanced / Other" by default display name.

This is a minor change affecting Library Authors.

## Supporting information

Resolves: https://github.com/openedx/frontend-app-authoring/issues/1513#issuecomment-2715841482
Private-ref: [FAL-4119](https://tasks.opencraft.com/browse/FAL-4119)

## Testing instructions

1. Install some extra XBlocks to appear in the "Advanced / Other" list, e.g. [in-video-quiz](https://github.com/openedx/xblock-in-video-quiz) or [freetextresponse](https://github.com/openedx/xblock-free-text-response). The installed XBlocks must have a `display_name` property and be listed in [`settings.LIBRARY_ENABLED_BLOCKS`](https://github.com/openedx/edx-platform/blob/694bf77993bf0d209301d907be0ece89bb71282a/cms/envs/common.py#L2907).
    ```
    tutor dev exec cms
    app@f7fc04098de3:~/edx-platform$ pip install git+https://github.com/openedx/xblock-in-video-quiz
    app@f7fc04098de3:~/edx-platform$ touch cms/envs/common.py  # to reload Studio
    ```
2. In the Authoring MFE, create or view an existing library.
3. Click "New" to view the "add component" sidebar. Select "Advanced / Other"
4. Ensure the list of other XBlocks is sorted alphabetically.

## Other information

I'm not positive this PR is necessary, as the XBlock types returned from the libraries API seem to be alphabetically sorted already? But it doesn't hurt anything.