### PR TITLE
feat: add never show assessment msg in subsection

### DIFF
--- a/src/course-outline/xblock-status/NeverShowAssessmentResultMessage.jsx
+++ b/src/course-outline/xblock-status/NeverShowAssessmentResultMessage.jsx
@@ -1,0 +1,20 @@
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Icon } from '@openedx/paragon';
+import { HelpOutline } from '@openedx/paragon/icons';
+import messages from '../../generic/configure-modal/messages';
+
+const NeverShowAssessmentResultMessage = () => {
+  const intl = useIntl();
+  return (
+    <div className="d-flex align-items-center" data-testid="never-show-assessment-result-message">
+      <Icon className="mr-1" size="sm" src={HelpOutline} />
+      <span className="status-hide-after-due-value">
+        {intl.formatMessage(messages.neverShowAssessmentResults)}
+      </span>
+    </div>
+  );
+};
+
+NeverShowAssessmentResultMessage.propTypes = {};
+
+export default NeverShowAssessmentResultMessage;

--- a/src/course-outline/xblock-status/XBlockStatus.jsx
+++ b/src/course-outline/xblock-status/XBlockStatus.jsx
@@ -7,6 +7,8 @@ import GradingPolicyAlert from './GradingPolicyAlert';
 import GradingTypeAndDueDate from './GradingTypeAndDueDate';
 import StatusMessages from './StatusMessages';
 import HideAfterDueMessage from './HideAfterDueMessage';
+import NeverShowAssessmentResultMessage from './NeverShowAssessmentResultMessage';
+import { ShowAnswerTypesKeys } from '../../editors/data/constants/problem';
 
 const XBlockStatus = ({
   isSelfPaced,
@@ -33,6 +35,7 @@ const XBlockStatus = ({
     graded,
     courseGraders,
     hideAfterDue,
+    showCorrectness,
   } = blockData;
 
   const isInstructorPaced = !isSelfPaced;
@@ -40,6 +43,9 @@ const XBlockStatus = ({
 
   return (
     <div className="text-secondary-400 x-small mb-1">
+      {category === COURSE_BLOCK_NAMES.sequential.id && showCorrectness === ShowAnswerTypesKeys.NEVER && (
+        <NeverShowAssessmentResultMessage />
+      )}
       {!isVertical && (
         <ReleaseStatus
           isInstructorPaced={isInstructorPaced}
@@ -116,6 +122,7 @@ XBlockStatus.propTypes = {
     graded: PropTypes.bool,
     courseGraders: PropTypes.arrayOf(PropTypes.string.isRequired),
     hideAfterDue: PropTypes.bool,
+    showCorrectness: PropTypes.string,
   }).isRequired,
 };
 

--- a/src/course-outline/xblock-status/XBlockStatus.test.jsx
+++ b/src/course-outline/xblock-status/XBlockStatus.test.jsx
@@ -7,6 +7,7 @@ import { initializeMockApp } from '@edx/frontend-platform';
 import initializeStore from '../../store';
 import XBlockStatus from './XBlockStatus';
 import messages from './messages';
+import genericMessages from '../../generic/configure-modal/messages';
 
 let store;
 
@@ -225,6 +226,7 @@ const subsection = {
   graded: true,
   courseGraders: ['Homework'],
   hideAfterDue: true,
+  showCorrectness: 'never',
 };
 
 describe('<XBlockStatus /> for Instructor paced Subsection', () => {
@@ -274,6 +276,13 @@ describe('<XBlockStatus /> for Instructor paced Subsection', () => {
     const hideAfterDueMessage = queryByTestId('hide-after-due-message');
     expect(hideAfterDueMessage).toBeInTheDocument();
     expect(hideAfterDueMessage).toHaveTextContent(messages.hiddenAfterDueDate.defaultMessage);
+
+    // check never show assessment result message
+    const neverShowAssessmentResultMessage = queryByTestId('never-show-assessment-result-message');
+    expect(neverShowAssessmentResultMessage).toBeInTheDocument();
+    expect(neverShowAssessmentResultMessage).toHaveTextContent(
+      genericMessages.neverShowAssessmentResults.defaultMessage,
+    );
 
     // check status messages
     const statusDiv = queryByTestId('status-messages-div');
@@ -402,6 +411,13 @@ describe('<XBlockStatus /> for self paced Subsection', () => {
     expect(hideAfterDueMessage).toBeInTheDocument();
     expect(hideAfterDueMessage).toHaveTextContent(messages.hiddenAfterEndDate.defaultMessage);
 
+    // check never show assessment result message
+    const neverShowAssessmentResultMessage = queryByTestId('never-show-assessment-result-message');
+    expect(neverShowAssessmentResultMessage).toBeInTheDocument();
+    expect(neverShowAssessmentResultMessage).toHaveTextContent(
+      genericMessages.neverShowAssessmentResults.defaultMessage,
+    );
+
     // check status messages
     const statusDiv = queryByTestId('status-messages-div');
     expect(statusDiv).toBeInTheDocument();
@@ -467,6 +483,10 @@ describe('<XBlockStatus /> for unit', () => {
     // check hide after due date message
     // hide after due date message should not be visible as the flag is set to false
     expect(queryByTestId('hide-after-due-message')).not.toBeInTheDocument();
+
+    // check never show assessment result message
+    // never show assessment result message should not be visible as the flag is set to false
+    expect(queryByTestId('never-show-assessment-result-message')).not.toBeInTheDocument();
 
     // check status messages for partition info
     const statusDiv = queryByTestId('status-messages-div');


### PR DESCRIPTION
**Ticket:** [TNL-11769](https://2u-internal.atlassian.net/browse/TNL-11769)
- add never show assessment result message in subsection card

**Before:** 
![before](https://github.com/user-attachments/assets/0ec6939a-bb28-436d-bb79-ceff895bc208)

**After:**
![after](https://github.com/user-attachments/assets/bbc8b406-1c1f-4679-a1c2-4d8d43e5ad29)
