### PR TITLE
chore: Enable ora2 in libraries by default [FC-0076]

### DIFF
--- a/.env
+++ b/.env
@@ -45,5 +45,4 @@ ENABLE_HOME_PAGE_COURSE_API_V2=true
 ENABLE_CHECKLIST_QUALITY=''
 ENABLE_GRADING_METHOD_IN_PROBLEMS=false
 # "Multi-level" blocks are unsupported in libraries
-# TODO: Missing support for ORA2
-LIBRARY_UNSUPPORTED_BLOCKS="conditional,step-builder,problem-builder,openassessment"
+LIBRARY_UNSUPPORTED_BLOCKS="conditional,step-builder,problem-builder"

--- a/.env.test
+++ b/.env.test
@@ -40,5 +40,4 @@ ENABLE_HOME_PAGE_COURSE_API_V2=true
 ENABLE_CHECKLIST_QUALITY=true
 ENABLE_GRADING_METHOD_IN_PROBLEMS=false
 # "Multi-level" blocks are unsupported in libraries
-# TODO: Missing support for ORA2
-LIBRARY_UNSUPPORTED_BLOCKS="conditional,step-builder,problem-builder,openassessment"
+LIBRARY_UNSUPPORTED_BLOCKS="conditional,step-builder,problem-builder"

--- a/src/library-authoring/add-content/AddContent.test.tsx
+++ b/src/library-authoring/add-content/AddContent.test.tsx
@@ -84,7 +84,7 @@ describe('<AddContent />', () => {
     expect(screen.queryByRole('button', { name: /collection/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /text/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /problem/i })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /open reponse/i })).not.toBeInTheDocument(); // Excluded from MVP
+    expect(screen.queryByRole('button', { name: /open reponse/i })).toBeInTheDocument(); // Excluded from MVP
     expect(screen.queryByRole('button', { name: /drag drop/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /video/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /copy from clipboard/i })).not.toBeInTheDocument();


### PR DESCRIPTION
## Description

- Enables ORA2 blocks in libraries by default
- Which edX user roles will this change impact? "Course Author"

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/1512
- Internal ticket: [FAL-3992](https://tasks.opencraft.com/browse/FAL-3992)

## Testing instructions

- Verify that the tests covers the new code.
- Go to the library home of a library.
- Verify that you can create and edit ORA2


## Other information

N/A