### PR TITLE
fix(search-manager): send search keywords to facet search too

### DIFF
--- a/src/search-manager/data/api.ts
+++ b/src/search-manager/data/api.ts
@@ -285,6 +285,8 @@ export async function fetchSearchResults({
   // The second query is to get the possible values for the "block types" filter
   if (!skipBlockTypeFetch) {
     queries.push({
+      // We send search keywords so that the search results coincide with the filter counts.
+      q: searchKeywords,
       indexUid: indexName,
       facets: ['block_type', 'content.problem_types', 'publish_status'],
       filter: [


### PR DESCRIPTION
## Description

Filter counts depends on the response for the meilisearch faceted search. Since the search keywords affect the search results, in order to make the block type filter counts reflect the search results, we need to include the search keywords into the faceted search too. 

Before
![image](https://github.com/user-attachments/assets/8449352f-a8c9-44f0-aafa-3622a51ab4c4)

After
![image](https://github.com/user-attachments/assets/2b753c9b-8eec-404e-8887-275b20612cbb)


## Supporting information

- Fixes https://github.com/openedx/frontend-app-authoring/issues/2005
- [Private-ref](https://tasks.opencraft.com/browse/FAL-4160)

## Testing instructions

- On any course open the search modal from the top right magnifier
- Make any search
- Open the block types filter
- Assert that the numbers coincide 

## Other information

I found a related issue where if you change the search keywords after applying a block type filter, the block type filter disappears. (https://github.com/openedx/frontend-app-authoring/issues/2005#issuecomment-2899441474)