### PR TITLE
fix: studio time zone conversion issue

### DIFF
--- a/src/course-outline/status-bar/StatusBar.jsx
+++ b/src/course-outline/status-bar/StatusBar.jsx
@@ -64,7 +64,7 @@ const StatusBar = ({
     totalCourseBestPracticesChecks,
   } = checklist;
 
-  const courseReleaseDateObj = moment.utc(courseReleaseDate, 'MMM DD, YYYY at HH:mm UTC', true);
+  const courseReleaseDateObj = moment.utc(courseReleaseDate, 'MMM DD, YYYY [at] HH:mm UTC', true);
   const checkListTitle = `${completedCourseLaunchChecks + completedCourseBestPracticesChecks}/${totalCourseLaunchChecks + totalCourseBestPracticesChecks}`;
   const scheduleDestination = () => new URL(`settings/details/${courseId}#schedule`, config.STUDIO_BASE_URL).href;
 


### PR DESCRIPTION
Ticket: [TNL-11993](https://2u-internal.atlassian.net/browse/TNL-11993)

When we specify in Studio (Settings > Schedule & Details) that the course needs to start on a specific date at 12:00 UTC, it is converted into 02:00 AM (Dutch time). 
It should be converted to 02:00 PM.

 I did a check with multiple other start times and my findings are:
- Until 11:59 UTC the time is converted to 1:59 PM, what is correct
- Starting at 12:00 UTC until 12:59 it is converted to AM instead of PM
- From 13:00 UTC onwards it is converted to 14:00 PM, as expected.

**Solution:** 
Format was wrong where we were converting the string to UTC datetime obj. So, I have corrected the format in this PR.

**Before:**
![before](https://github.com/user-attachments/assets/159776cc-a6ce-4cb3-86e7-89d30b8c17ec)

**After:**
![after](https://github.com/user-attachments/assets/37504562-95e4-445e-af91-6442a6b56f42)
