### PR TITLE
fix: searching "all courses" from studio home wasn't working

### DIFF
--- a/src/studio-home/data/api.js
+++ b/src/studio-home/data/api.js
@@ -24,6 +24,7 @@ export async function getStudioHomeCourses(search) {
 /**
  * Get's studio home courses.
  * @param {string} search - Query string parameters for filtering the courses.
+ *   TODO: this should be an object with a list of allowed keys and values; not a string.
  * @param {object} customParams - Additional custom parameters for the API request.
  * @returns {Promise<Object>} - A Promise that resolves to the response data containing the studio home courses.
  * Note: We are changing /api/contentstore/v1 to /api/contentstore/v2 due to upcoming breaking changes.

--- a/src/studio-home/data/thunks.js
+++ b/src/studio-home/data/thunks.js
@@ -14,6 +14,13 @@ import {
   fetchCourseDataSuccessV2,
 } from './slice';
 
+/**
+ * Load both the "Studio Home" data and the course list. Store it in the Redux state.
+ *
+ * TODO: this should be replaced with two separate React Query hooks - one that calls
+ * useQuery() to load the "studio home" data, and another that calls useQuery() to
+ * load the course list.
+ */
 function fetchStudioHomeData(
   search,
   hasHomeData,


### PR DESCRIPTION
## Description

Bug:
1. From the Studio home page, click the ![Search](https://github.com/user-attachments/assets/ac68b3a9-1df0-4379-86ba-15cf6679e8e1) icon in the header.
2. Type any search term into the field:
    ![Screenshot of search field](https://github.com/user-attachments/assets/5b1d8b35-de2e-43af-925f-31992f693973)
3. The page will reload and the search modal will be closed.

A proper long-term fix will be to convert more data loading to React Query, but for now this solves the bug by not updating the course list whenever the `location.search` changes; just when relevant fields change. It also adds comments questioning the logic of using `location.search` at all.

## Supporting information

## Testing instructions

See bug reproduction steps above. Try that before and after this PR. Also make sure the various search & filter functions for the course list on the studio home page are still working.
