### PR TITLE
fix: Error when viewing text component in RAW HTML

### DIFF
--- a/src/editors/sharedComponents/CodeEditor/hooks.js
+++ b/src/editors/sharedComponents/CodeEditor/hooks.js
@@ -100,7 +100,7 @@ export const createCodeMirrorDomNode = ({
 }) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
-    const languageExtension = CODEMIRROR_LANGUAGES[lang]();
+    const languageExtension = CODEMIRROR_LANGUAGES[lang] ? CODEMIRROR_LANGUAGES[lang]() : xml();
     const cleanText = cleanHTML({ initialText });
     const newState = EditorState.create({
       doc: cleanText,


### PR DESCRIPTION
**Ticket**: [TNL-11959](https://2u-internal.atlassian.net/browse/TNL-11959)
- This PR fixes the error when viewing text component in RAW HTML as `lang` was passed `undefined` and `CODEMIRROR_LANGUAGES[lang]()` was throwing this: `TypeError: Ap[i] is not a function`

### **Before:**
![before](https://github.com/user-attachments/assets/f1de02cf-7d4d-4e2c-ba99-1e55d6e3f6e4)

### **After:**
![after](https://github.com/user-attachments/assets/82ff85c5-72f9-4fd1-b3dd-e885c2095339)
