### PR TITLE
fix: hide Email staff to create course link

### DIFF
--- a/src/studio-home/home-sidebar/index.jsx
+++ b/src/studio-home/home-sidebar/index.jsx
@@ -22,8 +22,10 @@ const HomeSidebar = () => {
   const { home: aboutHomeLink } = useHelpUrls(['home']);
 
   // eslint-disable-next-line max-len
-  const isShowMailToGetInstruction = courseCreatorStatus === COURSE_CREATOR_STATES.disallowedForThisSite
-    && !!studioRequestEmail;
+  const isShowMailToGetInstruction = ![
+    COURSE_CREATOR_STATES.disallowedForThisSite,
+    COURSE_CREATOR_STATES.granted,
+  ].includes(courseCreatorStatus) && !!studioRequestEmail;
   const isShowUnrequestedInstruction = courseCreatorStatus === COURSE_CREATOR_STATES.unrequested;
   const isShowDeniedInstruction = courseCreatorStatus === COURSE_CREATOR_STATES.denied;
 

--- a/src/studio-home/hooks.jsx
+++ b/src/studio-home/hooks.jsx
@@ -69,7 +69,10 @@ const useStudioHome = () => {
   } = studioHomeData;
 
   const isShowOrganizationDropdown = optimizationEnabled && courseCreatorStatus === COURSE_CREATOR_STATES.granted;
-  const isShowEmailStaff = courseCreatorStatus === COURSE_CREATOR_STATES.disallowedForThisSite && !!studioRequestEmail;
+  const isShowEmailStaff = ![
+    COURSE_CREATOR_STATES.disallowedForThisSite,
+    COURSE_CREATOR_STATES.granted,
+  ].includes(courseCreatorStatus) && !!studioRequestEmail;
   const isShowProcessing = allowCourseReruns && rerunCreatorStatus && inProcessCourseActions?.length > 0;
   const hasAbilityToCreateNewCourse = courseCreatorStatus === COURSE_CREATOR_STATES.granted;
   const anyQueryIsPending = [deleteNotificationSavingStatus, courseCreatorSavingStatus, savingCreateRerunStatus]


### PR DESCRIPTION
Ticket: [TNL-11419 -  Course authors should not be see this links to email staff to create courses](https://2u-internal.atlassian.net/browse/TNL-11419)
In this PR:
- disable both links i.e. `Email staff to create course` & `contact Your Platform Name Here staff to help you create a course.` Both these links redirect to email to staff team. Note: These links should also be disabled by default for staff users.
- when DISABLE_COURSE_CREATION is set to True on backend([link1](https://github.com/openedx/edx-platform/blob/0611c7891a4a2c726c5f4e505baf1b50b68bd895/cms/djangoapps/contentstore/views/course.py#L1734C5-L1735C59), [link2](https://github.com/openedx/edx-platform/blob/0611c7891a4a2c726c5f4e505baf1b50b68bd895/cms/envs/common.py#L458C5-L468C38)), it should not show staff email links.

**Before:**
<img width="1792" alt="Screenshot 2025-06-11 at 4 33 04 PM" src="https://github.com/user-attachments/assets/93e1ce6c-580a-4ee6-8d5f-9640393e6653" />


**After:**
<img width="1792" alt="Screenshot 2025-06-11 at 5 02 34 PM" src="https://github.com/user-attachments/assets/5fdd8460-e9c5-474a-8263-143546620d8b" />

