### PR TITLE
chore: simplify imports in library-authoring/data/apiHooks.ts

### DIFF
--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -9,43 +9,6 @@ import {
 import { useCallback } from 'react';
 
 import { getLibraryId } from '../../generic/key-utils';
-import {
-  type GetLibrariesV2CustomParams,
-  type ContentLibrary,
-  type XBlockFields,
-  type UpdateXBlockFieldsRequest,
-  getContentLibrary,
-  createLibraryBlock,
-  deleteLibraryBlock,
-  getContentLibraryV2List,
-  commitLibraryChanges,
-  revertLibraryChanges,
-  updateLibraryMetadata,
-  getLibraryTeam,
-  addLibraryTeamMember,
-  deleteLibraryTeamMember,
-  updateLibraryTeamMember,
-  libraryPasteClipboard,
-  getLibraryBlockMetadata,
-  getXBlockFields,
-  updateXBlockFields,
-  createCollection,
-  getXBlockOLX,
-  updateCollectionMetadata,
-  type UpdateCollectionComponentsRequest,
-  addItemsToCollection,
-  type CreateLibraryCollectionDataRequest,
-  getCollectionMetadata,
-  deleteCollection,
-  restoreCollection,
-  setXBlockOLX,
-  getXBlockAssets,
-  removeItemsFromCollection,
-  publishXBlock,
-  deleteXBlockAsset,
-  restoreLibraryBlock,
-  getBlockTypes,
-} from './api';
 import * as api from './api';
 import { VersionSpec } from '../LibraryBlock';
 
@@ -76,7 +39,7 @@ export const libraryAuthoringQueryKeys = {
     'content',
   ],
   /** Keys for the list of all libraries */
-  contentLibraryList: (customParams?: GetLibrariesV2CustomParams) => [
+  contentLibraryList: (customParams?: api.GetLibrariesV2CustomParams) => [
     ...libraryAuthoringQueryKeys.all,
     'list',
     ...(customParams ? [customParams] : []),
@@ -157,7 +120,7 @@ export function invalidateComponentData(queryClient: QueryClient, contentLibrary
 export const useContentLibrary = (libraryId: string | undefined) => (
   useQuery({
     queryKey: libraryAuthoringQueryKeys.contentLibrary(libraryId),
-    queryFn: () => getContentLibrary(libraryId!),
+    queryFn: () => api.getContentLibrary(libraryId!),
     enabled: libraryId !== undefined,
   })
 );
@@ -168,7 +131,7 @@ export const useContentLibrary = (libraryId: string | undefined) => (
 export const useCreateLibraryBlock = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: createLibraryBlock,
+    mutationFn: api.createLibraryBlock,
     onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibrary(variables.libraryId) });
       queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, variables.libraryId) });
