### PR TITLE
Display details tab as default in collections

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.test.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.test.tsx
@@ -509,8 +509,8 @@ describe('<LibraryAuthoringPage />', () => {
     // Switch back to the collection
     fireEvent.click((await screen.findByText('Collection 1')));
 
-    // The Manage (default) tab should be selected because the collection does not have a Preview tab
-    expect(screen.getByRole('tab', { name: 'Manage' })).toHaveAttribute('aria-selected', 'true');
+    // The Details (default) tab should be selected because the collection does not have a Preview tab
+    expect(screen.getByRole('tab', { name: 'Details' })).toHaveAttribute('aria-selected', 'true');
   });
 
   const problemTypes = {

--- a/src/library-authoring/collections/CollectionInfo.tsx
+++ b/src/library-authoring/collections/CollectionInfo.tsx
@@ -31,7 +31,7 @@ const CollectionInfo = () => {
 
   const tab: CollectionInfoTab = (
     sidebarTab && isCollectionInfoTab(sidebarTab)
-  ) ? sidebarTab : COLLECTION_INFO_TABS.Manage;
+  ) ? sidebarTab : COLLECTION_INFO_TABS.Details;
 
   const collectionId = sidebarComponentInfo?.id;
   // istanbul ignore if: this should never happen

--- a/src/library-authoring/collections/LibraryCollectionPage.test.tsx
+++ b/src/library-authoring/collections/LibraryCollectionPage.test.tsx
@@ -444,7 +444,7 @@ describe('<LibraryCollectionPage />', () => {
     );
     axiosMock.onPatch(collectionUrl).reply(200);
 
-    expect(await screen.findByRole('heading')).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /Test Collection/i })).toBeInTheDocument();
     expect(screen.queryByText(/add content/i)).not.toBeInTheDocument();
 
     // Open Add content sidebar


### PR DESCRIPTION
## Description
When click on a collection title, the sidebar should open with the Details tab by default, changing this behavior also changed if you go inside the collection sidebar by default opens Details tab too

## Supporting information
Fixes #1525 

## Testing instructions
Demo video
https://github.com/user-attachments/assets/13c5ea39-f9cb-4d1a-966b-0e4ffc5f59ba
