### PR TITLE
fix: unit xblock adaptivity

### DIFF
--- a/src/course-unit/course-sequence/CourseSequence.scss
+++ b/src/course-unit/course-sequence/CourseSequence.scss
@@ -28,6 +28,10 @@
     min-width: 0;
   }
 
+  .sequence-navigation-tabs {
+    max-width: 100%;
+  }
+
   .sequence-navigation-tabs-container {
     flex: 1 1 100%;
     // min-width 0 prevents the flex item from overflowing the parent container


### PR DESCRIPTION
## Description
Remove extra space in the course unit page on small screens:
<img width="914" alt="image" src="https://github.com/user-attachments/assets/ff1063e4-fd56-467f-85a9-7cba55f55b58" />

## Original pull requests:
- master branch https://github.com/openedx/frontend-app-authoring/pull/1872 

## Testing instructions
- go to the course unit page
- set the window resolution to 950px in width