### PR TITLE
fix: removing edX text reference on video fallback message

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/__snapshots__/index.test.jsx.snap
@@ -68,10 +68,8 @@ exports[`VideoSourceWidget snapshots snapshots: renders as expected with default
     className="mt-3"
   >
     <FormattedMessage
-      defaultMessage="To be sure all learners can access the video, edX
-    recommends providing additional videos in both .mp4 and
-    .webm formats.  The first listed video compatible with the
-    learner's device will play."
+      defaultMessage="To be sure all learners can access the video, it is recommended to provide additional videos in both .mp4 and
+    .webm formats.  The first listed video compatible with the learner's device will play."
       description="Test explaining reason for fallback videos"
       id="authoring.videoeditor.videoSource.fallbackVideo.message"
     />
@@ -227,10 +225,8 @@ exports[`VideoSourceWidget snapshots snapshots: renders as expected with videoSh
     className="mt-3"
   >
     <FormattedMessage
-      defaultMessage="To be sure all learners can access the video, edX
-    recommends providing additional videos in both .mp4 and
-    .webm formats.  The first listed video compatible with the
-    learner's device will play."
+      defaultMessage="To be sure all learners can access the video, it is recommended to provide additional videos in both .mp4 and
+    .webm formats.  The first listed video compatible with the learner's device will play."
       description="Test explaining reason for fallback videos"
       id="authoring.videoeditor.videoSource.fallbackVideo.message"
     />

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/index.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/index.test.jsx
@@ -3,9 +3,12 @@ import React from 'react';
 import { dispatch } from 'react-redux';
 import { shallow } from '@edx/react-unit-test-utils';
 
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { formatMessage } from '../../../../../../testUtils';
 import { VideoSourceWidgetInternal as VideoSourceWidget } from '.';
 import * as hooks from './hooks';
+import messages from './messages';
 
 jest.mock('react-redux', () => {
   const dispatchFn = jest.fn();
@@ -104,6 +107,27 @@ describe('VideoSourceWidget', () => {
       expect(control.props.floatingLabel).toEqual('Video URL');
       control.props.onBlur('onBlur event');
       expect(hook.updateVideoURL).toHaveBeenCalledWith('onBlur event', '');
+    });
+  });
+
+  describe('VideoSourceWidget', () => {
+    it('calls addFallbackVideo when the add button is clicked', () => {
+      // eslint-disable-next-line global-require
+      const { fallbackHooks } = require('./hooks');
+      const { addFallbackVideo } = fallbackHooks();
+
+      render(
+        <IntlProvider locale="en" messages={messages}>
+          <VideoSourceWidget intl={{ formatMessage: ({ defaultMessage }) => defaultMessage }} />
+        </IntlProvider>,
+      );
+
+      // Find the button by its text (from messages.addButtonLabel)
+      const addButton = screen.getByRole('button');
+
+      fireEvent.click(addButton);
+
+      expect(addFallbackVideo).toHaveBeenCalled();
     });
   });
 });

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/messages.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/messages.js
@@ -40,10 +40,8 @@ const messages = defineMessages({
   },
   fallbackVideoMessage: {
     id: 'authoring.videoeditor.videoSource.fallbackVideo.message',
-    defaultMessage: `To be sure all learners can access the video, edX
-    recommends providing additional videos in both .mp4 and
-    .webm formats.  The first listed video compatible with the
-    learner's device will play.`,
+    defaultMessage: `To be sure all learners can access the video, it is recommended to provide additional videos in both .mp4 and
+    .webm formats.  The first listed video compatible with the learner's device will play.`,
     description: 'Test explaining reason for fallback videos',
   },
   fallbackVideoLabel: {


### PR DESCRIPTION
## Description

Updating video fallback message to remove edX reference.

<img width="1140" alt="Captura de pantalla 2025-05-16 a la(s) 3 08 31 p m" src="https://github.com/user-attachments/assets/3ff911c8-e78c-4977-a137-a60f6312f4fb" />

## Supporting information

#1015
https://github.com/openedx/wg-build-test-release/issues/491

## Testing instructions
On studio dashboard enter to a course
Click to edit or create a unit
Add a new component video type
On the video modal scroll down to fallback video section and verify the text.
