### PR TITLE
fix: update advanced module list not working

### DIFF
--- a/src/advanced-settings/data/api.js
+++ b/src/advanced-settings/data/api.js
@@ -5,6 +5,7 @@ import {
 } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { camelCase } from 'lodash';
+import { convertObjectToSnakeCase } from '../../utils';
 
 const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
 export const getCourseAdvancedSettingsApiUrl = (courseId) => `${getApiBaseUrl()}/api/contentstore/v0/advanced_settings/${courseId}`;
@@ -41,7 +42,7 @@ export async function getCourseAdvancedSettings(courseId) {
  */
 export async function updateCourseAdvancedSettings(courseId, settings) {
   const { data } = await getAuthenticatedHttpClient()
-    .patch(`${getCourseAdvancedSettingsApiUrl(courseId)}`, settings);
+    .patch(`${getCourseAdvancedSettingsApiUrl(courseId)}`, convertObjectToSnakeCase(settings));
   const keepValues = {};
   Object.keys(data).forEach((key) => {
     keepValues[camelCase(key)] = { value: data[key].value };


### PR DESCRIPTION
Ticket: [TNL-12010](https://2u-internal.atlassian.net/browse/TNL-12010)
Backend was expecting `{'advanced_modules', {'value': ['poll', 'problem-builder', 'h5pxblock']}}` 
but after this [PR](https://github.com/openedx/frontend-app-authoring/pull/1581) merged, it was receiving `{'advancedModules', ['poll', 'problem-builder', 'h5pxblock']}`

It's better to send snake case settings from frontend instead of changing/fixing the function at backend [here](https://github.com/openedx/edx-platform/blob/447fd0b6cbbb5a517d3490fee36a1c901c7e8a4d/cms/djangoapps/models/settings/course_metadata.py#L261C17-L262C71).
If we change line 262 from `val = model['value']` to `val = model`, it will still fail on next line `if hasattr(block, key) and getattr(block, key) != val:` as  `hasattr(block, 'advancedModules')` is incorrect. It needs `advancedModules` as key.

**Before:**
<img width="1792" alt="Screenshot 2025-06-18 at 6 20 36 PM" src="https://github.com/user-attachments/assets/5997777b-0767-4568-b571-c851cc5b107d" />

**After:**
<img width="1792" alt="Screenshot 2025-06-18 at 6 22 10 PM" src="https://github.com/user-attachments/assets/f27ccb43-90cc-4b51-8e35-0f1a3b00762d" />
