### PR TITLE
Remove icon and empty breadcrumb from libraries component selection

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -15,12 +15,11 @@ import {
   Breadcrumb,
   Button,
   Container,
-  Icon,
   Stack,
   Tab,
   Tabs,
 } from '@openedx/paragon';
-import { Add, ArrowBack, InfoOutline } from '@openedx/paragon/icons';
+import { Add, InfoOutline } from '@openedx/paragon/icons';
 import { Link, useLocation } from 'react-router-dom';
 
 import Loading from '../generic/Loading';
@@ -224,15 +223,10 @@ const LibraryAuthoringPage = ({
     <Breadcrumb
       links={[
         {
-          label: '',
-          to: '',
-        },
-        {
           label: intl.formatMessage(messages.returnToLibrarySelection),
           onClick: returnToLibrarySelection,
         },
       ]}
-      spacer={<Icon src={ArrowBack} size="sm" />}
       linkAs={Link}
     />
   ) : undefined;


### PR DESCRIPTION
## Description
When working with the modal component selection window, there are problems with incorrect placement of the Change Library link stroke. So product suggested to remove icon and empty link.

## Supporting information
Fixes #1894 

## Testing instructions
Go to a course -> add a new unit -> select Libraries -> select a library -> try to go back to change library

Before:
<img width="1359" alt="Screenshot 2025-06-10 at 4 35 18 p m" src="https://github.com/user-attachments/assets/e2a3b8f7-9247-4326-9efd-930430fe2653" />

After:

https://github.com/user-attachments/assets/e4d6c80b-ffcb-45fe-8749-61e8c87d00a2

