### PR TITLE
fix: Subsections should come before Sections

### DIFF
--- a/src/library-authoring/routes.ts
+++ b/src/library-authoring/routes.ts
@@ -48,8 +48,8 @@ export enum ContentType {
   collections = 'collections',
   components = 'components',
   units = 'units',
-  sections = 'sections',
   subsections = 'subsections',
+  sections = 'sections',
 }
 
 export const allLibraryPageTabs: ContentType[] = Object.values(ContentType);


### PR DESCRIPTION
## Description

Subsections are bigger than Units and smaller than Sections, so the order of the library authoring tabs should be: Units, Subsections, Sections. Before this PR, the order was: Units, Sections, Subsections.

## Supporting information

### Before

<img width="942" alt="Screenshot 2025-06-17 at 4 29 01 PM" src="https://github.com/user-attachments/assets/47210f80-aee9-440e-8774-9c4db69b8454" />

### After

<img width="942" alt="Screenshot 2025-06-17 at 4 30 52 PM" src="https://github.com/user-attachments/assets/222281b4-76cb-4af0-9afa-8bd479ef6adb" />
