### PR TITLE
fix: untranslated user facing texts for i18n

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = createConfig(
       'no-restricted-exports': 'off',
       // There is no reason to disallow this syntax anymore; we don't use regenerator-runtime in new browsers
       'no-restricted-syntax': 'off',
-      'i18n/no-hardcoded-strings': 'warn'
     },
     settings: {
       // Import URLs should be resolved using aliases

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = createConfig(
       'no-restricted-exports': 'off',
       // There is no reason to disallow this syntax anymore; we don't use regenerator-runtime in new browsers
       'no-restricted-syntax': 'off',
+      'i18n/no-hardcoded-strings': 'warn'
     },
     settings: {
       // Import URLs should be resolved using aliases

--- a/src/accessibility-page/AccessibilityPage.jsx
+++ b/src/accessibility-page/AccessibilityPage.jsx
@@ -25,7 +25,9 @@ const AccessibilityPage = ({
     </Helmet>
     <Header isHiddenMainMenu />
     <Container size="xl" classNamae="px-4">
-      <AccessibilityBody {...{ ACCESSIBILITY_EMAIL, COMMUNITY_ACCESSIBILITY_LINK }} />
+      <AccessibilityBody
+        {...{ email: ACCESSIBILITY_EMAIL, communityAccessibilityLink: COMMUNITY_ACCESSIBILITY_LINK }}
+      />
       <AccessibilityForm accessibilityEmail={ACCESSIBILITY_EMAIL} />
     </Container>
     <StudioFooterSlot />

--- a/src/accessibility-page/AccessibilityPage.jsx
+++ b/src/accessibility-page/AccessibilityPage.jsx
@@ -9,30 +9,28 @@ import messages from './messages';
 import AccessibilityBody from './AccessibilityBody';
 import AccessibilityForm from './AccessibilityForm';
 
+import { COMMUNITY_ACCESSIBILITY_LINK, ACCESSIBILITY_EMAIL } from './constants';
+
 const AccessibilityPage = ({
   // injected
   intl,
-}) => {
-  const communityAccessibilityLink = 'https://www.edx.org/accessibility';
-  const email = 'accessibility@edx.org';
-  return (
-    <>
-      <Helmet>
-        <title>
-          {intl.formatMessage(messages.pageTitle, {
-            siteName: process.env.SITE_NAME,
-          })}
-        </title>
-      </Helmet>
-      <Header isHiddenMainMenu />
-      <Container size="xl" classNamae="px-4">
-        <AccessibilityBody {...{ email, communityAccessibilityLink }} />
-        <AccessibilityForm accessibilityEmail={email} />
-      </Container>
-      <StudioFooterSlot />
-    </>
-  );
-};
+}) => (
+  <>
+    <Helmet>
+      <title>
+        {intl.formatMessage(messages.pageTitle, {
+          siteName: process.env.SITE_NAME,
+        })}
+      </title>
+    </Helmet>
+    <Header isHiddenMainMenu />
+    <Container size="xl" classNamae="px-4">
+      <AccessibilityBody {...{ ACCESSIBILITY_EMAIL, COMMUNITY_ACCESSIBILITY_LINK }} />
+      <AccessibilityForm accessibilityEmail={ACCESSIBILITY_EMAIL} />
+    </Container>
+    <StudioFooterSlot />
+  </>
+);
 
 AccessibilityPage.propTypes = {
   // injected

--- a/src/accessibility-page/constants.js
+++ b/src/accessibility-page/constants.js
@@ -1,0 +1,2 @@
+export const COMMUNITY_ACCESSIBILITY_LINK = 'https://www.edx.org/accessibility';
+export const ACCESSIBILITY_EMAIL = 'accessibility@edx.org';

--- a/src/certificates/certificate-create-form/CertificatesCreateForm.test.jsx
+++ b/src/certificates/certificate-create-form/CertificatesCreateForm.test.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable i18n/no-hardcoded-strings */
 import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';

--- a/src/certificates/certificate-create-form/CertificatesCreateForm.test.jsx
+++ b/src/certificates/certificate-create-form/CertificatesCreateForm.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable i18n/no-hardcoded-strings */
 import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';

--- a/src/course-outline/card-header/CardHeader.jsx
+++ b/src/course-outline/card-header/CardHeader.jsx
@@ -120,7 +120,7 @@ const CardHeader = ({
               value={titleValue}
               name="displayName"
               onChange={(e) => setTitleValue(e.target.value)}
-              aria-label="edit field"
+              aria-label={intl.formatMessage(messages.editFieldAriaLabel)}
               onBlur={() => onEditSubmit(titleValue)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {

--- a/src/course-outline/card-header/messages.js
+++ b/src/course-outline/card-header/messages.js
@@ -1,6 +1,10 @@
 import { defineMessages } from '@edx/frontend-platform/i18n';
 
 const messages = defineMessages({
+  editFieldAriaLabel: {
+    id: 'course-authoring.course-outline.card.edit-field.aria-label',
+    defaultMessage: 'Edit field',
+  },
   expandTooltip: {
     id: 'course-authoring.course-outline.card.expandTooltip',
     defaultMessage: 'Collapse/Expand this card',

--- a/src/editors/containers/EditorContainer/components/TitleHeader/EditableHeader.jsx
+++ b/src/editors/containers/EditorContainer/components/TitleHeader/EditableHeader.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Form } from '@openedx/paragon';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import EditConfirmationButtons from './EditConfirmationButtons';
+
+import messages from './messages';
 
 const EditableHeader = ({
   handleChange,
@@ -11,20 +14,23 @@ const EditableHeader = ({
   inputRef,
   localTitle,
   cancelEdit,
-}) => (
-  <Form.Group onBlur={(e) => updateTitle(e)}>
-    <Form.Control
-      style={{ paddingInlineEnd: 'calc(1rem + 84px)' }}
-      autoFocus
-      trailingElement={<EditConfirmationButtons {...{ updateTitle, cancelEdit }} />}
-      onChange={handleChange}
-      onKeyDown={handleKeyDown}
-      placeholder="Title"
-      ref={inputRef}
-      value={localTitle}
-    />
-  </Form.Group>
-);
+}) => {
+  const intl = useIntl();
+  return (
+    <Form.Group onBlur={(e) => updateTitle(e)}>
+      <Form.Control
+        style={{ paddingInlineEnd: 'calc(1rem + 84px)' }}
+        autoFocus
+        trailingElement={<EditConfirmationButtons {...{ updateTitle, cancelEdit }} />}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={intl.formatMessage(messages.editTitlePlaceholder)}
+        ref={inputRef}
+        value={localTitle}
+      />
+    </Form.Group>
+  );
+};
 EditableHeader.defaultProps = {
   inputRef: null,
 };

--- a/src/editors/containers/EditorContainer/components/TitleHeader/messages.js
+++ b/src/editors/containers/EditorContainer/components/TitleHeader/messages.js
@@ -17,6 +17,11 @@ const messages = defineMessages({
     defaultMessage: 'Edit Title',
     description: 'Screen reader label title for icon button to edit the xblock title',
   },
+  editTitlePlaceholder: {
+    id: 'authoring.texteditor.header.editTitleLabel',
+    defaultMessage: 'Title',
+    description: 'Screen reader label title for icon button to edit the xblock title',
+  },
   cancelTitleEdit: {
     id: 'authoring.texteditor.header.cancelTitleEdit',
     defaultMessage: 'Cancel',

--- a/src/editors/containers/EditorContainer/components/TitleHeader/messages.js
+++ b/src/editors/containers/EditorContainer/components/TitleHeader/messages.js
@@ -18,7 +18,7 @@ const messages = defineMessages({
     description: 'Screen reader label title for icon button to edit the xblock title',
   },
   editTitlePlaceholder: {
-    id: 'authoring.texteditor.header.editTitleLabel',
+    id: 'authoring.texteditor.header.editTitleLabelPlaceholder',
     defaultMessage: 'Title',
     description: 'Screen reader label title for icon button to edit the xblock title',
   },

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
@@ -130,7 +130,7 @@ const AnswerOption = ({
         </Collapsible.Body>
       </div>
       <div className="d-flex flex-row flex-nowrap">
-        <Collapsible.Trigger aria-label="Toggle feedback" className="btn-icon btn-icon-primary btn-icon-md align-items-center">
+        <Collapsible.Trigger aria-label={intl.formatMessage(messages.feedbackToggleIconAriaLabel)} className="btn-icon btn-icon-primary btn-icon-md align-items-center">
           <Icon
             src={FeedbackOutline}
             alt={intl.formatMessage(messages.feedbackToggleIconAltText)}

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/messages.js
@@ -26,6 +26,11 @@ const messages = defineMessages({
     defaultMessage: 'Feedback message',
     description: 'Placeholder text for feedback text',
   },
+  feedbackToggleIconAriaLabel: {
+    id: 'authoring.answerwidget.feedback.icon.aria-label',
+    defaultMessage: 'Toggle feedback',
+    description: 'Aria label feedback toggle icon',
+  },
   feedbackToggleIconAltText: {
     id: 'authoring.answerwidget.feedback.icon.alt',
     defaultMessage: 'Toggle feedback',

--- a/src/editors/containers/VideoEditor/components/SelectVideoModal.jsx
+++ b/src/editors/containers/VideoEditor/components/SelectVideoModal.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import { Button } from '@openedx/paragon';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { thunkActions } from '../../../data/redux';
 import BaseModal from '../../../sharedComponents/BaseModal';
@@ -11,6 +12,7 @@ import BaseModal from '../../../sharedComponents/BaseModal';
 // should be re-thought and cleaned up to avoid this pattern.
 // eslint-disable-next-line import/no-self-import
 import * as module from './SelectVideoModal';
+import messages from './messages';
 
 export const hooks = {
   videoList: ({ fetchVideos }) => {
@@ -31,6 +33,7 @@ export const SelectVideoModal = ({
   close,
   setSelection,
 }) => {
+  const intl = useIntl();
   const videos = module.hooks.videoList({ fetchVideos });
   const onSelectClick = module.hooks.onSelectClick({
     setSelection,
@@ -41,7 +44,7 @@ export const SelectVideoModal = ({
     <BaseModal
       isOpen={isOpen}
       close={close}
-      title="Add a video"
+      title={intl.formatMessage(messages.selectVideoModalTitle)}
       confirmAction={<Button variant="primary" onClick={onSelectClick}>Next</Button>}
     >
       {/* Content selection */}

--- a/src/editors/containers/VideoEditor/components/SelectVideoModal.test.jsx
+++ b/src/editors/containers/VideoEditor/components/SelectVideoModal.test.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { SelectVideoModal, hooks } from './SelectVideoModal';
+import messages from './messages';
+
+const mockStore = configureStore([]);
+const mockFetchVideos = jest.fn();
+const mockSetSelection = jest.fn();
+const mockClose = jest.fn();
+
+jest.mock('./SelectVideoModal', () => ({
+  ...jest.requireActual('./SelectVideoModal'),
+  hooks: {
+    videoList: jest.fn(),
+    onSelectClick: jest.fn(),
+  },
+}));
+
+describe('SelectVideoModal', () => {
+  let store;
+
+  beforeEach(() => {
+    store = mockStore({});
+    jest.clearAllMocks();
+  });
+
+  it('renders the modal with the correct title', () => {
+    hooks.videoList.mockReturnValue([{ externalUrl: 'video1.mp4' }]);
+
+    render(
+      <Provider store={store}>
+        <IntlProvider locale="en" messages={messages}>
+          <SelectVideoModal
+            isOpen
+            close={mockClose}
+            setSelection={mockSetSelection}
+            fetchVideos={mockFetchVideos}
+          />
+        </IntlProvider>
+      </Provider>,
+    );
+
+    expect(screen.getByText(messages.selectVideoModalTitle.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('calls close when the modal is closed', () => {
+    hooks.videoList.mockReturnValue([]);
+
+    render(
+      <Provider store={store}>
+        <IntlProvider locale="en" messages={messages}>
+          <SelectVideoModal
+            isOpen
+            close={mockClose}
+            setSelection={mockSetSelection}
+            fetchVideos={mockFetchVideos}
+          />
+        </IntlProvider>
+      </Provider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(mockClose).toHaveBeenCalled();
+  });
+});

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDetails.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDetails.jsx
@@ -39,11 +39,11 @@ const LicenseDetails = ({
           <div className="mb-3">
             <FormattedMessage {...messages.detailsSubsectionTitle} />
           </div>
-          {license === LicenseTypes.allRightsReserved ? (
+          {license === LicenseTypes.allRightsReserved && (
             <div className="mt-2">
               <FormattedMessage {...messages.allRightsReservedSectionMessage} />
             </div>
-          ) : null}
+          )}
           {license === LicenseTypes.creativeCommons
             ? (
               <Stack gap={4}>

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDetails.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDetails.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import {
   FormattedMessage,
   injectIntl,
+  useIntl,
 } from '@edx/frontend-platform/i18n';
 import {
   ActionRow,
@@ -29,123 +30,126 @@ const LicenseDetails = ({
   level,
   // redux
   updateField,
-}) => (
-  level !== LicenseLevel.course && details && license !== 'select' ? (
-    <div className="x-small border-primary-100 border-bottom m-0 pr-1">
-      <Form.Group className="pb-2">
-        <div className="mb-3">
-          <FormattedMessage {...messages.detailsSubsectionTitle} />
-        </div>
-        {license === LicenseTypes.allRightsReserved ? (
-          <div className="mt-2">
-            <FormattedMessage {...messages.allRightsReservedSectionMessage} />
+}) => {
+  const intl = useIntl();
+  return (
+    level !== LicenseLevel.course && details && license !== 'select' ? (
+      <div className="x-small border-primary-100 border-bottom m-0 pr-1">
+        <Form.Group className="pb-2">
+          <div className="mb-3">
+            <FormattedMessage {...messages.detailsSubsectionTitle} />
           </div>
-        ) : null}
-        {license === LicenseTypes.creativeCommons
-          ? (
-            <Stack gap={4}>
-              <div className="border-primary-100 border-bottom pb-4">
-                <Form.Group>
-                  <ActionRow>
-                    <Icon className="text-primary-500" src={Attribution} />
-                    <Form.Label className="my-0 text-primary-500">
-                      <FormattedMessage {...messages.attributionCheckboxLabel} />
-                    </Form.Label>
-                    <ActionRow.Spacer />
-                    <CheckboxControl
-                      disabled
-                      checked
-                      aria-label="Checkbox"
-                    />
-                  </ActionRow>
-                </Form.Group>
-                <div>
-                  <FormattedMessage {...messages.attributionSectionDescription} />
-                </div>
-              </div>
-              <div className="border-primary-100 border-bottom pb-4">
-                <Form.Group>
-                  <ActionRow>
-                    <Icon src={Nc} />
-                    <Form.Label className="my-0 text-primary-500">
-                      <FormattedMessage {...messages.noncommercialCheckboxLabel} />
-                    </Form.Label>
-                    <ActionRow.Spacer />
-                    <CheckboxControl
-                      checked={details.noncommercial}
-                      disabled={level === LicenseLevel.course}
-                      onChange={(e) => updateField({
-                        licenseDetails: {
-                          ...details,
-                          noncommercial: e.target.checked,
-                        },
-                      })}
-                      aria-label="Checkbox"
-                    />
-                  </ActionRow>
-                </Form.Group>
-                <div>
-                  <FormattedMessage {...messages.noncommercialSectionDescription} />
-                </div>
-              </div>
-              <div className="border-primary-100 border-bottom pb-4">
-                <Form.Group>
-                  <ActionRow>
-                    <Icon src={Nd} />
-                    <Form.Label className="my-0 text-primary-500">
-                      <FormattedMessage {...messages.noDerivativesCheckboxLabel} />
-                    </Form.Label>
-                    <ActionRow.Spacer />
-                    <CheckboxControl
-                      checked={details.noDerivatives}
-                      disabled={level === LicenseLevel.course}
-                      onChange={(e) => updateField({
-                        licenseDetails: {
-                          ...details,
-                          noDerivatives: e.target.checked,
-                          shareAlike: e.target.checked ? false : details.shareAlike,
-                        },
-                      })}
-                      aria-label="Checkbox"
-                    />
-                  </ActionRow>
-                </Form.Group>
-                <div>
-                  <FormattedMessage {...messages.noDerivativesSectionDescription} />
-                </div>
-              </div>
-              <div>
-                <Form.Group>
-                  <ActionRow>
-                    <Icon src={Sa} />
-                    <Form.Label className="my-0 text-primary-500">
-                      <FormattedMessage {...messages.shareAlikeCheckboxLabel} />
-                    </Form.Label>
-                    <ActionRow.Spacer />
-                    <CheckboxControl
-                      checked={details.shareAlike}
-                      disabled={level === LicenseLevel.course}
-                      onChange={(e) => updateField({
-                        licenseDetails: {
-                          ...details,
-                          shareAlike: e.target.checked,
-                          noDerivatives: e.target.checked ? false : details.noDerivatives,
-                        },
-                      })}
-                      aria-label="Checkbox"
-                    />
-                  </ActionRow>
-                </Form.Group>
-                <div>
-                  <FormattedMessage {...messages.shareAlikeSectionDescription} />
-                </div>
-              </div>
-            </Stack>
+          {license === LicenseTypes.allRightsReserved ? (
+            <div className="mt-2">
+              <FormattedMessage {...messages.allRightsReservedSectionMessage} />
+            </div>
           ) : null}
-      </Form.Group>
-    </div>
-  ) : null
-);
+          {license === LicenseTypes.creativeCommons
+            ? (
+              <Stack gap={4}>
+                <div className="border-primary-100 border-bottom pb-4">
+                  <Form.Group>
+                    <ActionRow>
+                      <Icon className="text-primary-500" src={Attribution} />
+                      <Form.Label className="my-0 text-primary-500">
+                        <FormattedMessage {...messages.attributionCheckboxLabel} />
+                      </Form.Label>
+                      <ActionRow.Spacer />
+                      <CheckboxControl
+                        disabled
+                        checked
+                        aria-label={intl.formatMessage(messages.attributionCheckboxAriaLabel)}
+                      />
+                    </ActionRow>
+                  </Form.Group>
+                  <div>
+                    <FormattedMessage {...messages.attributionSectionDescription} />
+                  </div>
+                </div>
+                <div className="border-primary-100 border-bottom pb-4">
+                  <Form.Group>
+                    <ActionRow>
+                      <Icon src={Nc} />
+                      <Form.Label className="my-0 text-primary-500">
+                        <FormattedMessage {...messages.noncommercialCheckboxLabel} />
+                      </Form.Label>
+                      <ActionRow.Spacer />
+                      <CheckboxControl
+                        checked={details.noncommercial}
+                        disabled={level === LicenseLevel.course}
+                        onChange={(e) => updateField({
+                          licenseDetails: {
+                            ...details,
+                            noncommercial: e.target.checked,
+                          },
+                        })}
+                        aria-label={intl.formatMessage(messages.noncommercialCheckboxAriaLabel)}
+                      />
+                    </ActionRow>
+                  </Form.Group>
+                  <div>
+                    <FormattedMessage {...messages.noncommercialSectionDescription} />
+                  </div>
+                </div>
+                <div className="border-primary-100 border-bottom pb-4">
+                  <Form.Group>
+                    <ActionRow>
+                      <Icon src={Nd} />
+                      <Form.Label className="my-0 text-primary-500">
+                        <FormattedMessage {...messages.noDerivativesCheckboxLabel} />
+                      </Form.Label>
+                      <ActionRow.Spacer />
+                      <CheckboxControl
+                        checked={details.noDerivatives}
+                        disabled={level === LicenseLevel.course}
+                        onChange={(e) => updateField({
+                          licenseDetails: {
+                            ...details,
+                            noDerivatives: e.target.checked,
+                            shareAlike: e.target.checked ? false : details.shareAlike,
+                          },
+                        })}
+                        aria-label={intl.formatMessage(messages.noDerivativesCheckboxAriaLabel)}
+                      />
+                    </ActionRow>
+                  </Form.Group>
+                  <div>
+                    <FormattedMessage {...messages.noDerivativesSectionDescription} />
+                  </div>
+                </div>
+                <div>
+                  <Form.Group>
+                    <ActionRow>
+                      <Icon src={Sa} />
+                      <Form.Label className="my-0 text-primary-500">
+                        <FormattedMessage {...messages.shareAlikeCheckboxLabel} />
+                      </Form.Label>
+                      <ActionRow.Spacer />
+                      <CheckboxControl
+                        checked={details.shareAlike}
+                        disabled={level === LicenseLevel.course}
+                        onChange={(e) => updateField({
+                          licenseDetails: {
+                            ...details,
+                            shareAlike: e.target.checked,
+                            noDerivatives: e.target.checked ? false : details.noDerivatives,
+                          },
+                        })}
+                        aria-label={intl.formatMessage(messages.shareAlikeCheckboxAriaLabel)}
+                      />
+                    </ActionRow>
+                  </Form.Group>
+                  <div>
+                    <FormattedMessage {...messages.shareAlikeSectionDescription} />
+                  </div>
+                </div>
+              </Stack>
+            ) : null}
+        </Form.Group>
+      </div>
+    ) : null
+  );
+};
 
 LicenseDetails.propTypes = {
   license: PropTypes.string.isRequired,

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDetails.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDetails.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import {
   FormattedMessage,
   injectIntl,
-  useIntl,
+  intlShape,
 } from '@edx/frontend-platform/i18n';
 import {
   ActionRow,
@@ -30,126 +30,124 @@ const LicenseDetails = ({
   level,
   // redux
   updateField,
-}) => {
-  const intl = useIntl();
-  return (
-    level !== LicenseLevel.course && details && license !== 'select' ? (
-      <div className="x-small border-primary-100 border-bottom m-0 pr-1">
-        <Form.Group className="pb-2">
-          <div className="mb-3">
-            <FormattedMessage {...messages.detailsSubsectionTitle} />
+  intl,
+}) => (
+  level !== LicenseLevel.course && details && license !== 'select' ? (
+    <div className="x-small border-primary-100 border-bottom m-0 pr-1">
+      <Form.Group className="pb-2">
+        <div className="mb-3">
+          <FormattedMessage {...messages.detailsSubsectionTitle} />
+        </div>
+        {license === LicenseTypes.allRightsReserved && (
+          <div className="mt-2">
+            <FormattedMessage {...messages.allRightsReservedSectionMessage} />
           </div>
-          {license === LicenseTypes.allRightsReserved && (
-            <div className="mt-2">
-              <FormattedMessage {...messages.allRightsReservedSectionMessage} />
-            </div>
-          )}
-          {license === LicenseTypes.creativeCommons
-            ? (
-              <Stack gap={4}>
-                <div className="border-primary-100 border-bottom pb-4">
-                  <Form.Group>
-                    <ActionRow>
-                      <Icon className="text-primary-500" src={Attribution} />
-                      <Form.Label className="my-0 text-primary-500">
-                        <FormattedMessage {...messages.attributionCheckboxLabel} />
-                      </Form.Label>
-                      <ActionRow.Spacer />
-                      <CheckboxControl
-                        disabled
-                        checked
-                        aria-label={intl.formatMessage(messages.attributionCheckboxAriaLabel)}
-                      />
-                    </ActionRow>
-                  </Form.Group>
-                  <div>
-                    <FormattedMessage {...messages.attributionSectionDescription} />
-                  </div>
-                </div>
-                <div className="border-primary-100 border-bottom pb-4">
-                  <Form.Group>
-                    <ActionRow>
-                      <Icon src={Nc} />
-                      <Form.Label className="my-0 text-primary-500">
-                        <FormattedMessage {...messages.noncommercialCheckboxLabel} />
-                      </Form.Label>
-                      <ActionRow.Spacer />
-                      <CheckboxControl
-                        checked={details.noncommercial}
-                        disabled={level === LicenseLevel.course}
-                        onChange={(e) => updateField({
-                          licenseDetails: {
-                            ...details,
-                            noncommercial: e.target.checked,
-                          },
-                        })}
-                        aria-label={intl.formatMessage(messages.noncommercialCheckboxAriaLabel)}
-                      />
-                    </ActionRow>
-                  </Form.Group>
-                  <div>
-                    <FormattedMessage {...messages.noncommercialSectionDescription} />
-                  </div>
-                </div>
-                <div className="border-primary-100 border-bottom pb-4">
-                  <Form.Group>
-                    <ActionRow>
-                      <Icon src={Nd} />
-                      <Form.Label className="my-0 text-primary-500">
-                        <FormattedMessage {...messages.noDerivativesCheckboxLabel} />
-                      </Form.Label>
-                      <ActionRow.Spacer />
-                      <CheckboxControl
-                        checked={details.noDerivatives}
-                        disabled={level === LicenseLevel.course}
-                        onChange={(e) => updateField({
-                          licenseDetails: {
-                            ...details,
-                            noDerivatives: e.target.checked,
-                            shareAlike: e.target.checked ? false : details.shareAlike,
-                          },
-                        })}
-                        aria-label={intl.formatMessage(messages.noDerivativesCheckboxAriaLabel)}
-                      />
-                    </ActionRow>
-                  </Form.Group>
-                  <div>
-                    <FormattedMessage {...messages.noDerivativesSectionDescription} />
-                  </div>
-                </div>
+        )}
+        {license === LicenseTypes.creativeCommons
+          ? (
+            <Stack gap={4}>
+              <div className="border-primary-100 border-bottom pb-4">
+                <Form.Group>
+                  <ActionRow>
+                    <Icon className="text-primary-500" src={Attribution} />
+                    <Form.Label className="my-0 text-primary-500">
+                      <FormattedMessage {...messages.attributionCheckboxLabel} />
+                    </Form.Label>
+                    <ActionRow.Spacer />
+                    <CheckboxControl
+                      disabled
+                      checked
+                      aria-label={intl.formatMessage(messages.attributionCheckboxAriaLabel)}
+                    />
+                  </ActionRow>
+                </Form.Group>
                 <div>
-                  <Form.Group>
-                    <ActionRow>
-                      <Icon src={Sa} />
-                      <Form.Label className="my-0 text-primary-500">
-                        <FormattedMessage {...messages.shareAlikeCheckboxLabel} />
-                      </Form.Label>
-                      <ActionRow.Spacer />
-                      <CheckboxControl
-                        checked={details.shareAlike}
-                        disabled={level === LicenseLevel.course}
-                        onChange={(e) => updateField({
-                          licenseDetails: {
-                            ...details,
-                            shareAlike: e.target.checked,
-                            noDerivatives: e.target.checked ? false : details.noDerivatives,
-                          },
-                        })}
-                        aria-label={intl.formatMessage(messages.shareAlikeCheckboxAriaLabel)}
-                      />
-                    </ActionRow>
-                  </Form.Group>
-                  <div>
-                    <FormattedMessage {...messages.shareAlikeSectionDescription} />
-                  </div>
+                  <FormattedMessage {...messages.attributionSectionDescription} />
                 </div>
-              </Stack>
-            ) : null}
-        </Form.Group>
-      </div>
-    ) : null
-  );
-};
+              </div>
+              <div className="border-primary-100 border-bottom pb-4">
+                <Form.Group>
+                  <ActionRow>
+                    <Icon src={Nc} />
+                    <Form.Label className="my-0 text-primary-500">
+                      <FormattedMessage {...messages.noncommercialCheckboxLabel} />
+                    </Form.Label>
+                    <ActionRow.Spacer />
+                    <CheckboxControl
+                      checked={details.noncommercial}
+                      disabled={level === LicenseLevel.course}
+                      onChange={(e) => updateField({
+                        licenseDetails: {
+                          ...details,
+                          noncommercial: e.target.checked,
+                        },
+                      })}
+                      aria-label={intl.formatMessage(messages.noncommercialCheckboxAriaLabel)}
+                    />
+                  </ActionRow>
+                </Form.Group>
+                <div>
+                  <FormattedMessage {...messages.noncommercialSectionDescription} />
+                </div>
+              </div>
+              <div className="border-primary-100 border-bottom pb-4">
+                <Form.Group>
+                  <ActionRow>
+                    <Icon src={Nd} />
+                    <Form.Label className="my-0 text-primary-500">
+                      <FormattedMessage {...messages.noDerivativesCheckboxLabel} />
+                    </Form.Label>
+                    <ActionRow.Spacer />
+                    <CheckboxControl
+                      checked={details.noDerivatives}
+                      disabled={level === LicenseLevel.course}
+                      onChange={(e) => updateField({
+                        licenseDetails: {
+                          ...details,
+                          noDerivatives: e.target.checked,
+                          shareAlike: e.target.checked ? false : details.shareAlike,
+                        },
+                      })}
+                      aria-label={intl.formatMessage(messages.noDerivativesCheckboxAriaLabel)}
+                    />
+                  </ActionRow>
+                </Form.Group>
+                <div>
+                  <FormattedMessage {...messages.noDerivativesSectionDescription} />
+                </div>
+              </div>
+              <div>
+                <Form.Group>
+                  <ActionRow>
+                    <Icon src={Sa} />
+                    <Form.Label className="my-0 text-primary-500">
+                      <FormattedMessage {...messages.shareAlikeCheckboxLabel} />
+                    </Form.Label>
+                    <ActionRow.Spacer />
+                    <CheckboxControl
+                      checked={details.shareAlike}
+                      disabled={level === LicenseLevel.course}
+                      onChange={(e) => updateField({
+                        licenseDetails: {
+                          ...details,
+                          shareAlike: e.target.checked,
+                          noDerivatives: e.target.checked ? false : details.noDerivatives,
+                        },
+                      })}
+                      aria-label={intl.formatMessage(messages.shareAlikeCheckboxAriaLabel)}
+                    />
+                  </ActionRow>
+                </Form.Group>
+                <div>
+                  <FormattedMessage {...messages.shareAlikeSectionDescription} />
+                </div>
+              </div>
+            </Stack>
+          ) : null}
+      </Form.Group>
+    </div>
+  ) : null
+);
 
 LicenseDetails.propTypes = {
   license: PropTypes.string.isRequired,
@@ -162,6 +160,7 @@ LicenseDetails.propTypes = {
   level: PropTypes.string.isRequired,
   // redux
   updateField: PropTypes.func.isRequired,
+  intl: intlShape.isRequired,
 };
 
 export const mapStateToProps = () => ({});

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDetails.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDetails.test.jsx
@@ -52,8 +52,11 @@ describe('LicenseDetails', () => {
       ).toMatchSnapshot();
     });
     test('snapshots: renders as expected with level set to block and license set to Creative Commons', () => {
+      const mockIntl = {
+        formatMessage: jest.fn(({ defaultMessage }) => defaultMessage),
+      };
       expect(
-        shallow(<LicenseDetails {...props} level="block" license="creative-commons" />).snapshot,
+        shallow(<LicenseDetails {...props} level="block" license="creative-commons" intl={mockIntl} />).snapshot,
       ).toMatchSnapshot();
     });
   });

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/messages.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/messages.js
@@ -77,6 +77,11 @@ const messages = defineMessages({
     defaultMessage: 'When a video has a different license than the course as a whole, learners see the license at the bottom right of the video player.',
     description: 'Message explaining where video specific licenses are seen by users',
   },
+  attributionCheckboxAriaLabel: {
+    id: 'authoring.videoeditor.license.attributionCheckboxAriaLabel',
+    defaultMessage: 'Checkbox',
+    description: 'Aria label for attribution checkbox',
+  },
   attributionCheckboxLabel: {
     id: 'authoring.videoeditor.license.attributionCheckboxLabel',
     defaultMessage: 'Attribution',
@@ -86,6 +91,11 @@ const messages = defineMessages({
     id: 'authoring.videoeditor.license.attributionSectionDescription',
     defaultMessage: 'Allow others to copy, distribute, display and perform your copyrighted work but only if they give credit the way you request. Currently, this option is required.',
     description: 'Attribution card section defining attribution license',
+  },
+  noncommercialCheckboxAriaLabel: {
+    id: 'authoring.videoeditor.license.noncommercialCheckboxAriaLabel',
+    defaultMessage: 'Checkbox',
+    description: 'Aria label for noncommercial checkbox',
   },
   noncommercialCheckboxLabel: {
     id: 'authoring.videoeditor.license.noncommercialCheckboxLabel',
@@ -97,6 +107,11 @@ const messages = defineMessages({
     defaultMessage: 'Allow others to copy, distribute, display and perform your work - and derivative works based upon it - but for noncommercial purposes only.',
     description: 'Noncommercial card section defining noncommercial license',
   },
+  noDerivativesCheckboxAriaLabel: {
+    id: 'authoring.videoeditor.license.noDerivativesCheckboxAriaLabel',
+    defaultMessage: 'Checkbox',
+    description: 'Aria label for No Derivatives checkbox',
+  },
   noDerivativesCheckboxLabel: {
     id: 'authoring.videoeditor.license.noDerivativesCheckboxLabel',
     defaultMessage: 'No Derivatives',
@@ -106,6 +121,11 @@ const messages = defineMessages({
     id: 'authoring.videoeditor.license.noDerivativesSectionDescription',
     defaultMessage: 'Allow others to copy, distribute, display and perform only verbatim copies of your work, not derivative works based upon it. This option is incompatible with "Share Alike".',
     description: 'No Derivatives card section defining no derivatives license',
+  },
+  shareAlikeCheckboxAriaLabel: {
+    id: 'authoring.videoeditor.license.shareAlikeCheckboxAriaLabel',
+    defaultMessage: 'Checkbox',
+    description: 'Aria label for Share Alike checkbox',
   },
   shareAlikeCheckboxLabel: {
     id: 'authoring.videoeditor.license.shareAlikeCheckboxLabel',

--- a/src/editors/containers/VideoEditor/components/messages.ts
+++ b/src/editors/containers/VideoEditor/components/messages.ts
@@ -1,0 +1,11 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  selectVideoModalTitle: {
+    id: 'authoring.videoEditor.selectVideoModal.title',
+    defaultMessage: 'Add a video',
+    description: 'Title for the select video modal.',
+  },
+});
+
+export default messages;

--- a/src/files-and-videos/generic/FileInput.jsx
+++ b/src/files-and-videos/generic/FileInput.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { getSupportedFormats } from '../videos-page/data/utils';
+import messages from './messages';
 
 export const useFileInput = ({
   onAddFile,
@@ -23,17 +25,20 @@ export const useFileInput = ({
   };
 };
 
-const FileInput = ({ fileInput: hook, supportedFileFormats, allowMultiple }) => (
-  <input
-    accept={getSupportedFormats(supportedFileFormats)}
-    aria-label="file-input"
-    className="upload d-none"
-    onChange={hook.addFile}
-    ref={hook.ref}
-    type="file"
-    multiple={allowMultiple}
-  />
-);
+const FileInput = ({ fileInput: hook, supportedFileFormats, allowMultiple }) => {
+  const intl = useIntl();
+  return (
+    <input
+      accept={getSupportedFormats(supportedFileFormats)}
+      aria-label={intl.formatMessage(messages.fileInputAriaLabel)}
+      className="upload d-none"
+      onChange={hook.addFile}
+      ref={hook.ref}
+      type="file"
+      multiple={allowMultiple}
+    />
+  );
+};
 
 FileInput.propTypes = {
   fileInput: PropTypes.shape({

--- a/src/files-and-videos/generic/messages.js
+++ b/src/files-and-videos/generic/messages.js
@@ -209,6 +209,11 @@ const messages = defineMessages({
     defaultMessage: 'Upload error',
     description: 'Title for upload error alert',
   },
+  fileInputAriaLabel: {
+    id: 'course-authoring.files-and-uploads.fileInput.ariaLabel',
+    defaultMessage: 'file-input',
+    description: 'Aria label for file input',
+  },
 });
 
 export default messages;

--- a/src/files-and-videos/generic/table-components/sort-and-filter-modal/SortAndFilterModal.jsx
+++ b/src/files-and-videos/generic/table-components/sort-and-filter-modal/SortAndFilterModal.jsx
@@ -91,7 +91,7 @@ const SortAndFilterModal = ({
             className="text-center"
             value="displayName,asc"
             type="radio"
-            aria-label="name descending radio"
+            aria-label={intl.formatMessage(messages.sortByNameAscendingAriaLabel)}
           >
             <FormattedMessage {...messages.sortByNameAscending} />
           </SelectableBox>
@@ -99,7 +99,7 @@ const SortAndFilterModal = ({
             className="text-center"
             value="dateAdded,desc"
             type="radio"
-            aria-label="date added descending radio"
+            aria-label={intl.formatMessage(messages.sortByNewestAriaLabel)}
           >
             <FormattedMessage {...messages.sortByNewest} />
           </SelectableBox>
@@ -107,7 +107,7 @@ const SortAndFilterModal = ({
             className="text-center"
             value="fileSize,desc"
             type="radio"
-            aria-label="file size descending radio"
+            aria-label={intl.formatMessage(messages.sortBySizeDescendingAriaLabel)}
           >
             <FormattedMessage {...messages.sortBySizeDescending} />
           </SelectableBox>
@@ -115,7 +115,7 @@ const SortAndFilterModal = ({
             className="text-center"
             value="displayName,desc"
             type="radio"
-            aria-label="name ascending radio"
+            aria-label={intl.formatMessage(messages.sortByNameDescendingAriaLabel)}
           >
             <FormattedMessage {...messages.sortByNameDescending} />
           </SelectableBox>
@@ -123,7 +123,7 @@ const SortAndFilterModal = ({
             className="text-center"
             value="dateAdded,asc"
             type="radio"
-            aria-label="date added ascending radio"
+            aria-label={intl.formatMessage(messages.sortByOldestAriaLabel)}
           >
             <FormattedMessage {...messages.sortByOldest} />
           </SelectableBox>
@@ -131,7 +131,7 @@ const SortAndFilterModal = ({
             className="text-center"
             value="fileSize,asc"
             type="radio"
-            aria-label="file size ascending radio"
+            aria-label={intl.formatMessage(messages.sortBySizeAscendingAriaLabel)}
           >
             <FormattedMessage {...messages.sortBySizeAscending} />
           </SelectableBox>

--- a/src/files-and-videos/generic/table-components/sort-and-filter-modal/messages.js
+++ b/src/files-and-videos/generic/table-components/sort-and-filter-modal/messages.js
@@ -25,25 +25,49 @@ const messages = defineMessages({
     id: 'course-authoring..files-and-videos.sort-and-filter.modal.sortByNameAscendingButton.label',
     defaultMessage: 'Name (A-Z)',
   },
+  sortByNameAscendingAriaLabel: {
+    id: 'course-authoring..files-and-videos.sort-and-filter.modal.sortByNameAscendingButton.aria-label',
+    defaultMessage: 'name descending radio',
+  },
   sortByNewest: {
     id: 'course-authoring..files-and-videos.sort-and-filter.modal.sortByNewestButton.label',
     defaultMessage: 'Newest',
+  },
+  sortByNewestAriaLabel: {
+    id: 'course-authoring..files-and-videos.sort-and-filter.modal.sortByNewestButton.label-label',
+    defaultMessage: 'date added descending radio',
   },
   sortBySizeDescending: {
     id: 'course-authoring..files-and-videos.sort-and-filter.modal.sortBySizeDescendingButton.label',
     defaultMessage: 'File size (High to low)',
   },
+  sortBySizeDescendingAriaLabel: {
+    id: 'course-authoring..files-and-videos.sort-and-filter.modal.sortBySizeDescendingButton.aria-label',
+    defaultMessage: 'file size descending radio',
+  },
   sortByNameDescending: {
     id: 'course-authoring..files-and-videos.sort-and-filter.modal.sortByNameDescendingButton.label',
     defaultMessage: 'Name (Z-A)',
+  },
+  sortByNameDescendingAriaLabel: {
+    id: 'course-authoring..files-and-videos.sort-and-filter.modal.sortByNameDescendingButton.aria-label',
+    defaultMessage: 'name ascending radio',
   },
   sortByOldest: {
     id: 'course-authoring..files-and-videos.sort-and-filter.modal.sortByOldestButton.label',
     defaultMessage: 'Oldest',
   },
+  sortByOldestAriaLabel: {
+    id: 'course-authoring..files-and-videos.sort-and-filter.modal.sortByOldestButton.aria-label',
+    defaultMessage: 'date added ascending radio',
+  },
   sortBySizeAscending: {
     id: 'course-authoring..files-and-videos.sort-and-filter.modal.sortBySizeAscendingButton.label',
     defaultMessage: 'File size (Low to high)',
+  },
+  sortBySizeAscendingAriaLabel: {
+    id: 'course-authoring..files-and-videos.sort-and-filter.modal.sortBySizeAscendingButton.aria-label',
+    defaultMessage: 'file size ascending radio',
   },
   applySortButton: {
     id: 'course-authoring..files-and-videos.sort-and-filter.modal.applyySortButton.label',

--- a/src/files-and-videos/videos-page/transcript-settings/OrderTranscriptForm.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/OrderTranscriptForm.jsx
@@ -119,14 +119,14 @@ const OrderTranscriptForm = ({
       >
         <SelectableBox
           value="order"
-          aria-label="none radio"
+          aria-label={intl.formatMessage(messages.noneAriaLabel)}
           className="text-center"
         >
           <FormattedMessage {...messages.noneLabel} />
         </SelectableBox>
         <SelectableBox
           value="Cielo24"
-          aria-label="Cielo24 radio"
+          aria-label={intl.formatMessage(messages.cieloAriaLabel)}
           className="text-center"
           disabled={!validCieloTranscriptionPlan && cieloHasCredentials}
         >
@@ -134,7 +134,7 @@ const OrderTranscriptForm = ({
         </SelectableBox>
         <SelectableBox
           value="3PlayMedia"
-          aria-label="3PlayMedia radio"
+          aria-label={intl.formatMessage(messages.threePlayMediaAriaLabel)}
           className="text-center"
           disabled={!validThreePlayTranscriptionPlan && threePlayHasCredentials}
         >

--- a/src/files-and-videos/videos-page/transcript-settings/messages.js
+++ b/src/files-and-videos/videos-page/transcript-settings/messages.js
@@ -28,15 +28,30 @@ const messages = defineMessages({
     defaultMessage: 'None',
     description: 'Label for order transcript None option',
   },
+  noneAriaLabel: {
+    id: 'course-authoring.video-uploads.transcriptSettings.orderTranscripts.none.aria-label',
+    defaultMessage: 'none radio',
+    description: 'Aria label for order transcript None option',
+  },
   cieloLabel: {
     id: 'course-authoring.video-uploads.transcriptSettings.orderTranscripts.cielo24.label',
     defaultMessage: 'Cielo24',
     description: 'Label for order transcript Cieol24 option',
   },
+  cieloAriaLabel: {
+    id: 'course-authoring.video-uploads.transcriptSettings.orderTranscripts.cielo24.aria-label',
+    defaultMessage: 'Cielo24 radio',
+    description: 'Aria label for order transcript Cieol24 option',
+  },
   threePlayMediaLabel: {
     id: 'course-authoring.video-uploads.transcriptSettings.orderTranscripts.3PlayMedia.label',
     defaultMessage: '3Play Media',
     description: 'Label for order transcript 3Play Media option',
+  },
+  threePlayMediaAriaLabel: {
+    id: 'course-authoring.video-uploads.transcriptSettings.orderTranscripts.3PlayMedia.aria-label',
+    defaultMessage: '3PlayMedia radio',
+    description: 'Aria label for order transcript 3Play Media option',
   },
   updateSettingsLabel: {
     id: 'course-authoring.video-uploads.transcriptSettings.orderTranscripts.updateSettings.label',

--- a/src/generic/configure-modal/AdvancedTab.jsx
+++ b/src/generic/configure-modal/AdvancedTab.jsx
@@ -5,7 +5,7 @@ import { Alert, Form, Hyperlink } from '@openedx/paragon';
 import {
   Warning as WarningIcon,
 } from '@openedx/paragon/icons';
-import { FormattedMessage, injectIntl } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, injectIntl, useIntl } from '@edx/frontend-platform/i18n';
 import messages from './messages';
 
 import PrereqSettings from './PrereqSettings';
@@ -31,6 +31,8 @@ const AdvancedTab = ({
     examReviewRules,
   } = values;
   let examTypeValue = 'none';
+
+  const intl = useIntl();
 
   if (isTimeLimited && isProctoredExam) {
     if (isOnboardingExam) {
@@ -183,7 +185,7 @@ const AdvancedTab = ({
             <Form.Control
               onChange={setCurrentTimeLimit}
               value={timeLimit}
-              placeholder="HH:MM"
+              placeholder={intl.formatMessage(messages.timeLimitPlaceholder)}
               pattern="^[0-9][0-9]:[0-5][0-9]$"
             />
           </Form.Group>

--- a/src/generic/configure-modal/messages.js
+++ b/src/generic/configure-modal/messages.js
@@ -239,6 +239,10 @@ const messages = defineMessages({
     id: 'course-authoring.course-outline.configure-modal.advanced-tab.time-allotted',
     defaultMessage: 'Time allotted (HH:MM):',
   },
+  timeLimitPlaceholder: {
+    id: 'course-authoring.course-outline.configure-modal.advanced-tab.time-limit-placeholder',
+    defaultMessage: 'HH:MM',
+  },
   timeLimitDescription: {
     id: 'course-authoring.course-outline.configure-modal.advanced-tab.time-limit-description',
     defaultMessage: 'Select a time allotment for the exam. If it is over 24 hours, type in the amount of time. You can grant individual learners extra time to complete the exam through the Instructor Dashboard.',

--- a/src/studio-home/tabs-section/courses-tab/courses-filters/index.jsx
+++ b/src/studio-home/tabs-section/courses-tab/courses-filters/index.jsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { SearchField } from '@openedx/paragon';
 import { debounce } from 'lodash';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { getStudioHomeCoursesParams } from '../../../data/selectors';
 import { updateStudioHomeCoursesCustomParams } from '../../../data/slice';
@@ -11,6 +12,7 @@ import { LoadingSpinner } from '../../../../generic/Loading';
 import CoursesTypesFilterMenu from './courses-types-filter-menu';
 import CoursesOrderFilterMenu from './courses-order-filter-menu';
 import './index.scss';
+import messages from './messages';
 
 /* regex to check if a string has only whitespace
   example "    "
@@ -32,6 +34,8 @@ const CoursesFilters = ({
     cleanFilters,
   } = studioHomeCoursesParams;
   const [inputSearchValue, setInputSearchValue] = useState('');
+
+  const intl = useIntl();
 
   const getFilterTypeData = (baseFilters) => ({
     archivedCourses: { ...baseFilters, archivedOnly: true, activeOnly: undefined },
@@ -107,7 +111,7 @@ const CoursesFilters = ({
           value={cleanFilters ? '' : inputSearchValue}
           className="mr-4"
           data-testid="input-filter-courses-search"
-          placeholder="Search"
+          placeholder={intl.formatMessage(messages.coursesSearchPlaceholder)}
         />
         {isLoading && (
           <span className="search-field-loading" data-testid="loading-search-spinner">

--- a/src/studio-home/tabs-section/courses-tab/courses-filters/messages.js
+++ b/src/studio-home/tabs-section/courses-tab/courses-filters/messages.js
@@ -1,0 +1,11 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
+  coursesSearchPlaceholder: {
+    id: 'course-authoring.studio-home.courses.search-placeholder',
+    defaultMessage: 'Search',
+  },
+});
+
+export default messages;

--- a/src/taxonomy/import-tags/ImportTagsWizard.jsx
+++ b/src/taxonomy/import-tags/ImportTagsWizard.jsx
@@ -40,7 +40,7 @@ const ExportStep = ({ taxonomy }) => {
   const intl = useIntl();
 
   return (
-    <Stepper.Step eventKey="export" title="export">
+    <Stepper.Step eventKey="export" title={intl.formatMessage(messages.importWizardStepperExportStepTitle)}>
       <Stack gap={3} data-testid="export-step">
         <p>{intl.formatMessage(messages.importWizardStepExportBody, { br: linebreak })}</p>
         <Stack gap={3} direction="horizontal">
@@ -97,7 +97,7 @@ const UploadStep = ({
   };
 
   return (
-    <Stepper.Step eventKey="upload" title="upload" hasError={!!importPlanError}>
+    <Stepper.Step eventKey="upload" title={intl.formatMessage(messages.importWizardStepperUploadStepTitle)} hasError={!!importPlanError}>
       <Stack gap={3} data-testid="upload-step">
         <p>{
           reimport
@@ -190,7 +190,7 @@ const PopulateStep = ({
   };
 
   return (
-    <Stepper.Step eventKey="populate" title="populate">
+    <Stepper.Step eventKey="populate" title={intl.formatMessage(messages.importWizardStepperPopulateStepTitle)}>
       <Stack gap={3} data-testid="populate-step">
         <Form.Group>
           <Form.Label>{ intl.formatMessage(messages.importWizardStepPopulateTaxonomyName) }</Form.Label>
@@ -222,7 +222,7 @@ const PlanStep = ({ importPlan }) => {
   const intl = useIntl();
 
   return (
-    <Stepper.Step eventKey="plan" title="plan">
+    <Stepper.Step eventKey="plan" title={intl.formatMessage(messages.importWizardStepperPlanStepTitle)}>
       <Stack gap={3} data-testid="plan-step">
         {intl.formatMessage(messages.importWizardStepPlanBody, { br: linebreak, changeCount: importPlan?.length })}
         <ul className="h-200px" style={{ overflow: 'scroll' }}>
@@ -249,7 +249,7 @@ const ConfirmStep = ({ importPlan }) => {
   const intl = useIntl();
 
   return (
-    <Stepper.Step eventKey="confirm" title="confirm">
+    <Stepper.Step eventKey="confirm" ttitle={intl.formatMessage(messages.importWizardStepperConfirmStepTitle)}>
       <Stack data-testid="confirm-step">
         {intl.formatMessage(
           messages.importWizardStepConfirmBody,

--- a/src/taxonomy/import-tags/ImportTagsWizard.jsx
+++ b/src/taxonomy/import-tags/ImportTagsWizard.jsx
@@ -249,7 +249,7 @@ const ConfirmStep = ({ importPlan }) => {
   const intl = useIntl();
 
   return (
-    <Stepper.Step eventKey="confirm" ttitle={intl.formatMessage(messages.importWizardStepperConfirmStepTitle)}>
+    <Stepper.Step eventKey="confirm" title={intl.formatMessage(messages.importWizardStepperConfirmStepTitle)}>
       <Stack data-testid="confirm-step">
         {intl.formatMessage(
           messages.importWizardStepConfirmBody,

--- a/src/taxonomy/import-tags/messages.ts
+++ b/src/taxonomy/import-tags/messages.ts
@@ -154,6 +154,26 @@ const messages = defineMessages({
     id: 'course-authoring.import-tags.error-alert.title',
     defaultMessage: 'Import error',
   },
+  importWizardStepperExportStepTitle: {
+    id: 'course-authoring.import-tags.wizard.stepper.export-step.title',
+    defaultMessage: 'Export',
+  },
+  importWizardStepperUploadStepTitle: {
+    id: 'course-authoring.import-tags.wizard.stepper.upload-step.title',
+    defaultMessage: 'Upload',
+  },
+  importWizardStepperPopulateStepTitle: {
+    id: 'course-authoring.import-tags.wizard.stepper.populate-step.title',
+    defaultMessage: 'Populate',
+  },
+  importWizardStepperPlanStepTitle: {
+    id: 'course-authoring.import-tags.wizard.stepper.plan-step.title',
+    defaultMessage: 'Plan',
+  },
+  importWizardStepperConfirmStepTitle: {
+    id: 'course-authoring.import-tags.wizard.stepper.confirm-step.title',
+    defaultMessage: 'Confirm',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description

Based on a report generated by an AI agent about improvements to untranslated strings according to the i18 guidelines, several files have been modified in order to fix these potential internationalization bugs.
Some of the fixes include:
- Untranslated placeholder texts
- Untranslated title texts
- Untranslated aria-label texts
- Hardcoded string constants

## Supporting information
This PR fixes [#1806](https://github.com/openedx/frontend-app-authoring/issues/1806)

## Testing instructions

- [AccessibilityPage](https://github.com/openedx/frontend-app-authoring/pull/1901/files#diff-7e5ee26cd10f2604414cf7ad94c3de1e6776a762ee735a92977b6ff825f7fea9)
Go to [accessibility page](http://apps.local.openedx.io:2001/authoring/accessibility)
If it shows an error, go to src/index.jsxL80 and remove the condition to always render this route.
Verify the links [Website Accessibility Policy](https://www.edx.org/accessibility) are pointing to the correct directions

- [CardHeader](https://github.com/openedx/frontend-app-authoring/pull/1901/files#diff-7b63f9898c2d9e7c2fbfa64ae3cb180560eee4ad3ba34a2bee3eda6599089d8a)
Go to the edit course content.
Hover a module name and click on the pencil icon that shows on hover, the module name turns into an input element
With devtools inspect the input text and look for the aria-label (it is a bit difficult since clicking turns the input into a label, so here is helpful to install the [react developer tools](https://chromewebstore.google.com/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi) and look for the specific component (wich is FormControl) on the Components tool)

- [courses-filters/index.jsx](https://github.com/openedx/frontend-app-authoring/pull/1901/files#diff-f970504b9f0fcd613b8df290917964121b7b09712cae9760ff41c4646833470e)
Go to the home of the authoring site.
Look for the input for searching on bellow the courses and libraries tabs.
Verify the placeholder of the input

- [EditableHeader](https://github.com/openedx/frontend-app-authoring/pull/1901/files#diff-ead0f041147d1261f5ea803b6179a2749ed29ac98603615f1d302c5ebb134807)
Select one of the sections of a module and click on the arrow to expand the content. 
Click on + New unit.
Select text component and then the text radio and click select button.
On the modal click on the pencil button to edit the title.
Remove the content of the input and the placeholder should appear.

- [AnswerWidget/AnswerOption](https://github.com/openedx/frontend-app-authoring/pull/1901/files#diff-ea1adaf1f5f1133b38c71a710149f4e68098f07fdbda79897aa7f9576a604c7f)
Select one of the sections of a module and click on the arrow to expand the content. 
Click on + New unit.
Select Problem component and then the single select option and click select button.
Scroll down the modal and there must be the Answers section.
Look for the button with an icon of a comment with an exclamation mark and inspect it.
On the devtools look for the aria-label of the parent div.

- [SelectVideoModal](https://github.com/openedx/frontend-app-authoring/pull/1901/files#diff-230d61b1879dd2baecfd469a5e9ea891e3765ee1acd38e668551c8f595458836)
This one is not testable since the component is not being used anywhere.

- [LicenseWidget/LicenseDetails](https://github.com/openedx/frontend-app-authoring/pull/1901/files#diff-f80c3726a36d71b074eee16e0243e55dffe96b3f05f7d8c677b777a2c4b638a0)
Select one of the sections of a module and click on the arrow to expand the content. 
Click on + New unit.
On the add new component section select Video option.
Scroll down to the License section and click + Add a license for this video.
On License Type select Creative Commons.
Scroll down to the License Details and inspect the checkboxes for the list options.
With devtools inspect the aria-label for all the  checkboxes.

- [FileInput](https://github.com/openedx/frontend-app-authoring/pull/1901/files#diff-f4a12d679d427b48ce919ef44c35dd06dfb15c528d93a5090d78ae3451998f22)
TBD.

- [SortAndFilterModal](https://github.com/openedx/frontend-app-authoring/pull/1901/files#diff-99e2905eb2350e754b09525f87f8e1d1b862d08eff9dc8eb433c6b1488acdb1e)
Go to the assets page for a course: http://apps.local.openedx.io:2001/authoring/course/{courseId}/assets
Click on the sort and filter button
On the modal, inspect the options on the Sort by section
Inspect the aria-label for each element

- [OrderTranscriptForm](https://github.com/openedx/frontend-app-authoring/pull/1901/files#diff-a3bf3a0f827af1ce6c6d23f7d500e50bf50b7f916dc5a9334969f126471202e2)
TBD

- [AdvancedTab](https://github.com/openedx/frontend-app-authoring/pull/1901/files#diff-52483e8fd32af20fe7e419cc7d8c62f6e896a2aa7e2afcf311e159f2888dfd81)
Go to the course content and select one of the sections of a module and click on the arrow to expand the content. 
Click on the three dots button and select configure.
Click on the Advance tab and select the timed radio.
Remove the content of the input labeled as Time allotted and the placeholder must appear.

- [ImportTagsWizard](https://github.com/openedx/frontend-app-authoring/pull/1901/files#diff-f88ee68cfef86847c9a7471bfd24c9764bcdcf086faa10cf9002817bbde5e3da)
Go to the taxonomies tab or  http://apps.local.openedx.io:2001/authoring/taxonomies
Click on the + Import button
Inspect the modal using the dev tools
On the DevTools Components tab search for StepperStep component, there must be 4 elements
Click on each of then and look for the title on the props section