### PR TITLE
[teak] fix: upstreamInfo is not always provided [FC-0090]

### DIFF
--- a/src/course-unit/CourseUnit.jsx
+++ b/src/course-unit/CourseUnit.jsx
@@ -140,7 +140,7 @@ const CourseUnit = ({ courseId }) => {
               />
             ) : null}
           </TransitionReplace>
-          {courseUnit.upstreamInfo.upstreamLink && (
+          {courseUnit.upstreamInfo?.upstreamLink && (
             <AlertMessage
               title={intl.formatMessage(
                 messages.alertLibraryUnitReadOnlyText,


### PR DESCRIPTION
## Description

Backports https://github.com/openedx/frontend-app-authoring/pull/2041 to Teak.
This issue affects Course Authors.

## Supporting information

* Part of https://github.com/openedx/frontend-app-authoring/issues/2007
* Private-ref: [FAL-4160](https://tasks.opencraft.com/browse/FAL-4160)

## Testing instructions

See https://github.com/openedx/frontend-app-authoring/pull/2041