### PR TITLE
feat: apply 2 column format for P&R page widgets

### DIFF
--- a/src/pages-and-resources/pages/PageCard.scss
+++ b/src/pages-and-resources/pages/PageCard.scss
@@ -1,8 +1,4 @@
-.desktop-card {
-  width: 19rem;
-  height: 14rem;
-}
-
+.desktop-card,
 .mobile-card {
   width: 100%;
   height: 14rem;

--- a/src/pages-and-resources/pages/PageGrid.jsx
+++ b/src/pages-and-resources/pages/PageGrid.jsx
@@ -7,8 +7,8 @@ const PageGrid = ({ pages, pluginSlotComponent, courseId }) => (
   <CardGrid columnSizes={{
     xs: 12,
     sm: 6,
-    lg: 4,
-    xl: 4,
+    lg: 6,
+    xl: 6,
   }}
   >
     {pages.map((page) => (


### PR DESCRIPTION
Ticket: [TNL-12036](https://2u-internal.atlassian.net/browse/TNL-12036)
In this PR, applying 2 column format for pages & resources page widgets.

**Before:**
<img width="1792" alt="Screenshot 2025-07-03 at 10 26 47 AM" src="https://github.com/user-attachments/assets/1ffcf1d9-7e34-4d2a-9472-5042d80b53b8" />

**After:**
![after](https://github.com/user-attachments/assets/2f855cd8-4077-4583-a70b-9113116e79b8)

