### PR TITLE
feat: select component and show sidebar on edit 

### DIFF
--- a/src/library-authoring/components/ComponentCard.test.tsx
+++ b/src/library-authoring/components/ComponentCard.test.tsx
@@ -11,6 +11,13 @@ import { ContentHit } from '../../search-manager';
 import ComponentCard from './ComponentCard';
 import { PublishStatus } from '../../search-manager/data/api';
 
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
+  useNavigate: () => mockNavigate,
+}));
+
 const contentHit: ContentHit = {
   id: '1',
   usageKey: 'lb:org1:demolib:html:a1fa8bdd-dc67-4976-9bf5-0ea75a9bca3d',
@@ -41,6 +48,8 @@ const contentHit: ContentHit = {
 
 const libraryId = 'lib:org1:Demo_Course';
 const render = () => baseRender(<ComponentCard hit={contentHit} />, {
+  path: '/library/:libraryId',
+  params: { libraryId },
   extraWrapper: ({ children }) => (
     <LibraryProvider libraryId={libraryId}>
       { children }
@@ -102,6 +111,26 @@ describe('<ComponentCard />', () => {
     await waitFor(() => {
       expect(mockShowToast).toHaveBeenCalledWith('Copying');
       expect(mockShowToast).toHaveBeenCalledWith('Error copying to clipboard');
+    });
+  });
+
+  it('should select component on clicking edit menu option', async () => {
+    initializeMocks();
+    render();
+
+    // Open menu
+    const menu = await screen.findByTestId('component-card-menu-toggle');
+    expect(menu).toBeInTheDocument();
+    fireEvent.click(menu);
+
+    // Click copy to clipboard
+    const editOption = await screen.findByRole('button', { name: 'Edit' });
+    expect(editOption).toBeInTheDocument();
+    fireEvent.click(editOption);
+    // Verify that the url is updated to component url i.e. component is selected
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: `/library/${libraryId}/component/${contentHit.usageKey}`,
+      search: '',
     });
   });
 });

--- a/src/library-authoring/components/ComponentMenu.tsx
+++ b/src/library-authoring/components/ComponentMenu.tsx
@@ -90,6 +90,12 @@ export const ComponentMenu = ({ usageKey }: { usageKey: string }) => {
     });
   };
 
+  const handleEdit = useCallback(() => {
+    navigateTo({ componentId: usageKey });
+    openComponentInfoSidebar(usageKey);
+    openComponentEditor(usageKey);
+  }, [usageKey]);
+
   const scheduleJumpToCollection = useRunOnNextRender(() => {
     // TODO: Ugly hack to make sure sidebar shows add to collection section
     // This needs to run after all changes to url takes place to avoid conflicts.
@@ -119,7 +125,7 @@ export const ComponentMenu = ({ usageKey }: { usageKey: string }) => {
         data-testid="component-card-menu-toggle"
       />
       <Dropdown.Menu>
-        <Dropdown.Item {...(canEdit ? { onClick: () => openComponentEditor(usageKey) } : { disabled: true })}>
+        <Dropdown.Item {...(canEdit ? { onClick: handleEdit } : { disabled: true })}>
           <FormattedMessage {...messages.menuEdit} />
         </Dropdown.Item>
         <Dropdown.Item onClick={updateClipboardClick}>

--- a/src/library-authoring/containers/UnitInfo.test.tsx
+++ b/src/library-authoring/containers/UnitInfo.test.tsx
@@ -19,23 +19,28 @@ mockGetContainerChildren.applyMock();
 const { libraryId } = mockContentLibrary;
 const { containerId } = mockGetContainerMetadata;
 
-const render = (showOnlyPublished: boolean = false) => baseRender(<UnitInfo />, {
-  extraWrapper: ({ children }) => (
-    <LibraryProvider
-      libraryId={libraryId}
-      showOnlyPublished={showOnlyPublished}
-    >
-      <SidebarProvider
-        initialSidebarComponentInfo={{
-          id: containerId,
-          type: SidebarBodyComponentId.UnitInfo,
-        }}
+const render = (showOnlyPublished: boolean = false) => {
+  const params: { libraryId: string, unitId?: string } = { libraryId, unitId: containerId };
+  return baseRender(<UnitInfo />, {
+    path: '/library/:libraryId/:unitId?',
+    params,
+    extraWrapper: ({ children }) => (
+      <LibraryProvider
+        libraryId={libraryId}
+        showOnlyPublished={showOnlyPublished}
       >
-        {children}
-      </SidebarProvider>
-    </LibraryProvider>
-  ),
-});
+        <SidebarProvider
+          initialSidebarComponentInfo={{
+            id: containerId,
+            type: SidebarBodyComponentId.UnitInfo,
+          }}
+        >
+          {children}
+        </SidebarProvider>
+      </LibraryProvider>
+    ),
+  });
+};
 let axiosMock: MockAdapter;
 let mockShowToast;
 
@@ -101,6 +106,6 @@ describe('<UnitInfo />', () => {
   it('show only published content', async () => {
     render(true);
     expect(await screen.findByTestId('unit-info-menu-toggle')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /text block published 1/i })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /text block published 1/i })).toBeInTheDocument();
   });
 });

--- a/src/library-authoring/data/api.test.ts
+++ b/src/library-authoring/data/api.test.ts
@@ -142,4 +142,13 @@ describe('library data API', () => {
     await api.removeLibraryContainerChildren(containerId, ['test']);
     expect(axiosMock.history.delete[0].url).toEqual(url);
   });
+
+  it('getContentLibraryV2List', async () => {
+    const url = api.getContentLibraryV2ListApiUrl();
+
+    axiosMock.onGet(url).reply(200, { some: 'data' });
+
+    await api.getContentLibraryV2List({ type: 'complex' });
+    expect(axiosMock.history.get[0].url).toEqual(url);
+  });
 });

--- a/src/library-authoring/units/LibraryUnitBlocks.tsx
+++ b/src/library-authoring/units/LibraryUnitBlocks.tsx
@@ -238,9 +238,7 @@ export const LibraryUnitBlocks = ({ preview }: LibraryUnitBlocksProps) => {
   const [hidePreviewFor, setHidePreviewFor] = useState<string | null>(null);
   const { showToast } = useContext(ToastContext);
 
-  const { readOnly, showOnlyPublished } = useLibraryContext();
-  const { sidebarComponentInfo } = useSidebarContext();
-  const unitId = sidebarComponentInfo?.id;
+  const { unitId, readOnly, showOnlyPublished } = useLibraryContext();
 
   const { openAddContentSidebar } = useSidebarContext();
 


### PR DESCRIPTION
## Description

Select component that is being edited in library and show its sidebar. Also fixes issue with children component listing in library unit page.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author"

## Supporting information

- Related to: https://github.com/openedx/frontend-app-authoring/issues/1803
- Related to: https://github.com/openedx/frontend-app-authoring/pull/1926/files#r2088216522
- `Private-ref`: https://tasks.opencraft.com/browse/FAL-4160

## Testing instructions

Verify that change described in https://github.com/openedx/frontend-app-authoring/issues/1803 is implemented and works in all pages.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.