### PR TITLE
Backport fix: enable markdown editor in libraries

### DIFF
--- a/src/editors/data/redux/thunkActions/problem.test.ts
+++ b/src/editors/data/redux/thunkActions/problem.test.ts
@@ -10,7 +10,6 @@ import {
 } from './problem';
 import { checkboxesOLXWithFeedbackAndHintsOLX, advancedProblemOlX, blankProblemOLX } from '../../../containers/ProblemEditor/data/mockData/olxTestData';
 import { ProblemTypeKeys } from '../../constants/problem';
-import * as requests from './requests';
 
 const mockOlx = 'SOmEVALue';
 const mockBuildOlx = jest.fn(() => mockOlx);
@@ -72,20 +71,11 @@ describe('problem thunkActions', () => {
     );
   });
   test('switchToMarkdownEditor dispatches correct actions', () => {
-    switchToMarkdownEditor()(dispatch, getState);
+    switchToMarkdownEditor()(dispatch);
 
     expect(dispatch).toHaveBeenCalledWith(
       actions.problem.updateField({
         isMarkdownEditorEnabled: true,
-      }),
-    );
-
-    expect(dispatch).toHaveBeenCalledWith(
-      requests.saveBlock({
-        content: {
-          settings: { markdown_edited: true },
-          olx: blockValue.data.data,
-        },
       }),
     );
   });
@@ -110,7 +100,7 @@ describe('problem thunkActions', () => {
 
     test('dispatches switchToMarkdownEditor when editorType is markdown', () => {
       switchEditor('markdown')(dispatch, getState);
-      expect(switchToMarkdownEditorMock).toHaveBeenCalledWith(dispatch, getState);
+      expect(switchToMarkdownEditorMock).toHaveBeenCalledWith(dispatch);
     });
   });
 

--- a/src/editors/data/redux/thunkActions/problem.ts
+++ b/src/editors/data/redux/thunkActions/problem.ts
@@ -24,17 +24,17 @@ export const switchToAdvancedEditor = () => (dispatch, getState) => {
   dispatch(actions.problem.updateField({ problemType: ProblemTypeKeys.ADVANCED, rawOLX }));
 };
 
-export const switchToMarkdownEditor = () => (dispatch, getState) => {
-  const state = getState();
+export const switchToMarkdownEditor = () => (dispatch) => {
   dispatch(actions.problem.updateField({ isMarkdownEditorEnabled: true }));
-  const { blockValue } = state.app;
-  const olx = get(blockValue, 'data.data', '');
-  const content = { settings: { markdown_edited: true }, olx };
-  // Sending a request to save the problem block with the updated markdown_edited value
-  dispatch(requests.saveBlock({ content }));
 };
 
-export const switchEditor = (editorType) => (dispatch, getState) => (editorType === 'advanced' ? switchToAdvancedEditor : switchToMarkdownEditor)()(dispatch, getState);
+export const switchEditor = (editorType) => (dispatch, getState) => {
+  if (editorType === 'advanced') {
+    switchToAdvancedEditor()(dispatch, getState);
+  } else {
+    switchToMarkdownEditor()(dispatch);
+  }
+};
 
 export const isBlankProblem = ({ rawOLX }) => {
   if (['<problem></problem>', '<problem/>'].includes(rawOLX.replace(/\s/g, ''))) {

--- a/src/library-authoring/components/ComponentEditorModal.tsx
+++ b/src/library-authoring/components/ComponentEditorModal.tsx
@@ -1,7 +1,9 @@
 import { getConfig } from '@edx/frontend-platform';
 import React from 'react';
-
+import { useSelector } from 'react-redux';
 import { useQueryClient } from '@tanstack/react-query';
+
+import { getWaffleFlags } from '../../data/selectors';
 import EditorPage from '../../editors/EditorPage';
 import { getBlockType } from '../../generic/key-utils';
 import { useLibraryContext } from '../common/context/LibraryContext';
@@ -21,6 +23,7 @@ export function canEditComponent(usageKey: string): boolean {
 export const ComponentEditorModal: React.FC<Record<never, never>> = () => {
   const { componentBeingEdited, closeComponentEditor, libraryId } = useLibraryContext();
   const queryClient = useQueryClient();
+  const { useReactMarkdownEditor } = useSelector(getWaffleFlags);
 
   if (componentBeingEdited === undefined) {
     return null;
@@ -37,6 +40,7 @@ export const ComponentEditorModal: React.FC<Record<never, never>> = () => {
       courseId={libraryId}
       blockType={blockType}
       blockId={componentBeingEdited.usageKey}
+      isMarkdownEditorEnabledForCourse={useReactMarkdownEditor}
       studioEndpointUrl={getConfig().STUDIO_BASE_URL}
       lmsEndpointUrl={getConfig().LMS_BASE_URL}
       onClose={onClose}


### PR DESCRIPTION
## Description

The markdown problem editor wasn't available in libraries, but probably unintentionally.

## Supporting information

Don't merge yet - there is a minor bug with this: https://github.com/openedx/frontend-app-authoring/issues/2099

## Testing instructions

Create a new problem in a library. Switch to markdown editor.
Confirm that if the waffle flag is modified, the markdown option is no longer available.

## Other information

