### PR TITLE
Files and Uploads search text is lost when using Sort and Filter more than once

### DIFF
--- a/src/files-and-videos/generic/table-components/sort-and-filter-modal/utils.js
+++ b/src/files-and-videos/generic/table-components/sort-and-filter-modal/utils.js
@@ -35,7 +35,7 @@ export const processFilters = (filters, columns, setAllFilters) => {
   const [displayNameFilter] = filters.filter(filter => isArray(filter));
   if (displayNameFilter) {
     const [id, filterValue] = displayNameFilter;
-    allFilters.push({ id, value: [filterValue] });
+    allFilters.push({ id, value: filterValue });
   }
 
   filterableColumns.forEach(({ id, filterChoices }) => {

--- a/src/files-and-videos/generic/table-components/sort-and-filter-modal/utils.test.js
+++ b/src/files-and-videos/generic/table-components/sort-and-filter-modal/utils.test.js
@@ -80,7 +80,7 @@ describe('processFilters', () => {
       const columns = [
         { id: 'test', filterChoices: [{ name: 'Filter', value: 'filter' }] },
       ];
-      const expectedParameter = [{ id: 'displayName', value: ['search'] }];
+      const expectedParameter = [{ id: 'displayName', value: 'search' }];
       processFilters(filters, columns, setAllFilters);
 
       expect(setAllFilters).toHaveBeenCalledWith(expectedParameter);


### PR DESCRIPTION
## Description

Files and Uploads search text is lost when using Sort and Filter more than once

## Supporting information
Fix for the following issue 
https://github.com/openedx/frontend-app-authoring/issues/2052

## After Fix
https://github.com/user-attachments/assets/c6cf343e-b233-4ace-8a29-185dfbad6692



## Testing instructions

Please provide detailed step-by-step instructions for manually testing this change.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
