### PR TITLE
refactor: CourseAuthoringUnitSidebarSlot

### DIFF
--- a/src/course-unit/CourseUnit.jsx
+++ b/src/course-unit/CourseUnit.jsx
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import {
-  Container, Layout, Stack, Button, TransitionReplace,
-  Alert,
+  Alert, Container, Layout, Button, TransitionReplace,
 } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
@@ -27,8 +26,6 @@ import AddComponent from './add-component/AddComponent';
 import HeaderTitle from './header-title/HeaderTitle';
 import Breadcrumbs from './breadcrumbs/Breadcrumbs';
 import Sequence from './course-sequence';
-import Sidebar from './sidebar';
-import SplitTestSidebarInfo from './sidebar/SplitTestSidebarInfo';
 import { useCourseUnit, useLayoutGrid, useScrollToLastPosition } from './hooks';
 import messages from './messages';
 import { PasteNotificationAlert } from './clipboard';
@@ -244,22 +241,15 @@ const CourseUnit = ({ courseId }) => {
               <IframePreviewLibraryXBlockChanges />
             </Layout.Element>
             <Layout.Element>
-              <Stack gap={3}>
-                {isUnitVerticalType && (
-                <CourseAuthoringUnitSidebarSlot
-                  courseId={courseId}
-                  blockId={blockId}
-                  unitTitle={unitTitle}
-                  xBlocks={courseVerticalChildren.children}
-                  readOnly={readOnly}
-                />
-                )}
-                {isSplitTestType && (
-                  <Sidebar data-testid="course-split-test-sidebar">
-                    <SplitTestSidebarInfo />
-                  </Sidebar>
-                )}
-              </Stack>
+              <CourseAuthoringUnitSidebarSlot
+                courseId={courseId}
+                blockId={blockId}
+                unitTitle={unitTitle}
+                xBlocks={courseVerticalChildren.children}
+                readOnly={readOnly}
+                isUnitVerticalType={isUnitVerticalType}
+                isSplitTestType={isSplitTestType}
+              />
             </Layout.Element>
           </Layout>
         </section>

--- a/src/plugin-slots/CourseAuthoringUnitSidebarSlot/README.md
+++ b/src/plugin-slots/CourseAuthoringUnitSidebarSlot/README.md
@@ -1,17 +1,27 @@
 # CourseAuthoringUnitSidebarSlot
 
-### Slot ID: `org.openedx.frontend.authoring.course_unit_sidebar.v1`
+The component currently holds 2 versions of the slot. Version 2 wraps version 1 and hence, is a
+superset of version 1.
+
+### Slot IDs:
+* `org.openedx.frontend.authoring.course_unit_sidebar.v2`
+* `org.openedx.frontend.authoring.course_unit_sidebar.v1`
 
 ### Slot ID Aliases
-* `course_authoring_unit_sidebar_slot`
+* `org.openedx.frontend.authoring.course_unit_sidebar.v1` - `course_authoring_unit_sidebar_slot`
 
 ### Plugin Props:
+
+#### Version 1
 
 * `courseId` - String.
 * `blockId` - String. The usage id of the current unit being viewed / edited.
 * `unitTitle` - String. The name of the current unit being viewed / edited.
 * `xBlocks` - Array of Objects. List of XBlocks in the Unit. Object structure defined in `index.tsx`.
 * `readOnly` - Boolean. True if the user should not be able to edit the contents of the unit.
+
+#### Extra props in Version 2
+
 * `isUnitVerticalType` - Boolean. If the unit category is `vertical`.
 * `isSplitTestType` - Boolean. If the unit category is `split_test`.
 
@@ -31,7 +41,7 @@ import { PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
 
 const config = {
   pluginSlots: {
-    'org.openedx.frontend.authoring.course_unit_sidebar.v1': {
+    'org.openedx.frontend.authoring.course_unit_sidebar.v2': {
       keepDefault: true,
       plugins: [
         {
@@ -65,11 +75,11 @@ const ProblemBlocks = ({unitTitle, xBlocks}) => (
       }
     </ul>
   </>
-); 
+);
 
 const config = {
   pluginSlots: {
-    'org.openedx.frontend.authoring.course_unit_sidebar.v1': {
+    'org.openedx.frontend.authoring.course_unit_sidebar.v2': {
       keepDefault: true,
       plugins: [
         {

--- a/src/plugin-slots/CourseAuthoringUnitSidebarSlot/README.md
+++ b/src/plugin-slots/CourseAuthoringUnitSidebarSlot/README.md
@@ -2,7 +2,8 @@
 
 ### Slot ID: `org.openedx.frontend.authoring.course_unit_sidebar.v2`
 
-### Slot ID Aliases: `course_authoring_unit_sidebar_slot_v2`
+### Slot ID Aliases
+* `course_authoring_unit_sidebar_slot_v2`
 
 ### Previous Version: [`org.openedx.frontend.authoring.course_unit_sidebar.v1`](./README.v1.md)
 

--- a/src/plugin-slots/CourseAuthoringUnitSidebarSlot/README.md
+++ b/src/plugin-slots/CourseAuthoringUnitSidebarSlot/README.md
@@ -12,6 +12,8 @@
 * `unitTitle` - String. The name of the current unit being viewed / edited.
 * `xBlocks` - Array of Objects. List of XBlocks in the Unit. Object structure defined in `index.tsx`.
 * `readOnly` - Boolean. True if the user should not be able to edit the contents of the unit.
+* `isUnitVerticalType` - Boolean. If the unit category is `vertical`.
+* `isSplitTestType` - Boolean. If the unit category is `split_test`.
 
 ## Description
 

--- a/src/plugin-slots/CourseAuthoringUnitSidebarSlot/README.md
+++ b/src/plugin-slots/CourseAuthoringUnitSidebarSlot/README.md
@@ -2,9 +2,6 @@
 
 ### Slot ID: `org.openedx.frontend.authoring.course_unit_sidebar.v2`
 
-### Slot ID Aliases
-* `course_authoring_unit_sidebar_slot_v2`
-
 ### Previous Version: [`org.openedx.frontend.authoring.course_unit_sidebar.v1`](./README.v1.md)
 
 ### Plugin Props:

--- a/src/plugin-slots/CourseAuthoringUnitSidebarSlot/README.v1.md
+++ b/src/plugin-slots/CourseAuthoringUnitSidebarSlot/README.v1.md
@@ -1,10 +1,8 @@
 # CourseAuthoringUnitSidebarSlot
 
-### Slot ID: `org.openedx.frontend.authoring.course_unit_sidebar.v2`
+### Slot ID: `org.openedx.frontend.authoring.course_unit_sidebar.v1`
 
-### Slot ID Aliases: `course_authoring_unit_sidebar_slot_v2`
-
-### Previous Version: [`org.openedx.frontend.authoring.course_unit_sidebar.v1`](./README.v1.md)
+### Slot ID Aliases: `course_authoring_unit_sidebar_slot`
 
 ### Plugin Props:
 
@@ -13,10 +11,8 @@
 * `unitTitle` - String. The name of the current unit being viewed / edited.
 * `xBlocks` - Array of Objects. List of XBlocks in the Unit. Object structure defined in `index.tsx`.
 * `readOnly` - Boolean. True if the user should not be able to edit the contents of the unit.
-* `isUnitVerticalType` - Boolean. If the unit category is `vertical`.
-* `isSplitTestType` - Boolean. If the unit category is `split_test`.
 
-## Description
+### Description
 
 The slot wraps the sidebar that is displayed on the unit editor page. It can
 be used to add additional sidebar components or modify the existing sidebar.
@@ -32,7 +28,7 @@ import { PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
 
 const config = {
   pluginSlots: {
-    'org.openedx.frontend.authoring.course_unit_sidebar.v2': {
+    'org.openedx.frontend.authoring.course_unit_sidebar.v1': {
       keepDefault: true,
       plugins: [
         {
@@ -70,7 +66,7 @@ const ProblemBlocks = ({unitTitle, xBlocks}) => (
 
 const config = {
   pluginSlots: {
-    'org.openedx.frontend.authoring.course_unit_sidebar.v2': {
+    'org.openedx.frontend.authoring.course_unit_sidebar.v1': {
       keepDefault: true,
       plugins: [
         {

--- a/src/plugin-slots/CourseAuthoringUnitSidebarSlot/README.v1.md
+++ b/src/plugin-slots/CourseAuthoringUnitSidebarSlot/README.v1.md
@@ -17,6 +17,15 @@
 The slot wraps the sidebar that is displayed on the unit editor page. It can
 be used to add additional sidebar components or modify the existing sidebar.
 
+> [!IMPORTANT]
+> This document describes an older version `v1` of the `CourseAuthoringUnitSidebarSlot`.
+> It is recommended to use the `org.openedx.frontend.authoring.course_unit_sidebar.v2` slot ID for new plugins.
+
+The `v1` slot has the following limitations compared to the `v2` version:
+* It renders conditionally based on the `isUnitVerticalType` prop, which means the plugins won't be rendered in other scenarios like unit with library blocks.
+* It does **not** wrap the `SplitTestSidebarInfo` component. So it can't be hidden from the sidebar by overriding the components in the slot.
+* As it is not the primary child component of the sidebar, CSS styling for inserted components face limitations, such as an inability to be `sticky` or achieve 100% height.
+
 ## Example 1
 
 ![Screenshot of the unit sidebar surrounded by border](./images/unit_sidebar_with_border.png)

--- a/src/plugin-slots/CourseAuthoringUnitSidebarSlot/index.tsx
+++ b/src/plugin-slots/CourseAuthoringUnitSidebarSlot/index.tsx
@@ -1,6 +1,6 @@
 import { getConfig } from '@edx/frontend-platform';
 import { PluginSlot } from '@openedx/frontend-plugin-framework/dist';
-import {Stack} from '@openedx/paragon';
+import { Stack } from '@openedx/paragon';
 import TagsSidebarControls from '../../content-tags-drawer/tags-sidebar-controls';
 import Sidebar from '../../course-unit/sidebar';
 import LocationInfo from '../../course-unit/sidebar/LocationInfo';

--- a/src/plugin-slots/CourseAuthoringUnitSidebarSlot/index.tsx
+++ b/src/plugin-slots/CourseAuthoringUnitSidebarSlot/index.tsx
@@ -19,15 +19,20 @@ export const CourseAuthoringUnitSidebarSlot = (
   }: CourseAuthoringUnitSidebarSlotProps,
 ) => (
   <PluginSlot
-    id="org.openedx.frontend.authoring.course_unit_sidebar.v1"
-    idAliases={['course_authoring_unit_sidebar_slot']}
+    id="org.openedx.frontend.authoring.course_unit_sidebar.v2"
     pluginProps={{
-      blockId, courseId, unitTitle, xBlocks, readOnly,
+      blockId, courseId, unitTitle, xBlocks, readOnly, isUnitVerticalType, isSplitTestType,
     }}
   >
     <Stack gap={3}>
       {isUnitVerticalType && (
-        <>
+        <PluginSlot
+          id="org.openedx.frontend.authoring.course_unit_sidebar.v1"
+          idAliases={['course_authoring_unit_sidebar_slot']}
+          pluginProps={{
+            blockId, courseId, unitTitle, xBlocks, readOnly,
+          }}
+        >
           <Sidebar data-testid="course-unit-sidebar">
             <PublishControls blockId={blockId} />
           </Sidebar>
@@ -39,7 +44,7 @@ export const CourseAuthoringUnitSidebarSlot = (
           <Sidebar data-testid="course-unit-location-sidebar">
             <LocationInfo />
           </Sidebar>
-        </>
+        </PluginSlot>
       )}
       {isSplitTestType && (
         <Sidebar data-testid="course-split-test-sidebar">

--- a/src/plugin-slots/CourseAuthoringUnitSidebarSlot/index.tsx
+++ b/src/plugin-slots/CourseAuthoringUnitSidebarSlot/index.tsx
@@ -1,9 +1,11 @@
 import { getConfig } from '@edx/frontend-platform';
 import { PluginSlot } from '@openedx/frontend-plugin-framework/dist';
+import {Stack} from '@openedx/paragon';
 import TagsSidebarControls from '../../content-tags-drawer/tags-sidebar-controls';
 import Sidebar from '../../course-unit/sidebar';
 import LocationInfo from '../../course-unit/sidebar/LocationInfo';
 import PublishControls from '../../course-unit/sidebar/PublishControls';
+import SplitTestSidebarInfo from '../../course-unit/sidebar/SplitTestSidebarInfo';
 
 export const CourseAuthoringUnitSidebarSlot = (
   {
@@ -12,6 +14,8 @@ export const CourseAuthoringUnitSidebarSlot = (
     unitTitle,
     xBlocks,
     readOnly,
+    isUnitVerticalType,
+    isSplitTestType,
   }: CourseAuthoringUnitSidebarSlotProps,
 ) => (
   <PluginSlot
@@ -21,17 +25,28 @@ export const CourseAuthoringUnitSidebarSlot = (
       blockId, courseId, unitTitle, xBlocks, readOnly,
     }}
   >
-    <Sidebar data-testid="course-unit-sidebar">
-      <PublishControls blockId={blockId} />
-    </Sidebar>
-    {getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true' && (
-    <Sidebar className="tags-sidebar">
-      <TagsSidebarControls readOnly={readOnly} />
-    </Sidebar>
-    )}
-    <Sidebar data-testid="course-unit-location-sidebar">
-      <LocationInfo />
-    </Sidebar>
+    <Stack gap={3}>
+      {isUnitVerticalType && (
+        <>
+          <Sidebar data-testid="course-unit-sidebar">
+            <PublishControls blockId={blockId} />
+          </Sidebar>
+          {getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true' && (
+            <Sidebar className="tags-sidebar">
+              <TagsSidebarControls readOnly={readOnly} />
+            </Sidebar>
+          )}
+          <Sidebar data-testid="course-unit-location-sidebar">
+            <LocationInfo />
+          </Sidebar>
+        </>
+      )}
+      {isSplitTestType && (
+        <Sidebar data-testid="course-split-test-sidebar">
+          <SplitTestSidebarInfo />
+        </Sidebar>
+      )}
+    </Stack>
   </PluginSlot>
 );
 
@@ -47,4 +62,6 @@ interface CourseAuthoringUnitSidebarSlotProps {
   unitTitle: string;
   xBlocks: XBlock[];
   readOnly: boolean;
+  isUnitVerticalType: boolean;
+  isSplitTestType: boolean;
 }


### PR DESCRIPTION
## Description

The sidebar slot in the Course Unit page wrapped only a partial set of components that are being rendered when the unit is of 'vertical' type. This leads to 2 issues:
* the sidebar slot will not be rendered when the unit
  is not of `vertical` type
* the slot's position in the UI is inconsistent between
  the Course Outline page and Course Unit page

In this PR, all the elements of the sidebar column are wrapped into the slot.

Useful information to include:
- *Which edX user roles will this change impact?* "Course Author" and "Developer".
- *Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).* - No UI changes. 
- *Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.* - N/A

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.


## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.