### PR TITLE
UPLOAD_FILE_MAX_SIZE use constants instead of duplicated code values in filesupload page

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -52,7 +52,7 @@ export const DECODED_ROUTES = {
   ],
 };
 
-export const UPLOAD_FILE_MAX_SIZE = 20 * 1024 * 1024; // 100mb
+export const UPLOAD_FILE_MAX_SIZE = 1024 * 1024 * 1024; // 1GB
 
 export const COURSE_BLOCK_NAMES = ({
   chapter: { id: 'chapter', name: 'Section' },

--- a/src/files-and-videos/files-page/FilesPage.jsx
+++ b/src/files-and-videos/files-page/FilesPage.jsx
@@ -6,6 +6,7 @@ import { CheckboxFilter, Container } from '@openedx/paragon';
 import Placeholder from '../../editors/Placeholder';
 
 import { RequestStatus } from '../../data/constants';
+import { UPLOAD_FILE_MAX_SIZE } from '../../constants';
 import { useModels, useModel } from '../../generic/model-store';
 import {
   addAssetFile,
@@ -90,7 +91,8 @@ const FilesPage = ({
     usageErrorMessages: errorMessages.usageMetrics,
     fileType: 'file',
   };
-  const maxFileSize = 20 * 1048576;
+  //const maxFileSize = 20 * 1048576;
+  const maxFileSize = UPLOAD_FILE_MAX_SIZE;
 
   const activeColumn = {
     id: 'activeStatus',


### PR DESCRIPTION
## Description

This change modifies the behaviour of `src/files-and-videos/files-page/FilesPage.jsx` which originally used a hard coded value to represent the maximum upload file size. Originally a value of 20MB was coded in `FilesPage.jsx` in conjunction with a 20MB value defined in `src/constants.js` but left unused.

Useful information to include:
- Which user roles will this change impact? Course Author
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
BEFORE: 
<img width="408" height="206" alt="UPLOAD_FILE_MAX_SIZE  before" src="https://github.com/user-attachments/assets/aa78ee70-d938-4318-8612-1725a61ad654" />
AFTER: 
<img width="497" height="244" alt="UPLOAD_FILE_MAX_SIZE after" src="https://github.com/user-attachments/assets/1971af7d-7f9d-4013-ac3f-9cc0413e623f" />


## Supporting information

https://github.com/openedx/frontend-app-authoring/issues/2294

## Testing instructions

added using a plugin, followed by mfe rebuild
```
from tutormfe.hooks import MFE_APPS

@MFE_APPS.add()
def _override_authoring_mfe(mfes):
    mfes["authoring"] = {
        "repository": "https://github.com/MuPp3t33r/frontend-app-authoring.git",
        "version": "UPLOAD_FILE_MAX_SIZE", 
        "port": 2001, 
    }
    return mfes

```
## Other information

In order to validate that the value was correctly loaded from `constants.js`, I additionally modified the constant to increase it's value from the default 20MB to 1GB, this value better represents the upper limit of files typically uploaded into our server. This particular change may or may not be desired upstream
