### PR TITLE
fix: pointer-events issue on toast container

### DIFF
--- a/src/content-tags-drawer/ContentTagsDrawer.scss
+++ b/src/content-tags-drawer/ContentTagsDrawer.scss
@@ -37,3 +37,9 @@
     min-height: 100vh;
   }
 }
+
+// Fix a bug with a toast on edit tags sheet component: can't click on close toast button
+// https://github.com/openedx/frontend-app-authoring/issues/1898
+#toast-root[data-focus-on-hidden] {
+  pointer-events: initial !important;
+}


### PR DESCRIPTION
Fix issue with the pointer-events property on the toast container in the edit tags section:
https://github.com/openedx/frontend-app-authoring/issues/1898

For now it's have been problem that on the `toast-container` applies `data-focus-on-hidden="true"` attribute, that prevent click on the close toast button, it can be fixed via styles:
<img width="1728" alt="Screenshot 2025-06-12 at 17 15 41" src="https://github.com/user-attachments/assets/d5f17338-3759-4356-a61b-e83de05a5977" />
