### PR TITLE
fix: Issue on the Inplace editor [FC-0090]

### DIFF
--- a/src/generic/inplace-text-editor/InplaceTextEditor.test.tsx
+++ b/src/generic/inplace-text-editor/InplaceTextEditor.test.tsx
@@ -111,7 +111,7 @@ describe('<InplaceTextEditor />', () => {
     expect(screen.getByText('Test text')).toBeInTheDocument();
   });
 
-  it('should dissapear edit button while editing', async () => {
+  it('should disappear edit button while editing', async () => {
     render(<InplaceTextEditor text="Test text" onSave={mockOnSave} />);
 
     const title = screen.getByText('Test text');

--- a/src/generic/inplace-text-editor/InplaceTextEditor.test.tsx
+++ b/src/generic/inplace-text-editor/InplaceTextEditor.test.tsx
@@ -110,4 +110,25 @@ describe('<InplaceTextEditor />', () => {
     // Show original text
     expect(screen.getByText('Test text')).toBeInTheDocument();
   });
+
+  it('should dissapear edit button while editing', async () => {
+    render(<InplaceTextEditor text="Test text" onSave={mockOnSave} />);
+
+    const title = screen.getByText('Test text');
+    expect(title).toBeInTheDocument();
+
+    const editButton = screen.getByRole('button', { name: /edit/i });
+    expect(editButton).toBeInTheDocument();
+    fireEvent.click(editButton);
+
+    const textBox = screen.getByRole('textbox');
+    expect(editButton).not.toBeInTheDocument();
+
+    fireEvent.change(textBox, { target: { value: 'New text' } });
+    fireEvent.keyDown(textBox, { key: 'Enter', code: 'Enter', charCode: 13 });
+
+    expect(textBox).not.toBeInTheDocument();
+    expect(mockOnSave).toHaveBeenCalledWith('New text');
+    expect(await screen.findByRole('button', { name: /edit/i })).toBeInTheDocument();
+  });
 });

--- a/src/generic/inplace-text-editor/index.tsx
+++ b/src/generic/inplace-text-editor/index.tsx
@@ -92,17 +92,19 @@ export const InplaceTextEditor: React.FC<InplaceTextEditorProps> = ({
           />
         )
         : (
-          <Truncate className={textClassName}>
-            {text}
-          </Truncate>
+          <>
+            <Truncate className={textClassName}>
+              {text}
+            </Truncate>
+            <IconButton
+              src={Edit}
+              iconAs={Icon}
+              alt={intl.formatMessage(messages.editTextButtonAlt)}
+              onClick={handleEdit}
+              size="sm"
+            />
+          </>
         )}
-      <IconButton
-        src={Edit}
-        iconAs={Icon}
-        alt={intl.formatMessage(messages.editTextButtonAlt)}
-        onClick={handleEdit}
-        size="inline"
-      />
     </Stack>
   );
 };

--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -114,7 +114,7 @@ export const SubHeaderTitle = ({ title }: { title: ReactNode }) => {
   const showReadOnlyBadge = readOnly && !componentPickerMode;
 
   return (
-    <Stack direction="vertical" className='mt-1.5'>
+    <Stack direction="vertical" className="mt-1.5">
       {title}
       {showReadOnlyBadge && (
         <div>

--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -114,7 +114,7 @@ export const SubHeaderTitle = ({ title }: { title: ReactNode }) => {
   const showReadOnlyBadge = readOnly && !componentPickerMode;
 
   return (
-    <Stack direction="vertical">
+    <Stack direction="vertical" className='mt-1.5'>
       {title}
       {showReadOnlyBadge && (
         <div>

--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -619,7 +619,7 @@ export const useUpdateContainer = (containerId: string) => {
   return useMutation({
     mutationFn: (data: api.UpdateContainerDataRequest) => api.updateContainerMetadata(containerId, data),
     onMutate: (data) => {
-      const previousData = queryClient.getQueryData(containerQueryKey) as api.CollectionMetadata;
+      const previousData = queryClient.getQueryData(containerQueryKey) as api.Container;
       queryClient.setQueryData(containerQueryKey, {
         ...previousData,
         ...data,


### PR DESCRIPTION
## Description

- Fix the issue of the big edit icon 
- Makes the edit button disappear while editing
- Which edX user roles will this change impact? "Course Author.

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/1971
- Internal ticket: [FAL-4165](https://tasks.opencraft.com/browse/FAL-4165)

## Testing instructions

- Go to the library home of a library
- Create one unit, one section and one subsection.
- Go to the unit page and verify that the issue has been resolved.
- Go to the section page and verify that the issue has been resolved.
- Go to the subsection page and verify that the issue has been resolved.


## Other information

- I think that this PR can be backported to teak if necessary