### PR TITLE
fix: Update add existing content icons in section/subsection pages

### DIFF
--- a/src/library-authoring/add-content/AddContent.tsx
+++ b/src/library-authoring/add-content/AddContent.tsx
@@ -144,12 +144,21 @@ const AddContentView = ({
     />
   );
 
+  let existingContentIcon = getItemIcon('libraryContent');
+
+  if (insideSection) {
+    existingContentIcon = getItemIcon('subsection');
+  } else if (insideSubsection) {
+    existingContentIcon = getItemIcon('unit');
+  }
+
   const existingContentButton = (
     <AddContentButton
       key="libraryContent"
       contentType={{
         name: intl.formatMessage(contentMessages.libraryContentButton),
         blockType: 'libraryContent',
+        icon: existingContentIcon,
       }}
       onCreateContent={onCreateContent}
     />


### PR DESCRIPTION
## Description

Updates the icons of the add existing content icons in section/subsection pages: https://github.com/openedx/frontend-app-authoring/issues/1968#issuecomment-3001622086

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/1968#issuecomment-3001622086
- Internal ticket: [FAL-4191](https://tasks.opencraft.com/browse/FAL-4191)

## Testing instructions

- Go to the library home
- Create a Section and Subsection
- In the section page, click on `Add subsection`. In the sidebar, verify that both icons are the same.
- In the subsection page, click on `Add Unit`. In the sidebar, verify that both icons are the same.

## Other information

N/A