### PR TITLE
feat: rename component on unit page

### DIFF
--- a/src/generic/inplace-text-editor/InplaceTextEditor.test.tsx
+++ b/src/generic/inplace-text-editor/InplaceTextEditor.test.tsx
@@ -24,8 +24,8 @@ describe('<InplaceTextEditor />', () => {
     expect(screen.queryByRole('button', { name: /edit/ })).not.toBeInTheDocument();
   });
 
-  it('should render the edit button if showEditButton is true', () => {
-    render(<InplaceTextEditor text="Test text" onSave={mockOnSave} showEditButton />);
+  it('should render the edit button if alwaysShowEditButton is true', () => {
+    render(<InplaceTextEditor text="Test text" onSave={mockOnSave} alwaysShowEditButton />);
 
     expect(screen.getByText('Test text')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();

--- a/src/generic/inplace-text-editor/index.tsx
+++ b/src/generic/inplace-text-editor/index.tsx
@@ -12,7 +12,7 @@ import {
   OverlayTrigger,
   Stack,
 } from '@openedx/paragon';
-import { Edit } from '@openedx/paragon/icons';
+import { Edit, EditCircle } from '@openedx/paragon/icons';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import messages from './messages';
@@ -130,7 +130,7 @@ export const InplaceTextEditor: React.FC<InplaceTextEditorProps> = ({
         <IconWrapper>
           <Icon
             id="edit-text-icon"
-            src={Edit}
+            src={EditCircle}
             className="ml-1.5"
             onClick={handleEdit}
           />

--- a/src/generic/inplace-text-editor/index.tsx
+++ b/src/generic/inplace-text-editor/index.tsx
@@ -11,7 +11,7 @@ import {
   OverlayTrigger,
   Stack,
 } from '@openedx/paragon';
-import { Edit, EditCircle } from '@openedx/paragon/icons';
+import { Edit } from '@openedx/paragon/icons';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import messages from './messages';
@@ -127,7 +127,7 @@ export const InplaceTextEditor: React.FC<InplaceTextEditorProps> = ({
         <IconWrapper>
           <Icon
             id="edit-text-icon"
-            src={EditCircle}
+            src={Edit}
             className="ml-1.5"
             onClick={handleEdit}
           />

--- a/src/generic/inplace-text-editor/index.tsx
+++ b/src/generic/inplace-text-editor/index.tsx
@@ -2,7 +2,6 @@ import React, {
   useCallback,
   useEffect,
   useState,
-  useRef,
   forwardRef,
 } from 'react';
 import {
@@ -55,7 +54,6 @@ export const InplaceTextEditor: React.FC<InplaceTextEditorProps> = ({
 }) => {
   const intl = useIntl();
   const [inputIsActive, setIsActive] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   const handleOnChangeText = useCallback(
     (event) => {
@@ -124,7 +122,6 @@ export const InplaceTextEditor: React.FC<InplaceTextEditorProps> = ({
   return (
     <OverlayTrigger
       trigger={['hover', 'focus']}
-      container={containerRef.current}
       placement="right"
       overlay={(
         <IconWrapper>
@@ -137,10 +134,7 @@ export const InplaceTextEditor: React.FC<InplaceTextEditorProps> = ({
         </IconWrapper>
       )}
     >
-      <Stack
-        direction="horizontal"
-        gap={1}
-      >
+      <div>
         {inputIsActive
           ? (
             <Form.Control
@@ -163,8 +157,7 @@ export const InplaceTextEditor: React.FC<InplaceTextEditorProps> = ({
               {text}
             </span>
           )}
-        <div ref={containerRef} />
-      </Stack>
+      </div>
     </OverlayTrigger>
   );
 };

--- a/src/library-authoring/collections/CollectionInfoHeader.tsx
+++ b/src/library-authoring/collections/CollectionInfoHeader.tsx
@@ -46,7 +46,7 @@ const CollectionInfoHeader = () => {
       text={collection.title}
       readOnly={readOnly}
       textClassName="font-weight-bold m-1.5"
-      showEditButton
+      alwaysShowEditButton
     />
   );
 };

--- a/src/library-authoring/component-info/ComponentInfoHeader.test.tsx
+++ b/src/library-authoring/component-info/ComponentInfoHeader.test.tsx
@@ -98,7 +98,7 @@ describe('<ComponentInfoHeader />', () => {
     });
   });
 
-  it('should close edit library title on press Escape', async () => {
+  it('should close edit component title on press Escape', async () => {
     const url = getXBlockFieldsVersionApiUrl(usageKey, 'draft');
     axiosMock.onPost(url).reply(200);
     render();
@@ -117,7 +117,7 @@ describe('<ComponentInfoHeader />', () => {
     await waitFor(() => expect(axiosMock.history.post.length).toEqual(0));
   });
 
-  it('should show error on edit library tittle', async () => {
+  it('should show error on edit component tittle', async () => {
     const url = getXBlockFieldsApiUrl(usageKey);
     axiosMock.onPatch(url).reply(500);
     render();

--- a/src/library-authoring/component-info/ComponentInfoHeader.tsx
+++ b/src/library-authoring/component-info/ComponentInfoHeader.tsx
@@ -48,7 +48,7 @@ const ComponentInfoHeader = () => {
       text={xblockFields?.displayName}
       readOnly={readOnly}
       textClassName="font-weight-bold m-1.5"
-      showEditButton
+      alwaysShowEditButton
     />
   );
 };

--- a/src/library-authoring/containers/ContainerInfoHeader.tsx
+++ b/src/library-authoring/containers/ContainerInfoHeader.tsx
@@ -45,7 +45,7 @@ const ContainerInfoHeader = () => {
       text={container.displayName}
       readOnly={readOnly}
       textClassName="font-weight-bold m-1.5"
-      showEditButton
+      alwaysShowEditButton
     />
   );
 };

--- a/src/library-authoring/data/apiHooks.test.tsx
+++ b/src/library-authoring/data/apiHooks.test.tsx
@@ -161,7 +161,7 @@ describe('library api hooks', () => {
   });
 
   it('should delete a container', async () => {
-    const containerId = 'lct:org:lib1';
+    const containerId = 'lct:lib:org:unit:unit1';
     const url = getLibraryContainerApiUrl(containerId);
 
     axiosMock.onDelete(url).reply(200);
@@ -173,7 +173,7 @@ describe('library api hooks', () => {
   });
 
   it('should restore a container', async () => {
-    const containerId = 'lct:org:lib1';
+    const containerId = 'lct:lib:org:unit:unit1';
     const url = getLibraryContainerRestoreApiUrl(containerId);
 
     axiosMock.onPost(url).reply(200);
@@ -269,7 +269,7 @@ describe('library api hooks', () => {
   });
 
   it('should update container children', async () => {
-    const containerId = 'lct:org:lib1';
+    const containerId = 'lct:org:lib:unit:unit-1';
     const url = getLibraryContainerChildrenApiUrl(containerId);
 
     axiosMock.onPatch(url).reply(200);

--- a/src/library-authoring/data/apiHooks.test.tsx
+++ b/src/library-authoring/data/apiHooks.test.tsx
@@ -173,7 +173,7 @@ describe('library api hooks', () => {
   });
 
   it('should restore a container', async () => {
-    const containerId = 'lct:lib:org:unit:unit1';
+    const containerId = 'lct:org:lib:unit:unit1';
     const url = getLibraryContainerRestoreApiUrl(containerId);
 
     axiosMock.onPost(url).reply(200);

--- a/src/library-authoring/data/apiHooks.test.tsx
+++ b/src/library-authoring/data/apiHooks.test.tsx
@@ -161,7 +161,7 @@ describe('library api hooks', () => {
   });
 
   it('should delete a container', async () => {
-    const containerId = 'lct:lib:org:unit:unit1';
+    const containerId = 'lct:org:lib:unit:unit1';
     const url = getLibraryContainerApiUrl(containerId);
 
     axiosMock.onDelete(url).reply(200);

--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -375,8 +375,12 @@ export const useUpdateXBlockFields = (usageKey: string) => {
     mutationFn: (data: UpdateXBlockFieldsRequest) => updateXBlockFields(usageKey, data),
     onMutate: async (data) => {
       const queryKey = xblockQueryKeys.xblockFields(usageKey);
-      const previousBlockData = queryClient.getQueriesData(queryKey)[0][1] as XBlockFields;
+      const previousBlockData = queryClient.getQueriesData(queryKey)?.[0]?.[1] as XBlockFields | undefined;
       const formatedData = camelCaseObject(data);
+
+      if (!previousBlockData) {
+        return { previousBlockData };
+      }
 
       const newBlockData = {
         ...previousBlockData,
@@ -389,7 +393,7 @@ export const useUpdateXBlockFields = (usageKey: string) => {
 
       queryClient.setQueryData(queryKey, newBlockData);
 
-      return { previousBlockData, newBlockData };
+      return { previousBlockData };
     },
     onError: (_err, _data, context) => {
       queryClient.setQueryData(

--- a/src/library-authoring/units/messages.ts
+++ b/src/library-authoring/units/messages.ts
@@ -31,6 +31,16 @@ const messages = defineMessages({
     defaultMessage: 'Draft',
     description: 'Chip in components in unit page that is shown when component has unpublished changes',
   },
+  updateComponentSuccessMsg: {
+    id: 'course-authoring.library-authoring.unit-component.update.success',
+    defaultMessage: 'Component updated successfully.',
+    description: 'Message when the component is updated successfully',
+  },
+  updateComponentErrorMsg: {
+    id: 'course-authoring.library-authoring.unit-component.update.error',
+    defaultMessage: 'There was an error updating the component.',
+    description: 'Message when there is an error when updating the component',
+  },
   updateContainerSuccessMsg: {
     id: 'course-authoring.library-authoring.update-container-success-msg',
     defaultMessage: 'Container updated successfully.',


### PR DESCRIPTION
## Description

This PR allows renaming components inside a unit
![rename-component](https://github.com/user-attachments/assets/03f5110e-080d-46c8-aede-03a4579b173c)

## Additional Information
- Implements https://github.com/openedx/frontend-app-authoring/issues/1626

## Testing Instructions
- Open a Unit Page of a unit with some components
- Click on one component name and rename it
- Check if the name is updated sucessfully
- Do the same navigating using `Tab` and pressing any key to start editing the name

___
Private ref: [FAL-4065](https://tasks.opencraft.com/browse/FAL-4065)