### PR TITLE
feat: set the sidebar height in course unit to 100%

### DIFF
--- a/src/course-unit/CourseUnit.jsx
+++ b/src/course-unit/CourseUnit.jsx
@@ -220,7 +220,7 @@ const CourseUnit = ({ courseId }) => {
               <IframePreviewLibraryXBlockChanges />
             </Layout.Element>
             <Layout.Element>
-              <Stack gap={3}>
+              <Stack gap={3} className="h-100">
                 {isUnitVerticalType && (
                 <CourseAuthoringUnitSidebarSlot
                   courseId={courseId}


### PR DESCRIPTION
## Description

Fixes a minor bug where a container on the sidebar's height wasn't set to 100% causing its child elements to be rendered in limited space. This was affecting the plugin-slot components and is being rectified in this PR.

Useful information to include:
- Which edX user roles will this change impact? "Developer"


## Supporting information

- Split from https://github.com/openedx/frontend-app-authoring/pull/1845

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.


## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.