### PR TITLE
fix: incorrect video durations

### DIFF
--- a/src/files-and-videos/videos-page/data/utils.js
+++ b/src/files-and-videos/videos-page/data/utils.js
@@ -61,7 +61,7 @@ export const getFormattedDuration = (value) => {
   }
   const seconds = Math.floor(value % 60);
   const minutes = Math.floor((value / 60) % 60);
-  const hours = Math.floor((value / 360) % 60);
+  const hours = Math.floor(value / 3600);
   const zeroPad = (num) => String(num).padStart(2, '0');
   return [hours, minutes, seconds].map(zeroPad).join(':');
 };


### PR DESCRIPTION
Ticket: [TNL-11638](https://2u-internal.atlassian.net/browse/TNL-11638)
- fix: incorrect video durations in video info tab and  videos list view.
- Time for short videos with length less than 6 minutes was being calculated correctly. Before the value was being divided by 360 which means if any video is more than 6 minutes(360 seconds), the hours will be calculated incorrectly as shown in below before & after fix images.
  
<img width="1350" alt="Screenshot 2025-04-24 at 5 08 07 PM" src="https://github.com/user-attachments/assets/1f2596f2-d065-4a2f-92e3-d50e44370ee3" />

  So In this PR, changed `360` to `3600` to correctly calculate hour and also removed `% 60` as it will result in false calculation of hours for the video with more than `60` hours length.


### **Before:**

<img width="1461" alt="Screenshot 2025-04-24 at 5 01 47 PM" src="https://github.com/user-attachments/assets/c2dfe5e8-333b-4676-82fd-56358330dac5" />

<img width="804" alt="Screenshot 2025-04-24 at 4 20 19 PM" src="https://github.com/user-attachments/assets/5248cf24-7367-4042-9719-010cbfd2caa4" />


### **After:**

<img width="1461" alt="Screenshot 2025-04-24 at 5 02 48 PM" src="https://github.com/user-attachments/assets/2343b160-ea93-4620-a019-d203edfccd99" />

<img width="804" alt="Screenshot 2025-04-24 at 4 20 01 PM" src="https://github.com/user-attachments/assets/f54fc8aa-05bc-4a8f-b2d7-9601a41832a1" />


### **Original Length:**
Original length is also `00:07:47` minutes.

<img width="981" alt="Screenshot 2025-04-24 at 4 21 09 PM" src="https://github.com/user-attachments/assets/27ea891f-d9a8-4d46-b7a2-805b66f88dca" />



