### PR TITLE
fix: don't import scss vars from brand package

### DIFF
--- a/plugins/course-apps/xpert_unit_summary/settings-modal/SettingsModal.scss
+++ b/plugins/course-apps/xpert_unit_summary/settings-modal/SettingsModal.scss
@@ -1,4 +1,3 @@
-@import "~@edx/brand/paragon/variables";
 @import "~@openedx/paragon/styles/scss/core/utilities-only";
 
 .summary-radio {


### PR DESCRIPTION
## Description

We shouldn't be importing this from `@edx/brand`. Paragon's [`utilities-only.scss` imports `variables`](https://github.com/openedx/paragon/blob/908fe823e134d106fe502fb85b3c3cdac8006ff3/styles/scss/core/utilities-only.scss#L2). [Paragon's `_variables.scss`](https://github.com/openedx/paragon/blob/release-23.x/styles/scss/core/_variables.scss) ensures the scss variables in this file compile to read css variables. Brand packages provide css variables.