### PR TITLE
fix: (backport) text truncate issue in the search modal

### DIFF
--- a/src/search-modal/SearchModal.scss
+++ b/src/search-modal/SearchModal.scss
@@ -66,4 +66,13 @@
       background-color: unset;
     }
   }
+
+  // Fix a bug with search modal: very long text is not truncated with an ellipsis
+  // https://github.com/openedx/frontend-app-authoring/issues/1900
+  .hit-description {
+    display: -webkit-box; /* stylelint-disable-line value-no-vendor-prefix */
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
 }

--- a/src/search-modal/SearchResult.tsx
+++ b/src/search-modal/SearchResult.tsx
@@ -181,7 +181,7 @@ const SearchResult: React.FC<{ hit: ContentHit }> = ({ hit }) => {
         <div className="hit-name small">
           <Highlight text={hit.formatted.displayName} />
         </div>
-        <div className="hit-description x-small text-truncate">
+        <div className="hit-description x-small">
           <Highlight text={hit.formatted.content?.htmlContent ?? ''} />
           <Highlight text={hit.formatted.content?.capaContent ?? ''} />
         </div>


### PR DESCRIPTION
fix: (backport) text truncate issue in the search modal

This is a backport of PR [#2137](https://github.com/openedx/frontend-app-authoring/pull/2137) into the `release/teak` branch.

Original PR: #2137
Merged into: `master`
Backport target: `release/teak`