### PR TITLE
Rename in content dropdown updates and libraries

### DIFF
--- a/src/header/hooks.test.js
+++ b/src/header/hooks.test.js
@@ -45,7 +45,7 @@ describe('header utils', () => {
         librariesV2Enabled: true,
       });
       const actualItems = renderHook(() => useContentMenuItems('course-123')).result.current;
-      expect(actualItems[1]).toEqual({ href: '/course/course-123/libraries', title: 'Libraries' });
+      expect(actualItems[1]).toEqual({ href: '/course/course-123/libraries', title: 'Library Updates' });
     });
   });
 

--- a/src/header/messages.js
+++ b/src/header/messages.js
@@ -23,13 +23,13 @@ const messages = defineMessages({
   },
   'header.links.libraries': {
     id: 'header.links.libraries',
-    defaultMessage: 'Libraries',
-    description: 'Link to Linked Libraries page in a course',
+    defaultMessage: 'Library Updates',
+    description: 'Link to Linked Libraries updates page in a course',
   },
   'header.links.updates': {
     id: 'header.links.updates',
-    defaultMessage: 'Updates',
-    description: 'Link to Studio Updates page',
+    defaultMessage: 'Course Updates',
+    description: 'Link to Studio Course Updates page',
   },
   'header.links.pages': {
     id: 'header.links.pages',


### PR DESCRIPTION
## Description
In the Content dropdown on Studio, we renamed "Updates" to "Course Updates" and "Library" to "Library Updates", so is a clearer path to access.

## Supporting information
Fixes #1755 

## Screenshots
![Screenshot 2025-05-19 at 11 14 05 a m](https://github.com/user-attachments/assets/2d76fd33-ff03-42bc-bf3c-d06adaa1385e)