### PR TITLE
test: replacing snapshot tests with rtl tests part 16

### DIFF
--- a/src/generic/hooks/tests/hooks.test.tsx
+++ b/src/generic/hooks/tests/hooks.test.tsx
@@ -3,7 +3,7 @@ import { getConfig } from '@edx/frontend-platform';
 import { act, renderHook } from '@testing-library/react';
 import { logError } from '@edx/frontend-platform/logging';
 import { iframeMessageTypes } from '../../../constants';
-import { useIframeBehavior, ifameBehaviorState } from '../useIframeBehavior';
+import { useIframeBehavior, iframeBehaviorState } from '../useIframeBehavior';
 import { useLoadBearingHook } from '../useLoadBearingHook';
 
 jest.useFakeTimers();
@@ -22,10 +22,10 @@ describe('useIframeBehavior', () => {
   const iframeRef = { current: { contentWindow: null } as HTMLIFrameElement };
 
   beforeEach(() => {
-    jest.spyOn(ifameBehaviorState, 'iframeHeight').mockImplementation(() => [0, setIframeHeight]);
-    jest.spyOn(ifameBehaviorState, 'hasLoaded').mockImplementation(() => [false, setHasLoaded]);
-    jest.spyOn(ifameBehaviorState, 'showError').mockImplementation(() => [false, setShowError]);
-    jest.spyOn(ifameBehaviorState, 'windowTopOffset').mockImplementation(() => [null, setWindowTopOffset]);
+    jest.spyOn(iframeBehaviorState, 'iframeHeight').mockImplementation(() => [0, setIframeHeight]);
+    jest.spyOn(iframeBehaviorState, 'hasLoaded').mockImplementation(() => [false, setHasLoaded]);
+    jest.spyOn(iframeBehaviorState, 'showError').mockImplementation(() => [false, setShowError]);
+    jest.spyOn(iframeBehaviorState, 'windowTopOffset').mockImplementation(() => [null, setWindowTopOffset]);
 
     window.scrollTo = jest.fn((x: number | ScrollToOptions, y?: number): void => {
       const scrollY = typeof x === 'number' ? y : (x as ScrollToOptions).top || 0;
@@ -43,7 +43,7 @@ describe('useIframeBehavior', () => {
 
   it('scrolls to previous position on video fullscreen exit', () => {
     const mockWindowTopOffset = 100;
-    jest.spyOn(ifameBehaviorState, 'windowTopOffset').mockImplementation(() => [mockWindowTopOffset, setWindowTopOffset]);
+    jest.spyOn(iframeBehaviorState, 'windowTopOffset').mockImplementation(() => [mockWindowTopOffset, setWindowTopOffset]);
     renderHook(() => useIframeBehavior({ id, iframeUrl, iframeRef }));
 
     const message = {

--- a/src/generic/hooks/useIframeBehavior.tsx
+++ b/src/generic/hooks/useIframeBehavior.tsx
@@ -6,11 +6,17 @@ import { iframeMessageTypes } from '../../constants';
 import { UseIFrameBehaviorReturnTypes, UseIFrameBehaviorTypes } from '../types';
 import { useEventListener } from './useEventListener';
 
-export const ifameBehaviorState = StrictDict({
-    iframeHeight: (val) => useState<number>(val), // eslint-disable-line
-    hasLoaded: (val) => useState<boolean>(val), // eslint-disable-line
-    showError: (val) => useState<boolean>(val), // eslint-disable-line
-    windowTopOffset: (val) => useState<number | null>(val), // eslint-disable-line
+/**
+ * Internal state hooks for useIFrameBehavior.
+ * Defined and exported here so they can be mocked/manipulated in tests.
+ */
+export const iframeBehaviorState = StrictDict({
+  /* eslint-disable react-hooks/rules-of-hooks */
+  iframeHeight: (val) => useState<number>(val),
+  hasLoaded: (val) => useState<boolean>(val),
+  showError: (val) => useState<boolean>(val),
+  windowTopOffset: (val) => useState<number | null>(val),
+  /* eslint-enable react-hooks/rules-of-hooks */
 });
 
 /**
@@ -36,10 +42,10 @@ export const useIframeBehavior = ({
   // Do not remove this hook.  See function description.
   useLoadBearingHook(id);
 
-  const [iframeHeight, setIframeHeight] = ifameBehaviorState.iframeHeight(0);
-  const [hasLoaded, setHasLoaded] = ifameBehaviorState.hasLoaded(false);
-  const [showError, setShowError] = ifameBehaviorState.showError(false);
-  const [windowTopOffset, setWindowTopOffset] = ifameBehaviorState.windowTopOffset(null);
+  const [iframeHeight, setIframeHeight] = iframeBehaviorState.iframeHeight(0);
+  const [hasLoaded, setHasLoaded] = iframeBehaviorState.hasLoaded(false);
+  const [showError, setShowError] = iframeBehaviorState.showError(false);
+  const [windowTopOffset, setWindowTopOffset] = iframeBehaviorState.windowTopOffset(null);
 
   const receiveMessage = useCallback((event: MessageEvent) => {
     if (!iframeRef.current || event.source !== iframeRef.current.contentWindow) {


### PR DESCRIPTION
## Description

Removing the use of the useKeyedState from the @edx/react-unit-test-utils library on the following files:
src/generic/hooks/useIframeBehavior.tsx
src/generic/hooks/tests/hooks.test.tsx

Closes https://github.com/openedx/frontend-app-authoring/issues/2250
