### PR TITLE
feat: button to publish a container [FC-0083]

### DIFF
--- a/src/library-authoring/containers/messages.ts
+++ b/src/library-authoring/containers/messages.ts
@@ -26,6 +26,21 @@ const messages = defineMessages({
     defaultMessage: 'Collections ({count})',
     description: 'Title for collections section in organize tab',
   },
+  publishContainerButton: {
+    id: 'course-authoring.library-authoring.container-sidebar.publish-button',
+    defaultMessage: 'Publish',
+    description: 'Button text to publish the unit/subsection/section',
+  },
+  publishContainerSuccess: {
+    id: 'course-authoring.library-authoring.container-sidebar.publish-success',
+    defaultMessage: 'All changes published',
+    description: 'Popup text after publishing a unit/subsection/section',
+  },
+  publishContainerFailed: {
+    id: 'course-authoring.library-authoring.container-sidebar.publish-failure',
+    defaultMessage: 'Failed to publish changes',
+    description: 'Popup text seen if publishing a unit/subsection/section fails',
+  },
   settingsTabTitle: {
     id: 'course-authoring.library-authoring.container-sidebar.settings-tab.title',
     defaultMessage: 'Settings',

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -124,6 +124,10 @@ export const getLibraryContainerChildrenApiUrl = (containerId: string) => `${get
  * Get the URL for library container collections.
  */
 export const getLibraryContainerCollectionsUrl = (containerId: string) => `${getLibraryContainerApiUrl(containerId)}collections/`;
+/**
+ * Get the URL for the API endpoint to publish a single container (+ children).
+ */
+export const getLibraryContainerPublishApiUrl = (containerId: string) => `${getLibraryContainerApiUrl(containerId)}publish/`;
 
 export interface ContentLibrary {
   id: string;
@@ -699,4 +703,14 @@ export async function removeLibraryContainerChildren(
     },
   );
   return camelCaseObject(data);
+}
+
+/**
+ * Publish a container, and any unpublished children within it.
+ *
+ * This doesn't return any data at the moment, but we could have it return a
+ * list of the auto-published children in the future, if that would be helpful.
+ */
+export async function publishContainer(containerId: string) {
+  await getAuthenticatedHttpClient().post(getLibraryContainerPublishApiUrl(containerId));
 }

--- a/src/library-authoring/data/apiHooks.test.tsx
+++ b/src/library-authoring/data/apiHooks.test.tsx
@@ -15,6 +15,7 @@ import {
   getLibraryContainerApiUrl,
   getLibraryContainerRestoreApiUrl,
   getLibraryContainerChildrenApiUrl,
+  getLibraryContainerPublishApiUrl,
 } from './api';
 import {
   useCommitLibraryChanges,
@@ -31,6 +32,7 @@ import {
   useAddComponentsToContainer,
   useUpdateContainerChildren,
   useRemoveContainerChildren,
+  usePublishContainer,
 } from './apiHooks';
 
 let axiosMock;
@@ -306,6 +308,18 @@ describe('library api hooks', () => {
     await result.current.mutateAsync([]);
     await waitFor(() => {
       expect(axiosMock.history.patch.length).toEqual(0);
+    });
+  });
+
+  describe('publishContainer', () => {
+    it('should publish a container', async () => {
+      const containerId = 'lct:org:lib:unit:1';
+      const url = getLibraryContainerPublishApiUrl(containerId);
+      axiosMock.onPost(url).reply(200);
+      const { result } = renderHook(() => usePublishContainer(containerId), { wrapper });
+      await result.current.mutateAsync();
+
+      expect(axiosMock.history.post[0].url).toEqual(url);
     });
   });
 });

--- a/src/library-authoring/units/LibraryUnitBlocks.tsx
+++ b/src/library-authoring/units/LibraryUnitBlocks.tsx
@@ -129,7 +129,7 @@ export const LibraryUnitBlocks = ({ preview }: LibraryUnitBlocksProps) => {
   };
 
   const onTagSidebarClose = () => {
-    queryClient.invalidateQueries(libraryAuthoringQueryKeys.containerChildren(unitId));
+    queryClient.invalidateQueries(libraryAuthoringQueryKeys.containerChildren(unitId!));
     closeManageTagsDrawer();
   };
 


### PR DESCRIPTION
## Description

Implements a _minimal_ version of https://github.com/openedx/frontend-app-authoring/issues/1627

Depends on https://github.com/openedx/edx-platform/pull/36543

Private ref [FAL-4069](https://tasks.opencraft.com/browse/FAL-4069)

## Test Instructions

1. Check out this PR and the required edx-platform PR.
2. Create or paste a unit that contains multiple components (xblocks).
3. Click on the new "Publish" button for that unit. (Note: there is no confirmation dialog.)
    a. Verify that the toast is shown:
        ![Screenshot 2025-04-17 at 2 35 11 PM](https://github.com/user-attachments/assets/2487e4a6-f110-4341-9844-6688cc38eb2a)
    b. Verify that the "Draft" badges on the preview have disappeared:
        ![Screenshot 2025-04-17 at 2 33 16 PM](https://github.com/user-attachments/assets/60ec8c19-bbea-4a1b-8865-3d3c73158b1c)
    c. Verify that the "Unpublished Changes" badges in the search results have disappeared:
        ![Screenshot](https://github.com/user-attachments/assets/e05206e7-6a34-4941-b049-a41c71f11756)
4. Make changes to a component that's in the the unit. Verify that both it and the unit now show "Unpublished Changesj" again.


## Screenshots of the new Publish Button

**When a unit is selected in the library, but not open - new "Publish" button:**

![Image](https://github.com/user-attachments/assets/8e166959-72a1-475a-9242-b258c5b3f421)

**When a unit is open - same new "Publish" button:**

![Image](https://github.com/user-attachments/assets/28c8d79c-8160-4b72-8203-186e992ee6bb)