### PR TITLE
fix: Text truncate issue in the search modal

### DIFF
--- a/src/search-modal/SearchModal.scss
+++ b/src/search-modal/SearchModal.scss
@@ -66,4 +66,13 @@
       background-color: unset;
     }
   }
+
+  // Fix a bug with search modal: very long text is not truncated with an ellipsis
+  // https://github.com/openedx/frontend-app-authoring/issues/1900
+  .hit-description {
+    display: -webkit-box; /* stylelint-disable-line value-no-vendor-prefix */
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
 }

--- a/src/search-modal/SearchResult.tsx
+++ b/src/search-modal/SearchResult.tsx
@@ -181,7 +181,7 @@ const SearchResult: React.FC<{ hit: ContentHit }> = ({ hit }) => {
         <div className="hit-name small">
           <Highlight text={hit.formatted.displayName} />
         </div>
-        <div className="hit-description x-small text-truncate">
+        <div className="hit-description x-small">
           <Highlight text={hit.formatted.content?.htmlContent ?? ''} />
           <Highlight text={hit.formatted.content?.capaContent ?? ''} />
         </div>
@@ -190,6 +190,7 @@ const SearchResult: React.FC<{ hit: ContentHit }> = ({ hit }) => {
         </div>
       </Stack>
       <IconButton
+        className="flex-shrink-0"
         src={OpenInNew}
         iconAs={Icon}
         onClick={openContextInNewWindow}


### PR DESCRIPTION
Fixed issue with the text-truncate property, does not correctly applied to the description in the search result item in the search modal:
https://github.com/openedx/frontend-app-authoring/issues/1900

Replaced `text-truncate` class which contains `white-space: nowrap;` rule and in this case, it breaks layout. 
Additionally fixed `btn-icon` that has shrunk due to lack of space.

Fix example:
<img width="1286" alt="Screenshot 2025-06-12 at 12 38 48" src="https://github.com/user-attachments/assets/d862a39b-fd06-4603-8d7a-e2d428e5fde8" />
