### PR TITLE
fix: rename library publish button

### DIFF
--- a/src/library-authoring/generic/status-widget/index.tsx
+++ b/src/library-authoring/generic/status-widget/index.tsx
@@ -85,6 +85,7 @@ type StatusWidgedProps = {
   publishedBy: string | null;
   numBlocks?: number;
   onCommit?: () => void;
+  onCommitLabel?: string;
   onRevert?: () => void;
 };
 
@@ -114,6 +115,7 @@ const StatusWidget = ({
   publishedBy,
   numBlocks,
   onCommit,
+  onCommitLabel,
   onRevert,
 }: StatusWidgedProps) => {
   const intl = useIntl();
@@ -188,7 +190,7 @@ const StatusWidget = ({
           </span>
           {onCommit && (
             <Button disabled={isPublished} onClick={onCommit}>
-              {intl.formatMessage(messages.publishButtonLabel)}
+              {onCommitLabel || intl.formatMessage(messages.publishButtonLabel)}
             </Button>
           )}
           {onRevert && (

--- a/src/library-authoring/library-info/LibraryPublishStatus.tsx
+++ b/src/library-authoring/library-info/LibraryPublishStatus.tsx
@@ -51,6 +51,7 @@ const LibraryPublishStatus = () => {
       <StatusWidget
         {...libraryData}
         onCommit={!readOnly ? commit : undefined}
+        onCommitLabel={intl.formatMessage(messages.publishLibraryButtonLabel)}
         onRevert={!readOnly ? openConfirmModal : undefined}
       />
       <DeleteModal

--- a/src/library-authoring/library-info/messages.ts
+++ b/src/library-authoring/library-info/messages.ts
@@ -76,6 +76,11 @@ const messages = defineMessages({
     defaultMessage: 'Discard',
     description: 'Button text for confirmation modal shown before discard library changes',
   },
+  publishLibraryButtonLabel: {
+    id: 'course-authoring.library-authoring.library.publishLibraryButtonLabel',
+    defaultMessage: 'Publish All Changes',
+    description: 'Button text for publish library button',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description

This PR renames the Library publish button from "Publish" to "Publish All Changes"

## Supporting information

- Related to https://github.com/openedx/frontend-app-authoring/issues/1467

## Testing instructions

Open the library sidebar and check if the "Publish All  Changes" button.

___
Private ref: [FAL-4160](https://tasks.opencraft.com/browse/FAL-4160)