### PR TITLE
fix: refresh xblock inline after accepting/rejecting library sync [FC-0090]

### DIFF
--- a/src/course-unit/preview-changes/index.test.tsx
+++ b/src/course-unit/preview-changes/index.test.tsx
@@ -85,7 +85,10 @@ describe('<IframePreviewLibraryXBlockChanges />', () => {
     const acceptBtn = await screen.findByRole('button', { name: 'Accept changes' });
     userEvent.click(acceptBtn);
     await waitFor(() => {
-      expect(mockSendMessageToIframe).toHaveBeenCalledWith(messageTypes.refreshXBlock, null);
+      expect(mockSendMessageToIframe).toHaveBeenCalledWith(
+        messageTypes.completeXBlockEditing,
+        { locator: usageKey },
+      );
       expect(axiosMock.history.post.length).toEqual(1);
       expect(axiosMock.history.post[0].url).toEqual(libraryBlockChangesUrl(usageKey));
     });
@@ -100,7 +103,6 @@ describe('<IframePreviewLibraryXBlockChanges />', () => {
     const acceptBtn = await screen.findByRole('button', { name: 'Accept changes' });
     userEvent.click(acceptBtn);
     await waitFor(() => {
-      expect(mockSendMessageToIframe).not.toHaveBeenCalledWith(messageTypes.refreshXBlock, null);
       expect(axiosMock.history.post.length).toEqual(1);
       expect(axiosMock.history.post[0].url).toEqual(libraryBlockChangesUrl(usageKey));
     });
@@ -118,7 +120,10 @@ describe('<IframePreviewLibraryXBlockChanges />', () => {
     const ignoreConfirmBtn = await screen.findByRole('button', { name: 'Ignore' });
     userEvent.click(ignoreConfirmBtn);
     await waitFor(() => {
-      expect(mockSendMessageToIframe).toHaveBeenCalledWith(messageTypes.refreshXBlock, null);
+      expect(mockSendMessageToIframe).toHaveBeenCalledWith(
+        messageTypes.completeXBlockEditing,
+        { locator: usageKey },
+      );
       expect(axiosMock.history.delete.length).toEqual(1);
       expect(axiosMock.history.delete[0].url).toEqual(libraryBlockChangesUrl(usageKey));
     });

--- a/src/course-unit/preview-changes/index.tsx
+++ b/src/course-unit/preview-changes/index.tsx
@@ -180,12 +180,14 @@ const IframePreviewLibraryXBlockChanges = () => {
     return null;
   }
 
+  const blockPayload = { locator: blockData.downstreamBlockId };
+
   return (
     <PreviewLibraryXBlockChanges
       blockData={blockData}
       isModalOpen={isModalOpen}
       closeModal={closeModal}
-      postChange={() => sendMessageToIframe(messageTypes.refreshXBlock, null)}
+      postChange={() => sendMessageToIframe(messageTypes.completeXBlockEditing, blockPayload)}
     />
   );
 };


### PR DESCRIPTION


## Description

When accepting/rejecting upstream changes to a course block, just reload the xblock that was changed.

This works around the scrolling issue reported below by avoiding reloading the entire unit. Also makes for a nicer editing experience.

## Supporting information

Part of: https://github.com/openedx/frontend-app-authoring/issues/1579
Private-ref: [FAL-4160](https://tasks.opencraft.com/browse/FAL-4160)

## Testing instructions

1. Create and publish a library component.
2. Copy/paste that component into a course unit.
3. Modify the original library component and publish the changes.
4. Refresh the course unit to see the pending changes.
5. Click the "refresh" button and accept or reject the changes.
    The synced block should update itself, and maintain the page scroll position.