### PR TITLE
feat: Adding loading and done states to the publish library button [FC-0097]

### DIFF
--- a/src/library-authoring/generic/status-widget/messages.ts
+++ b/src/library-authoring/generic/status-widget/messages.ts
@@ -46,6 +46,11 @@ const messages = defineMessages({
     defaultMessage: 'Publish',
     description: 'Label of publish button for an entity.',
   },
+  publishingButtonLabelState: {
+    id: 'course-authoring.library-authoring.generic.status-widget.publishing-button',
+    defaultMessage: 'Publishing',
+    description: 'Label of publish button for an entity in the publishing state.',
+  },
   discardChangesButtonLabel: {
     id: 'course-authoring.library-authoring.generic.status-widget.discard-button',
     defaultMessage: 'Discard Changes',

--- a/src/library-authoring/library-info/LibraryInfo.test.tsx
+++ b/src/library-authoring/library-info/LibraryInfo.test.tsx
@@ -105,7 +105,10 @@ describe('<LibraryInfo />', () => {
 
     expect(await screen.findByText(libraryData.org)).toBeInTheDocument();
 
-    expect(screen.getByText('Published')).toBeInTheDocument();
+    // First 'Published' from the state
+    expect(screen.getAllByText('Published')[0]).toBeInTheDocument();
+    // Second 'Published' from the published button
+    expect(screen.getAllByText('Published')[1]).toBeInTheDocument();
     expect(screen.getByText('July 26, 2024')).toBeInTheDocument();
     expect(screen.getByText('staff')).toBeInTheDocument();
   });
@@ -115,7 +118,10 @@ describe('<LibraryInfo />', () => {
 
     expect(await screen.findByText(libraryData.org)).toBeInTheDocument();
 
-    expect(screen.getByText('Published')).toBeInTheDocument();
+    // First 'Published' from the state
+    expect(screen.getAllByText('Published')[0]).toBeInTheDocument();
+    // Second 'Published' from the published button
+    expect(screen.getAllByText('Published')[1]).toBeInTheDocument();
     expect(screen.getByText('July 26, 2024')).toBeInTheDocument();
     expect(screen.queryByText('staff')).not.toBeInTheDocument();
   });

--- a/src/library-authoring/library-info/LibraryPublishStatus.tsx
+++ b/src/library-authoring/library-info/LibraryPublishStatus.tsx
@@ -18,14 +18,14 @@ const LibraryPublishStatus = () => {
   const revertLibraryChanges = useRevertLibraryChanges();
   const { showToast } = useContext(ToastContext);
 
-  const commit = useCallback(() => {
+  const commit = useCallback(async () => {
     if (libraryData) {
-      commitLibraryChanges.mutateAsync(libraryData.id)
-        .then(() => {
-          showToast(intl.formatMessage(messages.publishSuccessMsg));
-        }).catch(() => {
-          showToast(intl.formatMessage(messages.publishErrorMsg));
-        });
+      try {
+        await commitLibraryChanges.mutateAsync(libraryData.id);
+        showToast(intl.formatMessage(messages.publishSuccessMsg));
+      } catch (e) {
+        showToast(intl.formatMessage(messages.publishErrorMsg));
+      }
     }
   }, [libraryData]);
 


### PR DESCRIPTION
## Description

- Which edX user roles will this change impact? "Course Author".
- Adds loading and done states to the publish library button.

![image](https://github.com/user-attachments/assets/609e9e3e-b898-4d09-aa36-596d11452689)
![image](https://github.com/user-attachments/assets/7f29a721-7014-4ce0-8ce3-746c2cd90db2)

## Supporting information

Github issue: https://github.com/openedx/frontend-app-authoring/issues/2102
Internal ticket: [FAL-4219](https://tasks.opencraft.com/browse/FAL-4219)

## Testing instructions

- Go to the library home
- Update or create any component
- Open the library info sidebar.
- Click on `Publish all`. Verify that the button changes to the loading state.
- After finishing publishing, verify that the button changes to the done state.

## Other information

N/A