### PR TITLE
fix: NaN library components are out of sync [FC-0083]

### DIFF
--- a/src/course-libraries/OutOfSyncAlert.tsx
+++ b/src/course-libraries/OutOfSyncAlert.tsx
@@ -34,7 +34,7 @@ export const OutOfSyncAlert: React.FC<OutOfSyncAlertProps> = ({
 }) => {
   const intl = useIntl();
   const { data, isLoading } = useEntityLinksSummaryByDownstreamContext(courseId);
-  const outOfSyncCount = data?.reduce((count, lib) => count + lib.readyToSyncCount, 0);
+  const outOfSyncCount = data?.reduce((count, lib) => count + (lib.readyToSyncCount || 0), 0);
   const alertKey = `outOfSyncCountAlert-${courseId}`;
 
   useEffect(() => {

--- a/src/course-libraries/__mocks__/linkCourseSummary.json
+++ b/src/course-libraries/__mocks__/linkCourseSummary.json
@@ -14,7 +14,6 @@
   {
     "upstreamContextTitle": "CS problems",
     "upstreamContextKey": "lib:OpenedX:CSPROB",
-    "readyToSyncCount": 0,
     "totalCount": 3
   }
 ]


### PR DESCRIPTION
## Description

Fixes a bug in the course banner that happens when `readyToSyncCount` is absent/null in the backend data.

## Supporting information

* Closes: https://github.com/openedx/frontend-app-authoring/issues/1796
* Private-ref: [FAL-4143](https://tasks.opencraft.com/browse/FAL-4143)

## Testing instructions

I haven't figured out why this happens sometimes, so am not sure exactly how to test it manually.

But check the commits and their tests to see how:
1. [ae5e712](https://github.com/openedx/frontend-app-authoring/pull/1864/commits/ae5e71259b04eb04c7c91e01057a91d4fcdaf613) demonstrates the issue by breaking the existing test showing ["NaN library components are out of sync. Review updates to accept or ignore changes" as the banner text](https://github.com/openedx/frontend-app-authoring/actions/runs/14657161379/job/41134140206?pr=1864#step:4:222).
2. [3ca30e1](https://github.com/openedx/frontend-app-authoring/pull/1864/commits/3ca30e10d21de42ff92adcbb06e3f79049240d61) fixes the bug, as verified by the tests passing.

## Other information

Would like to merge before Teak if possible!