### PR TITLE
fix: invalidate library queries on restore container

### DIFF
--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -690,6 +690,7 @@ export const useRestoreContainer = (containerId: string) => {
   return useMutation({
     mutationFn: async () => api.restoreContainer(containerId),
     onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibrary(libraryId) });
       queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, libraryId) });
     },
   });


### PR DESCRIPTION
## Description

Restoring containers should invalidate queries in the library to show the deleted component without needing to refresh.

## Supporting information

* https://github.com/openedx/edx-platform/pull/36956
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4218

## Testing instructions

Delete any unit in subsection page or subsection in section page and restore, it should show up without requiring refresh.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.