### PR TITLE
fix: video & file page toggles due to page refreshing in course authoring mfe

### DIFF
--- a/src/files-and-videos/files-page/FilesPage.test.jsx
+++ b/src/files-and-videos/files-page/FilesPage.test.jsx
@@ -163,6 +163,7 @@ describe('FilesAndUploads', () => {
       store = initializeStore(initialState);
       axiosMock = new MockAdapter(getAuthenticatedHttpClient());
       file = new File(['(⌐□_□)'], 'download.png', { type: 'image/png' });
+      global.localStorage.clear();
     });
 
     afterEach(() => {

--- a/src/files-and-videos/files-page/factories/mockApiResponses.jsx
+++ b/src/files-and-videos/files-page/factories/mockApiResponses.jsx
@@ -58,8 +58,7 @@ export const initialState = {
       transcript: [],
       loading: '',
     },
-    filesCurrentView: 'card',
-    videosCurrentView: 'list',
+    defaultView: 'card',
   },
 };
 

--- a/src/files-and-videos/videos-page/VideosPage.test.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.test.jsx
@@ -110,6 +110,7 @@ describe('Videos page', () => {
       axiosMock = new MockAdapter(getAuthenticatedHttpClient());
       axiosUnauthenticateMock = new MockAdapter(getHttpClient());
       file = new File(['(⌐□_□)'], 'download.mp4', { type: 'video/mp4' });
+      global.localStorage.clear();
     });
 
     it('should return placeholder component', async () => {
@@ -166,6 +167,7 @@ describe('Videos page', () => {
       axiosMock = new MockAdapter(getAuthenticatedHttpClient());
       axiosUnauthenticateMock = new MockAdapter(getHttpClient());
       file = new File(['(⌐□_□)'], 'download.png', { type: 'image/png' });
+      global.localStorage.clear();
     });
 
     describe('table view', () => {

--- a/src/files-and-videos/videos-page/data/slice.js
+++ b/src/files-and-videos/videos-page/data/slice.js
@@ -23,18 +23,11 @@ const slice = createSlice({
       transcript: [],
       loading: '',
     },
-    filesCurrentView: 'list',
-    videosCurrentView: 'list',
+    defaultView: 'list',
   },
   reducers: {
     setVideoIds: (state, { payload }) => {
       state.videoIds = payload.videoIds;
-    },
-    setVideosCurrentViewState: (state, { payload }) => {
-      state.videosCurrentView = payload.videosCurrentView;
-    },
-    setFilesCurrentViewState: (state, { payload }) => {
-      state.filesCurrentView = payload.filesCurrentView;
     },
     setPageSettings: (state, { payload }) => {
       state.pageSettings = payload;
@@ -106,8 +99,6 @@ const slice = createSlice({
 
 export const {
   setVideoIds,
-  setVideosCurrentViewState,
-  setFilesCurrentViewState,
   setPageSettings,
   updateLoadingStatus,
   deleteVideoSuccess,

--- a/src/files-and-videos/videos-page/factories/mockApiResponses.jsx
+++ b/src/files-and-videos/videos-page/factories/mockApiResponses.jsx
@@ -84,8 +84,7 @@ export const initialState = {
       transcript: [],
       loading: '',
     },
-    filesCurrentView: 'list',
-    videosCurrentView: 'card',
+    defaultView: 'card',
   },
   models: {
     videos: {


### PR DESCRIPTION
Ticket: [TNL-11637](https://2u-internal.atlassian.net/browse/TNL-11637)

- react redux state changes back to default whenever page refreshes.
 - On course authoring mfe, whenever we redirect from one page to another, it automatically refreshes the page which react app shouldn't do.
 - So, instead of managing video and file pages previously selected view in react redux, save & manage these values in localStorage. So that page refreshes doesn't bother end users.

Attaching it's previously merged related [PR](https://github.com/openedx/frontend-app-authoring/pull/1808) which was made keeping in mind to make use of react redux. But unfortunately, page is refreshing every time user redirects to another page in same MFE. Usually in react App, page switching shouldn't refresh the page.