### PR TITLE
feat: New Transcript widget state on video editors on creation workflow [FC-0076]

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/CollapsibleFormWidget.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/CollapsibleFormWidget.jsx
@@ -20,11 +20,12 @@ const CollapsibleFormWidget = ({
   subtitle,
   title,
   fontSize,
+  bgColor,
   // injected
   intl,
 }) => (
   <Collapsible.Advanced
-    className="collapsible-card rounded mx-4 my-3 px-4 text-primary-500"
+    className={`collapsible-card rounded mx-4 my-3 px-4 text-primary-500 ${bgColor}`}
     defaultOpen
     open={isError || undefined}
   >
@@ -58,6 +59,7 @@ const CollapsibleFormWidget = ({
 CollapsibleFormWidget.defaultProps = {
   subtitle: null,
   fontSize: '',
+  bgColor: '',
 };
 
 CollapsibleFormWidget.propTypes = {
@@ -66,6 +68,7 @@ CollapsibleFormWidget.propTypes = {
   subtitle: PropTypes.node,
   title: PropTypes.node.isRequired,
   fontSize: PropTypes.string,
+  bgColor: PropTypes.string,
   // injected
   intl: intlShape.isRequired,
 };

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/CollapsibleFormWidget.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/CollapsibleFormWidget.jsx
@@ -20,12 +20,11 @@ const CollapsibleFormWidget = ({
   subtitle,
   title,
   fontSize,
-  bgColor,
   // injected
   intl,
 }) => (
   <Collapsible.Advanced
-    className={`collapsible-card rounded mx-4 my-3 px-4 text-primary-500 ${bgColor}`}
+    className="collapsible-card rounded mx-4 my-3 px-4 text-primary-500"
     defaultOpen
     open={isError || undefined}
   >
@@ -59,7 +58,6 @@ const CollapsibleFormWidget = ({
 CollapsibleFormWidget.defaultProps = {
   subtitle: null,
   fontSize: '',
-  bgColor: '',
 };
 
 CollapsibleFormWidget.propTypes = {
@@ -68,7 +66,6 @@ CollapsibleFormWidget.propTypes = {
   subtitle: PropTypes.node,
   title: PropTypes.node.isRequired,
   fontSize: PropTypes.string,
-  bgColor: PropTypes.string,
   // injected
   intl: intlShape.isRequired,
 };

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/__snapshots__/index.test.jsx.snap
@@ -4,12 +4,10 @@ exports[`TranscriptWidget component snapshots snapshot: render when \`isCreateWo
 <div
   className="mr-4 ml-4"
 >
-  <withDeprecatedProps(Card)
+  <Card
     className="bg-light-200"
   >
-    <ForwardRef
-      muted={false}
-      skeletonHeight={100}
+    <Card.Section
       title={
         <div
           className="text-gray-500"
@@ -23,8 +21,8 @@ exports[`TranscriptWidget component snapshots snapshot: render when \`isCreateWo
       >
         To add transcripts, save and reopen this video
       </div>
-    </ForwardRef>
-  </withDeprecatedProps(Card)>
+    </Card.Section>
+  </Card>
 </div>
 `;
 
@@ -40,7 +38,7 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -51,18 +49,16 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
     hideHeading={true}
     isError={true}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <ForwardRef
-    direction="vertical"
+  <Stack
     gap={3}
-    reversed={false}
   >
-    <FormGroup
+    <Form.Group
       className="border-primary-100 border-bottom"
     >
       <Transcript
@@ -70,70 +66,39 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
         language="en"
       />
       <ActionRow
-        as="div"
         className="mt-3.5"
-        isStacked={false}
       >
-        <ForwardRef
+        <Form.Checkbox
           checked={false}
           className="decorative-control-label"
-          controlAs={
-            {
-              "$$typeof": Symbol(react.forward_ref),
-              "defaultProps": {
-                "className": undefined,
-                "isIndeterminate": false,
-              },
-              "propTypes": {
-                "className": [Function],
-                "isIndeterminate": [Function],
-              },
-              "render": [Function],
-            }
-          }
-          disabled={false}
-          floatLabelLeft={false}
-          isInvalid={false}
-          isValid={false}
           onChange={[Function]}
         >
           <div
             className="small text-gray-700"
           >
-            <Memo(MemoizedFormattedMessage)
+            <FormattedMessage
               defaultMessage="Allow transcript downloads"
               description="Label for allow transcript downloads checkbox"
               id="authoring.videoeditor.transcripts.allowDownloadCheckboxLabel"
             />
           </div>
-        </ForwardRef>
+        </Form.Checkbox>
         <OverlayTrigger
-          defaultShow={false}
           key="top"
           overlay={
-            <ForwardRef
-              bsPrefix="tooltip"
+            <Tooltip
               id="tooltip-top"
-              placement="right"
             >
-              <Memo(MemoizedFormattedMessage)
+              <FormattedMessage
                 defaultMessage="Learners will see a link to download the transcript below the video."
                 description="Message for show by default checkbox"
                 id="authoring.videoeditor.transcripts.upload.allowDownloadTooltipMessage"
               />
-            </ForwardRef>
+            </Tooltip>
           }
           placement="top"
-          popperConfig={{}}
-          trigger={
-            [
-              "hover",
-              "focus",
-            ]
-          }
         >
-          <withDeprecatedProps(Icon)
-            src={[Function]}
+          <Icon
             style={
               {
                 "height": "16px",
@@ -142,61 +107,41 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
             }
           />
         </OverlayTrigger>
-        <ActionRowSpacer />
+        <ActionRow.Spacer />
       </ActionRow>
-      <ForwardRef
+      <Form.Checkbox
         checked={false}
         className="mt-3 decorative-control-label"
-        controlAs={
-          {
-            "$$typeof": Symbol(react.forward_ref),
-            "defaultProps": {
-              "className": undefined,
-              "isIndeterminate": false,
-            },
-            "propTypes": {
-              "className": [Function],
-              "isIndeterminate": [Function],
-            },
-            "render": [Function],
-          }
-        }
-        disabled={false}
-        floatLabelLeft={false}
-        isInvalid={false}
-        isValid={false}
         onChange={[Function]}
       >
         <div
           className="small text-gray-700"
         >
-          <Memo(MemoizedFormattedMessage)
+          <FormattedMessage
             defaultMessage="Show transcript in the video player by default"
             description="Label for show by default checkbox"
             id="authoring.videoeditor.transcripts.upload.showByDefaultCheckboxLabel"
           />
         </div>
-      </ForwardRef>
-    </FormGroup>
+      </Form.Checkbox>
+    </Form.Group>
     <div
       className="mt-2"
     >
-      <ForwardRef
+      <Button
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
-        disabled={false}
-        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <Memo(MemoizedFormattedMessage)
+        <FormattedMessage
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </ForwardRef>
+      </Button>
     </div>
-  </ForwardRef>
+  </Stack>
 </CollapsibleFormWidget>
 `;
 
@@ -212,7 +157,7 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
     hideHeading={true}
     isError={true}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -223,18 +168,16 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <ForwardRef
-    direction="vertical"
+  <Stack
     gap={3}
-    reversed={false}
   >
-    <FormGroup
+    <Form.Group
       className="border-primary-100 border-bottom"
     >
       <Transcript
@@ -246,70 +189,39 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
         language="fr"
       />
       <ActionRow
-        as="div"
         className="mt-3.5"
-        isStacked={false}
       >
-        <ForwardRef
+        <Form.Checkbox
           checked={false}
           className="decorative-control-label"
-          controlAs={
-            {
-              "$$typeof": Symbol(react.forward_ref),
-              "defaultProps": {
-                "className": undefined,
-                "isIndeterminate": false,
-              },
-              "propTypes": {
-                "className": [Function],
-                "isIndeterminate": [Function],
-              },
-              "render": [Function],
-            }
-          }
-          disabled={false}
-          floatLabelLeft={false}
-          isInvalid={false}
-          isValid={false}
           onChange={[Function]}
         >
           <div
             className="small text-gray-700"
           >
-            <Memo(MemoizedFormattedMessage)
+            <FormattedMessage
               defaultMessage="Allow transcript downloads"
               description="Label for allow transcript downloads checkbox"
               id="authoring.videoeditor.transcripts.allowDownloadCheckboxLabel"
             />
           </div>
-        </ForwardRef>
+        </Form.Checkbox>
         <OverlayTrigger
-          defaultShow={false}
           key="top"
           overlay={
-            <ForwardRef
-              bsPrefix="tooltip"
+            <Tooltip
               id="tooltip-top"
-              placement="right"
             >
-              <Memo(MemoizedFormattedMessage)
+              <FormattedMessage
                 defaultMessage="Learners will see a link to download the transcript below the video."
                 description="Message for show by default checkbox"
                 id="authoring.videoeditor.transcripts.upload.allowDownloadTooltipMessage"
               />
-            </ForwardRef>
+            </Tooltip>
           }
           placement="top"
-          popperConfig={{}}
-          trigger={
-            [
-              "hover",
-              "focus",
-            ]
-          }
         >
-          <withDeprecatedProps(Icon)
-            src={[Function]}
+          <Icon
             style={
               {
                 "height": "16px",
@@ -318,61 +230,41 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
             }
           />
         </OverlayTrigger>
-        <ActionRowSpacer />
+        <ActionRow.Spacer />
       </ActionRow>
-      <ForwardRef
+      <Form.Checkbox
         checked={false}
         className="mt-3 decorative-control-label"
-        controlAs={
-          {
-            "$$typeof": Symbol(react.forward_ref),
-            "defaultProps": {
-              "className": undefined,
-              "isIndeterminate": false,
-            },
-            "propTypes": {
-              "className": [Function],
-              "isIndeterminate": [Function],
-            },
-            "render": [Function],
-          }
-        }
-        disabled={false}
-        floatLabelLeft={false}
-        isInvalid={false}
-        isValid={false}
         onChange={[Function]}
       >
         <div
           className="small text-gray-700"
         >
-          <Memo(MemoizedFormattedMessage)
+          <FormattedMessage
             defaultMessage="Show transcript in the video player by default"
             description="Label for show by default checkbox"
             id="authoring.videoeditor.transcripts.upload.showByDefaultCheckboxLabel"
           />
         </div>
-      </ForwardRef>
-    </FormGroup>
+      </Form.Checkbox>
+    </Form.Group>
     <div
       className="mt-2"
     >
-      <ForwardRef
+      <Button
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
-        disabled={false}
-        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <Memo(MemoizedFormattedMessage)
+        <FormattedMessage
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </ForwardRef>
+      </Button>
     </div>
-  </ForwardRef>
+  </Stack>
 </CollapsibleFormWidget>
 `;
 
@@ -388,7 +280,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -399,18 +291,16 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <ForwardRef
-    direction="vertical"
+  <Stack
     gap={3}
-    reversed={false}
   >
-    <FormGroup
+    <Form.Group
       className="border-primary-100 border-bottom"
     >
       <Transcript
@@ -418,70 +308,39 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
         language="en"
       />
       <ActionRow
-        as="div"
         className="mt-3.5"
-        isStacked={false}
       >
-        <ForwardRef
+        <Form.Checkbox
           checked={true}
           className="decorative-control-label"
-          controlAs={
-            {
-              "$$typeof": Symbol(react.forward_ref),
-              "defaultProps": {
-                "className": undefined,
-                "isIndeterminate": false,
-              },
-              "propTypes": {
-                "className": [Function],
-                "isIndeterminate": [Function],
-              },
-              "render": [Function],
-            }
-          }
-          disabled={false}
-          floatLabelLeft={false}
-          isInvalid={false}
-          isValid={false}
           onChange={[Function]}
         >
           <div
             className="small text-gray-700"
           >
-            <Memo(MemoizedFormattedMessage)
+            <FormattedMessage
               defaultMessage="Allow transcript downloads"
               description="Label for allow transcript downloads checkbox"
               id="authoring.videoeditor.transcripts.allowDownloadCheckboxLabel"
             />
           </div>
-        </ForwardRef>
+        </Form.Checkbox>
         <OverlayTrigger
-          defaultShow={false}
           key="top"
           overlay={
-            <ForwardRef
-              bsPrefix="tooltip"
+            <Tooltip
               id="tooltip-top"
-              placement="right"
             >
-              <Memo(MemoizedFormattedMessage)
+              <FormattedMessage
                 defaultMessage="Learners will see a link to download the transcript below the video."
                 description="Message for show by default checkbox"
                 id="authoring.videoeditor.transcripts.upload.allowDownloadTooltipMessage"
               />
-            </ForwardRef>
+            </Tooltip>
           }
           placement="top"
-          popperConfig={{}}
-          trigger={
-            [
-              "hover",
-              "focus",
-            ]
-          }
         >
-          <withDeprecatedProps(Icon)
-            src={[Function]}
+          <Icon
             style={
               {
                 "height": "16px",
@@ -490,61 +349,41 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
             }
           />
         </OverlayTrigger>
-        <ActionRowSpacer />
+        <ActionRow.Spacer />
       </ActionRow>
-      <ForwardRef
+      <Form.Checkbox
         checked={false}
         className="mt-3 decorative-control-label"
-        controlAs={
-          {
-            "$$typeof": Symbol(react.forward_ref),
-            "defaultProps": {
-              "className": undefined,
-              "isIndeterminate": false,
-            },
-            "propTypes": {
-              "className": [Function],
-              "isIndeterminate": [Function],
-            },
-            "render": [Function],
-          }
-        }
-        disabled={false}
-        floatLabelLeft={false}
-        isInvalid={false}
-        isValid={false}
         onChange={[Function]}
       >
         <div
           className="small text-gray-700"
         >
-          <Memo(MemoizedFormattedMessage)
+          <FormattedMessage
             defaultMessage="Show transcript in the video player by default"
             description="Label for show by default checkbox"
             id="authoring.videoeditor.transcripts.upload.showByDefaultCheckboxLabel"
           />
         </div>
-      </ForwardRef>
-    </FormGroup>
+      </Form.Checkbox>
+    </Form.Group>
     <div
       className="mt-2"
     >
-      <ForwardRef
+      <Button
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
-        disabled={false}
-        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <Memo(MemoizedFormattedMessage)
+        <FormattedMessage
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </ForwardRef>
+      </Button>
     </div>
-  </ForwardRef>
+  </Stack>
 </CollapsibleFormWidget>
 `;
 
@@ -560,7 +399,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -571,19 +410,17 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <ForwardRef
-    direction="vertical"
+  <Stack
     gap={3}
-    reversed={false}
   >
     <Fragment>
-      <Memo(MemoizedFormattedMessage)
+      <FormattedMessage
         defaultMessage="Add video transcripts (.srt files only) for improved accessibility."
         description="Message for adding first transcript"
         id="authoring.videoeditor.transcripts.upload.firstTranscriptMessage"
@@ -595,22 +432,20 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     <div
       className="mt-2"
     >
-      <ForwardRef
+      <Button
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
-        disabled={false}
-        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <Memo(MemoizedFormattedMessage)
+        <FormattedMessage
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </ForwardRef>
+      </Button>
     </div>
-  </ForwardRef>
+  </Stack>
 </CollapsibleFormWidget>
 `;
 
@@ -626,7 +461,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -637,19 +472,17 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <ForwardRef
-    direction="vertical"
+  <Stack
     gap={3}
-    reversed={false}
   >
     <Fragment>
-      <Memo(MemoizedFormattedMessage)
+      <FormattedMessage
         defaultMessage="Add video transcripts (.srt files only) for improved accessibility."
         description="Message for adding first transcript"
         id="authoring.videoeditor.transcripts.upload.firstTranscriptMessage"
@@ -658,22 +491,20 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     <div
       className="mt-2"
     >
-      <ForwardRef
+      <Button
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
-        disabled={false}
-        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <Memo(MemoizedFormattedMessage)
+        <FormattedMessage
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </ForwardRef>
+      </Button>
     </div>
-  </ForwardRef>
+  </Stack>
 </CollapsibleFormWidget>
 `;
 
@@ -689,7 +520,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -700,18 +531,16 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <ForwardRef
-    direction="vertical"
+  <Stack
     gap={3}
-    reversed={false}
   >
-    <FormGroup
+    <Form.Group
       className="border-primary-100 border-bottom"
     >
       <Transcript
@@ -719,70 +548,39 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
         language="en"
       />
       <ActionRow
-        as="div"
         className="mt-3.5"
-        isStacked={false}
       >
-        <ForwardRef
+        <Form.Checkbox
           checked={false}
           className="decorative-control-label"
-          controlAs={
-            {
-              "$$typeof": Symbol(react.forward_ref),
-              "defaultProps": {
-                "className": undefined,
-                "isIndeterminate": false,
-              },
-              "propTypes": {
-                "className": [Function],
-                "isIndeterminate": [Function],
-              },
-              "render": [Function],
-            }
-          }
-          disabled={false}
-          floatLabelLeft={false}
-          isInvalid={false}
-          isValid={false}
           onChange={[Function]}
         >
           <div
             className="small text-gray-700"
           >
-            <Memo(MemoizedFormattedMessage)
+            <FormattedMessage
               defaultMessage="Allow transcript downloads"
               description="Label for allow transcript downloads checkbox"
               id="authoring.videoeditor.transcripts.allowDownloadCheckboxLabel"
             />
           </div>
-        </ForwardRef>
+        </Form.Checkbox>
         <OverlayTrigger
-          defaultShow={false}
           key="top"
           overlay={
-            <ForwardRef
-              bsPrefix="tooltip"
+            <Tooltip
               id="tooltip-top"
-              placement="right"
             >
-              <Memo(MemoizedFormattedMessage)
+              <FormattedMessage
                 defaultMessage="Learners will see a link to download the transcript below the video."
                 description="Message for show by default checkbox"
                 id="authoring.videoeditor.transcripts.upload.allowDownloadTooltipMessage"
               />
-            </ForwardRef>
+            </Tooltip>
           }
           placement="top"
-          popperConfig={{}}
-          trigger={
-            [
-              "hover",
-              "focus",
-            ]
-          }
         >
-          <withDeprecatedProps(Icon)
-            src={[Function]}
+          <Icon
             style={
               {
                 "height": "16px",
@@ -791,61 +589,41 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
             }
           />
         </OverlayTrigger>
-        <ActionRowSpacer />
+        <ActionRow.Spacer />
       </ActionRow>
-      <ForwardRef
+      <Form.Checkbox
         checked={true}
         className="mt-3 decorative-control-label"
-        controlAs={
-          {
-            "$$typeof": Symbol(react.forward_ref),
-            "defaultProps": {
-              "className": undefined,
-              "isIndeterminate": false,
-            },
-            "propTypes": {
-              "className": [Function],
-              "isIndeterminate": [Function],
-            },
-            "render": [Function],
-          }
-        }
-        disabled={false}
-        floatLabelLeft={false}
-        isInvalid={false}
-        isValid={false}
         onChange={[Function]}
       >
         <div
           className="small text-gray-700"
         >
-          <Memo(MemoizedFormattedMessage)
+          <FormattedMessage
             defaultMessage="Show transcript in the video player by default"
             description="Label for show by default checkbox"
             id="authoring.videoeditor.transcripts.upload.showByDefaultCheckboxLabel"
           />
         </div>
-      </ForwardRef>
-    </FormGroup>
+      </Form.Checkbox>
+    </Form.Group>
     <div
       className="mt-2"
     >
-      <ForwardRef
+      <Button
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
-        disabled={false}
-        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <Memo(MemoizedFormattedMessage)
+        <FormattedMessage
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </ForwardRef>
+      </Button>
     </div>
-  </ForwardRef>
+  </Stack>
 </CollapsibleFormWidget>
 `;
 
@@ -861,7 +639,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -872,19 +650,17 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <ForwardRef
-    direction="vertical"
+  <Stack
     gap={3}
-    reversed={false}
   >
     <Fragment>
-      <Memo(MemoizedFormattedMessage)
+      <FormattedMessage
         defaultMessage="Add video transcripts (.srt files only) for improved accessibility."
         description="Message for adding first transcript"
         id="authoring.videoeditor.transcripts.upload.firstTranscriptMessage"
@@ -893,22 +669,20 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     <div
       className="mt-2"
     >
-      <ForwardRef
+      <Button
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
-        disabled={false}
-        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <Memo(MemoizedFormattedMessage)
+        <FormattedMessage
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </ForwardRef>
+      </Button>
     </div>
-  </ForwardRef>
+  </Stack>
 </CollapsibleFormWidget>
 `;
 
@@ -924,7 +698,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -935,18 +709,16 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <ForwardRef
-    direction="vertical"
+  <Stack
     gap={3}
-    reversed={false}
   >
-    <FormGroup
+    <Form.Group
       className="border-primary-100 border-bottom"
     >
       <Transcript
@@ -954,70 +726,39 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
         language="en"
       />
       <ActionRow
-        as="div"
         className="mt-3.5"
-        isStacked={false}
       >
-        <ForwardRef
+        <Form.Checkbox
           checked={false}
           className="decorative-control-label"
-          controlAs={
-            {
-              "$$typeof": Symbol(react.forward_ref),
-              "defaultProps": {
-                "className": undefined,
-                "isIndeterminate": false,
-              },
-              "propTypes": {
-                "className": [Function],
-                "isIndeterminate": [Function],
-              },
-              "render": [Function],
-            }
-          }
-          disabled={false}
-          floatLabelLeft={false}
-          isInvalid={false}
-          isValid={false}
           onChange={[Function]}
         >
           <div
             className="small text-gray-700"
           >
-            <Memo(MemoizedFormattedMessage)
+            <FormattedMessage
               defaultMessage="Allow transcript downloads"
               description="Label for allow transcript downloads checkbox"
               id="authoring.videoeditor.transcripts.allowDownloadCheckboxLabel"
             />
           </div>
-        </ForwardRef>
+        </Form.Checkbox>
         <OverlayTrigger
-          defaultShow={false}
           key="top"
           overlay={
-            <ForwardRef
-              bsPrefix="tooltip"
+            <Tooltip
               id="tooltip-top"
-              placement="right"
             >
-              <Memo(MemoizedFormattedMessage)
+              <FormattedMessage
                 defaultMessage="Learners will see a link to download the transcript below the video."
                 description="Message for show by default checkbox"
                 id="authoring.videoeditor.transcripts.upload.allowDownloadTooltipMessage"
               />
-            </ForwardRef>
+            </Tooltip>
           }
           placement="top"
-          popperConfig={{}}
-          trigger={
-            [
-              "hover",
-              "focus",
-            ]
-          }
         >
-          <withDeprecatedProps(Icon)
-            src={[Function]}
+          <Icon
             style={
               {
                 "height": "16px",
@@ -1026,61 +767,41 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
             }
           />
         </OverlayTrigger>
-        <ActionRowSpacer />
+        <ActionRow.Spacer />
       </ActionRow>
-      <ForwardRef
+      <Form.Checkbox
         checked={false}
         className="mt-3 decorative-control-label"
-        controlAs={
-          {
-            "$$typeof": Symbol(react.forward_ref),
-            "defaultProps": {
-              "className": undefined,
-              "isIndeterminate": false,
-            },
-            "propTypes": {
-              "className": [Function],
-              "isIndeterminate": [Function],
-            },
-            "render": [Function],
-          }
-        }
-        disabled={false}
-        floatLabelLeft={false}
-        isInvalid={false}
-        isValid={false}
         onChange={[Function]}
       >
         <div
           className="small text-gray-700"
         >
-          <Memo(MemoizedFormattedMessage)
+          <FormattedMessage
             defaultMessage="Show transcript in the video player by default"
             description="Label for show by default checkbox"
             id="authoring.videoeditor.transcripts.upload.showByDefaultCheckboxLabel"
           />
         </div>
-      </ForwardRef>
-    </FormGroup>
+      </Form.Checkbox>
+    </Form.Group>
     <div
       className="mt-2"
     >
-      <ForwardRef
+      <Button
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
-        disabled={false}
-        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <Memo(MemoizedFormattedMessage)
+        <FormattedMessage
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </ForwardRef>
+      </Button>
     </div>
-  </ForwardRef>
+  </Stack>
 </CollapsibleFormWidget>
 `;
 
@@ -1096,7 +817,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -1107,18 +828,16 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <Memo(MemoizedFormattedMessage)
+    <FormattedMessage
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <ForwardRef
-    direction="vertical"
+  <Stack
     gap={3}
-    reversed={false}
   >
-    <FormGroup
+    <Form.Group
       className="border-primary-100 border-bottom"
     >
       <Transcript
@@ -1126,70 +845,39 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
         language="es"
       />
       <ActionRow
-        as="div"
         className="mt-3.5"
-        isStacked={false}
       >
-        <ForwardRef
+        <Form.Checkbox
           checked={false}
           className="decorative-control-label"
-          controlAs={
-            {
-              "$$typeof": Symbol(react.forward_ref),
-              "defaultProps": {
-                "className": undefined,
-                "isIndeterminate": false,
-              },
-              "propTypes": {
-                "className": [Function],
-                "isIndeterminate": [Function],
-              },
-              "render": [Function],
-            }
-          }
-          disabled={false}
-          floatLabelLeft={false}
-          isInvalid={false}
-          isValid={false}
           onChange={[Function]}
         >
           <div
             className="small text-gray-700"
           >
-            <Memo(MemoizedFormattedMessage)
+            <FormattedMessage
               defaultMessage="Allow transcript downloads"
               description="Label for allow transcript downloads checkbox"
               id="authoring.videoeditor.transcripts.allowDownloadCheckboxLabel"
             />
           </div>
-        </ForwardRef>
+        </Form.Checkbox>
         <OverlayTrigger
-          defaultShow={false}
           key="top"
           overlay={
-            <ForwardRef
-              bsPrefix="tooltip"
+            <Tooltip
               id="tooltip-top"
-              placement="right"
             >
-              <Memo(MemoizedFormattedMessage)
+              <FormattedMessage
                 defaultMessage="Learners will see a link to download the transcript below the video."
                 description="Message for show by default checkbox"
                 id="authoring.videoeditor.transcripts.upload.allowDownloadTooltipMessage"
               />
-            </ForwardRef>
+            </Tooltip>
           }
           placement="top"
-          popperConfig={{}}
-          trigger={
-            [
-              "hover",
-              "focus",
-            ]
-          }
         >
-          <withDeprecatedProps(Icon)
-            src={[Function]}
+          <Icon
             style={
               {
                 "height": "16px",
@@ -1198,60 +886,40 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
             }
           />
         </OverlayTrigger>
-        <ActionRowSpacer />
+        <ActionRow.Spacer />
       </ActionRow>
-      <ForwardRef
+      <Form.Checkbox
         checked={false}
         className="mt-3 decorative-control-label"
-        controlAs={
-          {
-            "$$typeof": Symbol(react.forward_ref),
-            "defaultProps": {
-              "className": undefined,
-              "isIndeterminate": false,
-            },
-            "propTypes": {
-              "className": [Function],
-              "isIndeterminate": [Function],
-            },
-            "render": [Function],
-          }
-        }
-        disabled={false}
-        floatLabelLeft={false}
-        isInvalid={false}
-        isValid={false}
         onChange={[Function]}
       >
         <div
           className="small text-gray-700"
         >
-          <Memo(MemoizedFormattedMessage)
+          <FormattedMessage
             defaultMessage="Show transcript in the video player by default"
             description="Label for show by default checkbox"
             id="authoring.videoeditor.transcripts.upload.showByDefaultCheckboxLabel"
           />
         </div>
-      </ForwardRef>
-    </FormGroup>
+      </Form.Checkbox>
+    </Form.Group>
     <div
       className="mt-2"
     >
-      <ForwardRef
+      <Button
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
-        disabled={false}
-        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <Memo(MemoizedFormattedMessage)
+        <FormattedMessage
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </ForwardRef>
+      </Button>
     </div>
-  </ForwardRef>
+  </Stack>
 </CollapsibleFormWidget>
 `;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/__snapshots__/index.test.jsx.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TranscriptWidget component snapshots snapshot: render when \`isCreateWorkflow\` is \`True\` 1`] = `
+<div
+  className="mr-4 ml-4"
+>
+  <withDeprecatedProps(Card)
+    className="bg-light-200"
+  >
+    <ForwardRef
+      muted={false}
+      skeletonHeight={100}
+      title={
+        <div
+          className="text-gray-500"
+        >
+          Transcripts
+        </div>
+      }
+    >
+      <div
+        className="d-flex justify-content-around text-gray-700 pb-4 x-small"
+      >
+        To add transcripts, save and reopen this video
+      </div>
+    </ForwardRef>
+  </withDeprecatedProps(Card)>
+</div>
+`;
+
 exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with delete error message 1`] = `
 <CollapsibleFormWidget
   fontSize="x-small"
@@ -12,7 +40,7 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -23,16 +51,18 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
     hideHeading={true}
     isError={true}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <Stack
+  <ForwardRef
+    direction="vertical"
     gap={3}
+    reversed={false}
   >
-    <Form.Group
+    <FormGroup
       className="border-primary-100 border-bottom"
     >
       <Transcript
@@ -40,39 +70,70 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
         language="en"
       />
       <ActionRow
+        as="div"
         className="mt-3.5"
+        isStacked={false}
       >
-        <Form.Checkbox
+        <ForwardRef
           checked={false}
           className="decorative-control-label"
+          controlAs={
+            {
+              "$$typeof": Symbol(react.forward_ref),
+              "defaultProps": {
+                "className": undefined,
+                "isIndeterminate": false,
+              },
+              "propTypes": {
+                "className": [Function],
+                "isIndeterminate": [Function],
+              },
+              "render": [Function],
+            }
+          }
+          disabled={false}
+          floatLabelLeft={false}
+          isInvalid={false}
+          isValid={false}
           onChange={[Function]}
         >
           <div
             className="small text-gray-700"
           >
-            <FormattedMessage
+            <Memo(MemoizedFormattedMessage)
               defaultMessage="Allow transcript downloads"
               description="Label for allow transcript downloads checkbox"
               id="authoring.videoeditor.transcripts.allowDownloadCheckboxLabel"
             />
           </div>
-        </Form.Checkbox>
+        </ForwardRef>
         <OverlayTrigger
+          defaultShow={false}
           key="top"
           overlay={
-            <Tooltip
+            <ForwardRef
+              bsPrefix="tooltip"
               id="tooltip-top"
+              placement="right"
             >
-              <FormattedMessage
+              <Memo(MemoizedFormattedMessage)
                 defaultMessage="Learners will see a link to download the transcript below the video."
                 description="Message for show by default checkbox"
                 id="authoring.videoeditor.transcripts.upload.allowDownloadTooltipMessage"
               />
-            </Tooltip>
+            </ForwardRef>
           }
           placement="top"
+          popperConfig={{}}
+          trigger={
+            [
+              "hover",
+              "focus",
+            ]
+          }
         >
-          <Icon
+          <withDeprecatedProps(Icon)
+            src={[Function]}
             style={
               {
                 "height": "16px",
@@ -81,41 +142,61 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
             }
           />
         </OverlayTrigger>
-        <ActionRow.Spacer />
+        <ActionRowSpacer />
       </ActionRow>
-      <Form.Checkbox
+      <ForwardRef
         checked={false}
         className="mt-3 decorative-control-label"
+        controlAs={
+          {
+            "$$typeof": Symbol(react.forward_ref),
+            "defaultProps": {
+              "className": undefined,
+              "isIndeterminate": false,
+            },
+            "propTypes": {
+              "className": [Function],
+              "isIndeterminate": [Function],
+            },
+            "render": [Function],
+          }
+        }
+        disabled={false}
+        floatLabelLeft={false}
+        isInvalid={false}
+        isValid={false}
         onChange={[Function]}
       >
         <div
           className="small text-gray-700"
         >
-          <FormattedMessage
+          <Memo(MemoizedFormattedMessage)
             defaultMessage="Show transcript in the video player by default"
             description="Label for show by default checkbox"
             id="authoring.videoeditor.transcripts.upload.showByDefaultCheckboxLabel"
           />
         </div>
-      </Form.Checkbox>
-    </Form.Group>
+      </ForwardRef>
+    </FormGroup>
     <div
       className="mt-2"
     >
-      <Button
+      <ForwardRef
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
+        disabled={false}
+        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <FormattedMessage
+        <Memo(MemoizedFormattedMessage)
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </Button>
+      </ForwardRef>
     </div>
-  </Stack>
+  </ForwardRef>
 </CollapsibleFormWidget>
 `;
 
@@ -131,7 +212,7 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
     hideHeading={true}
     isError={true}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -142,16 +223,18 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <Stack
+  <ForwardRef
+    direction="vertical"
     gap={3}
+    reversed={false}
   >
-    <Form.Group
+    <FormGroup
       className="border-primary-100 border-bottom"
     >
       <Transcript
@@ -163,39 +246,70 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
         language="fr"
       />
       <ActionRow
+        as="div"
         className="mt-3.5"
+        isStacked={false}
       >
-        <Form.Checkbox
+        <ForwardRef
           checked={false}
           className="decorative-control-label"
+          controlAs={
+            {
+              "$$typeof": Symbol(react.forward_ref),
+              "defaultProps": {
+                "className": undefined,
+                "isIndeterminate": false,
+              },
+              "propTypes": {
+                "className": [Function],
+                "isIndeterminate": [Function],
+              },
+              "render": [Function],
+            }
+          }
+          disabled={false}
+          floatLabelLeft={false}
+          isInvalid={false}
+          isValid={false}
           onChange={[Function]}
         >
           <div
             className="small text-gray-700"
           >
-            <FormattedMessage
+            <Memo(MemoizedFormattedMessage)
               defaultMessage="Allow transcript downloads"
               description="Label for allow transcript downloads checkbox"
               id="authoring.videoeditor.transcripts.allowDownloadCheckboxLabel"
             />
           </div>
-        </Form.Checkbox>
+        </ForwardRef>
         <OverlayTrigger
+          defaultShow={false}
           key="top"
           overlay={
-            <Tooltip
+            <ForwardRef
+              bsPrefix="tooltip"
               id="tooltip-top"
+              placement="right"
             >
-              <FormattedMessage
+              <Memo(MemoizedFormattedMessage)
                 defaultMessage="Learners will see a link to download the transcript below the video."
                 description="Message for show by default checkbox"
                 id="authoring.videoeditor.transcripts.upload.allowDownloadTooltipMessage"
               />
-            </Tooltip>
+            </ForwardRef>
           }
           placement="top"
+          popperConfig={{}}
+          trigger={
+            [
+              "hover",
+              "focus",
+            ]
+          }
         >
-          <Icon
+          <withDeprecatedProps(Icon)
+            src={[Function]}
             style={
               {
                 "height": "16px",
@@ -204,41 +318,61 @@ exports[`TranscriptWidget component snapshots snapshot: renders ErrorAlert with 
             }
           />
         </OverlayTrigger>
-        <ActionRow.Spacer />
+        <ActionRowSpacer />
       </ActionRow>
-      <Form.Checkbox
+      <ForwardRef
         checked={false}
         className="mt-3 decorative-control-label"
+        controlAs={
+          {
+            "$$typeof": Symbol(react.forward_ref),
+            "defaultProps": {
+              "className": undefined,
+              "isIndeterminate": false,
+            },
+            "propTypes": {
+              "className": [Function],
+              "isIndeterminate": [Function],
+            },
+            "render": [Function],
+          }
+        }
+        disabled={false}
+        floatLabelLeft={false}
+        isInvalid={false}
+        isValid={false}
         onChange={[Function]}
       >
         <div
           className="small text-gray-700"
         >
-          <FormattedMessage
+          <Memo(MemoizedFormattedMessage)
             defaultMessage="Show transcript in the video player by default"
             description="Label for show by default checkbox"
             id="authoring.videoeditor.transcripts.upload.showByDefaultCheckboxLabel"
           />
         </div>
-      </Form.Checkbox>
-    </Form.Group>
+      </ForwardRef>
+    </FormGroup>
     <div
       className="mt-2"
     >
-      <Button
+      <ForwardRef
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
+        disabled={false}
+        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <FormattedMessage
+        <Memo(MemoizedFormattedMessage)
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </Button>
+      </ForwardRef>
     </div>
-  </Stack>
+  </ForwardRef>
 </CollapsibleFormWidget>
 `;
 
@@ -254,7 +388,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -265,16 +399,18 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <Stack
+  <ForwardRef
+    direction="vertical"
     gap={3}
+    reversed={false}
   >
-    <Form.Group
+    <FormGroup
       className="border-primary-100 border-bottom"
     >
       <Transcript
@@ -282,39 +418,70 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
         language="en"
       />
       <ActionRow
+        as="div"
         className="mt-3.5"
+        isStacked={false}
       >
-        <Form.Checkbox
+        <ForwardRef
           checked={true}
           className="decorative-control-label"
+          controlAs={
+            {
+              "$$typeof": Symbol(react.forward_ref),
+              "defaultProps": {
+                "className": undefined,
+                "isIndeterminate": false,
+              },
+              "propTypes": {
+                "className": [Function],
+                "isIndeterminate": [Function],
+              },
+              "render": [Function],
+            }
+          }
+          disabled={false}
+          floatLabelLeft={false}
+          isInvalid={false}
+          isValid={false}
           onChange={[Function]}
         >
           <div
             className="small text-gray-700"
           >
-            <FormattedMessage
+            <Memo(MemoizedFormattedMessage)
               defaultMessage="Allow transcript downloads"
               description="Label for allow transcript downloads checkbox"
               id="authoring.videoeditor.transcripts.allowDownloadCheckboxLabel"
             />
           </div>
-        </Form.Checkbox>
+        </ForwardRef>
         <OverlayTrigger
+          defaultShow={false}
           key="top"
           overlay={
-            <Tooltip
+            <ForwardRef
+              bsPrefix="tooltip"
               id="tooltip-top"
+              placement="right"
             >
-              <FormattedMessage
+              <Memo(MemoizedFormattedMessage)
                 defaultMessage="Learners will see a link to download the transcript below the video."
                 description="Message for show by default checkbox"
                 id="authoring.videoeditor.transcripts.upload.allowDownloadTooltipMessage"
               />
-            </Tooltip>
+            </ForwardRef>
           }
           placement="top"
+          popperConfig={{}}
+          trigger={
+            [
+              "hover",
+              "focus",
+            ]
+          }
         >
-          <Icon
+          <withDeprecatedProps(Icon)
+            src={[Function]}
             style={
               {
                 "height": "16px",
@@ -323,41 +490,61 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
             }
           />
         </OverlayTrigger>
-        <ActionRow.Spacer />
+        <ActionRowSpacer />
       </ActionRow>
-      <Form.Checkbox
+      <ForwardRef
         checked={false}
         className="mt-3 decorative-control-label"
+        controlAs={
+          {
+            "$$typeof": Symbol(react.forward_ref),
+            "defaultProps": {
+              "className": undefined,
+              "isIndeterminate": false,
+            },
+            "propTypes": {
+              "className": [Function],
+              "isIndeterminate": [Function],
+            },
+            "render": [Function],
+          }
+        }
+        disabled={false}
+        floatLabelLeft={false}
+        isInvalid={false}
+        isValid={false}
         onChange={[Function]}
       >
         <div
           className="small text-gray-700"
         >
-          <FormattedMessage
+          <Memo(MemoizedFormattedMessage)
             defaultMessage="Show transcript in the video player by default"
             description="Label for show by default checkbox"
             id="authoring.videoeditor.transcripts.upload.showByDefaultCheckboxLabel"
           />
         </div>
-      </Form.Checkbox>
-    </Form.Group>
+      </ForwardRef>
+    </FormGroup>
     <div
       className="mt-2"
     >
-      <Button
+      <ForwardRef
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
+        disabled={false}
+        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <FormattedMessage
+        <Memo(MemoizedFormattedMessage)
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </Button>
+      </ForwardRef>
     </div>
-  </Stack>
+  </ForwardRef>
 </CollapsibleFormWidget>
 `;
 
@@ -373,7 +560,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -384,17 +571,19 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <Stack
+  <ForwardRef
+    direction="vertical"
     gap={3}
+    reversed={false}
   >
     <Fragment>
-      <FormattedMessage
+      <Memo(MemoizedFormattedMessage)
         defaultMessage="Add video transcripts (.srt files only) for improved accessibility."
         description="Message for adding first transcript"
         id="authoring.videoeditor.transcripts.upload.firstTranscriptMessage"
@@ -406,20 +595,22 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     <div
       className="mt-2"
     >
-      <Button
+      <ForwardRef
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
+        disabled={false}
+        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <FormattedMessage
+        <Memo(MemoizedFormattedMessage)
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </Button>
+      </ForwardRef>
     </div>
-  </Stack>
+  </ForwardRef>
 </CollapsibleFormWidget>
 `;
 
@@ -435,7 +626,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -446,17 +637,19 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <Stack
+  <ForwardRef
+    direction="vertical"
     gap={3}
+    reversed={false}
   >
     <Fragment>
-      <FormattedMessage
+      <Memo(MemoizedFormattedMessage)
         defaultMessage="Add video transcripts (.srt files only) for improved accessibility."
         description="Message for adding first transcript"
         id="authoring.videoeditor.transcripts.upload.firstTranscriptMessage"
@@ -465,20 +658,22 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     <div
       className="mt-2"
     >
-      <Button
+      <ForwardRef
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
+        disabled={false}
+        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <FormattedMessage
+        <Memo(MemoizedFormattedMessage)
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </Button>
+      </ForwardRef>
     </div>
-  </Stack>
+  </ForwardRef>
 </CollapsibleFormWidget>
 `;
 
@@ -494,7 +689,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -505,16 +700,18 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <Stack
+  <ForwardRef
+    direction="vertical"
     gap={3}
+    reversed={false}
   >
-    <Form.Group
+    <FormGroup
       className="border-primary-100 border-bottom"
     >
       <Transcript
@@ -522,39 +719,70 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
         language="en"
       />
       <ActionRow
+        as="div"
         className="mt-3.5"
+        isStacked={false}
       >
-        <Form.Checkbox
+        <ForwardRef
           checked={false}
           className="decorative-control-label"
+          controlAs={
+            {
+              "$$typeof": Symbol(react.forward_ref),
+              "defaultProps": {
+                "className": undefined,
+                "isIndeterminate": false,
+              },
+              "propTypes": {
+                "className": [Function],
+                "isIndeterminate": [Function],
+              },
+              "render": [Function],
+            }
+          }
+          disabled={false}
+          floatLabelLeft={false}
+          isInvalid={false}
+          isValid={false}
           onChange={[Function]}
         >
           <div
             className="small text-gray-700"
           >
-            <FormattedMessage
+            <Memo(MemoizedFormattedMessage)
               defaultMessage="Allow transcript downloads"
               description="Label for allow transcript downloads checkbox"
               id="authoring.videoeditor.transcripts.allowDownloadCheckboxLabel"
             />
           </div>
-        </Form.Checkbox>
+        </ForwardRef>
         <OverlayTrigger
+          defaultShow={false}
           key="top"
           overlay={
-            <Tooltip
+            <ForwardRef
+              bsPrefix="tooltip"
               id="tooltip-top"
+              placement="right"
             >
-              <FormattedMessage
+              <Memo(MemoizedFormattedMessage)
                 defaultMessage="Learners will see a link to download the transcript below the video."
                 description="Message for show by default checkbox"
                 id="authoring.videoeditor.transcripts.upload.allowDownloadTooltipMessage"
               />
-            </Tooltip>
+            </ForwardRef>
           }
           placement="top"
+          popperConfig={{}}
+          trigger={
+            [
+              "hover",
+              "focus",
+            ]
+          }
         >
-          <Icon
+          <withDeprecatedProps(Icon)
+            src={[Function]}
             style={
               {
                 "height": "16px",
@@ -563,41 +791,61 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
             }
           />
         </OverlayTrigger>
-        <ActionRow.Spacer />
+        <ActionRowSpacer />
       </ActionRow>
-      <Form.Checkbox
+      <ForwardRef
         checked={true}
         className="mt-3 decorative-control-label"
+        controlAs={
+          {
+            "$$typeof": Symbol(react.forward_ref),
+            "defaultProps": {
+              "className": undefined,
+              "isIndeterminate": false,
+            },
+            "propTypes": {
+              "className": [Function],
+              "isIndeterminate": [Function],
+            },
+            "render": [Function],
+          }
+        }
+        disabled={false}
+        floatLabelLeft={false}
+        isInvalid={false}
+        isValid={false}
         onChange={[Function]}
       >
         <div
           className="small text-gray-700"
         >
-          <FormattedMessage
+          <Memo(MemoizedFormattedMessage)
             defaultMessage="Show transcript in the video player by default"
             description="Label for show by default checkbox"
             id="authoring.videoeditor.transcripts.upload.showByDefaultCheckboxLabel"
           />
         </div>
-      </Form.Checkbox>
-    </Form.Group>
+      </ForwardRef>
+    </FormGroup>
     <div
       className="mt-2"
     >
-      <Button
+      <ForwardRef
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
+        disabled={false}
+        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <FormattedMessage
+        <Memo(MemoizedFormattedMessage)
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </Button>
+      </ForwardRef>
     </div>
-  </Stack>
+  </ForwardRef>
 </CollapsibleFormWidget>
 `;
 
@@ -613,7 +861,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -624,17 +872,19 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <Stack
+  <ForwardRef
+    direction="vertical"
     gap={3}
+    reversed={false}
   >
     <Fragment>
-      <FormattedMessage
+      <Memo(MemoizedFormattedMessage)
         defaultMessage="Add video transcripts (.srt files only) for improved accessibility."
         description="Message for adding first transcript"
         id="authoring.videoeditor.transcripts.upload.firstTranscriptMessage"
@@ -643,20 +893,22 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     <div
       className="mt-2"
     >
-      <Button
+      <ForwardRef
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
+        disabled={false}
+        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <FormattedMessage
+        <Memo(MemoizedFormattedMessage)
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </Button>
+      </ForwardRef>
     </div>
-  </Stack>
+  </ForwardRef>
 </CollapsibleFormWidget>
 `;
 
@@ -672,7 +924,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -683,16 +935,18 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <Stack
+  <ForwardRef
+    direction="vertical"
     gap={3}
+    reversed={false}
   >
-    <Form.Group
+    <FormGroup
       className="border-primary-100 border-bottom"
     >
       <Transcript
@@ -700,39 +954,70 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
         language="en"
       />
       <ActionRow
+        as="div"
         className="mt-3.5"
+        isStacked={false}
       >
-        <Form.Checkbox
+        <ForwardRef
           checked={false}
           className="decorative-control-label"
+          controlAs={
+            {
+              "$$typeof": Symbol(react.forward_ref),
+              "defaultProps": {
+                "className": undefined,
+                "isIndeterminate": false,
+              },
+              "propTypes": {
+                "className": [Function],
+                "isIndeterminate": [Function],
+              },
+              "render": [Function],
+            }
+          }
+          disabled={false}
+          floatLabelLeft={false}
+          isInvalid={false}
+          isValid={false}
           onChange={[Function]}
         >
           <div
             className="small text-gray-700"
           >
-            <FormattedMessage
+            <Memo(MemoizedFormattedMessage)
               defaultMessage="Allow transcript downloads"
               description="Label for allow transcript downloads checkbox"
               id="authoring.videoeditor.transcripts.allowDownloadCheckboxLabel"
             />
           </div>
-        </Form.Checkbox>
+        </ForwardRef>
         <OverlayTrigger
+          defaultShow={false}
           key="top"
           overlay={
-            <Tooltip
+            <ForwardRef
+              bsPrefix="tooltip"
               id="tooltip-top"
+              placement="right"
             >
-              <FormattedMessage
+              <Memo(MemoizedFormattedMessage)
                 defaultMessage="Learners will see a link to download the transcript below the video."
                 description="Message for show by default checkbox"
                 id="authoring.videoeditor.transcripts.upload.allowDownloadTooltipMessage"
               />
-            </Tooltip>
+            </ForwardRef>
           }
           placement="top"
+          popperConfig={{}}
+          trigger={
+            [
+              "hover",
+              "focus",
+            ]
+          }
         >
-          <Icon
+          <withDeprecatedProps(Icon)
+            src={[Function]}
             style={
               {
                 "height": "16px",
@@ -741,41 +1026,61 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
             }
           />
         </OverlayTrigger>
-        <ActionRow.Spacer />
+        <ActionRowSpacer />
       </ActionRow>
-      <Form.Checkbox
+      <ForwardRef
         checked={false}
         className="mt-3 decorative-control-label"
+        controlAs={
+          {
+            "$$typeof": Symbol(react.forward_ref),
+            "defaultProps": {
+              "className": undefined,
+              "isIndeterminate": false,
+            },
+            "propTypes": {
+              "className": [Function],
+              "isIndeterminate": [Function],
+            },
+            "render": [Function],
+          }
+        }
+        disabled={false}
+        floatLabelLeft={false}
+        isInvalid={false}
+        isValid={false}
         onChange={[Function]}
       >
         <div
           className="small text-gray-700"
         >
-          <FormattedMessage
+          <Memo(MemoizedFormattedMessage)
             defaultMessage="Show transcript in the video player by default"
             description="Label for show by default checkbox"
             id="authoring.videoeditor.transcripts.upload.showByDefaultCheckboxLabel"
           />
         </div>
-      </Form.Checkbox>
-    </Form.Group>
+      </ForwardRef>
+    </FormGroup>
     <div
       className="mt-2"
     >
-      <Button
+      <ForwardRef
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
+        disabled={false}
+        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <FormattedMessage
+        <Memo(MemoizedFormattedMessage)
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </Button>
+      </ForwardRef>
     </div>
-  </Stack>
+  </ForwardRef>
 </CollapsibleFormWidget>
 `;
 
@@ -791,7 +1096,7 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to upload transcript. Please try again."
       description="Message presented to user when transcript fails to upload"
       id="authoring.videoeditor.transcript.error.uploadTranscriptError"
@@ -802,16 +1107,18 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
     hideHeading={true}
     isError={false}
   >
-    <FormattedMessage
+    <Memo(MemoizedFormattedMessage)
       defaultMessage="Failed to delete transcript. Please try again."
       description="Message presented to user when transcript fails to delete"
       id="authoring.videoeditor.transcript.error.deleteTranscriptError"
     />
   </ErrorAlert>
-  <Stack
+  <ForwardRef
+    direction="vertical"
     gap={3}
+    reversed={false}
   >
-    <Form.Group
+    <FormGroup
       className="border-primary-100 border-bottom"
     >
       <Transcript
@@ -819,39 +1126,70 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
         language="es"
       />
       <ActionRow
+        as="div"
         className="mt-3.5"
+        isStacked={false}
       >
-        <Form.Checkbox
+        <ForwardRef
           checked={false}
           className="decorative-control-label"
+          controlAs={
+            {
+              "$$typeof": Symbol(react.forward_ref),
+              "defaultProps": {
+                "className": undefined,
+                "isIndeterminate": false,
+              },
+              "propTypes": {
+                "className": [Function],
+                "isIndeterminate": [Function],
+              },
+              "render": [Function],
+            }
+          }
+          disabled={false}
+          floatLabelLeft={false}
+          isInvalid={false}
+          isValid={false}
           onChange={[Function]}
         >
           <div
             className="small text-gray-700"
           >
-            <FormattedMessage
+            <Memo(MemoizedFormattedMessage)
               defaultMessage="Allow transcript downloads"
               description="Label for allow transcript downloads checkbox"
               id="authoring.videoeditor.transcripts.allowDownloadCheckboxLabel"
             />
           </div>
-        </Form.Checkbox>
+        </ForwardRef>
         <OverlayTrigger
+          defaultShow={false}
           key="top"
           overlay={
-            <Tooltip
+            <ForwardRef
+              bsPrefix="tooltip"
               id="tooltip-top"
+              placement="right"
             >
-              <FormattedMessage
+              <Memo(MemoizedFormattedMessage)
                 defaultMessage="Learners will see a link to download the transcript below the video."
                 description="Message for show by default checkbox"
                 id="authoring.videoeditor.transcripts.upload.allowDownloadTooltipMessage"
               />
-            </Tooltip>
+            </ForwardRef>
           }
           placement="top"
+          popperConfig={{}}
+          trigger={
+            [
+              "hover",
+              "focus",
+            ]
+          }
         >
-          <Icon
+          <withDeprecatedProps(Icon)
+            src={[Function]}
             style={
               {
                 "height": "16px",
@@ -860,40 +1198,60 @@ exports[`TranscriptWidget component snapshots snapshots: renders as expected wit
             }
           />
         </OverlayTrigger>
-        <ActionRow.Spacer />
+        <ActionRowSpacer />
       </ActionRow>
-      <Form.Checkbox
+      <ForwardRef
         checked={false}
         className="mt-3 decorative-control-label"
+        controlAs={
+          {
+            "$$typeof": Symbol(react.forward_ref),
+            "defaultProps": {
+              "className": undefined,
+              "isIndeterminate": false,
+            },
+            "propTypes": {
+              "className": [Function],
+              "isIndeterminate": [Function],
+            },
+            "render": [Function],
+          }
+        }
+        disabled={false}
+        floatLabelLeft={false}
+        isInvalid={false}
+        isValid={false}
         onChange={[Function]}
       >
         <div
           className="small text-gray-700"
         >
-          <FormattedMessage
+          <Memo(MemoizedFormattedMessage)
             defaultMessage="Show transcript in the video player by default"
             description="Label for show by default checkbox"
             id="authoring.videoeditor.transcripts.upload.showByDefaultCheckboxLabel"
           />
         </div>
-      </Form.Checkbox>
-    </Form.Group>
+      </ForwardRef>
+    </FormGroup>
     <div
       className="mt-2"
     >
-      <Button
+      <ForwardRef
         className="text-primary-500 font-weight-bold justify-content-start pl-0"
+        disabled={false}
+        iconBefore={[Function]}
         onClick={[Function]}
         size="sm"
         variant="link"
       >
-        <FormattedMessage
+        <Memo(MemoizedFormattedMessage)
           defaultMessage="Add a transcript"
           description="Label for upload button"
           id="authoring.videoeditor.transcripts.upload.label"
         />
-      </Button>
+      </ForwardRef>
     </div>
-  </Stack>
+  </ForwardRef>
 </CollapsibleFormWidget>
 `;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/index.jsx
@@ -98,9 +98,29 @@ const TranscriptWidget = ({
   const fullTextLanguages = module.hooks.transcriptLanguages(transcripts, intl);
   const hasTranscripts = module.hooks.hasTranscripts(transcripts);
   const isLibrary = useSelector(selectors.app.isLibrary);
+  const isCreateWorkflow = useSelector(selectors.app.shouldCreateBlock);
   const dispatch = useDispatch();
   if (isLibrary) {
     dispatch(thunkActions.video.updateTranscriptHandlerUrl());
+  }
+
+  if (isCreateWorkflow) {
+    return (
+      <CollapsibleFormWidget
+        fontSize="x-small"
+        isError={Object.keys(error).length !== 0}
+        title={(
+          <div className="text-gray-500">
+            {intl.formatMessage(messages.title)}
+          </div>
+        )}
+        bgColor="bg-light-200"
+      >
+        <div className="d-flex justify-content-around text-gray-700">
+          {intl.formatMessage(messages.videoCreationWarning)}
+        </div>
+      </CollapsibleFormWidget>
+    );
   }
 
   return (

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/index.jsx
@@ -14,6 +14,7 @@ import {
   OverlayTrigger,
   Tooltip,
   ActionRow,
+  Card,
 } from '@openedx/paragon';
 import { Add, InfoOutline } from '@openedx/paragon/icons';
 
@@ -106,20 +107,21 @@ const TranscriptWidget = ({
 
   if (isCreateWorkflow) {
     return (
-      <CollapsibleFormWidget
-        fontSize="x-small"
-        isError={Object.keys(error).length !== 0}
-        title={(
-          <div className="text-gray-500">
-            {intl.formatMessage(messages.title)}
-          </div>
-        )}
-        bgColor="bg-light-200"
-      >
-        <div className="d-flex justify-content-around text-gray-700">
-          {intl.formatMessage(messages.videoCreationWarning)}
-        </div>
-      </CollapsibleFormWidget>
+      <div className="mr-4 ml-4">
+        <Card className="bg-light-200">
+          <Card.Section
+            title={(
+              <div className="text-gray-500">
+                {intl.formatMessage(messages.title)}
+              </div>
+            )}
+          >
+            <div className="d-flex justify-content-around text-gray-700 pb-4 x-small">
+              {intl.formatMessage(messages.videoCreationWarning)}
+            </div>
+          </Card.Section>
+        </Card>
+      </div>
     );
   }
 

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/index.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/index.test.jsx
@@ -1,3 +1,4 @@
+import 'CourseAuthoring/editors/setupEditorTest';
 import React from 'react';
 import { shallow } from '@edx/react-unit-test-utils';
 import { useSelector } from 'react-redux';

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/index.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/index.test.jsx
@@ -1,6 +1,6 @@
-import 'CourseAuthoring/editors/setupEditorTest';
 import React from 'react';
 import { shallow } from '@edx/react-unit-test-utils';
+import { useSelector } from 'react-redux';
 
 import { RequestKeys } from '../../../../../../data/constants/requests';
 
@@ -35,6 +35,7 @@ jest.mock('../../../../../../data/redux', () => ({
   selectors: {
     app: {
       isLibrary: jest.fn(state => ({ isLibrary: state })),
+      shouldCreateBlock: jest.fn(() => false),
     },
     video: {
       transcripts: jest.fn(state => ({ transcripts: state })),
@@ -51,7 +52,19 @@ jest.mock('../../../../../../data/redux', () => ({
 jest.mock('../CollapsibleFormWidget', () => 'CollapsibleFormWidget');
 jest.mock('./Transcript', () => 'Transcript');
 
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: jest.fn(() => jest.fn()),
+  useSelector: jest.fn(),
+}));
+
+useSelector.mockImplementation((selectorFn) => selectorFn({}));
+
 describe('TranscriptWidget', () => {
+  beforeEach(() => {
+    selectors.app.shouldCreateBlock.mockReset();
+  });
+
   describe('hooks', () => {
     describe('transcriptLanguages', () => {
       test('empty list of transcripts returns ', () => {
@@ -153,6 +166,12 @@ describe('TranscriptWidget', () => {
       test('snapshot: renders ErrorAlert with delete error message', () => {
         expect(
           shallow(<TranscriptWidget {...props} isDeleteError transcripts={['en']} />).snapshot,
+        ).toMatchSnapshot();
+      });
+      test('snapshot: render when `isCreateWorkflow` is `True`', () => {
+        selectors.app.shouldCreateBlock.mockReturnValue(true);
+        expect(
+          shallow(<TranscriptWidget {...props} />).snapshot,
         ).toMatchSnapshot();
       });
     });

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/messages.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/messages.js
@@ -117,6 +117,11 @@ const messages = defineMessages({
     defaultMessage: 'We found transcript for this video on YouTube. Would you like to import it now?',
     description: 'Message for import transcript card asking user if they want to import transcript',
   },
+  videoCreationWarning: {
+    id: 'authoring.videoEditor.transcrtipts.videoCreation.message',
+    defaultMessage: 'To add transcripts, save and reopen this video',
+    description: 'Warning message when the user is creating a video',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description

- New Transcript widget state on video editors on creation workflow
- Which edX user roles will this change impact? "Course Author",

![image](https://github.com/user-attachments/assets/8a0a7bcf-cbb0-4e40-82af-24117acf8308)


## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/1352#issuecomment-2807096263
- Internal ticket: [FAL-4137](https://tasks.opencraft.com/browse/FAL-4137)

## Testing instructions

- Go to the library home of a library
- Create a new video block, on the editor verify the new state of the Transcript Widget.
- Save the video.
- Edit the video and verify the old state of the Transcript Widget


## Other information

N/A