### PR TITLE
Html button in text component editor backport

### DIFF
--- a/src/editors/sharedComponents/CodeEditor/hooks.js
+++ b/src/editors/sharedComponents/CodeEditor/hooks.js
@@ -100,7 +100,7 @@ export const createCodeMirrorDomNode = ({
 }) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
-    const languageExtension = CODEMIRROR_LANGUAGES[lang]();
+    const languageExtension = CODEMIRROR_LANGUAGES[lang] ? CODEMIRROR_LANGUAGES[lang]() : xml();
     const cleanText = cleanHTML({ initialText });
     const newState = EditorState.create({
       doc: cleanText,

--- a/src/editors/sharedComponents/SourceCodeModal/__snapshots__/index.test.jsx.snap
+++ b/src/editors/sharedComponents/SourceCodeModal/__snapshots__/index.test.jsx.snap
@@ -41,6 +41,7 @@ exports[`SourceCodeModal renders as expected with default behavior 1`] = `
   >
     <injectIntl(ShimmedIntlComponent)
       innerRef="moCKrEf"
+      lang="html"
       value="mOckHtMl"
     />
   </div>

--- a/src/editors/sharedComponents/SourceCodeModal/index.jsx
+++ b/src/editors/sharedComponents/SourceCodeModal/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -41,6 +40,7 @@ const SourceCodeModal = ({
         <CodeEditor
           innerRef={ref}
           value={value}
+          lang="html" // hardcoded value to do lookup on CODEMIRROR_LANGUAGES
         />
       </div>
     </BaseModal>


### PR DESCRIPTION
## Description

Backport: https://github.com/openedx/frontend-app-authoring/pull/1869 and https://github.com/openedx/frontend-app-authoring/pull/2043

## Supporting information

Fixes: https://github.com/openedx/wg-build-test-release/issues/466

## Testing instructions

Go to Section > Subsection > Unit (Text)
Click on the "text" button in the Add Components panel
Text editor opens in a modal
Click on the text editor HTML functions

## Other Information 

The CodeEditor hook createCodeMirrorDomNode is doing a lookup on CODEMIRROR_LANGUAGES but we never set the lang on the component. Since this is referenced in the project to be specifically an HTML editor, I hardcoded the "html" string to the prop for the lookup to succeed. Otherwise, there is a new change on master that includes the default as xml() (this wasn't included in the current teak release).
See default here: https://github.com/tonybusa/frontend-app-authoring/blob/html-button-in-text-component-editor/src/editors/sharedComponents/CodeEditor/hooks.js#L103