### PR TITLE
feat: Sync units in course outline [FC-0083]

### DIFF
--- a/src/course-outline/__mocks__/courseOutlineIndex.js
+++ b/src/course-outline/__mocks__/courseOutlineIndex.js
@@ -292,6 +292,11 @@ module.exports = {
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
                       },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
+                      },
                     },
                   ],
                 },
@@ -675,6 +680,11 @@ module.exports = {
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
                       },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
+                      },
                     },
                     {
                       id: 'block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_2dbb0072785e',
@@ -758,6 +768,11 @@ module.exports = {
                         ],
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
+                      },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
                       },
                     },
                     {
@@ -843,6 +858,11 @@ module.exports = {
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
                       },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
+                      },
                     },
                     {
                       id: 'block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_d32bf9b2242c',
@@ -927,6 +947,11 @@ module.exports = {
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
                       },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
+                      },
                     },
                     {
                       id: 'block-v1:edX+DemoX+Demo_Course+type@vertical+block@4e592689563243c484af947465eaef0d',
@@ -1010,6 +1035,11 @@ module.exports = {
                         ],
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
+                      },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
                       },
                     },
                   ],
@@ -1196,6 +1226,11 @@ module.exports = {
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
                       },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
+                      },
                     },
                     {
                       id: 'block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_aae927868e55',
@@ -1279,6 +1314,11 @@ module.exports = {
                         ],
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
+                      },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
                       },
                     },
                     {
@@ -1364,6 +1404,11 @@ module.exports = {
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
                       },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
+                      },
                     },
                     {
                       id: 'block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_bc69a47c6fae',
@@ -1448,6 +1493,11 @@ module.exports = {
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
                       },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
+                      },
                     },
                     {
                       id: 'block-v1:edX+DemoX+Demo_Course+type@vertical+block@8f89194410954e768bde1764985454a7',
@@ -1531,6 +1581,11 @@ module.exports = {
                         ],
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
+                      },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
                       },
                     },
                   ],
@@ -1716,6 +1771,11 @@ module.exports = {
                         ],
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
+                      },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
                       },
                     },
                   ],
@@ -1995,6 +2055,11 @@ module.exports = {
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
                       },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
+                      },
                     },
                     {
                       id: 'block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_f04afeac0131',
@@ -2078,6 +2143,11 @@ module.exports = {
                         ],
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
+                      },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
                       },
                     },
                     {
@@ -2163,6 +2233,11 @@ module.exports = {
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
                       },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
+                      },
                     },
                     {
                       id: 'block-v1:edX+DemoX+Demo_Course+type@vertical+block@f91d8d31f7cf48ce990f8d8745ae4cfa',
@@ -2246,6 +2321,11 @@ module.exports = {
                         ],
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
+                      },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
                       },
                     },
                     {
@@ -2331,6 +2411,11 @@ module.exports = {
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
                       },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
+                      },
                     },
                     {
                       id: 'block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_36e0beb03f0a',
@@ -2414,6 +2499,11 @@ module.exports = {
                         ],
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
+                      },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
                       },
                     },
                     {
@@ -2499,6 +2589,11 @@ module.exports = {
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
                       },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
+                      },
                     },
                     {
                       id: 'block-v1:edX+DemoX+Demo_Course+type@vertical+block@c7e98fd39a6944edb6b286c32e1150ff',
@@ -2583,6 +2678,11 @@ module.exports = {
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
                       },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
+                      },
                     },
                     {
                       id: 'block-v1:edX+DemoX+Demo_Course+type@vertical+block@d6eaa391d2be41dea20b8b1bfbcb1c45',
@@ -2666,6 +2766,11 @@ module.exports = {
                         ],
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
+                      },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
                       },
                     },
                   ],
@@ -2944,6 +3049,11 @@ module.exports = {
                         ],
                         selectedPartitionIndex: -1,
                         selectedGroupsLabel: '',
+                      },
+                      upstreamInfo: {
+                        readyToSync: false,
+                        upstreamRef: undefined,
+                        versionSynced: undefined,
                       },
                     },
                   ],

