### PR TITLE
fix: increase max value for the grace period

### DIFF
--- a/src/grading-settings/deadline-section/utils.js
+++ b/src/grading-settings/deadline-section/utils.js
@@ -17,7 +17,7 @@ export function formatTime(time) {
  * @returns {boolean} - returns `true` if `inputStr` is a valid time, else `false`.
  */
 export function timerValidation(inputStr, setShowSavePrompt, setIsError) {
-  const timePattern = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+  const timePattern = /^(?:\d{2,3}):[0-5]\d$/;
 
   const isValid = timePattern.test(inputStr);
   setShowSavePrompt(isValid);


### PR DESCRIPTION
Ticket: [TNL-11994](https://2u-internal.atlassian.net/browse/TNL-11994)
- Users were not able to select equal to/more than 24 hours for grace period.
- Increased max value for the grace period as same as it was before in the legacy experience.


**Grace Period length in legacy experience:**
![legacy](https://github.com/user-attachments/assets/aec613b8-608c-4363-99dc-1a353be02566)

**Before in New MFE experience:**
![before](https://github.com/user-attachments/assets/27c65011-8860-4655-9769-b76a4b04b005)

**After in New MFE experience:**
![after](https://github.com/user-attachments/assets/55e4a119-370f-4e75-a71e-48ec6e585d13)
