### PR TITLE
feat: Update Course Optimizer label from BETA to NEW

### DIFF
--- a/src/header/hooks.jsx
+++ b/src/header/hooks.jsx
@@ -118,7 +118,7 @@ export const useToolsMenuItems = courseId => {
       title: (
         <>
           {intl.formatMessage(messages['header.links.optimizer'])}
-          <Badge variant="primary" className="ml-2">{intl.formatMessage(courseOptimizerMessages.beta)}</Badge>
+          <Badge variant="primary" className="ml-2">{intl.formatMessage(courseOptimizerMessages.new)}</Badge>
         </>
       ),
     }] : []),

--- a/src/optimizer-page/CourseOptimizerPage.tsx
+++ b/src/optimizer-page/CourseOptimizerPage.tsx
@@ -150,7 +150,7 @@ const CourseOptimizerPage: FC<{ courseId: string }> = ({ courseId }) => {
                     (
                       <span style={{ display: 'inline-flex', alignItems: 'center' }}>
                         {intl.formatMessage(messages.headingTitle)}
-                        <Badge variant="primary" className="ml-2" style={{ fontSize: 'large' }}>{intl.formatMessage(messages.beta)}</Badge>
+                        <Badge variant="primary" className="ml-2" style={{ fontSize: 'large' }}>{intl.formatMessage(messages.new)}</Badge>
                       </span>
                     )
                   }

--- a/src/optimizer-page/messages.js
+++ b/src/optimizer-page/messages.js
@@ -9,9 +9,9 @@ const messages = defineMessages({
     id: 'course-authoring.course-optimizer.heading.title',
     defaultMessage: 'Course optimizer',
   },
-  beta: {
-    id: 'course-authoring.course-optimizer.beta',
-    defaultMessage: 'Beta',
+  new: {
+    id: 'course-authoring.course-optimizer.new',
+    defaultMessage: 'New',
   },
   headingSubtitle: {
     id: 'course-authoring.course-optimizer.heading.subtitle',


### PR DESCRIPTION
## Summary

This PR updates the **Course Optimizer** page in the CMS by replacing the **"BETA"** tag with **"NEW"** in the following locations:

- CMS header menu (navigation)
- Page title of the Course Optimizer


---

## Changes

- Replaced `"BETA"` with `"NEW"` in the header UI component
- Ensured consistency across both UI and metadata

---

## Jira Ticket
[2U internal Jira ticket](https://2u-internal.atlassian.net/browse/TNL2-150)

---

## Notes

- This is a UI/label change only — no backend or logic modifications were made.

## Screenshots
**Before:**
<img width="1533" height="611" alt="Screenshot 2025-07-11 at 2 55 23 PM" src="https://github.com/user-attachments/assets/28ba2244-79e7-4e1c-a50a-ed4bd125b34d" />


**After:**
<img width="1577" height="579" alt="Screenshot 2025-07-11 at 2 53 08 PM" src="https://github.com/user-attachments/assets/84218746-3cdb-4c86-8f6f-baddb1e96af4" />



---
 