### PR TITLE
refactor: Update delete/restore components in libraries

### DIFF
--- a/src/library-authoring/components/ComponentDeleter.test.tsx
+++ b/src/library-authoring/components/ComponentDeleter.test.tsx
@@ -57,7 +57,14 @@ describe('<ComponentDeleter />', () => {
 
   it('deletes the block when confirmed, shows a toast with undo option and restores block on undo', async () => {
     const mockCancel = jest.fn();
-    render(<ComponentDeleter usageKey={usageKey} isConfirmingDelete cancelDelete={mockCancel} />, renderArgs);
+    render(
+      <ComponentDeleter
+        usageKey={mockDeleteLibraryBlock.inContainersKey}
+        isConfirmingDelete
+        cancelDelete={mockCancel}
+      />,
+      renderArgs,
+    );
 
     const modal = screen.getByRole('dialog', { name: 'Delete Component' });
     expect(modal).toBeVisible();
@@ -73,8 +80,8 @@ describe('<ComponentDeleter />', () => {
     const restoreFn = mockShowToast.mock.calls[0][1].onClick;
     restoreFn();
     await waitFor(() => {
-      expect(mockRestore).toHaveBeenCalled();
       expect(mockShowToast).toHaveBeenCalledWith('Undo successful');
     });
+    expect(mockRestore).toHaveBeenCalled();
   });
 });

--- a/src/library-authoring/components/ComponentDeleter.tsx
+++ b/src/library-authoring/components/ComponentDeleter.tsx
@@ -36,9 +36,9 @@ const ComponentDeleter = ({ usageKey, ...props }: Props) => {
   const sidebarComponentUsageKey = sidebarComponentInfo?.id;
 
   const restoreComponentMutation = useRestoreLibraryBlock();
-  const restoreComponent = useCallback(async () => {
+  const restoreComponent = useCallback(async (affectedContainersKeys: string[]) => {
     try {
-      await restoreComponentMutation.mutateAsync({ usageKey });
+      await restoreComponentMutation.mutateAsync({ usageKey, affectedContainersKeys });
       showToast(intl.formatMessage(messages.undoDeleteComponentToastSuccess));
     } catch (e) {
       showToast(intl.formatMessage(messages.undoDeleteComponentToastFailed));
@@ -47,12 +47,13 @@ const ComponentDeleter = ({ usageKey, ...props }: Props) => {
 
   const deleteComponentMutation = useDeleteLibraryBlock();
   const doDelete = React.useCallback(async () => {
-    await deleteComponentMutation.mutateAsync({ usageKey });
+    const { affectedContainers } = await deleteComponentMutation.mutateAsync({ usageKey });
+    const affectedContainersKeys = affectedContainers.map((container) => container.id);
     showToast(
       intl.formatMessage(messages.deleteComponentSuccess),
       {
         label: intl.formatMessage(messages.undoDeleteCollectionToastAction),
-        onClick: restoreComponent,
+        onClick: () => restoreComponent(affectedContainersKeys),
       },
     );
     props.cancelDelete();

--- a/src/library-authoring/data/api.mocks.ts
+++ b/src/library-authoring/data/api.mocks.ts
@@ -232,17 +232,6 @@ mockCreateLibraryBlock.applyMock = () => (
 );
 
 /**
- * Mock for `deleteLibraryBlock()`
- */
-export async function mockDeleteLibraryBlock(): ReturnType<typeof api.deleteLibraryBlock> {
-  // no-op
-}
-/** Apply this mock. Returns a spy object that can tell you if it's been called. */
-mockDeleteLibraryBlock.applyMock = () => (
-  jest.spyOn(api, 'deleteLibraryBlock').mockImplementation(mockDeleteLibraryBlock)
-);
-
-/**
  * Mock for `restoreLibraryBlock()`
  */
 export async function mockRestoreLibraryBlock(): ReturnType<typeof api.restoreLibraryBlock> {
@@ -710,3 +699,26 @@ mockGetUnpaginatedEntityLinks.applyMock = () => jest.spyOn(
   courseLibApi,
   'getUnpaginatedEntityLinks',
 ).mockImplementation(mockGetUnpaginatedEntityLinks);
+
+/**
+ * Mock for `deleteLibraryBlock()`
+ */
+export async function mockDeleteLibraryBlock({ usageKey }): ReturnType<typeof api.deleteLibraryBlock> {
+  const thisMock = mockDeleteLibraryBlock;
+  switch (usageKey) {
+    case mockLibraryBlockMetadata.usageKeyPublished: return thisMock.emptyData;
+    case thisMock.inContainersKey: return thisMock.inContainersData;
+    default: return thisMock.emptyData;
+  }
+}
+mockDeleteLibraryBlock.emptyData = {
+  affectedContainers: [],
+};
+mockDeleteLibraryBlock.inContainersKey = 'lb:Axim:TEST:html:571fe018-f3ce-45c9-8f53-5dafcb422flo';
+mockDeleteLibraryBlock.inContainersData = {
+  affectedContainers: [mockGetContainerMetadata.containerData],
+};
+/** Apply this mock. Returns a spy object that can tell you if it's been called. */
+mockDeleteLibraryBlock.applyMock = () => (
+  jest.spyOn(api, 'deleteLibraryBlock').mockImplementation(mockDeleteLibraryBlock)
+);

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -241,6 +241,11 @@ export interface DeleteBlockDataRequest {
   usageKey: string;
 }
 
+export interface RestoreBlockDataRequest {
+  usageKey: string;
+  affectedContainersKeys?: string[];
+}
+
 export interface CollectionMetadata {
   key: string;
   title: string;
@@ -292,6 +297,25 @@ export interface BlockTypeMetadata {
   displayName: string;
 }
 
+export interface Container {
+  id: string;
+  containerType: 'unit';
+  displayName: string;
+  lastPublished: string | null;
+  publishedBy: string | null;
+  createdBy: string | null;
+  lastDraftCreated: string | null;
+  lastDraftCreatedBy: string | null,
+  hasUnpublishedChanges: boolean;
+  created: string;
+  modified: string;
+  collections: CollectionMetadata[];
+}
+
+export interface DeleteLibraryBlockResponse {
+  affectedContainers: Container[],
+}
+
 export type UpdateCollectionComponentsRequest = Partial<CreateLibraryCollectionDataRequest>;
 
 /**
@@ -318,14 +342,20 @@ export async function createLibraryBlock({
   return camelCaseObject(data);
 }
 
-export async function deleteLibraryBlock({ usageKey }: DeleteBlockDataRequest): Promise<void> {
+export async function deleteLibraryBlock({ usageKey }: DeleteBlockDataRequest): Promise<DeleteLibraryBlockResponse> {
   const client = getAuthenticatedHttpClient();
-  await client.delete(getLibraryBlockMetadataUrl(usageKey));
+  const { data } = await client.delete(getLibraryBlockMetadataUrl(usageKey));
+  return camelCaseObject(data);
 }
 
-export async function restoreLibraryBlock({ usageKey }: DeleteBlockDataRequest): Promise<void> {
+export async function restoreLibraryBlock({
+  usageKey,
+  affectedContainersKeys = [],
+}: RestoreBlockDataRequest): Promise<void> {
   const client = getAuthenticatedHttpClient();
-  await client.post(getLibraryBlockRestoreUrl(usageKey));
+  await client.post(getLibraryBlockRestoreUrl(usageKey), {
+    affected_containers: affectedContainersKeys,
+  });
 }
 
 /**
@@ -590,21 +620,6 @@ export async function createLibraryContainer(
   const client = getAuthenticatedHttpClient();
   const { data } = await client.post(getLibraryContainersApiUrl(libraryId), snakeCaseObject(containerData));
   return camelCaseObject(data);
-}
-
-export interface Container {
-  id: string;
-  containerType: 'unit';
-  displayName: string;
-  lastPublished: string | null;
-  publishedBy: string | null;
-  createdBy: string | null;
-  lastDraftCreated: string | null;
-  lastDraftCreatedBy: string | null,
-  hasUnpublishedChanges: boolean;
-  created: string;
-  modified: string;
-  collections: CollectionMetadata[];
 }
 
 /**


### PR DESCRIPTION
## Description

- Update the delete component func to catch the response of affectedContainers of the delete component API
- Update the restore component func to pass the affectedContainers
- Users can delete a component from a unit
- The component IS deleted, and does NOT remain present in the library
- A toast shows that the component was removed, and allows the user to undo.
- Which edX user roles will this change impact? "Course Author".


## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/1623
- Depends on: https://github.com/openedx/edx-platform/pull/36552
- Internal link: [FAL-4062](https://tasks.opencraft.com/browse/FAL-4062)


## Testing instructions

- Go to the library home of a library
- Create two new components in the library
- Create two new units in the library.
- Add both components to both units.
- Open a unit
- `Delete` a component. Don't restore it.
- Verify that the component is gone in both units and the library.
- `Delete` the other component. Restore it.
- Verify that the component is restored and remains in both units and the library.

## Other information

N/A