### PR TITLE
fix: manage access modal on duplicated xblock

### DIFF
--- a/src/course-unit/CourseUnit.test.jsx
+++ b/src/course-unit/CourseUnit.test.jsx
@@ -469,6 +469,10 @@ describe('<CourseUnit />', () => {
     });
 
     axiosMock
+      .onGet(getCourseUnitApiUrl(blockId))
+      .reply(200, courseUnitIndexMock);
+
+    axiosMock
       .onPost(postXBlockBaseApiUrl({
         parent_locator: blockId,
         duplicate_source_locator: courseVerticalChildrenMock.children[0].block_id,
@@ -2173,6 +2177,17 @@ describe('<CourseUnit />', () => {
       .map((child) => (child.block_id === targetBlockId
         ? { ...child, block_type: 'html' }
         : child));
+
+    axiosMock
+      .onGet(getCourseUnitApiUrl(blockId))
+      .reply(200, courseUnitIndexMock);
+
+    axiosMock
+      .onPost(postXBlockBaseApiUrl({
+        parent_locator: blockId,
+        duplicate_source_locator: courseVerticalChildrenMock.children[0].block_id,
+      }))
+      .replyOnce(200, { locator: '1234567890' });
 
     axiosMock
       .onGet(getCourseVerticalChildrenApiUrl(blockId))

--- a/src/course-unit/data/thunk.js
+++ b/src/course-unit/data/thunk.js
@@ -262,6 +262,8 @@ export function duplicateUnitItemQuery(itemId, xblockId, callback) {
       callback(courseKey, locator);
       const courseUnit = await getCourseUnitData(itemId);
       dispatch(fetchCourseItemSuccess(courseUnit));
+      const courseVerticalChildrenData = await getCourseVerticalChildren(itemId);
+      dispatch(updateCourseVerticalChildren(courseVerticalChildrenData));
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
     } catch (error) {


### PR DESCRIPTION
## Description
The xBlock Manage Access modal doesn't open on duplicated xBlock without page reload.

## Step to reproduce:
- open CMS
- open course
- open section > subsection > units
- add unit
- dublicate unit
- click on the unit menu > manage access
![image](https://github.com/user-attachments/assets/d71cfa38-fe1e-4bb1-b5f1-6c23244cf1ec)
- access modal doesn't display
- refresh page and click on the unit menu > manage access
- access modal displays

## Backports:
- teak release https://github.com/openedx/frontend-app-authoring/pull/1874

## Other information
**Settings**
```
EDX_PLATFORM_REPOSITORY: https://github.com/openedx/edx-platform.git
EDX_PLATFORM_VERSION: master

TUTOR_GROVE_NEW_MFES:
  authoring:
    port: 18000
    repository: https://github.com/raccoongang/frontend-app-course-authoring.git
    version: romaniuk/fix/manage-access-modal-on-duplicated-xblock
```