@@ -182,7 +145,7 @@ export const useCreateLibraryBlock = () => {
 export const useDeleteLibraryBlock = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: deleteLibraryBlock,
+    mutationFn: api.deleteLibraryBlock,
     onSettled: (_data, _error, variables) => {
       const libraryId = getLibraryId(variables.usageKey);
       invalidateComponentData(queryClient, libraryId, variables.usageKey);
@@ -196,7 +159,7 @@ export const useDeleteLibraryBlock = () => {
 export const useRestoreLibraryBlock = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: restoreLibraryBlock,
+    mutationFn: api.restoreLibraryBlock,
     onSettled: (_data, _error, variables) => {
       const libraryId = getLibraryId(variables.usageKey);
       invalidateComponentData(queryClient, libraryId, variables.usageKey);
@@ -207,10 +170,10 @@ export const useRestoreLibraryBlock = () => {
 export const useUpdateLibraryMetadata = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: updateLibraryMetadata,
+    mutationFn: api.updateLibraryMetadata,
     onMutate: async (data) => {
       const queryKey = libraryAuthoringQueryKeys.contentLibrary(data.id);
-      const previousLibraryData = queryClient.getQueriesData(queryKey)[0][1] as ContentLibrary;
+      const previousLibraryData = queryClient.getQueriesData(queryKey)[0][1] as api.ContentLibrary;
 
       const newLibraryData = {
         ...previousLibraryData,
@@ -236,10 +199,10 @@ export const useUpdateLibraryMetadata = () => {
 /**
  * Builds the query to fetch list of V2 Libraries
  */
-export const useContentLibraryV2List = (customParams: GetLibrariesV2CustomParams) => (
+export const useContentLibraryV2List = (customParams: api.GetLibrariesV2CustomParams) => (
   useQuery({
     queryKey: libraryAuthoringQueryKeys.contentLibraryList(customParams),
-    queryFn: () => getContentLibraryV2List(customParams),
+    queryFn: () => api.getContentLibraryV2List(customParams),
     keepPreviousData: true,
   })
 );
@@ -247,7 +210,7 @@ export const useContentLibraryV2List = (customParams: GetLibrariesV2CustomParams
 export const useCommitLibraryChanges = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: commitLibraryChanges,
+    mutationFn: api.commitLibraryChanges,
     onSettled: (_data, _error, libraryId) => {
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibrary(libraryId) });
     },
@@ -257,7 +220,7 @@ export const useCommitLibraryChanges = () => {
 export const useRevertLibraryChanges = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: revertLibraryChanges,
+    mutationFn: api.revertLibraryChanges,
     onSettled: (_data, _error, libraryId) => {
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibrary(libraryId) });
       queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, libraryId) });
@@ -271,7 +234,7 @@ export const useRevertLibraryChanges = () => {
 export const useLibraryTeam = (libraryId?: string) => (
   useQuery({
     queryKey: libraryAuthoringQueryKeys.libraryTeam(libraryId),
-    queryFn: () => getLibraryTeam(libraryId!),
+    queryFn: () => api.getLibraryTeam(libraryId!),
     enabled: libraryId !== undefined,
   })
 );
@@ -282,7 +245,7 @@ export const useLibraryTeam = (libraryId?: string) => (
 export const useBlockTypesMetadata = (libraryId?: string) => (
   useQuery({
     queryKey: libraryAuthoringQueryKeys.blockTypes(libraryId),
-    queryFn: () => getBlockTypes(libraryId!),
+    queryFn: () => api.getBlockTypes(libraryId!),
     enabled: libraryId !== undefined,
   })
 );
@@ -295,7 +258,7 @@ export const useAddLibraryTeamMember = (libraryId: string | undefined) => {
   const queryKey = libraryAuthoringQueryKeys.libraryTeam(libraryId);
 
   return useMutation({
-    mutationFn: addLibraryTeamMember,
+    mutationFn: api.addLibraryTeamMember,
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey });
     },
@@ -310,7 +273,7 @@ export const useDeleteLibraryTeamMember = (libraryId: string | undefined) => {
   const queryKey = libraryAuthoringQueryKeys.libraryTeam(libraryId);
 
   return useMutation({
-    mutationFn: deleteLibraryTeamMember,
+    mutationFn: api.deleteLibraryTeamMember,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey });
     },
@@ -325,7 +288,7 @@ export const useUpdateLibraryTeamMember = (libraryId: string | undefined) => {
   const queryKey = libraryAuthoringQueryKeys.libraryTeam(libraryId);
 
   return useMutation({
-    mutationFn: updateLibraryTeamMember,
+    mutationFn: api.updateLibraryTeamMember,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey });
     },
@@ -335,7 +298,7 @@ export const useUpdateLibraryTeamMember = (libraryId: string | undefined) => {
 export const useLibraryPasteClipboard = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: libraryPasteClipboard,
+    mutationFn: api.libraryPasteClipboard,
     onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibrary(variables.libraryId) });
       queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, variables.libraryId) });
@@ -346,7 +309,7 @@ export const useLibraryPasteClipboard = () => {
 export const useLibraryBlockMetadata = (usageId: string | undefined) => (
   useQuery({
     queryKey: xblockQueryKeys.componentMetadata(usageId!),
-    queryFn: () => getLibraryBlockMetadata(usageId!),
+    queryFn: () => api.getLibraryBlockMetadata(usageId!),
     enabled: !!usageId,
   })
 );
@@ -354,7 +317,7 @@ export const useLibraryBlockMetadata = (usageId: string | undefined) => (
 export const useXBlockFields = (usageKey: string, version: VersionSpec = 'draft') => (
   useQuery({
     queryKey: xblockQueryKeys.xblockFields(usageKey, version),
-    queryFn: () => getXBlockFields(usageKey, version),
+    queryFn: () => api.getXBlockFields(usageKey, version),
     enabled: !!usageKey,
   })
 );
@@ -363,10 +326,10 @@ export const useUpdateXBlockFields = (usageKey: string) => {
   const contentLibraryId = getLibraryId(usageKey);
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (data: UpdateXBlockFieldsRequest) => updateXBlockFields(usageKey, data),
+    mutationFn: (data: api.UpdateXBlockFieldsRequest) => api.updateXBlockFields(usageKey, data),
     onMutate: async (data) => {
       const queryKey = xblockQueryKeys.xblockFields(usageKey);
-      const previousBlockData = queryClient.getQueriesData(queryKey)[0][1] as XBlockFields;
+      const previousBlockData = queryClient.getQueriesData(queryKey)[0][1] as api.XBlockFields;
       const formatedData = camelCaseObject(data);
 
       const newBlockData = {
@@ -400,7 +363,7 @@ export const useUpdateXBlockFields = (usageKey: string) => {
 export const useCreateLibraryCollection = (libraryId: string) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (data: CreateLibraryCollectionDataRequest) => createCollection(libraryId, data),
+    mutationFn: (data: api.CreateLibraryCollectionDataRequest) => api.createCollection(libraryId, data),
     onSettled: () => {
       queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, libraryId) });
     },
@@ -411,7 +374,7 @@ export const useCreateLibraryCollection = (libraryId: string) => {
 export const useXBlockOLX = (usageKey: string, version: VersionSpec) => (
   useQuery({
     queryKey: xblockQueryKeys.xblockOLX(usageKey),
-    queryFn: () => getXBlockOLX(usageKey, version),
+    queryFn: () => api.getXBlockOLX(usageKey, version),
     enabled: !!usageKey,
   })
 );
@@ -423,7 +386,7 @@ export const useUpdateXBlockOLX = (usageKey: string) => {
   const contentLibraryId = getLibraryId(usageKey);
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (newOLX: string) => setXBlockOLX(usageKey, newOLX),
+    mutationFn: (newOLX: string) => api.setXBlockOLX(usageKey, newOLX),
     onSuccess: (olxFromServer) => {
       queryClient.setQueryData(xblockQueryKeys.xblockOLX(usageKey), olxFromServer);
       invalidateComponentData(queryClient, contentLibraryId, usageKey);
@@ -438,7 +401,7 @@ export const usePublishComponent = (usageKey: string) => {
   const queryClient = useQueryClient();
   const contentLibraryId = getLibraryId(usageKey);
   return useMutation({
-    mutationFn: () => publishXBlock(usageKey),
+    mutationFn: () => api.publishXBlock(usageKey),
     onSettled: () => {
       invalidateComponentData(queryClient, contentLibraryId, usageKey);
     },
@@ -449,7 +412,7 @@ export const usePublishComponent = (usageKey: string) => {
 export const useXBlockAssets = (usageKey: string) => (
   useQuery({
     queryKey: xblockQueryKeys.xblockAssets(usageKey),
-    queryFn: () => getXBlockAssets(usageKey),
+    queryFn: () => api.getXBlockAssets(usageKey),
     enabled: !!usageKey,
   })
 );
@@ -468,7 +431,7 @@ export const useInvalidateXBlockAssets = (usageKey: string) => {
 export const useDeleteXBlockAsset = (usageKey: string) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (path: string) => deleteXBlockAsset(usageKey, path),
+    mutationFn: (path: string) => api.deleteXBlockAsset(usageKey, path),
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: xblockQueryKeys.xblockAssets(usageKey) });
     },
@@ -482,7 +445,7 @@ export const useCollection = (libraryId: string, collectionId: string) => (
   useQuery({
     enabled: !!libraryId && !!collectionId,
     queryKey: libraryAuthoringQueryKeys.collection(libraryId, collectionId),
-    queryFn: () => getCollectionMetadata(libraryId!, collectionId!),
+    queryFn: () => api.getCollectionMetadata(libraryId!, collectionId!),
   })
 );
 
@@ -492,7 +455,9 @@ export const useCollection = (libraryId: string, collectionId: string) => (
 export const useUpdateCollection = (libraryId: string, collectionId: string) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (data: UpdateCollectionComponentsRequest) => updateCollectionMetadata(libraryId, collectionId, data),
+    mutationFn: (data: api.UpdateCollectionComponentsRequest) => (
+      api.updateCollectionMetadata(libraryId, collectionId, data)
+    ),
     onSettled: () => {
       // NOTE: We invalidate the library query here because we need to update the library's
       // collection list.
@@ -510,7 +475,7 @@ export const useAddItemsToCollection = (libraryId?: string, collectionId?: strin
   return useMutation({
     mutationFn: async (usageKeys: string[]) => {
       if (libraryId !== undefined && collectionId !== undefined) {
-        return addItemsToCollection(libraryId, collectionId, usageKeys);
+        return api.addItemsToCollection(libraryId, collectionId, usageKeys);
       }
       return undefined;
     },
@@ -530,7 +495,7 @@ export const useRemoveItemsFromCollection = (libraryId?: string, collectionId?: 
   return useMutation({
     mutationFn: async (usageKeys: string[]) => {
       if (libraryId !== undefined && collectionId !== undefined) {
-        return removeItemsFromCollection(libraryId, collectionId, usageKeys);
+        return api.removeItemsFromCollection(libraryId, collectionId, usageKeys);
       }
       return undefined;
     },
@@ -548,7 +513,7 @@ export const useRemoveItemsFromCollection = (libraryId?: string, collectionId?: 
 export const useDeleteCollection = (libraryId: string, collectionId: string) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async () => deleteCollection(libraryId, collectionId),
+    mutationFn: async () => api.deleteCollection(libraryId, collectionId),
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibrary(libraryId) });
       queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, libraryId) });
@@ -562,7 +527,7 @@ export const useDeleteCollection = (libraryId: string, collectionId: string) => 
 export const useRestoreCollection = (libraryId: string, collectionId: string) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async () => restoreCollection(libraryId, collectionId),
+    mutationFn: async () => api.restoreCollection(libraryId, collectionId),
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibrary(libraryId) });
       queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, libraryId) });


### PR DESCRIPTION
This just simplifies how API methods are imported into one `apiHooks.ts` file, reducing the overall lines of code and chance for conflicts. Since we're importing all the API methods anyways, there is nothing to gain from explicitly importing each one separately.

Private ref: drive-by while working on FAL-4145