### PR TITLE
feat: disallow edits to units in courses that are sourced from a library

### DIFF
--- a/src/content-tags-drawer/tags-sidebar-controls/TagsSidebarBody.tsx
+++ b/src/content-tags-drawer/tags-sidebar-controls/TagsSidebarBody.tsx
@@ -1,5 +1,4 @@
-// @ts-check
-import React, { useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import {
   Card, Stack, Button, Collapsible, Icon,
 } from '@openedx/paragon';
@@ -10,10 +9,19 @@ import { ContentTagsDrawerSheet } from '..';
 
 import messages from '../messages';
 import { useContentTaxonomyTagsData } from '../data/apiHooks';
+import type { ContentTaxonomyTagData, Tag } from '../data/types';
 import { LoadingSpinner } from '../../generic/Loading';
 import TagsTree from '../TagsTree';
 
-const TagsSidebarBody = () => {
+interface TagsSidebarBodyProps {
+  readOnly: boolean
+}
+
+type TagTree = {
+  [key: string]: { children: TagTree, canChangeObjecttag: boolean, canDeleteObjecttag: boolean }
+};
+
+const TagsSidebarBody = ({ readOnly }: TagsSidebarBodyProps) => {
   const intl = useIntl();
   const [showManageTags, setShowManageTags] = useState(false);
   const contentId = useParams().blockId;
@@ -24,8 +32,8 @@ const TagsSidebarBody = () => {
     isSuccess: isContentTaxonomyTagsLoaded,
   } = useContentTaxonomyTagsData(contentId || '');
 
-  const buildTagsTree = (contentTags) => {
-    const resultTree = {};
+  const buildTagsTree = (contentTags: Tag[]) => {
+    const resultTree: TagTree = {};
     contentTags.forEach(item => {
       let currentLevel = resultTree;
 
@@ -46,7 +54,7 @@ const TagsSidebarBody = () => {
   };
 
   const tree = useMemo(() => {
-    const result = [];
+    const result: (Omit<ContentTaxonomyTagData, 'tags'> & { tags: TagTree })[] = [];
     if (isContentTaxonomyTagsLoaded && contentTaxonomyTagsData) {
       contentTaxonomyTagsData.taxonomies.forEach((taxonomy) => {
         result.push({
@@ -88,7 +96,13 @@ const TagsSidebarBody = () => {
               </div>
             )}
 
-          <Button className="mt-3 ml-2" variant="outline-primary" size="sm" onClick={() => setShowManageTags(true)}>
+          <Button
+            className="mt-3 ml-2"
+            variant="outline-primary"
+            size="sm"
+            onClick={() => setShowManageTags(true)}
+            disabled={readOnly}
+          >
             {intl.formatMessage(messages.manageTagsButton)}
           </Button>
         </Stack>
@@ -101,7 +115,5 @@ const TagsSidebarBody = () => {
     </>
   );
 };
-
-TagsSidebarBody.propTypes = {};
 
 export default TagsSidebarBody;

--- a/src/content-tags-drawer/tags-sidebar-controls/index.tsx
+++ b/src/content-tags-drawer/tags-sidebar-controls/index.tsx
@@ -1,10 +1,14 @@
 import TagsSidebarHeader from './TagsSidebarHeader';
 import TagsSidebarBody from './TagsSidebarBody';
 
-const TagsSidebarControls = () => (
+interface TagsSidebarControlsProps {
+  readOnly: boolean,
+}
+
+const TagsSidebarControls = ({ readOnly }: TagsSidebarControlsProps) => (
   <>
     <TagsSidebarHeader />
-    <TagsSidebarBody />
+    <TagsSidebarBody readOnly={readOnly} />
   </>
 );
 

--- a/src/course-outline/card-header/CardHeader.jsx
+++ b/src/course-outline/card-header/CardHeader.jsx
@@ -136,6 +136,7 @@ const CardHeader = ({
               alt={intl.formatMessage(messages.altButtonEdit)}
               iconAs={EditIcon}
               onClick={onClickEdit}
+              // @ts-ignore
               disabled={isDisabledEditField}
             />
           </>

--- a/src/course-outline/card-header/CardHeader.jsx
+++ b/src/course-outline/card-header/CardHeader.jsx
@@ -136,6 +136,7 @@ const CardHeader = ({
               alt={intl.formatMessage(messages.altButtonEdit)}
               iconAs={EditIcon}
               onClick={onClickEdit}
+              disabled={isDisabledEditField}
             />
           </>
         )}
@@ -178,6 +179,7 @@ const CardHeader = ({
               </Dropdown.Item>
               <Dropdown.Item
                 data-testid={`${namePrefix}-card-header__menu-configure-button`}
+                disabled={isDisabledEditField}
                 onClick={onClickConfigure}
               >
                 {intl.formatMessage(messages.menuConfigure)}
@@ -185,6 +187,7 @@ const CardHeader = ({
               {getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true' && (
                 <Dropdown.Item
                   data-testid={`${namePrefix}-card-header__menu-manage-tags-button`}
+                  disabled={isDisabledEditField}
                   onClick={openManageTagsDrawer}
                 >
                   {intl.formatMessage(messages.menuManageTags)}

--- a/src/course-outline/card-header/CardHeader.test.jsx
+++ b/src/course-outline/card-header/CardHeader.test.jsx
@@ -240,6 +240,35 @@ describe('<CardHeader />', () => {
     expect(await findByTestId('subsection-edit-field')).toBeDisabled();
   });
 
+  it('check editing is enabled when isDisabledEditField is false', async () => {
+    const { getByTestId } = renderComponent({
+      ...cardHeaderProps,
+    });
+
+    expect(getByTestId('subsection-edit-button')).toBeEnabled();
+
+    // Ensure menu items related to editing are enabled
+    const menuButton = getByTestId('subsection-card-header__menu-button');
+    await act(async () => fireEvent.click(menuButton));
+    expect(await getByTestId('subsection-card-header__menu-configure-button')).not.toHaveAttribute('aria-disabled');
+    expect(await getByTestId('subsection-card-header__menu-manage-tags-button')).not.toHaveAttribute('aria-disabled');
+  });
+
+  it('check editing is disabled when isDisabledEditField is true', async () => {
+    const { getByTestId } = renderComponent({
+      ...cardHeaderProps,
+      isDisabledEditField: true,
+    });
+
+    expect(await getByTestId('subsection-edit-button')).toBeDisabled();
+
+    // Ensure menu items related to editing are disabled
+    const menuButton = getByTestId('subsection-card-header__menu-button');
+    await act(async () => fireEvent.click(menuButton));
+    expect(await getByTestId('subsection-card-header__menu-configure-button')).toHaveAttribute('aria-disabled', 'true');
+    expect(await getByTestId('subsection-card-header__menu-manage-tags-button')).toHaveAttribute('aria-disabled', 'true');
+  });
+
   it('calls onClickDelete when item is clicked', async () => {
     const { findByText, findByTestId } = renderComponent();
 

--- a/src/course-outline/unit-card/UnitCard.jsx
+++ b/src/course-outline/unit-card/UnitCard.jsx
@@ -9,6 +9,7 @@ import { useSearchParams } from 'react-router-dom';
 import CourseOutlineUnitCardExtraActionsSlot from '../../plugin-slots/CourseOutlineUnitCardExtraActionsSlot';
 import { setCurrentItem, setCurrentSection, setCurrentSubsection } from '../data/slice';
 import { RequestStatus } from '../../data/constants';
+import { isUnitReadOnly } from '../../course-unit/data/utils';
 import CardHeader from '../card-header/CardHeader';
 import SortableItem from '../drag-helper/SortableItem';
 import TitleLink from '../card-header/TitleLink';
@@ -56,6 +57,8 @@ const UnitCard = ({
     enableCopyPasteUnits = false,
     discussionEnabled,
   } = unit;
+
+  const readOnly = isUnitReadOnly(unit);
 
   // re-create actions object for customizations
   const actions = { ...unitActions };
@@ -175,7 +178,7 @@ const UnitCard = ({
           isFormOpen={isFormOpen}
           closeForm={closeForm}
           onEditSubmit={handleEditSubmit}
-          isDisabledEditField={savingStatus === RequestStatus.IN_PROGRESS}
+          isDisabledEditField={readOnly || savingStatus === RequestStatus.IN_PROGRESS}
           onClickDuplicate={onDuplicateSubmit}
           titleComponent={titleComponent}
           namePrefix={namePrefix}
@@ -222,6 +225,7 @@ UnitCard.propTypes = {
     isHeaderVisible: PropTypes.bool,
     enableCopyPasteUnits: PropTypes.bool,
     discussionEnabled: PropTypes.bool,
+    upstream: PropTypes.string,
   }).isRequired,
   subsection: PropTypes.shape({
     id: PropTypes.string.isRequired,

--- a/src/course-outline/unit-card/UnitCard.jsx
+++ b/src/course-outline/unit-card/UnitCard.jsx
@@ -225,7 +225,6 @@ UnitCard.propTypes = {
     isHeaderVisible: PropTypes.bool,
     enableCopyPasteUnits: PropTypes.bool,
     discussionEnabled: PropTypes.bool,
-    upstream: PropTypes.string,
   }).isRequired,
   subsection: PropTypes.shape({
     id: PropTypes.string.isRequired,

--- a/src/course-unit/CourseUnit.jsx
+++ b/src/course-unit/CourseUnit.jsx
@@ -40,6 +40,7 @@ const CourseUnit = ({ courseId }) => {
   const { blockId } = useParams();
   const intl = useIntl();
   const {
+    courseUnit,
     isLoading,
     sequenceId,
     unitTitle,
@@ -74,6 +75,8 @@ const CourseUnit = ({ courseId }) => {
     addComponentTemplateData,
   } = useCourseUnit({ courseId, blockId });
   const layoutGrid = useLayoutGrid(unitCategory, isUnitLibraryType);
+
+  const readOnly = !!courseUnit.upstream;
 
   useEffect(() => {
     document.title = getPageHeadTitle('', unitTitle);
@@ -195,14 +198,16 @@ const CourseUnit = ({ courseId }) => {
                 courseVerticalChildren={courseVerticalChildren.children}
                 handleConfigureSubmit={handleConfigureSubmit}
               />
-              <AddComponent
-                parentLocator={blockId}
-                isSplitTestType={isSplitTestType}
-                isUnitVerticalType={isUnitVerticalType}
-                handleCreateNewCourseXBlock={handleCreateNewCourseXBlock}
-                addComponentTemplateData={addComponentTemplateData}
-              />
-              {showPasteXBlock && canPasteComponent && isUnitVerticalType && (
+              {!readOnly && (
+                <AddComponent
+                  parentLocator={blockId}
+                  isSplitTestType={isSplitTestType}
+                  isUnitVerticalType={isUnitVerticalType}
+                  handleCreateNewCourseXBlock={handleCreateNewCourseXBlock}
+                  addComponentTemplateData={addComponentTemplateData}
+                />
+              )}
+              {!readOnly && showPasteXBlock && canPasteComponent && isUnitVerticalType && (
                 <PasteComponent
                   clipboardData={sharedClipboardData}
                   onClick={
@@ -227,6 +232,7 @@ const CourseUnit = ({ courseId }) => {
                   blockId={blockId}
                   unitTitle={unitTitle}
                   xBlocks={courseVerticalChildren.children}
+                  readOnly={readOnly}
                 />
                 )}
                 {isSplitTestType && (

--- a/src/course-unit/CourseUnit.jsx
+++ b/src/course-unit/CourseUnit.jsx
@@ -76,7 +76,7 @@ const CourseUnit = ({ courseId }) => {
   } = useCourseUnit({ courseId, blockId });
   const layoutGrid = useLayoutGrid(unitCategory, isUnitLibraryType);
 
-  const readOnly = !!courseUnit.upstream;
+  const readOnly = !!courseUnit.readOnly;
 
   useEffect(() => {
     document.title = getPageHeadTitle('', unitTitle);

--- a/src/course-unit/CourseUnit.test.jsx
+++ b/src/course-unit/CourseUnit.test.jsx
@@ -2220,14 +2220,14 @@ describe('<CourseUnit />', () => {
     expect(editButton).toBeInTheDocument();
     expect(editButton).toBeDisabled();
 
-    // Disable the "Publish" button
+    // The "Publish" button should still be enabled
     const courseUnitSidebar = screen.getByTestId('course-unit-sidebar');
     const publishButton = within(courseUnitSidebar).getByRole(
       'button',
       { name: sidebarMessages.actionButtonPublishTitle.defaultMessage },
     );
     expect(publishButton).toBeInTheDocument();
-    expect(publishButton).toBeDisabled();
+    expect(publishButton).toBeEnabled();
 
     // Disable the "Manage Tags" button
     const manageTagsButton = screen.getByRole(

--- a/src/course-unit/CourseUnit.test.jsx
+++ b/src/course-unit/CourseUnit.test.jsx
@@ -2207,7 +2207,9 @@ describe('<CourseUnit />', () => {
       .onGet(getCourseUnitApiUrl(courseId))
       .reply(200, {
         ...courseUnitIndexMock,
-        upstream: 'lct:org:lib:unit:unit-1',
+        upstreamInfo: {
+          upstreamRef: 'lct:org:lib:unit:unit-1',
+        },
       });
     await executeThunk(fetchCourseUnitQuery(courseId), store.dispatch);
 

--- a/src/course-unit/CourseUnit.test.jsx
+++ b/src/course-unit/CourseUnit.test.jsx
@@ -2195,4 +2195,49 @@ describe('<CourseUnit />', () => {
         .toHaveBeenCalledWith(`/course/${courseId}/editor/html/${targetBlockId}`, { replace: true });
     });
   });
+
+  it('renders units from libraries with some components read-only', async () => {
+    setConfig({
+      ...getConfig(),
+      ENABLE_TAGGING_TAXONOMY_PAGES: 'true',
+    });
+    render(<RootWrapper />);
+
+    axiosMock
+      .onGet(getCourseUnitApiUrl(courseId))
+      .reply(200, {
+        ...courseUnitIndexMock,
+        upstream: 'lct:org:lib:unit:unit-1',
+      });
+    await executeThunk(fetchCourseUnitQuery(courseId), store.dispatch);
+
+    // Disable the "Edit" button
+    const unitHeaderTitle = screen.getByTestId('unit-header-title');
+    const editButton = within(unitHeaderTitle).getByRole(
+      'button',
+      { name: 'Edit' },
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toBeDisabled();
+
+    // Disable the "Publish" button
+    const courseUnitSidebar = screen.getByTestId('course-unit-sidebar');
+    const publishButton = within(courseUnitSidebar).getByRole(
+      'button',
+      { name: sidebarMessages.actionButtonPublishTitle.defaultMessage },
+    );
+    expect(publishButton).toBeInTheDocument();
+    expect(publishButton).toBeDisabled();
+
+    // Disable the "Manage Tags" button
+    const manageTagsButton = screen.getByRole(
+      'button',
+      { name: tagsDrawerMessages.manageTagsButton.defaultMessage },
+    );
+    expect(manageTagsButton).toBeInTheDocument();
+    expect(manageTagsButton).toBeDisabled();
+
+    // Does not render the "Add Components" section
+    expect(screen.queryByText(addComponentMessages.title.defaultMessage)).not.toBeInTheDocument();
+  });
 });

--- a/src/course-unit/add-component/AddComponent.jsx
+++ b/src/course-unit/add-component/AddComponent.jsx
@@ -208,10 +208,6 @@ const AddComponent = ({
   return null;
 };
 
-AddComponent.defaultProps = {
-  addComponentTemplateData: {},
-};
-
 AddComponent.propTypes = {
   isSplitTestType: PropTypes.bool.isRequired,
   isUnitVerticalType: PropTypes.bool.isRequired,

--- a/src/course-unit/data/thunk.js
+++ b/src/course-unit/data/thunk.js
@@ -38,7 +38,7 @@ import {
   updateCourseOutlineInfoLoadingStatus,
   updateMovedXBlockParams,
 } from './slice';
-import { getNotificationMessage } from './utils';
+import { getNotificationMessage, isUnitReadOnly } from './utils';
 
 export function fetchCourseUnitQuery(courseId) {
   return async (dispatch) => {
@@ -46,6 +46,8 @@ export function fetchCourseUnitQuery(courseId) {
 
     try {
       const courseUnit = await getCourseUnitData(courseId);
+      courseUnit.readOnly = isUnitReadOnly(courseUnit);
+
       dispatch(fetchCourseItemSuccess(courseUnit));
       dispatch(updateLoadingCourseUnitStatus({ status: RequestStatus.SUCCESSFUL }));
       return true;

--- a/src/course-unit/data/utils.js
+++ b/src/course-unit/data/utils.js
@@ -90,9 +90,9 @@ export const updateXBlockBlockIdToId = (data) => {
  *
  * Units sourced from libraries are read-only (temporary, for Teak).
  *
- * @param {object} unit - The unit data, should contain the 'upstream' key if set.
+ * @param {object} unit - uses the 'upstreamInfo' object if found.
  * @returns {boolean} True if readOnly, False if editable.
  */
-export const isUnitReadOnly = ({ upstream }) => (
-  upstream && upstream.startsWith('lct:')
+export const isUnitReadOnly = ({ upstreamInfo }) => (
+  upstreamInfo && upstreamInfo.upstreamRef && upstreamInfo.upstreamRef.startsWith('lct:')
 );

--- a/src/course-unit/data/utils.js
+++ b/src/course-unit/data/utils.js
@@ -84,3 +84,15 @@ export const updateXBlockBlockIdToId = (data) => {
 
   return updatedData;
 };
+
+/**
+ * Returns whether the given Unit should be read-only.
+ *
+ * Units sourced from libraries are read-only (temporary, for Teak).
+ *
+ * @param {object} unit - The unit data, should contain the 'upstream' key if set.
+ * @returns {boolean} True if readOnly, False if editable.
+ */
+export const isUnitReadOnly = ({ upstream }) => (
+  upstream && upstream.startsWith('lct:')
+);

--- a/src/course-unit/header-title/HeaderTitle.jsx
+++ b/src/course-unit/header-title/HeaderTitle.jsx
@@ -34,7 +34,7 @@ const HeaderTitle = ({
     COURSE_BLOCK_NAMES.component.id,
   ].includes(currentItemData.category);
 
-  const isReadOnly = !!currentItemData.upstream;
+  const readOnly = !!currentItemData.readOnly;
 
   const onConfigureSubmit = (...arg) => {
     handleConfigureSubmit(currentItemData.id, ...arg, closeConfigureModal);
@@ -82,13 +82,14 @@ const HeaderTitle = ({
           className="ml-1 flex-shrink-0"
           iconAs={EditIcon}
           onClick={handleTitleEdit}
-          disabled={isReadOnly}
+          disabled={readOnly}
         />
         <IconButton
           alt={intl.formatMessage(messages.altButtonSettings)}
           className="flex-shrink-0"
           iconAs={SettingsIcon}
           onClick={openConfigureModal}
+          disabled={readOnly}
         />
         <ConfigureModal
           isOpen={isConfigureModalOpen}

--- a/src/course-unit/header-title/HeaderTitle.jsx
+++ b/src/course-unit/header-title/HeaderTitle.jsx
@@ -34,6 +34,8 @@ const HeaderTitle = ({
     COURSE_BLOCK_NAMES.component.id,
   ].includes(currentItemData.category);
 
+  const isReadOnly = !!currentItemData.upstream;
+
   const onConfigureSubmit = (...arg) => {
     handleConfigureSubmit(currentItemData.id, ...arg, closeConfigureModal);
   };
@@ -80,6 +82,7 @@ const HeaderTitle = ({
           className="ml-1 flex-shrink-0"
           iconAs={EditIcon}
           onClick={handleTitleEdit}
+          disabled={isReadOnly}
         />
         <IconButton
           alt={intl.formatMessage(messages.altButtonSettings)}
@@ -102,6 +105,8 @@ const HeaderTitle = ({
   );
 };
 
+export default HeaderTitle;
+
 HeaderTitle.propTypes = {
   unitTitle: PropTypes.string.isRequired,
   isTitleEditFormOpen: PropTypes.bool.isRequired,
@@ -109,5 +114,3 @@ HeaderTitle.propTypes = {
   handleTitleEditSubmit: PropTypes.func.isRequired,
   handleConfigureSubmit: PropTypes.func.isRequired,
 };
-
-export default HeaderTitle;

--- a/src/course-unit/header-title/HeaderTitle.test.jsx
+++ b/src/course-unit/header-title/HeaderTitle.test.jsx
@@ -72,8 +72,25 @@ describe('<HeaderTitle />', () => {
 
     expect(getByRole('textbox', { name: messages.ariaLabelButtonEdit.defaultMessage })).toBeInTheDocument();
     expect(getByRole('textbox', { name: messages.ariaLabelButtonEdit.defaultMessage })).toHaveValue(unitTitle);
-    expect(getByRole('button', { name: messages.altButtonEdit.defaultMessage })).toBeInTheDocument();
-    expect(getByRole('button', { name: messages.altButtonSettings.defaultMessage })).toBeInTheDocument();
+    expect(getByRole('button', { name: messages.altButtonEdit.defaultMessage })).toBeEnabled();
+    expect(getByRole('button', { name: messages.altButtonSettings.defaultMessage })).toBeEnabled();
+  });
+
+  it('Units sourced from upstream show a disabled edit form and config menu', async () => {
+    // Override mock unit with one sourced from an upstream library
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    axiosMock
+      .onGet(getCourseUnitApiUrl(blockId))
+      .reply(200, {
+        ...courseUnitIndexMock,
+        upstream: 'lct:org:lib:unit:unit-1',
+      });
+    await executeThunk(fetchCourseUnitQuery(blockId), store.dispatch);
+
+    const { getByRole } = renderComponent();
+
+    expect(getByRole('button', { name: messages.altButtonEdit.defaultMessage })).toBeDisabled();
+    expect(getByRole('button', { name: messages.altButtonSettings.defaultMessage })).toBeDisabled();
   });
 
   it('calls toggle edit title form by clicking on Edit button', () => {

--- a/src/course-unit/header-title/HeaderTitle.test.jsx
+++ b/src/course-unit/header-title/HeaderTitle.test.jsx
@@ -83,7 +83,9 @@ describe('<HeaderTitle />', () => {
       .onGet(getCourseUnitApiUrl(blockId))
       .reply(200, {
         ...courseUnitIndexMock,
-        upstream: 'lct:org:lib:unit:unit-1',
+        upstreamInfo: {
+          upstreamRef: 'lct:org:lib:unit:unit-1',
+        },
       });
     await executeThunk(fetchCourseUnitQuery(blockId), store.dispatch);
 

--- a/src/course-unit/sidebar/PublishControls.tsx
+++ b/src/course-unit/sidebar/PublishControls.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useToggle } from '@openedx/paragon';
 import { InfoOutline as InfoOutlineIcon } from '@openedx/paragon/icons';
@@ -12,16 +11,22 @@ import { getCourseUnitData } from '../data/selectors';
 import messages from './messages';
 import ModalNotification from '../../generic/modal-notification';
 
-const PublishControls = ({ blockId }) => {
+interface PublishControlsProps {
+  blockId?: string,
+}
+
+const PublishControls = ({ blockId }: PublishControlsProps) => {
+  const unitData = useSelector(getCourseUnitData);
   const {
     title,
     locationId,
     releaseLabel,
     visibilityState,
     visibleToStaffOnly,
-  } = useCourseUnitData(useSelector(getCourseUnitData));
+  } = useCourseUnitData(unitData);
   const intl = useIntl();
   const { sendMessageToIframe } = useIframe();
+  const hasUpstream = !!unitData?.upstream;
 
   const [isDiscardModalOpen, openDiscardModal, closeDiscardModal] = useToggle(false);
   const [isVisibleModalOpen, openVisibleModal, closeVisibleModal] = useToggle(false);
@@ -65,6 +70,7 @@ const PublishControls = ({ blockId }) => {
         openVisibleModal={openVisibleModal}
         handlePublishing={handleCourseUnitPublish}
         visibleToStaffOnly={visibleToStaffOnly}
+        hasUpstream={hasUpstream}
       />
       <ModalNotification
         title={intl.formatMessage(messages.modalDiscardUnitChangesTitle)}
@@ -88,14 +94,6 @@ const PublishControls = ({ blockId }) => {
       />
     </>
   );
-};
-
-PublishControls.propTypes = {
-  blockId: PropTypes.string,
-};
-
-PublishControls.defaultProps = {
-  blockId: null,
 };
 
 export default PublishControls;

--- a/src/course-unit/sidebar/PublishControls.tsx
+++ b/src/course-unit/sidebar/PublishControls.tsx
@@ -26,7 +26,6 @@ const PublishControls = ({ blockId }: PublishControlsProps) => {
   } = useCourseUnitData(unitData);
   const intl = useIntl();
   const { sendMessageToIframe } = useIframe();
-  const hasUpstream = !!unitData?.upstream;
 
   const [isDiscardModalOpen, openDiscardModal, closeDiscardModal] = useToggle(false);
   const [isVisibleModalOpen, openVisibleModal, closeVisibleModal] = useToggle(false);
@@ -70,7 +69,6 @@ const PublishControls = ({ blockId }: PublishControlsProps) => {
         openVisibleModal={openVisibleModal}
         handlePublishing={handleCourseUnitPublish}
         visibleToStaffOnly={visibleToStaffOnly}
-        hasUpstream={hasUpstream}
       />
       <ModalNotification
         title={intl.formatMessage(messages.modalDiscardUnitChangesTitle)}

--- a/src/course-unit/sidebar/components/sidebar-footer/ActionButtons.tsx
+++ b/src/course-unit/sidebar/components/sidebar-footer/ActionButtons.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { Button } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -8,7 +7,17 @@ import { getCanEdit, getCourseUnitData } from '../../../data/selectors';
 import { useClipboard } from '../../../../generic/clipboard';
 import messages from '../../messages';
 
-const ActionButtons = ({ openDiscardModal, handlePublishing }) => {
+interface ActionButtonsProps {
+  openDiscardModal: () => void,
+  handlePublishing: () => void,
+  readOnly: boolean,
+}
+
+const ActionButtons = ({
+  openDiscardModal,
+  handlePublishing,
+  readOnly = false,
+}: ActionButtonsProps) => {
   const intl = useIntl();
   const {
     id,
@@ -22,7 +31,13 @@ const ActionButtons = ({ openDiscardModal, handlePublishing }) => {
   return (
     <>
       {(!published || hasChanges) && (
-        <Button size="sm" className="mt-3.5" variant="outline-primary" onClick={handlePublishing}>
+        <Button
+          size="sm"
+          className="mt-3.5"
+          variant="outline-primary"
+          onClick={handlePublishing}
+          disabled={readOnly}
+        >
           {intl.formatMessage(messages.actionButtonPublishTitle)}
         </Button>
       )}
@@ -32,6 +47,7 @@ const ActionButtons = ({ openDiscardModal, handlePublishing }) => {
           variant="link"
           onClick={openDiscardModal}
           className="course-unit-sidebar-footer__discard-changes__btn mt-2"
+          disabled={readOnly}
         >
           {intl.formatMessage(messages.actionButtonDiscardChangesTitle)}
         </Button>
@@ -50,11 +66,6 @@ const ActionButtons = ({ openDiscardModal, handlePublishing }) => {
       )}
     </>
   );
-};
-
-ActionButtons.propTypes = {
-  openDiscardModal: PropTypes.func.isRequired,
-  handlePublishing: PropTypes.func.isRequired,
 };
 
 export default ActionButtons;

--- a/src/course-unit/sidebar/components/sidebar-footer/ActionButtons.tsx
+++ b/src/course-unit/sidebar/components/sidebar-footer/ActionButtons.tsx
@@ -10,13 +10,11 @@ import messages from '../../messages';
 interface ActionButtonsProps {
   openDiscardModal: () => void,
   handlePublishing: () => void,
-  readOnly: boolean,
 }
 
 const ActionButtons = ({
   openDiscardModal,
   handlePublishing,
-  readOnly = false,
 }: ActionButtonsProps) => {
   const intl = useIntl();
   const {
@@ -36,7 +34,6 @@ const ActionButtons = ({
           className="mt-3.5"
           variant="outline-primary"
           onClick={handlePublishing}
-          disabled={readOnly}
         >
           {intl.formatMessage(messages.actionButtonPublishTitle)}
         </Button>
@@ -47,7 +44,6 @@ const ActionButtons = ({
           variant="link"
           onClick={openDiscardModal}
           className="course-unit-sidebar-footer__discard-changes__btn mt-2"
-          disabled={readOnly}
         >
           {intl.formatMessage(messages.actionButtonDiscardChangesTitle)}
         </Button>

--- a/src/course-unit/sidebar/components/sidebar-footer/UnitVisibilityInfo.tsx
+++ b/src/course-unit/sidebar/components/sidebar-footer/UnitVisibilityInfo.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { Form } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -10,7 +9,15 @@ import { PUBLISH_TYPES } from '../../../constants';
 import { getVisibilityTitle } from '../../utils';
 import messages from '../../messages';
 
-const UnitVisibilityInfo = ({ openVisibleModal, visibleToStaffOnly }) => {
+interface UnitVisibilityInfoProps {
+  openVisibleModal: () => void,
+  visibleToStaffOnly: boolean,
+}
+
+const UnitVisibilityInfo = ({
+  openVisibleModal,
+  visibleToStaffOnly,
+}: UnitVisibilityInfoProps) => {
   const intl = useIntl();
   const { blockId } = useParams();
   const dispatch = useDispatch();
@@ -57,11 +64,6 @@ const UnitVisibilityInfo = ({ openVisibleModal, visibleToStaffOnly }) => {
       </Form.Checkbox>
     </>
   );
-};
-
-UnitVisibilityInfo.propTypes = {
-  openVisibleModal: PropTypes.func.isRequired,
-  visibleToStaffOnly: PropTypes.bool.isRequired,
 };
 
 export default UnitVisibilityInfo;

--- a/src/course-unit/sidebar/components/sidebar-footer/index.tsx
+++ b/src/course-unit/sidebar/components/sidebar-footer/index.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import { Card, Stack } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
@@ -6,14 +5,25 @@ import messages from '../../messages';
 import UnitVisibilityInfo from './UnitVisibilityInfo';
 import ActionButtons from './ActionButtons';
 
+interface SidebarFooterProps {
+  locationId?: string,
+  displayUnitLocation?: boolean,
+  openDiscardModal: () => void,
+  openVisibleModal: () => void,
+  handlePublishing: () => void,
+  visibleToStaffOnly: boolean,
+  hasUpstream?: boolean,
+}
+
 const SidebarFooter = ({
   locationId,
   openVisibleModal,
   handlePublishing,
   openDiscardModal,
   visibleToStaffOnly,
-  displayUnitLocation,
-}) => {
+  displayUnitLocation = false,
+  hasUpstream = false,
+}: SidebarFooterProps) => {
   const intl = useIntl();
 
   return (
@@ -32,26 +42,13 @@ const SidebarFooter = ({
             <ActionButtons
               openDiscardModal={openDiscardModal}
               handlePublishing={handlePublishing}
+              readOnly={hasUpstream}
             />
           </>
         )}
       </Stack>
     </Card.Footer>
   );
-};
-
-SidebarFooter.propTypes = {
-  locationId: PropTypes.string,
-  displayUnitLocation: PropTypes.bool,
-  openDiscardModal: PropTypes.func,
-  openVisibleModal: PropTypes.func,
-  handlePublishing: PropTypes.func,
-  visibleToStaffOnly: PropTypes.bool.isRequired,
-};
-
-SidebarFooter.defaultProps = {
-  displayUnitLocation: false,
-  locationId: null,
 };
 
 export default SidebarFooter;

--- a/src/course-unit/sidebar/components/sidebar-footer/index.tsx
+++ b/src/course-unit/sidebar/components/sidebar-footer/index.tsx
@@ -12,7 +12,6 @@ interface SidebarFooterProps {
   openVisibleModal: () => void,
   handlePublishing: () => void,
   visibleToStaffOnly: boolean,
-  hasUpstream?: boolean,
 }
 
 const SidebarFooter = ({
@@ -22,7 +21,6 @@ const SidebarFooter = ({
   openDiscardModal,
   visibleToStaffOnly,
   displayUnitLocation = false,
-  hasUpstream = false,
 }: SidebarFooterProps) => {
   const intl = useIntl();
 
@@ -42,7 +40,6 @@ const SidebarFooter = ({
             <ActionButtons
               openDiscardModal={openDiscardModal}
               handlePublishing={handlePublishing}
-              readOnly={hasUpstream}
             />
           </>
         )}

--- a/src/generic/configure-modal/ConfigureModal.jsx
+++ b/src/generic/configure-modal/ConfigureModal.jsx
@@ -26,8 +26,8 @@ const ConfigureModal = ({
   onClose,
   onConfigureSubmit,
   currentItemData,
-  enableProctoredExams,
-  isXBlockComponent,
+  enableProctoredExams = false,
+  isXBlockComponent = false,
   isSelfPaced,
 }) => {
   const intl = useIntl();
@@ -318,11 +318,6 @@ const ConfigureModal = ({
       </div>
     </ModalDialog>
   );
-};
-
-ConfigureModal.defaultProps = {
-  isXBlockComponent: false,
-  enableProctoredExams: false,
 };
 
 ConfigureModal.propTypes = {

--- a/src/plugin-slots/CourseAuthoringUnitSidebarSlot/README.md
+++ b/src/plugin-slots/CourseAuthoringUnitSidebarSlot/README.md
@@ -11,6 +11,7 @@
 * `blockId` - String. The usage id of the current unit being viewed / edited.
 * `unitTitle` - String. The name of the current unit being viewed / edited.
 * `xBlocks` - Array of Objects. List of XBlocks in the Unit. Object structure defined in `index.tsx`.
+* `readOnly` - Boolean. True if the user should not be able to edit the contents of the unit.
 
 ## Description
 

--- a/src/plugin-slots/CourseAuthoringUnitSidebarSlot/index.tsx
+++ b/src/plugin-slots/CourseAuthoringUnitSidebarSlot/index.tsx
@@ -11,13 +11,14 @@ export const CourseAuthoringUnitSidebarSlot = (
     courseId,
     unitTitle,
     xBlocks,
+    readOnly,
   }: CourseAuthoringUnitSidebarSlotProps,
 ) => (
   <PluginSlot
     id="org.openedx.frontend.authoring.course_unit_sidebar.v1"
     idAliases={['course_authoring_unit_sidebar_slot']}
     pluginProps={{
-      blockId, courseId, unitTitle, xBlocks,
+      blockId, courseId, unitTitle, xBlocks, readOnly,
     }}
   >
     <Sidebar data-testid="course-unit-sidebar">
@@ -25,7 +26,7 @@ export const CourseAuthoringUnitSidebarSlot = (
     </Sidebar>
     {getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true' && (
     <Sidebar className="tags-sidebar">
-      <TagsSidebarControls />
+      <TagsSidebarControls readOnly={readOnly} />
     </Sidebar>
     )}
     <Sidebar data-testid="course-unit-location-sidebar">
@@ -45,4 +46,5 @@ interface CourseAuthoringUnitSidebarSlotProps {
   courseId: string;
   unitTitle: string;
   xBlocks: XBlock[];
+  readOnly: boolean;
 }


### PR DESCRIPTION
## Description

This PR disallows edits to units in courses (including title change, children change) that are sourced from a library.

## Supporting information

- Implements https://github.com/openedx/frontend-app-authoring/issues/1712
- Depends on https://github.com/openedx/edx-platform/pull/36558

## Testing instructions

- Open a unit that was added from a library (https://github.com/openedx/frontend-app-authoring/pull/1829)
- Checkout https://github.com/openedx/edx-platform/pull/36558
- Check that the Edit (near the title) is disabled
- Check that the "Publish" button on the sidebar is disabled
- Check that the "Manage Tags" button on the sidebar is disabled
- Check that you cannot add new blocks to the unit
- Check that you cannot change the children blocks on the unit

___
Private ref: [FAL-4112](https://tasks.opencraft.com/browse/FAL-4112)