### PR TITLE
fix: Inconsistent publish status filter menu placement in Library home page

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -299,7 +299,14 @@ const LibraryAuthoringPage = ({
               <SearchKeywordsField className="mr-3" />
               <FilterByTags />
               {!(insideCollections || insideUnits) && <FilterByBlockType />}
-              <FilterByPublished />
+              <FilterByPublished key={
+                // It is necessary to re-render `FilterByPublished` every time `FilterByBlockType`
+                // appears or disappears, this is because when the menu is opened it is rendered
+                // in a previous state, causing an inconsistency in its position.
+                // By changing the key we can re-render the component.
+                !(insideCollections || insideUnits) ? 'filter-published-1' : 'filter-published-2'
+              }
+              />
               <ClearFiltersButton />
               <ActionRow.Spacer />
               <SearchSortWidget />


### PR DESCRIPTION
## Description

Fix the bug described in https://github.com/openedx/frontend-app-authoring/issues/1859

## Supporting information

Github issue: https://github.com/openedx/frontend-app-authoring/issues/1859
Internal ticket: [FAL-4160](https://tasks.opencraft.com/browse/FAL-4160)

## Testing instructions

- Go to the library home of a library
- Go to the Collections tab
- Open the publish status filter and verify that the menu is in the correct position
- Go to the Home tab
- Open the publish status filter and verify that the menu is in the correct position.


## Other information

N/A