### PR TITLE
feat: open collection or unit page on double click only

### DIFF
--- a/src/library-authoring/collections/CollectionInfo.tsx
+++ b/src/library-authoring/collections/CollectionInfo.tsx
@@ -48,7 +48,8 @@ const CollectionInfo = () => {
     if (componentPickerMode) {
       setCollectionId(collectionId);
     } else {
-      navigateTo({ collectionId });
+      /* istanbul ignore next */
+      navigateTo({ collectionId, doubleClicked: true });
     }
   }, [componentPickerMode, navigateTo]);
 

--- a/src/library-authoring/components/BaseCard.tsx
+++ b/src/library-authoring/components/BaseCard.tsx
@@ -22,7 +22,7 @@ type BaseCardProps = {
   tags: ContentHitTags;
   actions: React.ReactNode;
   hasUnpublishedChanges?: boolean;
-  onSelect: () => void;
+  onSelect: (e?: React.MouseEvent) => void;
   selected?: boolean;
 };
 

--- a/src/library-authoring/components/CollectionCard.tsx
+++ b/src/library-authoring/components/CollectionCard.tsx
@@ -114,7 +114,7 @@ type CollectionCardProps = {
 
 const CollectionCard = ({ hit } : CollectionCardProps) => {
   const { componentPickerMode } = useComponentPickerContext();
-  const { showOnlyPublished } = useLibraryContext();
+  const { showOnlyPublished, setCollectionId } = useLibraryContext();
   const { openCollectionInfoSidebar, sidebarComponentInfo } = useSidebarContext();
 
   const {
@@ -136,11 +136,15 @@ const CollectionCard = ({ hit } : CollectionCardProps) => {
     && sidebarComponentInfo.id === collectionId;
 
   const { navigateTo } = useLibraryRoutes();
-  const openCollection = useCallback(() => {
+  const openCollection = useCallback((e?: React.MouseEvent) => {
     openCollectionInfoSidebar(collectionId);
+    const doubleClicked = (e?.detail || 0) > 1;
 
     if (!componentPickerMode) {
-      navigateTo({ collectionId });
+      navigateTo({ collectionId, doubleClicked });
+    } else if (doubleClicked) {
+      /* istanbul ignore next */
+      setCollectionId(collectionId);
     }
   }, [collectionId, navigateTo, openCollectionInfoSidebar]);
 

--- a/src/library-authoring/components/ContainerCard.tsx
+++ b/src/library-authoring/components/ContainerCard.tsx
@@ -204,12 +204,12 @@ const ContainerCard = ({ hit } : ContainerCardProps) => {
 
   const { navigateTo } = useLibraryRoutes();
 
-  const openContainer = useCallback(() => {
+  const openContainer = useCallback((e?: React.MouseEvent) => {
     if (itemType === 'unit') {
       openUnitInfoSidebar(unitId);
       setUnitId(unitId);
       if (!componentPickerMode) {
-        navigateTo({ unitId });
+        navigateTo({ unitId, doubleClicked: (e?.detail || 0) > 1 });
       }
     }
   }, [unitId, itemType, openUnitInfoSidebar, navigateTo]);

--- a/src/library-authoring/routes.ts
+++ b/src/library-authoring/routes.ts
@@ -49,6 +49,7 @@ export type NavigateToData = {
   collectionId?: string,
   contentType?: ContentType,
   unitId?: string,
+  doubleClicked?: boolean,
 };
 
 export type LibraryRoutesData = {
@@ -80,6 +81,7 @@ export const useLibraryRoutes = (): LibraryRoutesData => {
     collectionId,
     unitId,
     contentType,
+    doubleClicked,
   }: NavigateToData = {}) => {
     const {
       collectionId: urlCollectionId,
@@ -125,7 +127,7 @@ export const useLibraryRoutes = (): LibraryRoutesData => {
     } else if (insideCollections) {
       // We're inside the Collections tab,
       route = (
-        (collectionId && collectionId === (urlCollectionId || urlSelectedItemId))
+        (collectionId && doubleClicked)
           // now open the previously-selected collection,
           ? ROUTES.COLLECTION
           // or stay there to list all collections, or a selected collection.
@@ -142,7 +144,7 @@ export const useLibraryRoutes = (): LibraryRoutesData => {
     } else if (insideUnits) {
       // We're inside the units tab,
       route = (
-        (unitId && unitId === (urlUnitId || urlSelectedItemId))
+        (unitId && doubleClicked)
           // now open the previously-selected unit,
           ? ROUTES.UNIT
           // or stay there to list all units, or a selected unit.
@@ -156,10 +158,10 @@ export const useLibraryRoutes = (): LibraryRoutesData => {
       // We're inside the All Content tab, so stay there,
       // and select a component.
       route = ROUTES.COMPONENT;
-    } else if (collectionId && collectionId === (urlCollectionId || urlSelectedItemId)) {
+    } else if (collectionId && doubleClicked) {
       // now open the previously-selected collection
       route = ROUTES.COLLECTION;
-    } else if (unitId && unitId === (urlUnitId || urlSelectedItemId)) {
+    } else if (unitId && doubleClicked) {
       // now open the previously-selected unit
       route = ROUTES.UNIT;
     } else {


### PR DESCRIPTION
## Description

Opens collection or unit page only on double click.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Course Author"

## Supporting information

* Related to: https://github.com/openedx/frontend-app-authoring/issues/1883
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4160

## Testing instructions

Verify that collection and unit page is only opened when we double click the respective card.


## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
