### PR TITLE
fix: upstreamInfo is not always provided

### DIFF
--- a/src/course-unit/CourseUnit.jsx
+++ b/src/course-unit/CourseUnit.jsx
@@ -140,7 +140,7 @@ const CourseUnit = ({ courseId }) => {
               />
             ) : null}
           </TransitionReplace>
-          {courseUnit.upstreamInfo.upstreamLink && (
+          {courseUnit.upstreamInfo?.upstreamLink && (
             <AlertMessage
               title={intl.formatMessage(
                 messages.alertLibraryUnitReadOnlyText,


### PR DESCRIPTION
## Description

Fixes a bug when viewing a Problem Bank-type "unit" without upstream link information attached.

This issue affects Course Authors.

## Supporting information

* Part of https://github.com/openedx/frontend-app-authoring/issues/2007
* Private-ref: [FAL-4160](https://tasks.opencraft.com/browse/FAL-4160)

## Testing instructions

1. Create a library with two or more problem components.
2. Create a course + section + subsection + unit
3. Add a Problem Bank block to the unit, and add the library's problem components to the Problem Bank.
4. Click the View link in the Problem Bank, and verify that you can see the problem components without error.