### PR TITLE
Backport fix: files & uploads menu was truncated due to overflow-x (#2071)

### DIFF
--- a/src/files-and-videos/files-page/FilesPage.jsx
+++ b/src/files-and-videos/files-page/FilesPage.jsx
@@ -32,6 +32,7 @@ import { getFileSizeToClosestByte } from '../../utils';
 import FileThumbnail from './FileThumbnail';
 import FileInfoModalSidebar from './FileInfoModalSidebar';
 import FileValidationModal from './FileValidationModal';
+import './FilesPage.scss';
 
 const FilesPage = ({
   courseId,

--- a/src/files-and-videos/files-page/FilesPage.scss
+++ b/src/files-and-videos/files-page/FilesPage.scss
@@ -1,0 +1,5 @@
+.files-table {
+    .pgn__data-table-container {
+        overflow-x: visible;
+    }
+}


### PR DESCRIPTION
## Description
This PR is a Teak backport for #2071 , which fixes: Files and Uploads three-dot menu for a file is truncated when is a short list or on the next to last file of the table due to overflow-x that is set as auto in data table container, it seems to be hidden but creates a scrollbar and expects to scroll to see the menu.

## Supporting information
Fixes https://github.com/openedx/wg-build-test-release/issues/426

## Testing instructions

Go to content -> files -> click on the next to last file three dot menu
Before:
Short list
<img width="1414" alt="Screenshot 2025-06-03 at 11 54 43 a m" src="https://github.com/user-attachments/assets/04807e57-d7fb-4070-bb19-ba89bb426adc" />

Long list
<img width="1411" alt="Screenshot 2025-06-03 at 11 55 28 a m" src="https://github.com/user-attachments/assets/36c9c00b-dabd-4310-8263-61313e647668" />

After:
Short list
<img width="1416" alt="Screenshot 2025-06-03 at 11 54 13 a m" src="https://github.com/user-attachments/assets/17ef0704-4b3a-4b85-8c5c-bb89f36b7b46" />

Long list
<img width="1405" alt="Screenshot 2025-06-03 at 11 55 52 a m" src="https://github.com/user-attachments/assets/2b6240e7-c2ba-4300-9e65-857f2bf8fb56" />

## Other information
Master PR: #2071 