### PR TITLE
refactor: conditionally render `Replace video` button & fix redirection URLs

### DIFF
--- a/src/course-unit/CourseUnit.test.tsx
+++ b/src/course-unit/CourseUnit.test.tsx
@@ -78,6 +78,8 @@ import legacySidebarMessages from './legacy-sidebar/messages';
 import unitInfoMessages from './unit-sidebar/unit-info/messages';
 import messages from './messages';
 
+import { getApiWaffleFlagsUrl } from '../data/api';
+
 let axiosMock;
 let store;
 let mockShowToast;
@@ -170,6 +172,11 @@ describe('<CourseUnit />', () => {
     axiosMock
       .onGet(getContentTaxonomyTagsCountApiUrl(blockId))
       .reply(200, 17);
+    axiosMock.onGet(getApiWaffleFlagsUrl()).reply(200, {
+      waffle_flags: {
+        'studio.enable_new_video_uploads_page': true,
+      },
+    });
   });
 
   it('render CourseUnit component correctly', async () => {

--- a/src/editors/containers/VideoEditor/components/VideoEditorModal.test.tsx
+++ b/src/editors/containers/VideoEditor/components/VideoEditorModal.test.tsx
@@ -1,88 +1,60 @@
-import { render, waitFor, act } from '@testing-library/react';
-import { configureStore } from '@reduxjs/toolkit';
-import { MemoryRouter } from 'react-router-dom';
-import { AppProvider } from '@edx/frontend-platform/react';
-import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { initializeMockApp } from '@edx/frontend-platform';
+import { PartialEditorState, thunkActions } from '@src/editors/data/redux';
+import { initializeMocks, waitFor, act } from '@src/testUtils';
+import { editorRender, getEditorStore } from '@src/editors/editorTestRender';
 import VideoEditorModal from './VideoEditorModal';
-import { thunkActions } from '../../../data/redux';
 
-jest.mock('../../../data/redux', () => ({
-  ...jest.requireActual('../../../data/redux'),
-  thunkActions: {
-    video: {
-      loadVideoData: jest
-        .fn()
-        .mockImplementation(() => ({ type: 'MOCK_ACTION' })),
+thunkActions.video.loadVideoData = jest.fn().mockImplementation(() => ({ type: 'MOCK_ACTION' }));
+
+const initialState: PartialEditorState = {
+  app: {
+    videos: {},
+    learningContextId: 'course-v1:test+test+test',
+    blockId: 'some-block-id',
+    courseDetails: {},
+  },
+  requests: {
+    uploadAsset: { status: 'inactive', response: {} as any },
+    uploadTranscript: { status: 'inactive', response: {} as any },
+    deleteTranscript: { status: 'inactive', response: {} as any },
+    fetchVideos: { status: 'inactive', response: {} as any },
+  },
+  video: {
+    videoSource: '',
+    videoId: '',
+    fallbackVideos: ['', ''],
+    allowVideoDownloads: false,
+    allowVideoSharing: { level: 'block', value: false },
+    thumbnail: undefined,
+    transcripts: [],
+    selectedVideoTranscriptUrls: {},
+    allowTranscriptDownloads: false,
+    duration: {
+      startTime: '00:00:00',
+      stopTime: '00:00:00',
+      total: '00:00:00',
     },
   },
-}));
+};
 
 describe('VideoUploader', () => {
-  let store;
-
   beforeEach(async () => {
-    store = configureStore({
-      reducer: (state, action) => (action && action.newState ? action.newState : state),
-      preloadedState: {
-        app: {
-          videos: [],
-          learningContextId: 'course-v1:test+test+test',
-          blockId: 'some-block-id',
-          courseDetails: {},
-        },
-        requests: {
-          uploadAsset: { status: 'inactive' },
-          uploadTranscript: { status: 'inactive' },
-          deleteTranscript: { status: 'inactive' },
-          fetchVideos: { status: 'inactive' },
-        },
-        video: {
-          videoSource: '',
-          videoId: '',
-          fallbackVideos: ['', ''],
-          allowVideoDownloads: false,
-          allowVideoSharing: { level: 'block', value: false },
-          thumbnail: null,
-          transcripts: [],
-          transcriptHandlerUrl: '',
-          selectedVideoTranscriptUrls: {},
-          allowTranscriptDownloads: false,
-          duration: {
-            startTime: '00:00:00',
-            stopTime: '00:00:00',
-            total: '00:00:00',
-          },
-        },
-      },
-    });
-    initializeMockApp({
-      authenticatedUser: {
-        userId: 3,
-        username: 'test-user',
-        administrator: true,
-        roles: [],
-      },
-    });
+    initializeMocks();
   });
 
-  const renderComponent = async () =>
-    render(
-      <AppProvider store={store} wrapWithRouter={false}>
-        <IntlProvider locale="en">
-          <MemoryRouter
-            initialEntries={[
-              '/some/path?selectedVideoId=id_1&selectedVideoUrl=https://video.com',
-            ]}
-          >
-            <VideoEditorModal isLibrary={false} />
-          </MemoryRouter>
-        </IntlProvider>
-      </AppProvider>,
-    );
+  const renderComponent = () => (
+    editorRender(
+      <VideoEditorModal isLibrary={false} />,
+      {
+        routerProps: {
+          initialEntries: ['/some/path?selectedVideoId=id_1&selectedVideoUrl=https://video.com'],
+        },
+        initialState,
+      },
+    )
+  );
 
   it('should render the component and call loadVideoData with correct parameters', async () => {
-    await renderComponent();
+    renderComponent();
     await waitFor(() => {
       expect(thunkActions.video.loadVideoData).toHaveBeenCalledWith(
         'id_1',
@@ -92,10 +64,11 @@ describe('VideoUploader', () => {
   });
 
   it('should call loadVideoData again when isLoaded state changes', async () => {
-    await renderComponent();
+    renderComponent();
     await waitFor(() => {
-      expect(thunkActions.video.loadVideoData).toHaveBeenCalledTimes(2);
+      expect(thunkActions.video.loadVideoData).toHaveBeenCalledTimes(1);
     });
+    const store = getEditorStore();
 
     act(() => {
       store.dispatch({
@@ -111,7 +84,7 @@ describe('VideoUploader', () => {
     });
 
     await waitFor(() => {
-      expect(thunkActions.video.loadVideoData).toHaveBeenCalledTimes(3);
+      expect(thunkActions.video.loadVideoData).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/editors/containers/VideoEditor/components/VideoEditorModal.tsx
+++ b/src/editors/containers/VideoEditor/components/VideoEditorModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
+import { useWaffleFlags } from '@src/data/apiHooks';
 import * as appHooks from '../../../hooks';
 import { thunkActions, selectors } from '../../../data/redux';
 import VideoSettingsModal from './VideoSettingsModal';
@@ -41,6 +42,7 @@ const VideoEditorModal: React.FC<Props> = ({
   const isLoaded = useSelector(
     (state) => selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchVideos }),
   );
+  const { useNewVideoUploadsPage } = useWaffleFlags();
 
   useEffect(() => {
     hooks.initialize(dispatch, selectedVideoId, selectedVideoUrl);
@@ -52,6 +54,7 @@ const VideoEditorModal: React.FC<Props> = ({
         onReturn: onSettingsReturn,
         isLibrary,
         onClose,
+        useNewVideoUploadsPage,
       }}
     />
   );

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.test.tsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.test.tsx
@@ -1,0 +1,62 @@
+import {
+  screen,
+  fireEvent,
+  initializeMocks,
+} from '@src/testUtils';
+import { editorRender } from '@src/editors/editorTestRender';
+import VideoSettingsModal from '.';
+
+const defaultProps = {
+  onReturn: jest.fn(),
+  isLibrary: false,
+  onClose: jest.fn(),
+  useNewVideoUploadsPage: true,
+};
+
+const renderComponent = (overrideProps = {}) => {
+  const customInitialState = {
+    app: {
+      videos: {},
+      learningContextId: 'course-v1:test+test+test',
+      blockId: 'some-block-id',
+      courseDetails: {},
+    },
+  };
+
+  initializeMocks();
+
+  return {
+    ...editorRender(
+      <VideoSettingsModal {...defaultProps} {...overrideProps} />,
+      { initialState: customInitialState },
+    ),
+  };
+};
+
+describe('<VideoSettingsModal />', () => {
+  beforeEach(async () => {
+    window.scrollTo = jest.fn();
+  });
+
+  it('renders back button when useNewVideoUploadsPage is true and isLibrary is false', () => {
+    renderComponent();
+    expect(screen.getByRole('button', { name: /replace video/i })).toBeInTheDocument();
+  });
+
+  it('does not render back button when isLibrary is true', () => {
+    renderComponent({ isLibrary: true });
+    expect(screen.queryByRole('button', { name: /replace video/i })).not.toBeInTheDocument();
+  });
+
+  it('calls onReturn when back button is clicked', () => {
+    renderComponent();
+    fireEvent.click(screen.getByRole('button', { name: /replace video/i }));
+    expect(defaultProps.onReturn).toHaveBeenCalled();
+  });
+
+  it('calls onClose if onReturn is not provided', () => {
+    renderComponent({ onReturn: null });
+    fireEvent.click(screen.getByRole('button', { name: /replace video/i }));
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+});

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.tsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.tsx
@@ -21,20 +21,22 @@ interface Props {
   onReturn: () => void;
   isLibrary: boolean;
   onClose?: (() => void) | null;
+  useNewVideoUploadsPage?: boolean;
 }
 
 const VideoSettingsModal: React.FC<Props> = ({
   onReturn,
   isLibrary,
   onClose,
+  useNewVideoUploadsPage,
 }) => (
   <>
-    {!isLibrary && (
+    {!isLibrary && useNewVideoUploadsPage && (
       <Button
         variant="link"
         className="text-primary-500"
         size="sm"
-        onClick={onClose || onReturn}
+        onClick={onReturn || onClose}
         style={{
           textDecoration: 'none',
           marginLeft: '3px',

--- a/src/editors/containers/VideoGallery/hooks.test.jsx
+++ b/src/editors/containers/VideoGallery/hooks.test.jsx
@@ -1,0 +1,170 @@
+import { renderHook, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import * as hooks from './hooks';
+import * as appHooks from '../../hooks';
+import { filterKeys } from './utils';
+
+jest.mock('react-redux', () => {
+  const actual = jest.requireActual('react-redux');
+  return {
+    ...actual,
+    useSelector: jest.fn((selectorFn) =>
+      selectorFn({
+        app: {
+          learningContextId: 'course-v1:id',
+          blockId: 'block-v1:id',
+        },
+      })
+    ),
+  };
+});
+
+jest.mock('../../hooks', () => ({
+  navigateTo: jest.fn(),
+}));
+
+const createStore = (customState = {}) =>
+  configureStore({
+    reducer: () => customState,
+  });
+
+describe('hooks module', () => {
+  describe('useSearchAndSortProps', () => {
+    it('should update search string', () => {
+      const { result } = renderHook(() => hooks.useSearchAndSortProps());
+      act(() => {
+        result.current.onSearchChange({ target: { value: 'test' } });
+      });
+      expect(result.current.searchString).toBe('test');
+    });
+
+    it('should toggle hideSelectedVideos', () => {
+      const { result } = renderHook(() => hooks.useSearchAndSortProps());
+      expect(result.current.hideSelectedVideos).toBe(false);
+      act(() => {
+        result.current.onSwitchClick();
+      });
+      expect(result.current.hideSelectedVideos).toBe(true);
+    });
+  });
+
+  describe('filterListBySearch', () => {
+    it('filters videoList based on searchString', () => {
+      const filtered = hooks.filterListBySearch({
+        searchString: 'video',
+        videoList: [{ displayName: 'video 1' }, { displayName: 'other' }],
+      });
+      expect(filtered).toHaveLength(1);
+    });
+  });
+
+  describe('filterListByStatus', () => {
+    it('returns full list for anyStatus', () => {
+      const list = [{ status: 'uploading' }];
+      const result = hooks.filterListByStatus({ statusFilter: filterKeys.anyStatus, videoList: list });
+      expect(result).toEqual(list);
+    });
+
+    it('filters list by matching status', () => {
+      const list = [
+        { status: filterKeys.uploading },
+        { status: filterKeys.failed },
+      ];
+      const result = hooks.filterListByStatus({ statusFilter: 'uploading', videoList: list });
+      expect(result).toHaveLength(1);
+      expect(result[0].status).toBe(filterKeys.uploading);
+    });
+  });
+
+  describe('getstatusBadgeVariant', () => {
+    it('returns correct variant for status', () => {
+      expect(hooks.getstatusBadgeVariant({ status: filterKeys.failed })).toBe('danger');
+      expect(hooks.getstatusBadgeVariant({ status: filterKeys.uploading })).toBe('light');
+      expect(hooks.getstatusBadgeVariant({ status: 'unknown' })).toBe(null);
+    });
+  });
+
+  describe('buildVideos', () => {
+    it('converts rawVideos into display format', () => {
+      jest.spyOn(hooks, 'getstatusBadgeVariant').mockReturnValue('light');
+      jest.spyOn(hooks, 'getStatusMessage').mockReturnValue('Uploading');
+
+      const rawVideos = {
+        one: {
+          edx_video_id: 'vid1',
+          client_video_id: 'Video 1',
+          course_video_image_url: 'img1.jpg',
+          created: '2024-01-01T00:00:00Z',
+          status_nontranslated: 'uploading',
+          duration: '10:00',
+          transcripts: [],
+        },
+      };
+      const result = hooks.buildVideos({ rawVideos });
+      expect(result[0].id).toBe('vid1');
+      expect(result[0].statusBadgeVariant).toBe('light');
+      expect(result[0].statusMessage).toBe('Uploading');
+    });
+  });
+
+  describe('useVideoListProps - selectBtnProps', () => {
+    const videos = [{ displayName: 'Test Video', status: 'ready' }];
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    const wrapper = ({ children }) => <Provider store={createStore()}>{children}</Provider>;
+
+    it('navigates to video editor when a video is selected', async () => {
+      const { result } = renderHook(
+        () =>
+          hooks.useVideoListProps({
+            searchSortProps: {
+              searchString: '',
+              sortBy: 'dateNewest',
+              filterBy: filterKeys.anyStatus,
+              hideSelectedVideos: false,
+            },
+            videos,
+          }),
+        { wrapper },
+      );
+
+      act(() => {
+        result.current.galleryProps.onHighlightChange({ target: { value: 'video123' } });
+      });
+
+      act(() => {
+        result.current.selectBtnProps.onClick();
+      });
+
+      expect(appHooks.navigateTo).toHaveBeenCalledWith(
+        '/course/course-v1:id/editor/video/block-v1:id?selectedVideoId=video123',
+      );
+    });
+
+    it('sets showSelectVideoError to true if no video is selected', () => {
+      const { result } = renderHook(
+        () =>
+          hooks.useVideoListProps({
+            searchSortProps: {
+              searchString: '',
+              sortBy: 'dateNewest',
+              filterBy: filterKeys.anyStatus,
+              hideSelectedVideos: false,
+            },
+            videos,
+          }),
+        { wrapper },
+      );
+
+      act(() => {
+        result.current.selectBtnProps.onClick();
+      });
+
+      expect(result.current.galleryError.show).toBe(true);
+    });
+  });
+});

--- a/src/editors/containers/VideoUploadEditor/hooks.test.jsx
+++ b/src/editors/containers/VideoUploadEditor/hooks.test.jsx
@@ -1,0 +1,108 @@
+import * as hooks from './hooks';
+import * as appHooks from '../../hooks';
+import { thunkActions } from '../../data/redux';
+
+jest.mock('../../data/store', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+const mockState = {
+  app: {
+    learningContextId: 'course-v1:id',
+    blockId: 'block-v1:id',
+  },
+};
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(selector => selector(mockState)),
+}));
+
+jest.mock('../../hooks', () => ({
+  navigateTo: jest.fn(),
+}));
+
+jest.mock('../../data/redux', () => ({
+  thunkActions: {
+    video: {
+      uploadVideo: jest.fn(),
+    },
+  },
+  selectors: {
+    app: {
+      learningContextId: jest.fn(state => state.app.learningContextId),
+      blockId: jest.fn(state => state.app.blockId),
+    },
+  },
+}));
+
+describe('hooks module', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('postUploadRedirect', () => {
+    it('returns a function that navigates to the correct URL', () => {
+      const storeState = {
+        app: {
+          learningContextId: 'course-v1:test',
+          blockId: 'block-123',
+        },
+      };
+      const redirectFn = hooks.postUploadRedirect(storeState);
+      redirectFn('test-video-url');
+
+      expect(appHooks.navigateTo).toHaveBeenCalledWith(
+        '/course/course-v1:test/editor/video/block-123?selectedVideoUrl=test-video-url',
+      );
+    });
+
+    it('uses custom uploadType in URL if provided', () => {
+      const storeState = {
+        app: {
+          learningContextId: 'course-v1:test',
+          blockId: 'block-123',
+        },
+      };
+      const redirectFn = hooks.postUploadRedirect(storeState, 'customType');
+      redirectFn('test-video-url');
+
+      expect(appHooks.navigateTo).toHaveBeenCalledWith(
+        '/course/course-v1:test/editor/video/block-123?customType=test-video-url',
+      );
+    });
+  });
+
+  describe('useUploadVideo', () => {
+    it('dispatches uploadVideo thunk with correct parameters', async () => {
+      const dispatch = jest.fn();
+      const supportedFiles = ['file1.mp4'];
+      const setLoadSpinner = jest.fn();
+      const postUploadRedirectFunction = jest.fn();
+
+      await hooks.useUploadVideo({
+        dispatch,
+        supportedFiles,
+        setLoadSpinner,
+        postUploadRedirectFunction,
+      });
+
+      expect(thunkActions.video.uploadVideo).toHaveBeenCalledWith({
+        supportedFiles,
+        setLoadSpinner,
+        postUploadRedirectFunction,
+      });
+      expect(dispatch).toHaveBeenCalled();
+    });
+  });
+
+  describe('useHistoryGoBack', () => {
+    it('returns a function that calls window.history.back', () => {
+      window.history.back = jest.fn();
+      const goBack = hooks.useHistoryGoBack();
+      goBack();
+      expect(window.history.back).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/editors/data/redux/index.ts
+++ b/src/editors/data/redux/index.ts
@@ -26,6 +26,11 @@ const rootReducer = (state: any, action: any) => {
     return editorReducer(undefined, action);
   }
 
+  // For test purposes only:
+  if (action.type === 'UPDATE_STATE') {
+    return action.newState;
+  }
+
   return editorReducer(state, action);
 };
 

--- a/src/editors/data/store.test.js
+++ b/src/editors/data/store.test.js
@@ -20,7 +20,7 @@ jest.mock('redux-logger', () => ({
 jest.mock('redux-thunk', () => 'thunkMiddleware');
 jest.mock('redux', () => ({
   applyMiddleware: (...middleware) => ({ applied: middleware }),
-  createStore: (reducer, middleware) => ({ reducer, middleware }),
+  createStore: (reducer, preloadedState, middleware) => ({ reducer, preloadedState, middleware }),
 }));
 jest.mock('@redux-devtools/extension', () => ({
   composeWithDevToolsLogOnlyInProduction: (middleware) => ({ withDevTools: middleware }),

--- a/src/editors/data/store.ts
+++ b/src/editors/data/store.ts
@@ -3,15 +3,16 @@ import thunkMiddleware from 'redux-thunk';
 import { composeWithDevToolsLogOnlyInProduction } from '@redux-devtools/extension';
 import { createLogger } from 'redux-logger';
 
-import reducer, { actions, selectors, type EditorState } from './redux';
+import reducer, { actions, PartialEditorState, selectors, type EditorState } from './redux';
 
-export const createStore = () => {
+export const createStore = (preloadedState?: PartialEditorState) => {
   const loggerMiddleware = createLogger();
 
   const middleware = [thunkMiddleware, loggerMiddleware];
 
   const store: redux.Store<EditorState> = redux.createStore<EditorState, any, any, any>(
     reducer as any,
+    preloadedState as EditorState,
     composeWithDevToolsLogOnlyInProduction(redux.applyMiddleware(...middleware)),
   );
 

--- a/src/editors/editorTestRender.tsx
+++ b/src/editors/editorTestRender.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render as baseRender, WrapperOptions } from '../testUtils';
+import { Store } from 'redux';
+import { render as baseRender, RouteOptions, WrapperOptions } from '../testUtils';
 import { EditorContextProvider } from './EditorContext';
-import { initializeStore, type PartialEditorState } from './data/redux'; // adjust path if needed
+import { type PartialEditorState } from './data/redux';
+import { createStore } from './data/store';
+import { type EditorState } from './data/redux';
+
+// Tests use this store, while non-test code uses the store in `@src/editors/data/store.ts`, but they have the same
+// type.
+let editorStore: Store<EditorState>;
 
 /**
  * Custom render function for testing React components with the editor context and Redux store.
@@ -16,20 +23,25 @@ export const editorRender = (
     initialState = {},
     learningContextId = 'course-v1:Org+COURSE+RUN',
     ...options
-  }: Omit<WrapperOptions, 'extraWrapper'> & { initialState?: PartialEditorState; learningContextId?: string; } = {},
+  }:
+    & Omit<WrapperOptions, 'extraWrapper'>
+    & RouteOptions
+    & { initialState?: PartialEditorState; learningContextId?: string; } = {},
 ) => {
-  // We might need a way for the test cases to access this store directly. In that case we could allow either an
-  // initialState parameter OR an editorStore parameter.
-  const store = initializeStore(initialState);
+  editorStore = createStore(initialState);
 
   return baseRender(ui, {
     ...options,
     extraWrapper: ({ children }) => (
       <EditorContextProvider learningContextId={learningContextId}>
-        <Provider store={store}>
+        <Provider store={editorStore}>
           {children}
         </Provider>
       </EditorContextProvider>
     ),
   });
 };
+
+export function getEditorStore() {
+  return editorStore;
+}


### PR DESCRIPTION
## Description
Fix the error that makes the page go blank after clicking the `Replace video` button.

With some frequent changes, the page does not go blank, but the `Replace video` button closes the modal without redirecting to the video gallery view. This PR adds the prefix `/authoring/` to some URLs, which caused the page to go blank after clicking `Replace video`. On the other hand, taking into account the comment https://github.com/openedx/frontend-app-authoring/issues/1540#issuecomment-2730983169 , it fetches the waffle flags so it can check and render the button `Replace video` conditionally.

## Supporting information
https://github.com/openedx/wg-build-test-release/issues/418

## Testing instructions
1. Add a new video component.
2. Edit the component
3. Click the 'replace video' button.


## Evidence
### Before
The button `Replace video` appears, but it does nothing; it only closes the modal
[Screencast from 07-05-25 17:08:13.webm](https://github.com/user-attachments/assets/2b797c26-7e80-4344-b64d-8837a529294b)


### After
The button `Replace Video` can be hidden or shown by changing the WaffleFlag `contentstore.new_studio_mfe.use_new_video_uploads_page`; now, when the flag is on, the user is redirected to the video gallery view
[Screencast from 07-05-25 17:09:22.webm](https://github.com/user-attachments/assets/47453548-ef47-4262-8db6-c134981df12d)


