### PR TITLE
fix: rename library publish button to "Publish All"

### DIFF
--- a/src/library-authoring/library-info/messages.ts
+++ b/src/library-authoring/library-info/messages.ts
@@ -78,7 +78,7 @@ const messages = defineMessages({
   },
   publishLibraryButtonLabel: {
     id: 'course-authoring.library-authoring.library.publishLibraryButtonLabel',
-    defaultMessage: 'Publish All Changes',
+    defaultMessage: 'Publish All',
     description: 'Button text for publish library button',
   },
 });


### PR DESCRIPTION
## Description

This PR renames the Library publish button from "Publish All Changes" to "Publish All"

## Supporting information

- Related to https://github.com/openedx/frontend-app-authoring/issues/1467#issuecomment-2897986744

## Testing instructions

Open the library sidebar and check if the "Publish All" button.

___
Private ref: [FAL-4160](https://tasks.opencraft.com/browse/FAL-4160)