### PR TITLE
fix: open component with keyboard within unit page

### DIFF
--- a/src/library-authoring/units/LibraryUnitBlocks.tsx
+++ b/src/library-authoring/units/LibraryUnitBlocks.tsx
@@ -184,7 +184,6 @@ const ComponentBlock = ({ block, readOnly, isDragging }: ComponentBlockProps) =>
         onClick={(e) => !readOnly && handleComponentSelection(e.detail)}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
-            console.log('Enter key pressed', e.detail);
             handleComponentSelection(e.detail);
           }
         }}

--- a/src/library-authoring/units/LibraryUnitBlocks.tsx
+++ b/src/library-authoring/units/LibraryUnitBlocks.tsx
@@ -182,6 +182,12 @@ const ComponentBlock = ({ block, readOnly, isDragging }: ComponentBlockProps) =>
         }}
         isClickable={!readOnly}
         onClick={(e) => !readOnly && handleComponentSelection(e.detail)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            console.log('Enter key pressed', e.detail);
+            handleComponentSelection(e.detail);
+          }
+        }}
         disabled={readOnly}
         cardClassName={sidebarItemInfo?.id === block.originalId ? 'selected' : undefined}
       >


### PR DESCRIPTION
## Description

When selecting a component inside a unit with the keyboard, opening it in the sidebar by pressing enter was not working.

## Supporting information

- Previous related PR: https://github.com/openedx/frontend-app-authoring/pull/2209
- Issue: https://github.com/openedx/frontend-app-authoring/issues/2196#issuecomment-3022779839
- [Private-Ref](https://tasks.opencraft.com/browse/FAL-4240)

## Testing instructions

* In the library home, create a unit.
* Open the unit page, and create multiple components
* select one component card with the keyboard. Press Enter. The sidebar should open