### PR TITLE
fix: search modal refresh on typing

### DIFF
--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -97,12 +97,6 @@ jest.mock('./data/api', () => ({
   getTagsCount: () => jest.fn().mockResolvedValue({}),
 }));
 
-jest.mock('../studio-home/hooks', () => ({
-  useStudioHome: () => ({
-    librariesV2Enabled: true,
-  }),
-}));
-
 // Mock ComponentPicker to call onComponentSelected on click
 jest.mock('../library-authoring/component-picker', () => ({
   ComponentPicker: (props) => {
@@ -160,7 +154,9 @@ describe('<CourseOutline />', () => {
       pathname: mockPathname,
     });
 
-    store = initializeStore();
+    store = initializeStore({
+      studioHome: { studioHomeData: { librariesV2Enabled: true } },
+    });
     axiosMock = new MockAdapter(getAuthenticatedHttpClient());
     axiosMock
       .onGet(getCourseOutlineIndexApiUrl(courseId))
@@ -177,6 +173,10 @@ describe('<CourseOutline />', () => {
       }))
       .reply(200, courseLaunchMock);
     await executeThunk(fetchCourseOutlineIndexQuery(courseId), store.dispatch);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('render CourseOutline component correctly', async () => {

--- a/src/course-outline/subsection-card/SubsectionCard.jsx
+++ b/src/course-outline/subsection-card/SubsectionCard.jsx
@@ -3,7 +3,7 @@ import React, {
   useContext, useEffect, useState, useRef, useCallback,
 } from 'react';
 import PropTypes from 'prop-types';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Button, StandardModal, useToggle } from '@openedx/paragon';
@@ -25,8 +25,8 @@ import messages from './messages';
 import { ComponentPicker } from '../../library-authoring';
 import { COMPONENT_TYPES } from '../../generic/block-type-utils/constants';
 import { ContainerType } from '../../generic/key-utils';
-import { useStudioHome } from '../../studio-home/hooks';
 import { ContentType } from '../../library-authoring/routes';
+import { getStudioHomeData } from '../../studio-home/data/selectors';
 
 const SubsectionCard = ({
   section,
@@ -57,7 +57,7 @@ const SubsectionCard = ({
   const [isFormOpen, openForm, closeForm] = useToggle(false);
   const namePrefix = 'subsection';
   const { sharedClipboardData, showPasteUnit } = useClipboard();
-  const { librariesV2Enabled } = useStudioHome();
+  const { librariesV2Enabled } = useSelector(getStudioHomeData);
   const [
     isAddLibraryUnitModalOpen,
     openAddLibraryUnitModal,

--- a/src/course-outline/subsection-card/SubsectionCard.test.jsx
+++ b/src/course-outline/subsection-card/SubsectionCard.test.jsx
@@ -24,8 +24,9 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-jest.mock('../../studio-home/hooks', () => ({
-  useStudioHome: () => ({
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: () => ({
     librariesV2Enabled: true,
   }),
 }));


### PR DESCRIPTION
## Description

The whole page was being refreshed while searching content from course outline page due to fetching of waffle flag on changes in location search field.

## Supporting information

Related to https://github.com/openedx/frontend-app-authoring/issues/1902
`Private-ref`: https://tasks.opencraft.com/browse/FAL-4161

## Testing instructions

Verify that the bug described in https://github.com/openedx/frontend-app-authoring/issues/1902 is fixed and the functionality of hiding `Use unit from library` button on disabling new libraries still works.


## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
