### PR TITLE
fix: remove an extra editing xblock modal on unit page

### DIFF
--- a/src/course-unit/CourseUnit.test.jsx
+++ b/src/course-unit/CourseUnit.test.jsx
@@ -720,12 +720,6 @@ describe('<CourseUnit />', () => {
       userEvent.click(problemButton);
     });
 
-    await waitFor(() => {
-      expect(screen.getByRole('heading', {
-        name: new RegExp(`${addComponentMessages.blockEditorModalTitle.defaultMessage}`, 'i'),
-      })).toBeInTheDocument();
-    });
-
     axiosMock
       .onGet(getCourseSectionVerticalApiUrl(blockId))
       .reply(200, courseSectionVerticalMock);

--- a/src/course-unit/add-component/AddComponent.jsx
+++ b/src/course-unit/add-component/AddComponent.jsx
@@ -254,13 +254,7 @@ const AddComponent = ({
             />
           </div>
         </StandardModal>
-        <StandardModal
-          title={intl.formatMessage(messages.blockEditorModalTitle)}
-          isOpen={isXBlockEditorModalOpen}
-          onClose={closeXBlockEditorModal}
-          isOverflowVisible={false}
-          size="xl"
-        >
+        {isXBlockEditorModalOpen && (
           <div className="editor-page">
             <EditorPage
               courseId={courseId}
@@ -272,7 +266,7 @@ const AddComponent = ({
               returnFunction={/* istanbul ignore next */ () => onXBlockSave}
             />
           </div>
-        </StandardModal>
+        )}
       </div>
     );
   }

--- a/src/course-unit/add-component/messages.js
+++ b/src/course-unit/add-component/messages.js
@@ -36,11 +36,6 @@ const messages = defineMessages({
     defaultMessage: 'Select video',
     description: 'Video picker modal title.',
   },
-  blockEditorModalTitle: {
-    id: 'course-authoring.course-unit.modal.block-editor-title.text',
-    defaultMessage: 'Edit component',
-    description: 'Block editor modal title.',
-  },
   modalContainerTitle: {
     id: 'course-authoring.course-unit.modal.container.title',
     defaultMessage: 'Add {componentTitle} component',

--- a/src/course-unit/xblock-container-iframe/index.tsx
+++ b/src/course-unit/xblock-container-iframe/index.tsx
@@ -218,13 +218,7 @@ const XBlockContainerIframe: FC<XBlockContainerIframeProps> = ({
           />
         </div>
       </StandardModal>
-      <StandardModal
-        title={intl.formatMessage(messages.blockEditorModalTitle)}
-        isOpen={isXBlockEditorModalOpen}
-        onClose={closeXBlockEditorModal}
-        isOverflowVisible={false}
-        size="xl"
-      >
+      {isXBlockEditorModalOpen && (
         <div className="editor-page">
           <EditorPage
             courseId={courseId}
@@ -236,7 +230,7 @@ const XBlockContainerIframe: FC<XBlockContainerIframeProps> = ({
             returnFunction={/* istanbul ignore next */ () => onXBlockSave}
           />
         </div>
-      </StandardModal>
+      )}
       {Object.keys(accessManagedXBlockData).length ? (
         <ConfigureModal
           isXBlockComponent

--- a/src/course-unit/xblock-container-iframe/messages.ts
+++ b/src/course-unit/xblock-container-iframe/messages.ts
@@ -19,11 +19,6 @@ const messages = defineMessages({
     id: 'course-authoring.course-unit.xblock.video-editor.title',
     defaultMessage: 'Select video',
   },
-  blockEditorModalTitle: {
-    id: 'course-authoring.course-unit.xblock.editor.title',
-    defaultMessage: 'Edit component',
-    description: 'Block editor modal title.',
-  },
 });
 
 export default messages;


### PR DESCRIPTION
### Issues

- https://github.com/openedx/frontend-app-authoring/issues/2106
- https://github.com/openedx/frontend-app-authoring/issues/2107

## Description

Remove an extra editing xBlock modal on the unit page.

## Video

https://github.com/user-attachments/assets/e75a9c14-24de-430b-b933-8d87d38ef687

## Testing instructions

- In Studio, add a new unit and insert a text component.
- Try to insert/edit a link, an emoji, a special character, or an iframe.
- You can see the TinyMCE modal.
