### PR TITLE
fix:TNL-11190 Center content for choosing problem type

### DIFF
--- a/src/editors/EditorPage.test.tsx
+++ b/src/editors/EditorPage.test.tsx
@@ -49,7 +49,7 @@ describe('EditorPage', () => {
     initializeMocks();
   });
 
-  test('it can display the Text (html) editor in a modal', async () => {
+  test('it can display the Text (html) editor in a fullscreen modal', async () => {
     jest.spyOn(editorCmsApi, 'fetchBlockById').mockImplementationOnce(async () => (
       { status: 200, data: snakeCaseObject(fieldsHtml) }
     ));
@@ -61,8 +61,8 @@ describe('EditorPage', () => {
 
     const modalElement = screen.getByRole('dialog');
     expect(modalElement.classList).toContain('pgn__modal');
-    expect(modalElement.classList).toContain('pgn__modal-xl');
-    expect(modalElement.classList).not.toContain('pgn__modal-fullscreen');
+    expect(modalElement.classList).toContain('pgn__modal-fullscreen');
+    expect(modalElement.classList).not.toContain('pgn__modal-xl');
   });
 
   test('it shows the Advanced Editor if there is no corresponding editor', async () => {

--- a/src/editors/containers/EditorContainer/index.tsx
+++ b/src/editors/containers/EditorContainer/index.tsx
@@ -38,10 +38,10 @@ export const EditorModalWrapper: React.FC<WrapperProps & { onClose: () => void; 
 };
 
 export const EditorModalBody: React.FC<WrapperProps & { className?: string; style?: React.CSSProperties }> = ({ children, className = '', style = {} }) => (
-   <ModalDialog.Body className={`pb-0 ${className}`} style={style}>
+  <ModalDialog.Body className={`pb-0 ${className}`} style={style}>
     {children}
-    </ModalDialog.Body>
-  );
+  </ModalDialog.Body>
+);
 
 // eslint-disable-next-line react/jsx-no-useless-fragment
 export const FooterWrapper: React.FC<WrapperProps> = ({ children }) => <>{ children }</>;

--- a/src/editors/containers/EditorContainer/index.tsx
+++ b/src/editors/containers/EditorContainer/index.tsx
@@ -28,16 +28,20 @@ interface WrapperProps {
   children: React.ReactNode;
 }
 
-export const EditorModalWrapper: React.FC<WrapperProps & { onClose: () => void }> = ({ children, onClose }) => {
+export const EditorModalWrapper: React.FC<WrapperProps & { onClose: () => void; size?: 'sm' | 'md' | 'lg' | 'xl' | 'fullscreen'; }> = ({ children, onClose, size = 'fullscreen' }) => {
   const intl = useIntl();
 
   const title = intl.formatMessage(messages.modalTitle);
   return (
-    <ModalDialog isOpen size="xl" isOverflowVisible={false} onClose={onClose} title={title}>{children}</ModalDialog>
+    <ModalDialog isOpen size={size} isOverflowVisible={false} onClose={onClose} title={title}>{children}</ModalDialog>
   );
 };
 
-export const EditorModalBody: React.FC<WrapperProps> = ({ children }) => <ModalDialog.Body className="pb-0">{ children }</ModalDialog.Body>;
+export const EditorModalBody: React.FC<WrapperProps & { className?: string; style?: React.CSSProperties }> = ({ children, className = '', style = {} }) => (
+   <ModalDialog.Body className={`pb-0 ${className}`} style={style}>
+    {children}
+    </ModalDialog.Body>
+  );
 
 // eslint-disable-next-line react/jsx-no-useless-fragment
 export const FooterWrapper: React.FC<WrapperProps> = ({ children }) => <>{ children }</>;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.scss
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.scss
@@ -55,6 +55,8 @@
 }
 
 .pgn__modal-body-content {
+  width: 100%;
+
   .editor-body{
     overflow: visible !important;
   }

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/index.tsx
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/index.tsx
@@ -36,7 +36,7 @@ const SelectTypeWrapper: React.FC<Props> = ({
   const setBlockTitle = React.useCallback((title) => dispatch(actions.app.setBlockTitle(title)), [dispatch]);
 
   return (
-    <EditorModalWrapper onClose={handleCancel}>
+    <EditorModalWrapper onClose={handleCancel} size='fullscreen'>
       <ModalDialog.Header className="shadow-sm zindex-10">
         <ModalDialog.Title>
           <FormattedMessage {...messages.selectTypeTitle} />
@@ -50,7 +50,7 @@ const SelectTypeWrapper: React.FC<Props> = ({
           </div>
         </ModalDialog.Title>
       </ModalDialog.Header>
-      <EditorModalBody>
+      <EditorModalBody className="d-flex justify-content-center align-items-center" style={{ minHeight: '100%' }}>
         {children}
       </EditorModalBody>
       <FooterWrapper>

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/index.tsx
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/index.tsx
@@ -36,7 +36,7 @@ const SelectTypeWrapper: React.FC<Props> = ({
   const setBlockTitle = React.useCallback((title) => dispatch(actions.app.setBlockTitle(title)), [dispatch]);
 
   return (
-    <EditorModalWrapper onClose={handleCancel} size='fullscreen'>
+    <EditorModalWrapper onClose={handleCancel} size="fullscreen">
       <ModalDialog.Header className="shadow-sm zindex-10">
         <ModalDialog.Title>
           <FormattedMessage {...messages.selectTypeTitle} />


### PR DESCRIPTION
## Description

This is a UI change which was requested to make the problem selection in  full screen mode instead of a centered modal view. Screenshots are attached for before and after changes


## Supporting information
This is the link to the ticket created in Jira
 [TNL-11190]( https://2u-internal.atlassian.net/browse/TNL-11190).

## Testing instructions

1. Go to any course. 
2. Click on a unit
3. Click problem and the change can be seen

### Before :
<img width="1647" alt="before" src="https://github.com/user-attachments/assets/ad52efcf-55c4-4549-9d7f-0221cfa926cc" />

### After:
<img width="1649" alt="after" src="https://github.com/user-attachments/assets/be5fd10c-8542-48b0-bdca-12089e805b61" />


