### PR TITLE
fix: increase sidebar width to prevent menu overflow

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.scss
+++ b/src/library-authoring/LibraryAuthoringPage.scss
@@ -13,7 +13,7 @@
 
 .library-authoring-sidebar {
   z-index: 1000; // same as header
-  flex: 450px 0 0;
+  flex: 455px 0 0;
   position: sticky;
   top: 0;
   right: 0;


### PR DESCRIPTION
## Description

This PR subtly increases the sidebar width to prevent the overflow menu from wrapping to a second line when two scrollbars are present.

![image](https://github.com/user-attachments/assets/82702339-6d36-461d-b225-66e25a14679e)

## Supporting information
- Related to: https://github.com/openedx/frontend-app-authoring/issues/1822

## Testing instructions

This should be done in Chrome:
- Open a content library and select a component
- Reduce the screen width (i.e., by opening the console) to force both the library page and the sidebar to show a scrollbar
- Check that you can reproduce the bug
- Checkout this branch and check if the bug is fixed

## Other information

Another approach would be to remove the duplicated sidebar by adjusting the sidebar height to match the content, but this would alter the sticky behavior, where we always see the top of the sidebar while scrolling through the content.