### PR TITLE
feat: added process to sync discussions topic on page load

### DIFF
--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -27,7 +27,7 @@ import { RequestStatus } from '../data/constants';
 import {
   fetchCourseBestPracticesQuery,
   fetchCourseLaunchQuery,
-  fetchCourseOutlineIndexQuery,
+  fetchCourseOutlineIndexQuery, syncDiscussionsTopics,
   updateCourseSectionHighlightsQuery,
 } from './data/thunk';
 import initializeStore from '../store';
@@ -132,6 +132,10 @@ jest.mock('@dnd-kit/core', () => ({
   closestCorners: jest.fn(),
 }));
 
+jest.mock('./data/api', () => ({
+  ...jest.requireActual('./data/api'),
+  createDiscussionsTopics: jest.fn().mockResolvedValue(undefined),
+}));
 // eslint-disable-next-line no-promise-executor-return
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -177,6 +181,7 @@ describe('<CourseOutline />', () => {
       }))
       .reply(200, courseLaunchMock);
     await executeThunk(fetchCourseOutlineIndexQuery(courseId), store.dispatch);
+    await executeThunk(syncDiscussionsTopics(courseId), store.dispatch);
   });
 
   it('render CourseOutline component correctly', async () => {

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -47,7 +47,7 @@ import CourseOutline from './CourseOutline';
 import configureModalMessages from '../generic/configure-modal/messages';
 import pasteButtonMessages from '../generic/clipboard/paste-component/messages';
 import messages from './messages';
-import { getClipboardUrl } from '../generic/data/api';
+import {getApiBaseUrl, getClipboardUrl} from '../generic/data/api';
 import headerMessages from './header-navigations/messages';
 import cardHeaderMessages from './card-header/messages';
 import enableHighlightsModalMessages from './enable-highlights-modal/messages';
@@ -132,10 +132,6 @@ jest.mock('@dnd-kit/core', () => ({
   closestCorners: jest.fn(),
 }));
 
-jest.mock('./data/api', () => ({
-  ...jest.requireActual('./data/api'),
-  createDiscussionsTopics: jest.fn().mockResolvedValue(undefined),
-}));
 // eslint-disable-next-line no-promise-executor-return
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -180,6 +176,10 @@ describe('<CourseOutline />', () => {
         courseId, gradedOnly: true, validateOras: true, all: true,
       }))
       .reply(200, courseLaunchMock);
+    // add mock for getApiBaseUrl()}/api/discussions/v0/course/${courseId}/sync_discussion_topics
+    axiosMock
+      .onPost(`${getApiBaseUrl()}/api/discussions/v0/course/${courseId}/sync_discussion_topics`)
+      .reply(200, {});
     await executeThunk(fetchCourseOutlineIndexQuery(courseId), store.dispatch);
     await executeThunk(syncDiscussionsTopics(courseId), store.dispatch);
   });
