### PR TITLE
fix: disable special exams config if feature flag is disabled

### DIFF
--- a/src/course-outline/CourseOutline.tsx
+++ b/src/course-outline/CourseOutline.tsx
@@ -36,7 +36,11 @@ import { ContentType } from '@src/library-authoring/routes';
 import { NOTIFICATION_MESSAGES } from '@src/constants';
 import { COMPONENT_TYPES } from '@src/generic/block-type-utils/constants';
 import { XBlock } from '@src/data/types';
-import { getCurrentItem, getProctoredExamsFlag } from './data/selectors';
+import {
+  getCurrentItem,
+  getProctoredExamsFlag,
+  getTimedExamsFlag,
+} from './data/selectors';
 import { COURSE_BLOCK_NAMES } from './constants';
 import StatusBar from './status-bar/StatusBar';
 import EnableHighlightsModal from './enable-highlights-modal/EnableHighlightsModal';
@@ -167,6 +171,7 @@ const CourseOutline = ({ courseId }: CourseOutlineProps) => {
   const deleteCategory = COURSE_BLOCK_NAMES[currentItemData.category]?.name.toLowerCase();
 
   const enableProctoredExams = useSelector(getProctoredExamsFlag);
+  const enableTimedExams = useSelector(getTimedExamsFlag);
 
   /**
    * Move section to new index
@@ -505,6 +510,7 @@ const CourseOutline = ({ courseId }: CourseOutlineProps) => {
           onConfigureSubmit={handleConfigureItemSubmit}
           currentItemData={currentItemData}
           enableProctoredExams={enableProctoredExams}
+          enableTimedExams={enableTimedExams}
           isSelfPaced={statusBarData.isSelfPaced}
         />
         <DeleteModal

--- a/src/course-outline/data/selectors.ts
+++ b/src/course-outline/data/selectors.ts
@@ -9,6 +9,7 @@ export const getCurrentSubsection = (state) => state.courseOutline.currentSubsec
 export const getCourseActions = (state) => state.courseOutline.actions;
 export const getCustomRelativeDatesActiveFlag = (state) => state.courseOutline.isCustomRelativeDatesActive;
 export const getProctoredExamsFlag = (state) => state.courseOutline.enableProctoredExams;
+export const getTimedExamsFlag = (state) => state.courseOutline.enableTimedExams;
 export const getPasteFileNotices = (state) => state.courseOutline.pasteFileNotices;
 export const getErrors = (state) => state.courseOutline.errors;
 export const getCreatedOn = (state) => state.courseOutline.createdOn;

--- a/src/course-outline/data/slice.ts
+++ b/src/course-outline/data/slice.ts
@@ -47,6 +47,7 @@ const initialState = {
     allowMoveDown: false,
   },
   enableProctoredExams: false,
+  enableTimedExams: false,
   pasteFileNotices: {},
   createdOn: null,
 } satisfies CourseOutlineState as unknown as CourseOutlineState;
@@ -60,6 +61,7 @@ const slice = createSlice({
       state.sectionsList = payload.courseStructure?.childInfo?.children || [];
       state.isCustomRelativeDatesActive = payload.isCustomRelativeDatesActive;
       state.enableProctoredExams = payload.courseStructure?.enableProctoredExams;
+      state.enableTimedExams = payload.courseStructure?.enableTimedExams;
       state.createdOn = payload.createdOn;
     },
     updateOutlineIndexLoadingStatus: (state: CourseOutlineState, { payload }) => {

--- a/src/course-outline/data/types.ts
+++ b/src/course-outline/data/types.ts
@@ -59,6 +59,7 @@ export interface CourseOutlineState {
   currentItem: XBlock | {};
   actions: XBlockActions;
   enableProctoredExams: boolean;
+  enableTimedExams: boolean;
   pasteFileNotices: object;
   createdOn: null | Date;
 }

--- a/src/generic/configure-modal/AdvancedTab.jsx
+++ b/src/generic/configure-modal/AdvancedTab.jsx
@@ -1,10 +1,14 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { Alert, Form, Hyperlink } from '@openedx/paragon';
 import {
-  Warning as WarningIcon,
-} from '@openedx/paragon/icons';
+  Alert,
+  Form,
+  Hyperlink,
+  OverlayTrigger,
+  Tooltip,
+} from '@openedx/paragon';
+import { Warning as WarningIcon, Question } from '@openedx/paragon/icons';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import messages from './messages';
 
@@ -17,6 +21,7 @@ const AdvancedTab = ({
   releasedToStudents,
   wasExamEverLinkedWithExternal,
   enableProctoredExams,
+  enableTimedExams = true,
   supportsOnboarding,
   wasProctoredExam,
   showReviewRules,
@@ -129,7 +134,26 @@ const AdvancedTab = ({
 
   return (
     <>
-      <h5 className="mt-4 text-gray-700"><FormattedMessage {...messages.setSpecialExam} /></h5>
+      <div className="d-flex align-items-center mt-4">
+        <h5 className="text-gray-700 mb-0">
+          <FormattedMessage {...messages.setSpecialExam} />
+        </h5>
+        {!enableTimedExams && (
+          <OverlayTrigger
+            placement="top"
+            overlay={(
+              <Tooltip>
+                <FormattedMessage {...messages.timedExamsDisabledTooltip} />
+              </Tooltip>
+            )}
+          >
+            <Question
+              className="ml-2 text-gray-500"
+              style={{ cursor: 'help' }}
+            />
+          </OverlayTrigger>
+        )}
+      </div>
       <hr />
       <Form.RadioSet
         name="specialExam"
@@ -137,11 +161,12 @@ const AdvancedTab = ({
         value={examTypeValue}
       >
         {renderAlerts()}
-        <Form.Radio value="none">
+        <Form.Radio value="none" disabled={!enableTimedExams}>
           <FormattedMessage {...messages.none} />
         </Form.Radio>
         <Form.Radio
           value="timed"
+          disabled={!enableTimedExams}
           description={<FormattedMessage {...messages.timedDescription} />}
           controlClassName="mw-1-25rem"
         >
@@ -242,6 +267,7 @@ AdvancedTab.defaultProps = {
   prereqs: [],
   wasExamEverLinkedWithExternal: false,
   enableProctoredExams: false,
+  enableTimedExams: true,
   supportsOnboarding: false,
   wasProctoredExam: false,
   showReviewRules: false,
@@ -269,6 +295,7 @@ AdvancedTab.propTypes = {
   releasedToStudents: PropTypes.bool.isRequired,
   wasExamEverLinkedWithExternal: PropTypes.bool,
   enableProctoredExams: PropTypes.bool,
+  enableTimedExams: PropTypes.bool,
   supportsOnboarding: PropTypes.bool,
   wasProctoredExam: PropTypes.bool,
   showReviewRules: PropTypes.bool,

--- a/src/generic/configure-modal/ConfigureModal.jsx
+++ b/src/generic/configure-modal/ConfigureModal.jsx
@@ -27,6 +27,7 @@ const ConfigureModal = ({
   onConfigureSubmit,
   currentItemData,
   enableProctoredExams = false,
+  enableTimedExams = false,
   isXBlockComponent = false,
   isSelfPaced,
 }) => {
@@ -172,7 +173,7 @@ const ConfigureModal = ({
       case COURSE_BLOCK_NAMES.libraryContent.id:
       case COURSE_BLOCK_NAMES.splitTest.id:
       case COURSE_BLOCK_NAMES.component.id:
-      // groupAccess should be {partitionId: [group1, group2]} or {} if selectedPartitionIndex === -1
+        // groupAccess should be {partitionId: [group1, group2]} or {} if selectedPartitionIndex === -1
         if (data.selectedPartitionIndex >= 0) {
           const partitionId = userPartitionInfo.selectablePartitions[data.selectedPartitionIndex].id;
           groupAccess[partitionId] = data.selectedGroups.map(g => parseInt(g, 10));
@@ -239,6 +240,7 @@ const ConfigureModal = ({
                 releasedToStudents={releasedToStudents}
                 wasExamEverLinkedWithExternal={wasExamEverLinkedWithExternal}
                 enableProctoredExams={enableProctoredExams}
+                enableTimedExams={enableTimedExams}
                 supportsOnboarding={supportsOnboarding}
                 showReviewRules={showReviewRules}
                 wasProctoredExam={isProctoredExam}
@@ -325,6 +327,7 @@ ConfigureModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   onConfigureSubmit: PropTypes.func.isRequired,
   enableProctoredExams: PropTypes.bool,
+  enableTimedExams: PropTypes.bool,
   currentItemData: PropTypes.shape({
     displayName: PropTypes.string,
     start: PropTypes.string,

--- a/src/generic/configure-modal/messages.js
+++ b/src/generic/configure-modal/messages.js
@@ -231,6 +231,10 @@ const messages = defineMessages({
     id: 'course-authoring.course-outline.configure-modal.advanced-tab.practice-exam-description',
     defaultMessage: 'Use a practice proctored exam to introduce learners to the proctoring tools and processes. Results of a practice exam do not affect a learner\'s grade.',
   },
+  timedExamsDisabledTooltip: {
+    id: 'course-authoring.course-outline.configure-modal.advanced-tab.timed-exams-disabled-tooltip',
+    defaultMessage: 'Timed exams are not enabled for this Open edX instance',
+  },
   advancedTabTitle: {
     id: 'course-authoring.course-outline.configure-modal.advanced-tab.title',
     defaultMessage: 'Advanced',


### PR DESCRIPTION
## Description

Check if `enableTimeExams` flag is True or False

- If it's true, maintain current behavior
- If it's false, disable time exams configuration and show a tooltip to let the user know they don't have that feature enabled.

## Supporting information

Discussion here: https://github.com/openedx/frontend-app-authoring/issues/1896

## Testing instructions

You need to enable/disable `FEATURES['ENABLE_SPECIAL_EXAMS']` on the backend in order to test.

Enabled:
<img width="876" height="611" alt="Screenshot 2025-07-23 at 3 42 32 p m" src="https://github.com/user-attachments/assets/bd749f39-d4b6-4b33-b006-55c9d2c4965e" />

Disabled:
<img width="1030" height="596" alt="Screenshot 2025-07-23 at 3 44 20 p m" src="https://github.com/user-attachments/assets/94e2a2a7-67cb-47f7-a7a4-e7e7d0032706" />
