### PR TITLE
fix: delete and remove modals styling

### DIFF
--- a/src/generic/delete-modal/DeleteModal.tsx
+++ b/src/generic/delete-modal/DeleteModal.tsx
@@ -18,6 +18,8 @@ interface DeleteModalProps {
   variant?: string;
   btnLabel?: string;
   icon?: React.ElementType;
+  buttonVariant?: 'tertiary' | 'brand' | 'primary' | 'danger';
+  cancelButtonVariant?: 'tertiary' | 'brand' | 'primary' | 'default';
 }
 
 const DeleteModal = ({
@@ -28,6 +30,8 @@ const DeleteModal = ({
   title,
   description,
   variant = 'default',
+  buttonVariant = 'danger',
+  cancelButtonVariant = 'default',
   btnLabel,
   icon,
 }: DeleteModalProps) => {
@@ -47,7 +51,7 @@ const DeleteModal = ({
       footerNode={(
         <ActionRow>
           <Button
-            variant="tertiary"
+            variant={cancelButtonVariant}
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
@@ -62,7 +66,7 @@ const DeleteModal = ({
               e.stopPropagation();
               await onDeleteSubmit();
             }}
-            variant="brand"
+            variant={buttonVariant}
             label={defaultBtnLabel}
           />
         </ActionRow>

--- a/src/library-authoring/containers/ContainerRemover.tsx
+++ b/src/library-authoring/containers/ContainerRemover.tsx
@@ -79,6 +79,8 @@ const ContainerRemover = ({
       title={removeWarningTitle}
       description={removeText}
       onDeleteSubmit={onRemove}
+      buttonVariant="primary"
+      cancelButtonVariant="tertiary"
       btnLabel={intl.formatMessage(messages.removeContainerButton, {
         containerName: itemType.charAt(0).toUpperCase() + itemType.slice(1),
       })}

--- a/src/studio-home/tabs-section/courses-tab/courses-filters/index.test.jsx
+++ b/src/studio-home/tabs-section/courses-tab/courses-filters/index.test.jsx
@@ -141,6 +141,7 @@ describe('CoursesFilters', () => {
     fireEvent.change(searchInput, { target: { value: '   ' } });
     await waitFor(() => expect(dispatchMock).not.toHaveBeenCalled(), { timeout: 500 });
     expect(dispatchMock).not.toHaveBeenCalled();
+    // just a coment to trigger a build
   });
 
   it('should display the loading spinner when isLoading is true', () => {

--- a/src/studio-home/tabs-section/courses-tab/courses-filters/index.test.jsx
+++ b/src/studio-home/tabs-section/courses-tab/courses-filters/index.test.jsx
@@ -141,7 +141,6 @@ describe('CoursesFilters', () => {
     fireEvent.change(searchInput, { target: { value: '   ' } });
     await waitFor(() => expect(dispatchMock).not.toHaveBeenCalled(), { timeout: 500 });
     expect(dispatchMock).not.toHaveBeenCalled();
-    // just a coment to trigger a build
   });
 
   it('should display the loading spinner when isLoading is true', () => {


### PR DESCRIPTION
## Description

Styles the container delete and remove modals according to the designs.

## Supporting information

- Issue: https://github.com/openedx/frontend-app-authoring/issues/1985
- [Private-Ref](https://tasks.opencraft.com/browse/FAL-4174)

## Testing instructions

- Open the libraries v2 and create/open a Section/Subsection. 
- Create a new subsection/unit
- Try to delete it from the card menu
- Assert the confirmation warning looks like this: 

<img width="647" alt="image" src="https://github.com/user-attachments/assets/9490613e-cbd9-4751-a45a-8c126ce14a46" />

- Try to remove it
- Assert the dialog looks like this

<img width="573" alt="image" src="https://github.com/user-attachments/assets/4e51c6ec-5edf-4f2e-8a0f-e9ffa27d4eea" />