@@ -243,8 +243,8 @@ describe('<CourseOutline />', () => {
       async () => fireEvent.change(optionDropdown, { target: { value: VIDEO_SHARING_OPTIONS.allOff } }),
     );
 
-    expect(axiosMock.history.post.length).toBe(1);
-    expect(axiosMock.history.post[0].data).toBe(JSON.stringify({
+    expect(axiosMock.history.post.length).çÏ(2);
+    expect(axiosMock.history.post[1].data).toBe(JSON.stringify({
       metadata: {
         video_sharing_options: VIDEO_SHARING_OPTIONS.allOff,
       },
@@ -266,8 +266,8 @@ describe('<CourseOutline />', () => {
       async () => fireEvent.change(optionDropdown, { target: { value: VIDEO_SHARING_OPTIONS.allOff } }),
     );
 
-    expect(axiosMock.history.post.length).toBe(1);
-    expect(axiosMock.history.post[0].data).toBe(JSON.stringify({
+    expect(axiosMock.history.post.length).toBe(2);
+    expect(axiosMock.history.post[1].data).toBe(JSON.stringify({
       metadata: {
         video_sharing_options: VIDEO_SHARING_OPTIONS.allOff,
       },
@@ -412,10 +412,10 @@ describe('<CourseOutline />', () => {
       });
     const newUnitButton = await within(subsectionElement).findByTestId('new-unit-button');
     await act(async () => fireEvent.click(newUnitButton));
-    expect(axiosMock.history.post.length).toBe(1);
+    expect(axiosMock.history.post.length).toBe(2);
     const [section] = courseOutlineIndexMock.courseStructure.childInfo.children;
     const [subsection] = section.childInfo.children;
-    expect(axiosMock.history.post[0].data).toBe(JSON.stringify({
+    expect(axiosMock.history.post[1].data).toBe(JSON.stringify({
       parent_locator: subsection.id,
       category: COURSE_BLOCK_NAMES.vertical.id,
       display_name: COURSE_BLOCK_NAMES.vertical.name,
@@ -446,11 +446,11 @@ describe('<CourseOutline />', () => {
     const dummyBtn = await screen.findByRole('button', { name: 'Dummy button' });
     fireEvent.click(dummyBtn);
 
-    waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+    waitFor(() => expect(axiosMock.history.post.length).toBe(2));
 
     const [section] = courseOutlineIndexMock.courseStructure.childInfo.children;
     const [subsection] = section.childInfo.children;
-    expect(axiosMock.history.post[0].data).toBe(JSON.stringify({
+    expect(axiosMock.history.post[1].data).toBe(JSON.stringify({
       type: COMPONENT_TYPES.libraryV2,
       category: 'vertical',
       parent_locator: subsection.id,
@@ -891,8 +891,8 @@ describe('<CourseOutline />', () => {
     const saveButton = await findByTestId('configure-save-button');
     await act(async () => fireEvent.click(saveButton));
 
-    expect(axiosMock.history.post.length).toBe(1);
-    expect(axiosMock.history.post[0].data).toBe(JSON.stringify({
+    expect(axiosMock.history.post.length).toBe(2);
+    expect(axiosMock.history.post[1].data).toBe(JSON.stringify({
       publish: 'republish',
       metadata: {
         visible_to_staff_only: true,
@@ -991,8 +991,8 @@ describe('<CourseOutline />', () => {
     await act(async () => fireEvent.click(saveButton));
 
     // verify request
-    expect(axiosMock.history.post.length).toBe(1);
-    expect(axiosMock.history.post[0].data).toBe(JSON.stringify(expectedRequestData));
+    expect(axiosMock.history.post.length).toBe(2);
+    expect(axiosMock.history.post[1].data).toBe(JSON.stringify(expectedRequestData));
 
     // reopen modal and check values
     await act(async () => fireEvent.click(subsectionDropdownButton));
@@ -1127,8 +1127,8 @@ describe('<CourseOutline />', () => {
     await act(async () => fireEvent.click(saveButton));
 
     // verify request
-    expect(axiosMock.history.post.length).toBe(1);
-    expect(axiosMock.history.post[0].data).toBe(JSON.stringify(expectedRequestData));
+    expect(axiosMock.history.post.length).toBe(2);
+    expect(axiosMock.history.post[1].data).toBe(JSON.stringify(expectedRequestData));
 
     // reopen modal and check values
     await act(async () => fireEvent.click(subsectionDropdownButton));
@@ -1247,8 +1247,8 @@ describe('<CourseOutline />', () => {
     await act(async () => fireEvent.click(saveButton));
 
     // verify request
-    expect(axiosMock.history.post.length).toBe(1);
-    expect(axiosMock.history.post[0].data).toBe(JSON.stringify(expectedRequestData));
+    expect(axiosMock.history.post.length).toBe(2);
+    expect(axiosMock.history.post[1].data).toBe(JSON.stringify(expectedRequestData));
 
     // reopen modal and check values
     await act(async () => fireEvent.click(subsectionDropdownButton));
@@ -1347,8 +1347,8 @@ describe('<CourseOutline />', () => {
     await act(async () => fireEvent.click(saveButton));
 
     // verify request
-    expect(axiosMock.history.post.length).toBe(1);
-    expect(axiosMock.history.post[0].data).toBe(JSON.stringify(expectedRequestData));
+    expect(axiosMock.history.post.length).toBe(2);
+    expect(axiosMock.history.post[1].data).toBe(JSON.stringify(expectedRequestData));
 
     // reopen modal and check values
     await act(async () => fireEvent.click(subsectionDropdownButton));
@@ -1443,8 +1443,8 @@ describe('<CourseOutline />', () => {
     await act(async () => fireEvent.click(saveButton));
 
     // verify request
-    expect(axiosMock.history.post.length).toBe(1);
-    expect(axiosMock.history.post[0].data).toBe(JSON.stringify(expectedRequestData));
+    expect(axiosMock.history.post.length).toBe(2);
+    expect(axiosMock.history.post[1].data).toBe(JSON.stringify(expectedRequestData));
 
     // reopen modal and check values
     await act(async () => fireEvent.click(subsectionDropdownButton));

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -47,7 +47,7 @@ import CourseOutline from './CourseOutline';
 import configureModalMessages from '../generic/configure-modal/messages';
 import pasteButtonMessages from '../generic/clipboard/paste-component/messages';
 import messages from './messages';
-import {getApiBaseUrl, getClipboardUrl} from '../generic/data/api';
+import { getApiBaseUrl, getClipboardUrl } from '../generic/data/api';
 import headerMessages from './header-navigations/messages';
 import cardHeaderMessages from './card-header/messages';
 import enableHighlightsModalMessages from './enable-highlights-modal/messages';

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -9,7 +9,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cloneDeep } from 'lodash';
 import { closestCorners } from '@dnd-kit/core';
-
+import { logError } from '@edx/frontend-platform/logging';
 import { useLocation } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import {
@@ -22,6 +22,7 @@ import {
   getCourseItemApiUrl,
   getXBlockBaseApiUrl,
   exportTags,
+  createDiscussionsTopics,
 } from './data/api';
 import { RequestStatus } from '../data/constants';
 import {
@@ -121,6 +122,10 @@ jest.mock('../library-authoring/component-picker', () => ({
   },
 }));
 
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
 const queryClient = new QueryClient();
 
 jest.mock('@dnd-kit/core', () => ({
@@ -190,6 +195,16 @@ describe('<CourseOutline />', () => {
       expect(getByText(messages.headingTitle.defaultMessage)).toBeInTheDocument();
       expect(getByText(messages.headingSubtitle.defaultMessage)).toBeInTheDocument();
     });
+  });
+
+  it('logs an error when syncDiscussionsTopics encounters an API failure', async () => {
+    axiosMock
+      .onGet(createDiscussionsTopics(courseId))
+      .reply(500, 'some internal error');
+
+    await executeThunk(syncDiscussionsTopics(), store.dispatch);
+
+    expect(logError).toHaveBeenCalledTimes(1);
   });
 
   it('handles course outline fetch api errors', async () => {

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -243,7 +243,7 @@ describe('<CourseOutline />', () => {
       async () => fireEvent.change(optionDropdown, { target: { value: VIDEO_SHARING_OPTIONS.allOff } }),
     );
 
-    expect(axiosMock.history.post.length).çÏ(2);
+    expect(axiosMock.history.post.length).toBe(2);
     expect(axiosMock.history.post[1].data).toBe(JSON.stringify({
       metadata: {
         video_sharing_options: VIDEO_SHARING_OPTIONS.allOff,

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -176,7 +176,6 @@ describe('<CourseOutline />', () => {
         courseId, gradedOnly: true, validateOras: true, all: true,
       }))
       .reply(200, courseLaunchMock);
-    // add mock for getApiBaseUrl()}/api/discussions/v0/course/${courseId}/sync_discussion_topics
     axiosMock
       .onPost(`${getApiBaseUrl()}/api/discussions/v0/course/${courseId}/sync_discussion_topics`)
       .reply(200, {});

--- a/src/course-outline/__mocks__/courseOutlineIndex.js
+++ b/src/course-outline/__mocks__/courseOutlineIndex.js
@@ -3149,6 +3149,7 @@ module.exports = {
       selectedGroupsLabel: '',
     },
   },
+  createdOn: new Date(),
   deprecatedBlocksInfo: {
     deprecatedEnabledBlockTypes: [],
     blocks: [],

--- a/src/course-outline/data/api.js
+++ b/src/course-outline/data/api.js
@@ -60,6 +60,17 @@ export async function getCourseOutlineIndex(courseId) {
 }
 
 /**
+ *
+ * @param courseId
+ * @returns {Promise<Array|Object>}
+ */
+export async function createDiscussionsTopics(courseId) {
+  const { data } = await getAuthenticatedHttpClient()
+    .post(`${getApiBaseUrl()}/api/discussions/v0/course/${courseId}/sync_discussion_topics`);
+  return camelCaseObject(data);
+}
+
+/**
  * Get course best practices.
  * @param {{courseId: string, excludeGraded: boolean, all: boolean}} options
  * @returns {Promise<{isSelfPaced: boolean, sections: any, subsection: any, units: any, videos: any }>}

--- a/src/course-outline/data/selectors.js
+++ b/src/course-outline/data/selectors.js
@@ -11,3 +11,4 @@ export const getCustomRelativeDatesActiveFlag = (state) => state.courseOutline.i
 export const getProctoredExamsFlag = (state) => state.courseOutline.enableProctoredExams;
 export const getPasteFileNotices = (state) => state.courseOutline.pasteFileNotices;
 export const getErrors = (state) => state.courseOutline.errors;
+export const getCreatedOn = (state) => state.courseOutline.createdOn;

--- a/src/course-outline/data/slice.js
+++ b/src/course-outline/data/slice.js
@@ -47,6 +47,7 @@ const slice = createSlice({
     },
     enableProctoredExams: false,
     pasteFileNotices: {},
+    createdOn: null,
   },
   reducers: {
     fetchOutlineIndexSuccess: (state, { payload }) => {
@@ -54,6 +55,7 @@ const slice = createSlice({
       state.sectionsList = payload.courseStructure?.childInfo?.children || [];
       state.isCustomRelativeDatesActive = payload.isCustomRelativeDatesActive;
       state.enableProctoredExams = payload.courseStructure?.enableProctoredExams;
+      state.createdOn = payload.createdOn;
     },
     updateOutlineIndexLoadingStatus: (state, { payload }) => {
       state.loadingStatus = {

--- a/src/course-outline/data/thunk.js
+++ b/src/course-outline/data/thunk.js
@@ -30,7 +30,7 @@ import {
   setVideoSharingOption,
   setCourseItemOrderList,
   pasteBlock,
-  dismissNotification,
+  dismissNotification, createDiscussionsTopics,
 } from './api';
 import {
   addSection,
@@ -91,6 +91,17 @@ export function fetchCourseOutlineIndexQuery(courseId) {
           errors: getErrorDetails(error, false),
         }));
       }
+    }
+  };
+}
+
+export function syncDiscussionsTopics(courseId) {
+  return async () => {
+    try {
+      await createDiscussionsTopics(courseId);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log('There was an issue in discussion topic sync', error);
     }
   };
 }

--- a/src/course-outline/data/thunk.js
+++ b/src/course-outline/data/thunk.js
@@ -1,3 +1,4 @@
+import { logError } from '@edx/frontend-platform/logging';
 import { RequestStatus } from '../../data/constants';
 import { NOTIFICATION_MESSAGES } from '../../constants';
 import { COURSE_BLOCK_NAMES } from '../constants';
@@ -100,8 +101,7 @@ export function syncDiscussionsTopics(courseId) {
     try {
       await createDiscussionsTopics(courseId);
     } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log('There was an issue in discussion topic sync', error);
+      logError(error);
     }
   };
 }

--- a/src/course-outline/hooks.jsx
+++ b/src/course-outline/hooks.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useToggle } from '@openedx/paragon';
 import { getConfig } from '@edx/frontend-platform';
 
+import moment from 'moment';
 import { getSavingStatus as getGenericSavingStatus } from '../generic/data/selectors';
 import { getWaffleFlags } from '../data/selectors';
 import { RequestStatus } from '../data/constants';
@@ -25,6 +26,7 @@ import {
   getCurrentSubsection,
   getCustomRelativeDatesActiveFlag,
   getErrors,
+  getCreatedOn,
 } from './data/selectors';
 import {
   addNewSectionQuery,
@@ -53,7 +55,7 @@ import {
   setUnitOrderListQuery,
   pasteClipboardContent,
   dismissNotificationQuery,
-  addUnitFromLibrary,
+  addUnitFromLibrary, syncDiscussionsTopics,
 } from './data/thunk';
 
 const useCourseOutline = ({ courseId }) => {
@@ -73,7 +75,7 @@ const useCourseOutline = ({ courseId }) => {
     mfeProctoredExamSettingsUrl,
     advanceSettingsUrl,
   } = useSelector(getOutlineIndexData);
-
+  const createdOn = useSelector(getCreatedOn);
   const { outlineIndexLoadingStatus, reIndexLoadingStatus } = useSelector(getLoadingStatus);
   const statusBarData = useSelector(getStatusBarData);
   const savingStatus = useSelector(getSavingStatus);
@@ -291,6 +293,12 @@ const useCourseOutline = ({ courseId }) => {
     dispatch(fetchCourseBestPracticesQuery({ courseId }));
     dispatch(fetchCourseLaunchQuery({ courseId }));
   }, [courseId]);
+
+  useEffect(() => {
+    if (createdOn && moment(new Date(createdOn)).isAfter(moment().subtract(31, 'days'))) {
+      dispatch(syncDiscussionsTopics);
+    }
+  }, [createdOn]);
 
   useEffect(() => {
     setShowSuccessAlert(reIndexLoadingStatus === RequestStatus.SUCCESSFUL);


### PR DESCRIPTION
## Description
This PR integrates a new API that properly synchronizes discussion topics when creating course re-runs. It addresses an issue where discussion topic data wasn't being correctly synced to new courses, particularly affecting larger courses.
## Problem
When creating re-runs of larger courses, discussion topic data was inconsistently synchronized to the new course, leading to data inconsistencies in the CSM UI.
## Solution
Implemented an API call that ensures discussion topic data is properly synchronized between the original course and its re-run. This guarantees that all discussion data remains up-to-date and consistent in the CMS UI.
