### PR TITLE
Fix logic of best practices checklist and remove mobile friendly check

### DIFF
--- a/src/course-checklist/ChecklistSection/messages.js
+++ b/src/course-checklist/ChecklistSection/messages.js
@@ -71,16 +71,6 @@ const messages = defineMessages({
     defaultMessage: 'Learners engage best with short videos followed by opportunities to practice. Ensure that 80% or more of course videos are less than 10 minutes long.',
     description: 'Description for a section that prompts a user to follow best practices for video length',
   },
-  mobileFriendlyVideoShortDescription: {
-    id: 'mobileFriendlyVideoShortDescription',
-    defaultMessage: 'Create mobile-friendly video',
-    description: 'Label for a section that describes mobile friendly videos',
-  },
-  mobileFriendlyVideoLongDescription: {
-    id: 'mobileFriendlyVideoLongDescription',
-    defaultMessage: 'Mobile-friendly videos can be viewed across all supported devices. Ensure that at least 90% of course videos are mobile friendly by uploading course videos to the edX video pipeline.',
-    description: 'Description for a section that prompts a user to follow best practices for mobile friendly videos',
-  },
   diverseSequencesShortDescription: {
     id: 'diverseSequencesShortDescription',
     defaultMessage: 'Build diverse learning sequences',

--- a/src/course-checklist/ChecklistSection/utils/courseChecklistData.jsx
+++ b/src/course-checklist/ChecklistSection/utils/courseChecklistData.jsx
@@ -37,10 +37,6 @@ export const checklistItems = {
       pacingTypeFilter: filters.ALL,
     },
     {
-      id: 'mobileFriendlyVideo',
-      pacingTypeFilter: filters.ALL,
-    },
-    {
       id: 'diverseSequences',
       pacingTypeFilter: filters.ALL,
     },

--- a/src/course-checklist/ChecklistSection/utils/courseChecklistValidators.js
+++ b/src/course-checklist/ChecklistSection/utils/courseChecklistValidators.js
@@ -36,7 +36,7 @@ export const hasAssignmentDeadlines = (assignments, dates) => {
 export const hasShortVideoDuration = (videos) => {
   if (videos.totalNumber === 0) {
     return false;
-  } if (videos.totalNumber > 0 && videos.durations.median <= 600) {
+  } if (videos.totalNumber > 0 && videos.durations.median !== null && videos.durations.median <= 600) {
     return true;
   }
 
@@ -47,7 +47,7 @@ export const hasDiverseSequences = (subsections) => {
   if (subsections.totalVisible === 0) {
     return false;
   } if (subsections.totalVisible > 0) {
-    return ((subsections.numWithOneBlockType / subsections.totalVisible) < 0.2);
+    return ((subsections.numWithOneBlockType / subsections.totalVisible) <= 0.2);
   }
 
   return false;

--- a/src/course-checklist/ChecklistSection/utils/courseChecklistValidators.js
+++ b/src/course-checklist/ChecklistSection/utils/courseChecklistValidators.js
@@ -35,18 +35,8 @@ export const hasAssignmentDeadlines = (assignments, dates) => {
 
 export const hasShortVideoDuration = (videos) => {
   if (videos.totalNumber === 0) {
-    return true;
+    return false;
   } if (videos.totalNumber > 0 && videos.durations.median <= 600) {
-    return true;
-  }
-
-  return false;
-};
-
-export const hasMobileFriendlyVideos = (videos) => {
-  if (videos.totalNumber === 0) {
-    return true;
-  } if (videos.totalNumber > 0 && (videos.numMobileEncoded / videos.totalNumber) >= 0.9) {
     return true;
   }
 
@@ -68,7 +58,7 @@ export const hasWeeklyHighlights = sections => (
 );
 
 export const hasShortUnitDepth = units => (
-  units.numBlocks.median <= 3
+  units.numBlocks.median <= 3 && units.totalVisible > 0
 );
 
 export const hasProctoringEscalationEmail = proctoring => (

--- a/src/course-checklist/ChecklistSection/utils/courseChecklistValidators.test.js
+++ b/src/course-checklist/ChecklistSection/utils/courseChecklistValidators.test.js
@@ -189,8 +189,8 @@ describe('courseCheckValidators utility functions', () => {
   );
 
   describe('hasShortVideoDuration', () => {
-    it('returns true if course run has no videos', () => {
-      expect(validators.hasShortVideoDuration({ totalNumber: 0 })).toEqual(true);
+    it('returns false if course run has no videos', () => {
+      expect(validators.hasShortVideoDuration({ totalNumber: 0 })).toEqual(false);
     });
 
     it('returns true if course run videos have a median duration <= to 600', () => {
@@ -200,22 +200,6 @@ describe('courseCheckValidators utility functions', () => {
 
     it('returns true if course run videos have a median duration > to 600', () => {
       expect(validators.hasShortVideoDuration({ totalNumber: 10, durations: { median: 700 } }))
-        .toEqual(false);
-    });
-  });
-
-  describe('hasMobileFriendlyVideos', () => {
-    it('returns true if course run has no videos', () => {
-      expect(validators.hasMobileFriendlyVideos({ totalNumber: 0 })).toEqual(true);
-    });
-
-    it('returns true if course run videos are >= 90% mobile friendly', () => {
-      expect(validators.hasMobileFriendlyVideos({ totalNumber: 10, numMobileEncoded: 9 }))
-        .toEqual(true);
-    });
-
-    it('returns true if course run videos are < 90% mobile friendly', () => {
-      expect(validators.hasMobileFriendlyVideos({ totalNumber: 10, numMobileEncoded: 8 }))
         .toEqual(false);
     });
   });
@@ -264,6 +248,7 @@ describe('courseCheckValidators utility functions', () => {
   describe('hasShortUnitDepth', () => {
     it('returns true when course run has median number of blocks <= 3', () => {
       const units = {
+        totalVisible: 2,
         numBlocks: {
           median: 3,
         },
@@ -274,6 +259,7 @@ describe('courseCheckValidators utility functions', () => {
 
     it('returns false when course run has median number of blocks > 3', () => {
       const units = {
+        totalVisible: 2,
         numBlocks: {
           median: 4,
         },

--- a/src/course-checklist/ChecklistSection/utils/getValidatedValue.js
+++ b/src/course-checklist/ChecklistSection/utils/getValidatedValue.js
@@ -14,8 +14,6 @@ const getValidatedValue = (data, id) => {
       return healthValidators.hasAssignmentDeadlines(data.assignments, data.dates);
     case 'videoDuration':
       return healthValidators.hasShortVideoDuration(data.videos);
-    case 'mobileFriendlyVideo':
-      return healthValidators.hasMobileFriendlyVideos(data.videos);
     case 'diverseSequences':
       return healthValidators.hasDiverseSequences(data.subsections);
     case 'weeklyHighlights':

--- a/src/course-checklist/ChecklistSection/utils/getValidatedValue.test.js
+++ b/src/course-checklist/ChecklistSection/utils/getValidatedValue.test.js
@@ -88,20 +88,6 @@ describe('getValidatedValue utility function', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  it('mobile friendly video', () => {
-    const spy = jest.fn();
-    localValidators.hasMobileFriendlyVideos = spy;
-
-    const props = {
-      data: {
-        videos: {},
-      },
-    };
-
-    getValidatedValue(props, 'mobileFriendlyVideo');
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-
   it('diverse sequences', () => {
     const spy = jest.fn();
     localValidators.hasDiverseSequences = spy;

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -482,7 +482,7 @@ describe('<CourseOutline />', () => {
       courseId, excludeGraded: true, all: true,
     }), store.dispatch);
 
-    expect(getByText('4/8 completed')).toBeInTheDocument();
+    expect(getByText('3/8 completed')).toBeInTheDocument();
   });
 
   it('render alerts if checklist api fails', async () => {

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -482,7 +482,7 @@ describe('<CourseOutline />', () => {
       courseId, excludeGraded: true, all: true,
     }), store.dispatch);
 
-    expect(getByText('4/9 completed')).toBeInTheDocument();
+    expect(getByText('4/8 completed')).toBeInTheDocument();
   });
 
   it('render alerts if checklist api fails', async () => {

--- a/src/course-outline/constants.js
+++ b/src/course-outline/constants.js
@@ -59,10 +59,6 @@ export const BEST_PRACTICES_CHECKLIST = /** @type {const} */ ({
       pacingTypeFilter: CHECKLIST_FILTERS.ALL,
     },
     {
-      id: 'mobileFriendlyVideo',
-      pacingTypeFilter: CHECKLIST_FILTERS.ALL,
-    },
-    {
       id: 'diverseSequences',
       pacingTypeFilter: CHECKLIST_FILTERS.ALL,
     },

--- a/src/course-outline/utils/courseChecklistValidators.js
+++ b/src/course-outline/utils/courseChecklistValidators.js
@@ -62,7 +62,7 @@ export const hasShortVideoDuration = (videos) => {
   if (totalNumber === 0) {
     return true;
   }
-  if (totalNumber > 0 && durations.median <= 600) {
+  if (totalNumber > 0 && durations.median !== null && durations.median <= 600) {
     return true;
   }
 
@@ -76,7 +76,7 @@ export const hasDiverseSequences = (subsections) => {
     return false;
   }
   if (totalVisible > 0) {
-    return ((numWithOneBlockType / totalVisible) < 0.2);
+    return ((numWithOneBlockType / totalVisible) <= 0.2);
   }
 
   return false;

--- a/src/course-outline/utils/courseChecklistValidators.js
+++ b/src/course-outline/utils/courseChecklistValidators.js
@@ -69,19 +69,6 @@ export const hasShortVideoDuration = (videos) => {
   return false;
 };
 
-export const hasMobileFriendlyVideos = (videos) => {
-  const { totalNumber, numMobileEncoded } = videos;
-
-  if (totalNumber === 0) {
-    return true;
-  }
-  if (totalNumber > 0 && (numMobileEncoded / totalNumber) >= 0.9) {
-    return true;
-  }
-
-  return false;
-};
-
 export const hasDiverseSequences = (subsections) => {
   const { totalVisible, numWithOneBlockType } = subsections;
 
@@ -101,6 +88,6 @@ export const hasWeeklyHighlights = (sections) => {
   return highlightsActiveForCourse && highlightsEnabled;
 };
 
-export const hasShortUnitDepth = (units) => units.numBlocks.median <= 3;
+export const hasShortUnitDepth = (units) => units.numBlocks.median <= 3 && units.totalVisible > 0;
 
 export const hasProctoringEscalationEmail = (proctoring) => proctoring.hasProctoringEscalationEmail;

--- a/src/course-outline/utils/courseChecklistValidators.test.js
+++ b/src/course-outline/utils/courseChecklistValidators.test.js
@@ -204,22 +204,6 @@ describe('courseCheckValidators utility functions', () => {
     });
   });
 
-  describe('hasMobileFriendlyVideos', () => {
-    it('returns true if course run has no videos', () => {
-      expect(validators.hasMobileFriendlyVideos({ totalNumber: 0 })).toEqual(true);
-    });
-
-    it('returns true if course run videos are >= 90% mobile friendly', () => {
-      expect(validators.hasMobileFriendlyVideos({ totalNumber: 10, numMobileEncoded: 9 }))
-        .toEqual(true);
-    });
-
-    it('returns true if course run videos are < 90% mobile friendly', () => {
-      expect(validators.hasMobileFriendlyVideos({ totalNumber: 10, numMobileEncoded: 8 }))
-        .toEqual(false);
-    });
-  });
-
   describe('hasDiverseSequences', () => {
     it('returns true if < 20% of visible subsections have more than one block type', () => {
       expect(validators.hasDiverseSequences({ totalVisible: 10, numWithOneBlockType: 1 }))
@@ -264,6 +248,7 @@ describe('courseCheckValidators utility functions', () => {
   describe('hasShortUnitDepth', () => {
     it('returns true when course run has median number of blocks <= 3', () => {
       const units = {
+        totalVisible: 2,
         numBlocks: {
           median: 3,
         },
@@ -274,6 +259,7 @@ describe('courseCheckValidators utility functions', () => {
 
     it('returns false when course run has median number of blocks > 3', () => {
       const units = {
+        totalVisible: 2,
         numBlocks: {
           median: 4,
         },

--- a/src/course-outline/utils/getChecklistForStatusBar.test.js
+++ b/src/course-outline/utils/getChecklistForStatusBar.test.js
@@ -90,7 +90,7 @@ describe('getChecklistForStatusBar util functions', () => {
 
     expect(getCourseBestPracticesChecklist(data)).toEqual({
       totalCourseBestPracticesChecks: 3,
-      completedCourseBestPracticesChecks: 2,
+      completedCourseBestPracticesChecks: 1,
     });
   });
 });

--- a/src/course-outline/utils/getChecklistForStatusBar.test.js
+++ b/src/course-outline/utils/getChecklistForStatusBar.test.js
@@ -89,7 +89,7 @@ describe('getChecklistForStatusBar util functions', () => {
     };
 
     expect(getCourseBestPracticesChecklist(data)).toEqual({
-      totalCourseBestPracticesChecks: 4,
+      totalCourseBestPracticesChecks: 3,
       completedCourseBestPracticesChecks: 2,
     });
   });

--- a/src/course-outline/utils/getChecklistValues.js
+++ b/src/course-outline/utils/getChecklistValues.js
@@ -32,8 +32,6 @@ const getChecklistValidatedValue = (data, id) => {
       return healthValidators.hasAssignmentDeadlines(assignments, dates);
     case 'videoDuration':
       return healthValidators.hasShortVideoDuration(videos);
-    case 'mobileFriendlyVideo':
-      return healthValidators.hasMobileFriendlyVideos(videos);
     case 'diverseSequences':
       return healthValidators.hasDiverseSequences(subsections);
     case 'weeklyHighlights':


### PR DESCRIPTION
## Description
Best Practices Checklist behavior was wrong for some cases, also in the issue was requested to completely remove mobile friendly video from the checklist.
Fixes:
- Video duration: if duration was null it shouldn't be marked as completed, if there were no videos shouldn't be marked as completed
- Unit depth: If course doesn't have units it shouldn't be marked as completed
- Diverse learning sequence: description mentions that 80% should contain multiple content types, so if it is exactly 80% it should be marked as completed

## Supporting information
Fixes https://github.com/openedx/frontend-app-authoring/issues/2070
Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Screenshots
Course with video but having units with more than 3 components
<img width="1366" alt="Screenshot 2025-05-28 at 2 33 36 p m" src="https://github.com/user-attachments/assets/5904cd8c-d7a8-4527-b626-871d223dd2b6" />

Course without video and having units with 3 or less components
<img width="1401" alt="Screenshot 2025-05-28 at 2 34 21 p m" src="https://github.com/user-attachments/assets/4f93f1b9-b44d-44e3-840a-823ce45847a2" />

Empty course
<img width="1382" alt="Screenshot 2025-05-28 at 2 50 51 p m" src="https://github.com/user-attachments/assets/ed816f63-97a5-42f3-b404-7e4afb4c9902" />

80% subsections contain different content types
<img width="1395" alt="Screenshot 2025-05-29 at 9 49 08 a m" src="https://github.com/user-attachments/assets/ba0d309d-67cc-4128-beb4-f77e47c9f0df" />

Note: No mobile friendly check in any of this cases due to removal.