--- a/src/course-outline/card-header/CardHeader.jsx
+++ b/src/course-outline/card-header/CardHeader.jsx
@@ -15,6 +15,7 @@ import {
 import {
   MoreVert as MoveVertIcon,
   EditOutline as EditIcon,
+  Sync as SyncIcon,
 } from '@openedx/paragon/icons';
 
 import { useContentTagsCount } from '../../generic/data/apiHooks';
@@ -55,6 +56,8 @@ const CardHeader = ({
   discussionsSettings,
   parentInfo,
   extraActionsComponent,
+  onClickSync,
+  readyToSync,
 }) => {
   const intl = useIntl();
   const [searchParams] = useSearchParams();
@@ -130,8 +133,17 @@ const CardHeader = ({
         ) : (
           <>
             {titleComponent}
+            {readyToSync && (
+              <IconButton
+                className="item-card-button-icon"
+                data-testid={`${namePrefix}-sync-button`}
+                alt={intl.formatMessage(messages.readyToSyncButtonAlt)}
+                iconAs={SyncIcon}
+                onClick={onClickSync}
+              />
+            )}
             <IconButton
-              className="item-card-edit-icon"
+              className="item-card-button-icon"
               data-testid={`${namePrefix}-edit-button`}
               alt={intl.formatMessage(messages.altButtonEdit)}
               iconAs={EditIcon}
@@ -259,6 +271,8 @@ CardHeader.defaultProps = {
   parentInfo: {},
   cardId: '',
   extraActionsComponent: null,
+  readyToSync: false,
+  onClickSync: null,
 };
 
 CardHeader.propTypes = {
@@ -305,6 +319,8 @@ CardHeader.propTypes = {
   // An optional component that is rendered before the dropdown. This is used by the Subsection
   // and Unit card components to render their plugin slots.
   extraActionsComponent: PropTypes.node,
+  onClickSync: PropTypes.func,
+  readyToSync: PropTypes.bool,
 };
 
 export default CardHeader;

--- a/src/course-outline/card-header/CardHeader.scss
+++ b/src/course-outline/card-header/CardHeader.scss
@@ -12,7 +12,7 @@
     color: $black;
   }
 
-  .item-card-edit-icon {
+  .item-card-button-icon {
     opacity: 0;
     transition: opacity .3s linear;
     margin-right: .5rem;
@@ -23,7 +23,7 @@
   }
 
   &:hover {
-    .item-card-edit-icon {
+    .item-card-button-icon {
       opacity: 1;
     }
   }

--- a/src/course-outline/card-header/CardHeader.test.jsx
+++ b/src/course-outline/card-header/CardHeader.test.jsx
@@ -368,4 +368,19 @@ describe('<CardHeader />', () => {
     renderComponent();
     expect(screen.queryByText('0')).not.toBeInTheDocument();
   });
+
+  it('should render sync button when is ready to sync', () => {
+    const mockClickSync = jest.fn();
+
+    renderComponent({
+      readyToSync: true,
+      onClickSync: mockClickSync,
+    });
+
+    const syncButton = screen.getByRole('button', { name: /update available - click to sync/i });
+    expect(syncButton).toBeInTheDocument();
+    fireEvent.click(syncButton);
+
+    expect(mockClickSync).toHaveBeenCalled();
+  });
 });

--- a/src/course-outline/card-header/messages.js
+++ b/src/course-outline/card-header/messages.js
@@ -77,6 +77,11 @@ const messages = defineMessages({
     id: 'course-authoring.course-outline.card.menu.manageTags',
     defaultMessage: 'Manage tags',
   },
+  readyToSyncButtonAlt: {
+    id: 'course-authoring.course-outline.card.button.sync.alt',
+    defaultMessage: 'Update available - click to sync',
+    description: 'Alt text for the sync icon button.',
+  },
 });
 
 export default messages;

--- a/src/course-unit/preview-changes/index.test.tsx
+++ b/src/course-unit/preview-changes/index.test.tsx
@@ -12,13 +12,13 @@ import IframePreviewLibraryXBlockChanges, { LibraryChangesMessageData } from '.'
 import { messageTypes } from '../constants';
 import { libraryBlockChangesUrl } from '../data/api';
 import { ToastActionData } from '../../generic/toast-context';
-import { getLibraryBlockMetadataUrl } from '../../library-authoring/data/api';
+import { getLibraryBlockMetadataUrl, getLibraryContainerApiUrl } from '../../library-authoring/data/api';
 
 const usageKey = 'some-id';
 const defaultEventData: LibraryChangesMessageData = {
   displayName: 'Test block',
   downstreamBlockId: usageKey,
-  upstreamBlockId: 'some-lib-id',
+  upstreamBlockId: 'lct:org:lib1:unit:1',
   upstreamBlockVersionSynced: 1,
   isVertical: false,
 };
@@ -85,6 +85,15 @@ describe('<IframePreviewLibraryXBlockChanges />', () => {
     render();
 
     expect(await screen.findByText('Preview changes: Test block -> New test block')).toBeInTheDocument();
+  });
+
+  it('renders both new and old title if they are different on units', async () => {
+    axiosMock.onGet(getLibraryContainerApiUrl(defaultEventData.upstreamBlockId)).reply(200, {
+      displayName: 'New test Unit',
+    });
+    render({ ...defaultEventData, isVertical: true, displayName: 'Test Unit' });
+
+    expect(await screen.findByText('Preview changes: Test Unit -> New test Unit')).toBeInTheDocument();
   });
 
   it('accept changes works', async () => {

--- a/src/course-unit/preview-changes/index.tsx
+++ b/src/course-unit/preview-changes/index.tsx
@@ -14,7 +14,7 @@ import messages from './messages';
 import { ToastContext } from '../../generic/toast-context';
 import LoadingButton from '../../generic/loading-button';
 import Loading from '../../generic/Loading';
-import { useLibraryBlockMetadata } from '../../library-authoring/data/apiHooks';
+import { useContainer, useLibraryBlockMetadata } from '../../library-authoring/data/apiHooks';
 
 export interface LibraryChangesMessageData {
   displayName: string,
@@ -48,14 +48,20 @@ export const PreviewLibraryXBlockChanges = ({
 
   // ignore changes confirmation modal toggle.
   const [isConfirmModalOpen, openConfirmModal, closeConfirmModal] = useToggle(false);
+
+  // TODO: Split into two different components to avoid making these two calls in which
+  // one will definitely fail
   const { data: componentMetadata } = useLibraryBlockMetadata(blockData?.upstreamBlockId);
+  const { data: unitMetadata } = useContainer(blockData?.upstreamBlockId);
+
+  const metadata = blockData?.isVertical ? unitMetadata : componentMetadata;
 
   const acceptChangesMutation = useAcceptLibraryBlockChanges();
   const ignoreChangesMutation = useIgnoreLibraryBlockChanges();
 
   const getTitle = useCallback(() => {
     const oldName = blockData?.displayName;
-    const newName = componentMetadata?.displayName;
+    const newName = metadata?.displayName;
 
     if (!oldName) {
       if (blockData?.isVertical) {
@@ -67,7 +73,7 @@ export const PreviewLibraryXBlockChanges = ({
       return intl.formatMessage(messages.title, { blockTitle: oldName });
     }
     return intl.formatMessage(messages.diffTitle, { oldName, newName });
-  }, [blockData, componentMetadata]);
+  }, [blockData, metadata]);
 
   const getBody = useCallback(() => {
     if (!blockData) {
@@ -78,6 +84,7 @@ export const PreviewLibraryXBlockChanges = ({
         usageKey={blockData.upstreamBlockId}
         oldVersion={blockData.upstreamBlockVersionSynced || 'published'}
         newVersion="published"
+        isContainer={blockData.isVertical}
       />
     );
   }, [blockData]);

--- a/src/library-authoring/component-comparison/CompareChangesWidget.tsx
+++ b/src/library-authoring/component-comparison/CompareChangesWidget.tsx
@@ -6,10 +6,21 @@ import { LibraryBlock, type VersionSpec } from '../LibraryBlock';
 
 import messages from './messages';
 
+const PreviewNotAvailable = () => {
+  const intl = useIntl();
+
+  return (
+    <div className="d-flex mt-4 justify-content-center">
+      {intl.formatMessage(messages.previewNotAvailable)}
+    </div>
+  );
+};
+
 interface Props {
   usageKey: string;
   oldVersion?: VersionSpec;
   newVersion?: VersionSpec;
+  isContainer?: boolean;
 }
 
 /**
@@ -20,7 +31,12 @@ interface Props {
  * In the future, it would be better to have a way of highlighting the changes
  * or showing a diff.
  */
-const CompareChangesWidget = ({ usageKey, oldVersion = 'published', newVersion = 'draft' }: Props) => {
+const CompareChangesWidget = ({
+  usageKey,
+  oldVersion = 'published',
+  newVersion = 'draft',
+  isContainer = false,
+}: Props) => {
   const intl = useIntl();
 
   return (
@@ -28,24 +44,28 @@ const CompareChangesWidget = ({ usageKey, oldVersion = 'published', newVersion =
       <Tabs variant="tabs" defaultActiveKey="new" id="preview-version-toggle" mountOnEnter>
         <Tab eventKey="old" title={intl.formatMessage(messages.oldVersionTitle)}>
           <div className="p-2 bg-white">
-            <IframeProvider>
-              <LibraryBlock
-                usageKey={usageKey}
-                version={oldVersion}
-                minHeight="50vh"
-              />
-            </IframeProvider>
+            {isContainer ? (<PreviewNotAvailable />) : (
+              <IframeProvider>
+                <LibraryBlock
+                  usageKey={usageKey}
+                  version={oldVersion}
+                  minHeight="50vh"
+                />
+              </IframeProvider>
+            )}
           </div>
         </Tab>
         <Tab eventKey="new" title={intl.formatMessage(messages.newVersionTitle)}>
           <div className="p-2 bg-white">
-            <IframeProvider>
-              <LibraryBlock
-                usageKey={usageKey}
-                version={newVersion}
-                minHeight="50vh"
-              />
-            </IframeProvider>
+            {isContainer ? (<PreviewNotAvailable />) : (
+              <IframeProvider>
+                <LibraryBlock
+                  usageKey={usageKey}
+                  version={newVersion}
+                  minHeight="50vh"
+                />
+              </IframeProvider>
+            )}
           </div>
         </Tab>
       </Tabs>

--- a/src/library-authoring/component-comparison/messages.ts
+++ b/src/library-authoring/component-comparison/messages.ts
@@ -17,6 +17,11 @@ const messages = defineMessages({
     defaultMessage: 'Compare Changes',
     description: 'Title used for the compare changes dialog',
   },
+  previewNotAvailable: {
+    id: 'course-authoring.library-authoring.component-comparison.preview-not-available',
+    defaultMessage: 'Preview not available',
+    description: 'Message shown when preview is not available.',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description

- Adds the sync button in unit cards in the course outline.
- Opens the compare previews.
- Functionality to sync units.
- Functionality to decline sync units.
- Which edX user roles will this change impact? "Course Author".

https://www.loom.com/share/70a14ccdb2ae487ea769be340d6ba845?sid=752e2e84-3553-4306-ad71-d21e40e4a682

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/1634
- Depends on: https://github.com/open-craft/edx-platform/pull/773
- Internal ticket: [FAL-4075](https://tasks.opencraft.com/browse/FAL-4075)

## Testing instructions

- Go to the library home of a library
- Create a unit
- Create a component and add it to the unit
- Publish the unit.
- Use this branch: https://github.com/openedx/frontend-app-authoring/pull/1829 and follow the testing instructions to add the unit to a course.
- On the library home, edit the unit title and add another component.
- Publish the unit.
- Return to the course outline (refresh the page) and verify that the sync button appears on the unit card.
- Click on the sync button. Verify the compare previews modal.
- Click on the `Accept changes` button.
- Verify that the unit title has been changed and that the new components have been added. Also, verify that the sync button is gone.
- On the library home, edit the unit title.
- Publish the unit.
- Return to the course outline (refresh the page) and click in the sync button.
- Click on the `Ignore changes` button.
- Verify that the sync button is gone and there are no changes in the unit

## Other information

- The "Preview not available" message has been added to the preview comparator. This will be addressed in a later task.