### PR TITLE
fix: update MIME type for tar.gz file acceptance in dropzone

### DIFF
--- a/src/import-page/file-section/FileSection.jsx
+++ b/src/import-page/file-section/FileSection.jsx
@@ -41,7 +41,7 @@ const FileSection = ({ intl, courseId }) => {
                   handleError,
                 ))
               }
-              accept={{ 'application/gzip': ['.tar.gz'] }}
+              accept={{ 'application/x-tar.gz': ['.tar.gz'] }}
               data-testid="dropzone"
               style={{ height: '200px' }}
             />


### PR DESCRIPTION
## Description

This PR solves an issue that allowed the users to import files `.gz` by making the drop zone allow only `.tar.gz` files 

## Supporting information

Resolves #1386 

## Testing instructions

Follow the instructions from the issue #1386 to verify that the behavior is not still like that

### Evidence
[Screencast from 24-04-25 17:38:25.webm](https://github.com/user-attachments/assets/92395a39-6187-4797-b745-adc79c9baa30)
