### PR TITLE
fix: allow units sourced from libraries to update their settings [FC-0083]

### DIFF
--- a/src/course-unit/header-title/HeaderTitle.jsx
+++ b/src/course-unit/header-title/HeaderTitle.jsx
@@ -89,7 +89,6 @@ const HeaderTitle = ({
           className="flex-shrink-0"
           iconAs={SettingsIcon}
           onClick={openConfigureModal}
-          disabled={readOnly}
         />
         <ConfigureModal
           isOpen={isConfigureModalOpen}

--- a/src/course-unit/header-title/HeaderTitle.test.jsx
+++ b/src/course-unit/header-title/HeaderTitle.test.jsx
@@ -76,7 +76,7 @@ describe('<HeaderTitle />', () => {
     expect(getByRole('button', { name: messages.altButtonSettings.defaultMessage })).toBeEnabled();
   });
 
-  it('Units sourced from upstream show a disabled edit form and config menu', async () => {
+  it('Units sourced from upstream show a disabled edit button', async () => {
     // Override mock unit with one sourced from an upstream library
     axiosMock = new MockAdapter(getAuthenticatedHttpClient());
     axiosMock
@@ -92,7 +92,7 @@ describe('<HeaderTitle />', () => {
     const { getByRole } = renderComponent();
 
     expect(getByRole('button', { name: messages.altButtonEdit.defaultMessage })).toBeDisabled();
-    expect(getByRole('button', { name: messages.altButtonSettings.defaultMessage })).toBeDisabled();
+    expect(getByRole('button', { name: messages.altButtonSettings.defaultMessage })).toBeEnabled();
   });
 
   it('calls toggle edit title form by clicking on Edit button', () => {


### PR DESCRIPTION
## Description

Allows downstream course Units to update their settings.

Course Authors using Library Units are affected by this change.

## Supporting information

* Follow-up to https://github.com/openedx/frontend-app-authoring/pull/1833/files
* Addresses [this comment](https://github.com/openedx/frontend-app-authoring/issues/1712#issuecomment-2829090892)
* Private-ref: [FAL-4112](https://tasks.opencraft.com/browse/FAL-4112)

## Testing instructions

1. Use latest edx-platform `master`, and run migrations.
2. Create a Library with a Unit in it, and Publish.
3. Create a Course, and add the Library Unit to  a Section > Subsection.
4. Browse to the Course Unit page, and edit the Settings using the cog icon. Change settings.
5. Return to the Library Unit, and update the Unit title and/or contents. Publish.
6. Return to the Course Outline, and click the "sync" icon that appears next to the Course Unit. Accept changes.
7. Return to the Course Unit page, and ensure the changes you made to Settings are unaffected.

## Other information

Please merge ASAP before Teak gets cut :)