### PR TITLE
fix: backport changes for html button in text component markdown editor

### DIFF
--- a/src/editors/sharedComponents/CodeEditor/hooks.js
+++ b/src/editors/sharedComponents/CodeEditor/hooks.js
@@ -100,7 +100,7 @@ export const createCodeMirrorDomNode = ({
 }) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
-    const languageExtension = CODEMIRROR_LANGUAGES[lang]();
+    const languageExtension = CODEMIRROR_LANGUAGES[lang] ? CODEMIRROR_LANGUAGES[lang]() : xml();
     const cleanText = cleanHTML({ initialText });
     const newState = EditorState.create({
       doc: cleanText,

--- a/src/editors/sharedComponents/SourceCodeModal/__snapshots__/index.test.jsx.snap
+++ b/src/editors/sharedComponents/SourceCodeModal/__snapshots__/index.test.jsx.snap
@@ -41,6 +41,7 @@ exports[`SourceCodeModal renders as expected with default behavior 1`] = `
   >
     <injectIntl(ShimmedIntlComponent)
       innerRef="moCKrEf"
+      lang="html"
       value="mOckHtMl"
     />
   </div>

--- a/src/editors/sharedComponents/SourceCodeModal/index.jsx
+++ b/src/editors/sharedComponents/SourceCodeModal/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -41,6 +40,7 @@ const SourceCodeModal = ({
         <CodeEditor
           innerRef={ref}
           value={value}
+          lang="html" // hardcoded value to do lookup on CODEMIRROR_LANGUAGES
         />
       </div>
     </BaseModal>


### PR DESCRIPTION
## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.


## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.