### PR TITLE
fix: search flickering

### DIFF
--- a/src/search-modal/SearchUI.tsx
+++ b/src/search-modal/SearchUI.tsx
@@ -37,6 +37,7 @@ const SearchUI: React.FC<{
         ...(searchThisCourse ? [`context_key = "${props.courseId}"`] : []),
       ]}
       closeSearchModal={props.closeSearchModal}
+      skipUrlUpdate
     >
       {/* We need to override z-index here or the <Dropdown.Menu> appears behind the <ModalDialog.Body>
         * But it can't be more then 9 because the close button has z-index 10. */}


### PR DESCRIPTION
## Description
This PR addresses an issue where typing into the course search modal causes the page to refresh and the modal to close unexpectedly. The root cause is the search context updating the URL with each keystroke, which is useful for some scenarios (e.g. sharing URLs), but not for modal-based searches like the course outline.

To resolve this, we modified the SearchProvider used by the course search modal to skip the URL update. This avoids the need to track modal state in the URL and prevents unnecessary page refreshes—resulting in a smoother user experience.

Fixes: https://github.com/openedx/wg-build-test-release/issues/478

## Useful information to include:
In scenarios where search is embedded in the page, updating the URL makes sense.
- In this case (course search modal), updating the URL:
- Closes the modal on every keystroke
- Causes jarring page reloads
- Would require complex logic to preserve modal state in the URL
By skipping the URL sync in this case, we simplify the behavior and improve usability.


## Before
https://github.com/user-attachments/assets/51401929-63b4-4bdd-bf01-913e9e8a05ca

## After
https://github.com/user-attachments/assets/728bd779-1962-4e28-9856-9c5fa0e4f4f1

## Testing instructions
1. Go to the Authoring module
2. Open any course outline
3. Click the search icon to open the modal
4. Type into the search input

### Expected Results
- The modal remains open while typing
- The page does not refresh on each keystroke
- Search behaves smoothly inside the modal