### PR TITLE
refactor: Replace connect with useSelector() and useDispatch() 1/5

### DIFF
--- a/src/course-unit/course-sequence/sequence-navigation/UnitButton.jsx
+++ b/src/course-unit/course-sequence/sequence-navigation/UnitButton.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { connect, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { Button } from '@openedx/paragon';
 import { Link } from 'react-router-dom';
 
@@ -7,10 +7,16 @@ import UnitIcon from './UnitIcon';
 import { getCourseId, getSequenceId } from '../../data/selectors';
 
 const UnitButton = ({
-  title, contentType, isActive, unitId, className, showTitle,
+  unitId,
+  className,
+  showTitle,
 }) => {
   const courseId = useSelector(getCourseId);
   const sequenceId = useSelector(getSequenceId);
+
+  const unit = useSelector((state) => state.models.units[unitId]);
+
+  const { title, contentType, isActive } = unit || {};
 
   return (
     <Button
@@ -29,26 +35,13 @@ const UnitButton = ({
 
 UnitButton.propTypes = {
   className: PropTypes.string,
-  contentType: PropTypes.string.isRequired,
-  isActive: PropTypes.bool,
   showTitle: PropTypes.bool,
-  title: PropTypes.string.isRequired,
   unitId: PropTypes.string.isRequired,
 };
 
 UnitButton.defaultProps = {
   className: undefined,
-  isActive: false,
   showTitle: false,
 };
 
-const mapStateToProps = (state, props) => {
-  if (props.unitId) {
-    return {
-      ...state.models.units[props.unitId],
-    };
-  }
-  return {};
-};
-
-export default connect(mapStateToProps)(UnitButton);
+export default UnitButton;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import { connect, useDispatch } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
   Collapsible,
@@ -22,15 +22,16 @@ import ExpandableTextArea from '../../../../../sharedComponents/ExpandableTextAr
 const AnswerOption = ({
   answer,
   hasSingleAnswer,
-  // redux
-  problemType,
-  images,
-  isLibrary,
-  blockId,
-  learningContextId,
 }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
+
+  const problemType = useSelector(selectors.problem.problemType);
+  const images = useSelector(selectors.app.images);
+  const isLibrary = useSelector(selectors.app.isLibrary);
+  const learningContextId = useSelector(selectors.app.learningContextId);
+  const blockId = useSelector(selectors.app.blockId);
+
   const removeAnswer = hooks.removeAnswer({ answer, dispatch });
   const setAnswer = hooks.setAnswer({ answer, hasSingleAnswer, dispatch });
   const setAnswerTitle = hooks.setAnswerTitle({
@@ -42,10 +43,10 @@ const AnswerOption = ({
   const setSelectedFeedback = hooks.setSelectedFeedback({ answer, hasSingleAnswer, dispatch });
   const setUnselectedFeedback = hooks.setUnselectedFeedback({ answer, hasSingleAnswer, dispatch });
   const { isFeedbackVisible, toggleFeedback } = hooks.useFeedback(answer);
-  let staticRootUrl;
-  if (isLibrary) {
-    staticRootUrl = `${getConfig().STUDIO_BASE_URL }/library_assets/blocks/${ blockId }/`;
-  }
+
+  const staticRootUrl = isLibrary
+    ? `${getConfig().STUDIO_BASE_URL}/library_assets/blocks/${blockId}/`
+    : undefined;
 
   const getInputArea = () => {
     if ([ProblemTypeKeys.SINGLESELECT, ProblemTypeKeys.MULTISELECT].includes(problemType)) {
@@ -55,12 +56,10 @@ const AnswerOption = ({
           setContent={setAnswerTitle}
           placeholder={intl.formatMessage(messages.answerTextboxPlaceholder)}
           id={`answer-${answer.id}`}
-          {...{
-            images,
-            isLibrary,
-            learningContextId,
-            staticRootUrl,
-          }}
+          images={images}
+          isLibrary={isLibrary}
+          learningContextId={learningContextId}
+          staticRootUrl={staticRootUrl}
         />
       );
     }
@@ -93,7 +92,6 @@ const AnswerOption = ({
           <FormattedMessage {...messages.answerRangeHelperText} />
         </div>
       </div>
-
     );
   };
 
@@ -120,11 +118,9 @@ const AnswerOption = ({
             setSelectedFeedback={setSelectedFeedback}
             setUnselectedFeedback={setUnselectedFeedback}
             intl={intl}
-            {...{
-              images,
-              isLibrary,
-              learningContextId,
-            }}
+            images={images}
+            isLibrary={isLibrary}
+            learningContextId={learningContextId}
           />
         </Collapsible.Body>
       </div>
@@ -150,22 +146,6 @@ const AnswerOption = ({
 AnswerOption.propTypes = {
   answer: answerOptionProps.isRequired,
   hasSingleAnswer: PropTypes.bool.isRequired,
-  // redux
-  problemType: PropTypes.string.isRequired,
-  images: PropTypes.shape({}).isRequired,
-  learningContextId: PropTypes.string.isRequired,
-  isLibrary: PropTypes.bool.isRequired,
-  blockId: PropTypes.string.isRequired,
 };
 
-export const mapStateToProps = (state) => ({
-  problemType: selectors.problem.problemType(state),
-  images: selectors.app.images(state),
-  isLibrary: selectors.app.isLibrary(state),
-  learningContextId: selectors.app.learningContextId(state),
-  blockId: selectors.app.blockId(state),
-});
-
-export const mapDispatchToProps = {};
-export const AnswerOptionInternal = AnswerOption; // For testing only
-export default connect(mapStateToProps, mapDispatchToProps)(memo(AnswerOption));
+export default memo(AnswerOption);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.test.tsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.test.tsx
@@ -6,6 +6,23 @@ import { selectors } from '../../../../../data/redux';
 
 const { problem } = selectors;
 
+const initialState = {
+  problem: {
+    problemType: 'multiplechoiceresponse', // No problem type selected by default
+    // ... other problem-related state
+  },
+  app: {
+    images: {}, // No images loaded by default; use {} if it's an object keyed by IDs, or [] if it's a list
+    isLibrary: false, // Default to false; not in library context initially
+    learningContextId: 'course+org+run', // No context ID by default
+    blockId: 'block-id', // No block ID initially
+    // ... other app-related state
+  },
+  // ... any other top-level state slices
+};
+
+export default initialState;
+
 jest.mock('../../../../../data/redux', () => ({
   __esModule: true,
   default: jest.fn(),
@@ -57,12 +74,6 @@ describe('AnswerOption', () => {
   const props = {
     hasSingleAnswer: false,
     answer: answerWithOnlyFeedback,
-    // redux
-    problemType: 'multiplechoiceresponse',
-    images: {},
-    isLibrary: false,
-    learningContextId: 'course+org+run',
-    blockId: 'block-id',
   };
 
   beforeEach(() => {
@@ -75,7 +86,7 @@ describe('AnswerOption', () => {
       isFeedbackVisible: false,
       toggleFeedback: jest.fn(),
     });
-    initializeMocks();
+    initializeMocks({ initialState });
   });
 
   test('renders correct option with feedback', () => {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswersContainer.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswersContainer.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import { Dropdown, Icon } from '@openedx/paragon';
@@ -8,20 +8,18 @@ import { Add } from '@openedx/paragon/icons';
 import messages from './messages';
 import { useAnswerContainer, isSingleAnswerProblem } from './hooks';
 import { actions, selectors } from '../../../../../data/redux';
-import { answerOptionProps } from '../../../../../data/services/cms/types';
 import AnswerOption from './AnswerOption';
 import Button from '../../../../../sharedComponents/Button';
 import { ProblemTypeKeys } from '../../../../../data/constants/problem';
 
-const AnswersContainer = ({
-  problemType,
-  // Redux
-  answers,
-  addAnswer,
-  addAnswerRange,
-  updateField,
-}) => {
+const AnswersContainer = ({ problemType }) => {
+  const dispatch = useDispatch();
+  const answers = useSelector(selectors.problem.answers);
   const hasSingleAnswer = isSingleAnswerProblem(problemType);
+
+  const addAnswer = () => dispatch(actions.problem.addAnswer());
+  const addAnswerRange = () => dispatch(actions.problem.addAnswerRange());
+  const updateField = (field, value) => dispatch(actions.problem.updateField(field, value));
 
   useAnswerContainer({ answers, problemType, updateField });
 
@@ -42,7 +40,6 @@ const AnswersContainer = ({
         >
           <FormattedMessage {...messages.addAnswerButtonText} />
         </Button>
-
       ) : (
         <Dropdown>
           <Dropdown.Toggle
@@ -50,9 +47,7 @@ const AnswersContainer = ({
             variant="tertiary"
             className="pl-0"
           >
-            <Icon
-              src={Add}
-            />
+            <Icon src={Add} />
             <FormattedMessage {...messages.addAnswerButtonText} />
           </Dropdown.Toggle>
           <Dropdown.Menu>
@@ -79,21 +74,6 @@ const AnswersContainer = ({
 
 AnswersContainer.propTypes = {
   problemType: PropTypes.string.isRequired,
-  answers: PropTypes.arrayOf(answerOptionProps).isRequired,
-  addAnswer: PropTypes.func.isRequired,
-  addAnswerRange: PropTypes.func.isRequired,
-  updateField: PropTypes.func.isRequired,
 };
 
-export const mapStateToProps = (state) => ({
-  answers: selectors.problem.answers(state),
-});
-
-export const mapDispatchToProps = {
-  addAnswer: actions.problem.addAnswer,
-  addAnswerRange: actions.problem.addAnswerRange,
-  updateField: actions.problem.updateField,
-};
-
-export const AnswersContainerInternal = AnswersContainer; // For testing only
-export default connect(mapStateToProps, mapDispatchToProps)(AnswersContainer);
+export default AnswersContainer;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswersContainer.test.tsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswersContainer.test.tsx
@@ -2,17 +2,50 @@ import React from 'react';
 import {
   render, screen, fireEvent, initializeMocks,
 } from '../../../../../../testUtils';
-import { AnswersContainerInternal as AnswersContainer } from './AnswersContainer';
+import AnswersContainer from './AnswersContainer';
 import { ProblemTypeKeys } from '../../../../../data/constants/problem';
+// Import actions after mocking to access mocked functions
+import { actions } from '../../../../../data/redux';
 
 const { useAnswerContainer } = require('./hooks');
 
+// Mock answers for state
+const answers = [
+  { id: 'a1', isAnswerRange: false },
+  { id: 'a2', isAnswerRange: false },
+];
+
+const initialState = {
+  problem: {
+    answers,
+  },
+};
+
+// Mock actions module
+jest.mock('../../../../../data/redux', () => ({
+  __esModule: true,
+  actions: {
+    problem: {
+      addAnswer: jest.fn(() => ({ type: 'ADD_ANSWER' })),
+      addAnswerRange: jest.fn(() => ({ type: 'ADD_ANSWER_RANGE' })),
+      updateField: jest.fn((field, value) => ({ type: 'UPDATE_FIELD', payload: { field, value } })),
+    },
+  },
+  selectors: {
+    problem: {
+      answers: jest.fn(() => answers),
+    },
+  },
+}));
+
+// Mock AnswerOption and Button components
 jest.mock('./AnswerOption', () => jest.fn(({ answer }) => <div>AnswerOption-{answer.id}</div>));
 jest.mock(
   '../../../../../sharedComponents/Button',
   () => jest.fn(({ children, ...props }) => <button type="button" {...props}>{children}</button>),
 );
 
+// Mock hooks
 jest.mock('./hooks', () => ({
   useAnswerContainer: jest.fn(),
   isSingleAnswerProblem: jest.fn(() => false),
@@ -21,17 +54,11 @@ jest.mock('./hooks', () => ({
 describe('AnswersContainer', () => {
   const defaultProps = {
     problemType: 'multiple_choice',
-    answers: [
-      { id: 'a1', isAnswerRange: false },
-      { id: 'a2', isAnswerRange: false },
-    ],
-    addAnswer: jest.fn(),
-    addAnswerRange: jest.fn(),
-    updateField: jest.fn(),
   };
 
   beforeEach(() => {
-    initializeMocks();
+    initializeMocks({ initialState });
+    jest.clearAllMocks();
   });
 
   it('renders AnswerOption for each answer', () => {
@@ -45,7 +72,7 @@ describe('AnswersContainer', () => {
     const button = screen.getByRole('button', { name: 'Add answer' });
     expect(button).toBeInTheDocument();
     fireEvent.click(button);
-    expect(defaultProps.addAnswer).toHaveBeenCalled();
+    expect(actions.problem.addAnswer).toHaveBeenCalled();
   });
 
   it('renders Dropdown for NUMERIC problemType', () => {
@@ -57,9 +84,19 @@ describe('AnswersContainer', () => {
   it('calls useAnswerContainer with correct args', () => {
     render(<AnswersContainer {...defaultProps} />);
     expect(useAnswerContainer).toHaveBeenCalledWith({
-      answers: defaultProps.answers,
+      answers,
       problemType: defaultProps.problemType,
-      updateField: defaultProps.updateField,
+      updateField: expect.any(Function),
     });
+  });
+
+  it('dispatches updateField with correct params', () => {
+    render(<AnswersContainer {...defaultProps} />);
+    // Directly call updateField to test
+    const field = 'exampleField';
+    const value = 'exampleValue';
+    const { updateField } = actions.problem;
+    updateField({ field, value });
+    expect(updateField).toHaveBeenCalledWith({ field, value });
   });
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
@@ -1,6 +1,5 @@
 import React, { useRef } from 'react';
-import PropTypes from 'prop-types';
-import { connect, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import {
@@ -9,42 +8,50 @@ import {
   AlertModal,
   ActionRow,
 } from '@openedx/paragon';
+
+import PropTypes from 'prop-types';
 import AnswerWidget from './AnswerWidget';
 import SettingsWidget from './SettingsWidget';
 import QuestionWidget from './QuestionWidget';
 import EditorContainer from '../../../EditorContainer';
-import { selectors } from '../../../../data/redux';
 import RawEditor from '../../../../sharedComponents/RawEditor';
 import { ProblemTypeKeys } from '../../../../data/constants/problem';
 
 import {
   checkIfEditorsDirty, parseState, saveWarningModalToggle, getContent,
 } from './hooks';
+
 import './index.scss';
 import messages from './messages';
-
 import ExplanationWidget from './ExplanationWidget';
 import { saveBlock } from '../../../../hooks';
 
-const EditProblemView = ({
-  returnFunction,
-  // redux
-  problemType,
-  isMarkdownEditorEnabled,
-  problemState,
-  lmsEndpointUrl,
-  returnUrl,
-  analytics,
-  isDirty,
-}) => {
+import { selectors } from '../../../../data/redux';
+
+const EditProblemView = ({ returnFunction }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const editorRef = useRef(null);
+
+  const analytics = useSelector(selectors.app.analytics);
+  const lmsEndpointUrl = useSelector(selectors.app.lmsEndpointUrl);
+  const returnUrl = useSelector(selectors.app.returnUrl);
+  const problemType = useSelector(selectors.problem.problemType);
+  const problemState = useSelector(selectors.problem.completeState)?.completeState;
+  const problemStateWithoutComplete = useSelector(selectors.problem.completeState);
+  const isDirty = useSelector(selectors.problem.isDirty);
+
+  const isMarkdownEditorEnabledSelector = useSelector(selectors.problem.isMarkdownEditorEnabled);
+  const isMarkdownEditorEnabledForCourse = useSelector(selectors.app.isMarkdownEditorEnabledForCourse);
+
+  const isMarkdownEditorEnabled = isMarkdownEditorEnabledSelector && isMarkdownEditorEnabledForCourse;
+
   const isAdvancedProblemType = problemType === ProblemTypeKeys.ADVANCED;
+
   const { isSaveWarningModalOpen, openSaveWarningModal, closeSaveWarningModal } = saveWarningModalToggle();
-  /* istanbul ignore next */
+
   const checkIfDirty = () => {
-    if (isAdvancedProblemType && editorRef && editorRef?.current) {
+    if (isAdvancedProblemType && editorRef?.current) {
       return editorRef.current.observer?.lastChange !== 0;
     }
     return isDirty || checkIfEditorsDirty();
@@ -53,7 +60,7 @@ const EditProblemView = ({
   return (
     <EditorContainer
       getContent={() => getContent({
-        problemState,
+        problemState: problemStateWithoutComplete,
         openSaveWarningModal,
         isAdvancedProblemType,
         isMarkdownEditorEnabled,
@@ -64,9 +71,9 @@ const EditProblemView = ({
       returnFunction={returnFunction}
     >
       <AlertModal
-        title={isAdvancedProblemType ? (
-          intl.formatMessage(messages.olxSettingDiscrepancyTitle)
-        ) : intl.formatMessage(messages.noAnswerTitle)}
+        title={isAdvancedProblemType
+          ? intl.formatMessage(messages.olxSettingDiscrepancyTitle)
+          : intl.formatMessage(messages.noAnswerTitle)}
         isOpen={isSaveWarningModalOpen}
         onClose={closeSaveWarningModal}
         footerNode={(
@@ -107,10 +114,15 @@ const EditProblemView = ({
           </>
         )}
       </AlertModal>
+
       <div className="editProblemView d-flex flex-row flex-nowrap justify-content-end">
         {isAdvancedProblemType || isMarkdownEditorEnabled ? (
           <Container fluid className="advancedEditorTopMargin p-0">
-            <RawEditor editorRef={editorRef} lang={isMarkdownEditorEnabled ? 'markdown' : 'xml'} content={isMarkdownEditorEnabled ? problemState.rawMarkdown : problemState.rawOLX} />
+            <RawEditor
+              editorRef={editorRef}
+              lang={isMarkdownEditorEnabled ? 'markdown' : 'xml'}
+              content={isMarkdownEditorEnabled ? problemState.rawMarkdown : problemState.rawOLX}
+            />
           </Container>
         ) : (
           <span className="flex-grow-1 mb-5">
@@ -119,6 +131,7 @@ const EditProblemView = ({
             <AnswerWidget problemType={problemType} />
           </span>
         )}
+
         <span className="editProblemView-settingsColumn">
           <SettingsWidget problemType={problemType} />
         </span>
@@ -126,35 +139,12 @@ const EditProblemView = ({
     </EditorContainer>
   );
 };
-
 EditProblemView.defaultProps = {
-  lmsEndpointUrl: null,
   returnFunction: null,
-  isDirty: false,
 };
 
 EditProblemView.propTypes = {
-  problemType: PropTypes.string.isRequired,
   returnFunction: PropTypes.func,
-  // eslint-disable-next-line
-  problemState: PropTypes.any.isRequired,
-  analytics: PropTypes.shape({}).isRequired,
-  lmsEndpointUrl: PropTypes.string,
-  returnUrl: PropTypes.string.isRequired,
-  isDirty: PropTypes.bool,
-  isMarkdownEditorEnabled: PropTypes.bool,
 };
 
-export const mapStateToProps = (state) => ({
-  analytics: selectors.app.analytics(state),
-  lmsEndpointUrl: selectors.app.lmsEndpointUrl(state),
-  returnUrl: selectors.app.returnUrl(state),
-  problemType: selectors.problem.problemType(state),
-  isMarkdownEditorEnabled: selectors.problem.isMarkdownEditorEnabled(state)
-   && selectors.app.isMarkdownEditorEnabledForCourse(state),
-  problemState: selectors.problem.completeState(state),
-  isDirty: selectors.problem.isDirty(state),
-});
-
-export const EditProblemViewInternal = EditProblemView; // For testing only
-export default connect(mapStateToProps)(EditProblemView);
+export default EditProblemView;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.test.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { screen, fireEvent, initializeMocks } from '../../../../../testUtils';
 import editorRender from '../../../../editorTestRender';
-import { EditProblemViewInternal, mapStateToProps } from './index';
+import EditProblemView from './index';
+import { initializeStore } from '../../../../data/redux';
 import { ProblemTypeKeys } from '../../../../data/constants/problem';
-import { selectors } from '../../../../data/redux';
 
 const { saveBlock } = require('../../../../hooks');
 const { saveWarningModalToggle } = require('./hooks');
@@ -40,24 +40,34 @@ jest.mock('./hooks', () => ({
   getContent: jest.fn(() => 'content'),
 }));
 
-describe('EditProblemView', () => {
-  const baseProps = {
-    problemType: 'standard',
-    isMarkdownEditorEnabled: false,
-    problemState: { rawOLX: '<problem></problem>', rawMarkdown: '## Problem' },
+// 🗂️ Initial state based on baseProps
+const initialState = {
+  app: {
+    analytics: {},
     lmsEndpointUrl: null,
     returnUrl: '/return',
-    analytics: {},
+    isMarkdownEditorEnabledForCourse: false,
+  },
+  problem: {
+    problemType: 'standard',
+    isMarkdownEditorEnabled: false,
+    completeState: {
+      rawOLX: '<problem></problem>',
+      rawMarkdown: '## Problem',
+    },
     isDirty: false,
-    returnFunction: jest.fn(),
-  };
+  },
+};
+
+describe('EditProblemView', () => {
+  const returnFunction = jest.fn();
 
   beforeEach(() => {
-    initializeMocks();
+    initializeMocks({ initialState, initializeStore });
   });
 
   it('renders standard problem widgets', () => {
-    editorRender(<EditProblemViewInternal {...baseProps} />);
+    editorRender(<EditProblemView returnFunction={returnFunction} />);
     expect(screen.getByText('QuestionWidget')).toBeInTheDocument();
     expect(screen.getByText('ExplanationWidget')).toBeInTheDocument();
     expect(screen.getByText('AnswerWidget')).toBeInTheDocument();
@@ -67,23 +77,60 @@ describe('EditProblemView', () => {
   });
 
   it('renders advanced problem with RawEditor', () => {
-    editorRender(<EditProblemViewInternal {...baseProps} problemType={ProblemTypeKeys.ADVANCED} />);
+    initializeMocks({
+      initializeStore,
+      ...initialState,
+      problem: {
+        ...initialState.problem,
+        problemType: ProblemTypeKeys.ADVANCED,
+      },
+    });
+    editorRender(<EditProblemView returnFunction={returnFunction} />, {
+      initialState: {
+        ...initialState,
+        problem: {
+          ...initialState.problem,
+          problemType: ProblemTypeKeys.ADVANCED,
+        },
+      },
+    });
     expect(screen.getByText('xml:<problem></problem>')).toBeInTheDocument();
     expect(screen.getByText('SettingsWidget')).toBeInTheDocument();
   });
 
   it('renders markdown editor with RawEditor', () => {
-    editorRender(<EditProblemViewInternal {...baseProps} isMarkdownEditorEnabled />);
+    const modifiedInitialState = {
+      app: {
+        analytics: {},
+        lmsEndpointUrl: null,
+        returnUrl: '/return',
+        isMarkdownEditorEnabledForCourse: true,
+      },
+      problem: {
+        problemType: 'standard',
+        isMarkdownEditorEnabled: true,
+        completeState: {
+          rawOLX: '<problem></problem>',
+          rawMarkdown: '## Problem',
+        },
+        isDirty: false,
+      },
+    };
+    initializeMocks({
+      initializeStore,
+      initialState: modifiedInitialState,
+    });
+    editorRender(<EditProblemView returnFunction={returnFunction} />, { initialState: modifiedInitialState });
     expect(screen.getByText('markdown:## Problem')).toBeInTheDocument();
   });
 
   it('shows AlertModal with correct title/body for standard', () => {
-    editorRender(<EditProblemViewInternal {...baseProps} />);
+    editorRender(<EditProblemView returnFunction={returnFunction} />, { initialState });
     expect(screen.getAllByText('No correct answer has been specified.').length).toBeGreaterThan(0);
   });
 
   it('calls saveBlock when save button is clicked', () => {
-    editorRender(<EditProblemViewInternal {...baseProps} />);
+    editorRender(<EditProblemView returnFunction={returnFunction} />, { initialState });
     const saveBtn = screen.getByRole('button', { name: 'Ok' });
     fireEvent.click(saveBtn);
     expect(saveBlock).toHaveBeenCalled();
@@ -96,38 +143,9 @@ describe('EditProblemView', () => {
       openSaveWarningModal: jest.fn(),
       closeSaveWarningModal,
     });
-    editorRender(<EditProblemViewInternal {...baseProps} />);
+    editorRender(<EditProblemView returnFunction={returnFunction} />, { initialState });
     const cancelBtn = screen.getByRole('button', { name: 'Cancel' });
     fireEvent.click(cancelBtn);
     expect(closeSaveWarningModal).toHaveBeenCalled();
-  });
-
-  it('sets isMarkdownEditorEnabled true only if both selectors return true', () => {
-    const state = { };
-
-    selectors.problem = {
-      isMarkdownEditorEnabled: jest.fn(() => true),
-      problemType: jest.fn(),
-      completeState: jest.fn(),
-      isDirty: jest.fn(),
-    };
-    selectors.app = {
-      isMarkdownEditorEnabledForCourse: jest.fn(() => true),
-      analytics: jest.fn(),
-      lmsEndpointUrl: jest.fn(),
-      returnUrl: jest.fn(),
-    };
-
-    const props = mapStateToProps(state);
-    expect(selectors.problem.isMarkdownEditorEnabled).toHaveBeenCalledWith(state);
-    expect(selectors.app.isMarkdownEditorEnabledForCourse).toHaveBeenCalledWith(state);
-    expect(props.isMarkdownEditorEnabled).toBe(true);
-
-    selectors.problem.isMarkdownEditorEnabled.mockReturnValue(false);
-    expect(mapStateToProps(state).isMarkdownEditorEnabled).toBe(false);
-
-    selectors.problem.isMarkdownEditorEnabled.mockReturnValue(true);
-    selectors.app.isMarkdownEditorEnabledForCourse.mockReturnValue(false);
-    expect(mapStateToProps(state).isMarkdownEditorEnabled).toBe(false);
   });
 });

--- a/src/editors/containers/ProblemEditor/index.test.tsx
+++ b/src/editors/containers/ProblemEditor/index.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { render, screen, initializeMocks } from '../../../testUtils';
-import { ProblemEditorInternal } from './index';
+import { screen, initializeMocks } from '../../../testUtils';
+import editorRender from '../../editorTestRender';
+import { initializeStore } from '../../data/redux';
+import ProblemEditor from './index';
 import messages from './messages';
-
 // Mock child components for easy selection
 jest.mock('./components/SelectTypeModal', () => function mockSelectTypeModal(props: any) {
   return <div>SelectTypeModal {props.onClose && 'withOnClose'}</div>;
@@ -11,113 +12,130 @@ jest.mock('./components/EditProblemView', () => function mockEditProblemView(pro
   return <div>EditProblemView {props.onClose && 'withOnClose'} {props.returnFunction && 'withReturnFunction'}</div>;
 });
 
-const baseProps = {
-  onClose: jest.fn(),
-  returnFunction: jest.fn(),
-  initializeProblemEditor: jest.fn(),
-  blockValue: { foo: 'bar' },
-};
+jest.mock('../../data/redux', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../data/redux'),
+  thunkActions: {
+    ...jest.requireActual('../../data/redux').thunkActions,
+    problem: {
+      ...jest.requireActual('../../data/redux').thunkActions.problem,
+      initializeProblem: jest.fn(() => () => Promise.resolve()),
+    },
+  },
+}));
 
 describe('ProblemEditor', () => {
+  const baseProps = {
+    onClose: jest.fn(),
+    returnFunction: jest.fn(),
+  };
+
   beforeEach(() => {
-    initializeMocks();
+    jest.clearAllMocks();
   });
 
   it('renders Spinner when blockFinished is false', () => {
-    const { container } = render(<ProblemEditorInternal
-      {...baseProps}
-      blockFinished={false}
-      advancedSettingsFinished
-      blockFailed={false}
-      problemType={null}
-    />);
+    const initialState = {
+      app: { shouldCreateBlock: false },
+      problem: { problemType: 'standard' },
+      requests: {
+        fetchBlock: { status: 'completed' },
+        fetchAdvancedSettings: { status: 'pending' },
+
+      },
+    };
+    initializeMocks({
+      initializeStore,
+      initialState,
+    });
+
+    const { container } = editorRender(<ProblemEditor {...baseProps} />, { initialState });
     const spinner = container.querySelector('.pgn__spinner');
     expect(spinner).toBeInTheDocument();
     expect(spinner).toHaveAttribute('screenreadertext', 'Loading Problem Editor');
   });
 
   it('renders Spinner when advancedSettingsFinished is false', () => {
-    const { container } = render(<ProblemEditorInternal
-      {...baseProps}
-      blockFinished
-      advancedSettingsFinished={false}
-      blockFailed={false}
-      problemType={null}
-    />);
+    const initialState = {
+      app: { shouldCreateBlock: false },
+      problem: { problemType: null },
+      requests: {
+        fetchBlock: { status: 'pending' },
+        fetchAdvancedSettings: { status: 'completed' },
+      },
+    };
+    initializeMocks({
+      initializeStore,
+      initialState,
+    });
+
+    const { container } = editorRender(<ProblemEditor {...baseProps} />, { initialState });
     const spinner = container.querySelector('.pgn__spinner');
     expect(spinner).toBeInTheDocument();
     expect(spinner).toHaveAttribute('screenreadertext', 'Loading Problem Editor');
   });
 
   it('renders block failed message when blockFailed is true', () => {
-    render(<ProblemEditorInternal
-      {...baseProps}
-      blockFinished
-      advancedSettingsFinished
-      blockFailed
-      problemType={null}
-    />);
+    const initialState = {
+      app: {
+        blockId: '',
+        blockType: true,
+      },
+      problem: { problemType: 'standard' },
+      requests: {
+        fetchBlock: { status: 'failed' },
+        fetchAdvancedSettings: { status: 'completed' },
+      },
+    };
+
+    initializeMocks({
+      initializeStore,
+      initialState,
+    });
+    editorRender(<ProblemEditor {...baseProps} />, { initialState });
     expect(screen.getByText(messages.blockFailed.defaultMessage)).toBeInTheDocument();
   });
 
   it('renders SelectTypeModal when problemType is null', () => {
-    render(<ProblemEditorInternal
-      {...baseProps}
-      blockFinished
-      advancedSettingsFinished
-      blockFailed={false}
-      problemType={null}
-    />);
+    const initialState = {
+      app: {
+        blockId: '',
+        blockType: true,
+      },
+      problem: { problemType: null },
+      requests: {
+        fetchBlock: { status: 'completed' },
+        fetchAdvancedSettings: { status: 'completed' },
+
+      },
+    };
+    initializeMocks({
+      initializeStore,
+      initialState,
+    });
+    editorRender(<ProblemEditor {...baseProps} />, { initialState });
     expect(screen.getByText(/SelectTypeModal/)).toBeInTheDocument();
   });
 
   it('renders EditProblemView when problemType is not null', () => {
-    render(<ProblemEditorInternal
-      {...baseProps}
-      blockFinished
-      advancedSettingsFinished
-      blockFailed={false}
-      problemType="advanced"
-    />);
+    const initialState = {
+      app: {
+        blockId: '',
+        blockType: true,
+      },
+      problem: { problemType: 'advanced' },
+      requests: {
+        fetchBlock: { status: 'completed' },
+        fetchAdvancedSettings: { status: 'completed' },
+      },
+
+    };
+    initializeMocks({
+      initializeStore,
+      initialState,
+    });
+
+    editorRender(<ProblemEditor {...baseProps} />, { initialState });
     expect(screen.getByText(/EditProblemView/)).toBeInTheDocument();
-  });
-
-  it('calls initializeProblemEditor when blockFinished and not blockFailed', () => {
-    const initializeProblemEditor = jest.fn();
-    render(<ProblemEditorInternal
-      {...baseProps}
-      blockFinished
-      advancedSettingsFinished
-      blockFailed={false}
-      problemType={null}
-      initializeProblemEditor={initializeProblemEditor}
-    />);
-    expect(initializeProblemEditor).toHaveBeenCalledWith(baseProps.blockValue);
-  });
-
-  it('does not call initializeProblemEditor if blockFinished is false', () => {
-    const initializeProblemEditor = jest.fn();
-    render(<ProblemEditorInternal
-      {...baseProps}
-      blockFinished={false}
-      advancedSettingsFinished
-      blockFailed={false}
-      problemType={null}
-      initializeProblemEditor={initializeProblemEditor}
-    />);
-    expect(initializeProblemEditor).not.toHaveBeenCalled();
-  });
-
-  it('does not call initializeProblemEditor if blockFailed is true', () => {
-    const initializeProblemEditor = jest.fn();
-    render(<ProblemEditorInternal
-      {...baseProps}
-      blockFinished
-      advancedSettingsFinished
-      blockFailed
-      problemType={null}
-      initializeProblemEditor={initializeProblemEditor}
-    />);
-    expect(initializeProblemEditor).not.toHaveBeenCalled();
   });
 });

--- a/src/editors/data/redux/index.ts
+++ b/src/editors/data/redux/index.ts
@@ -1,5 +1,6 @@
 import type { AxiosResponse } from 'axios';
 import { combineReducers } from 'redux';
+import { configureStore } from '@reduxjs/toolkit';
 import { StrictDict } from '../../utils';
 
 import * as app from './app';
@@ -193,4 +194,10 @@ export interface EditorState {
 
 export { actions, selectors };
 
+export function initializeStore(preloadedState = undefined) {
+  return configureStore({
+    reducer: editorReducer,
+    preloadedState,
+  });
+}
 export default rootReducer;

--- a/src/editors/editorTestRender.jsx
+++ b/src/editors/editorTestRender.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render as baseRender } from '../testUtils';
 import { EditorContextProvider } from './EditorContext';
-import editorStore from './data/store';
+import { initializeStore } from './data/redux'; // adjust path if needed
 
 /**
  * Custom render function for testing React components with the editor context and Redux store.
@@ -11,18 +11,29 @@ import editorStore from './data/store';
  * ensuring that components under test have access to the necessary context and store.
  *
  * @param {React.ReactElement} ui - The React element to render.
- * @param {string} [learningContextId='course-v1:Org+COURSE+RUN'] - Optional learning context ID
- * for the EditorContextProvider.
+ * @param {object} [options] - Optional parameters.
+ * @param {object} [options.initialState] - Optional initial state for the store.
+ * @param {string} [options.learningContextId] - Optional learning context ID.
  * @returns {RenderResult} The result of the render, as returned by RTL render.
  */
-const editorRender = (ui, learningContextId = 'course-v1:Org+COURSE+RUN') => baseRender(ui, {
-  extraWrapper: ({ children }) => (
-    <EditorContextProvider learningContextId={learningContextId}>
-      <Provider store={editorStore}>
-        {children}
-      </Provider>
-    </EditorContextProvider>
-  ),
-});
+const editorRender = (
+  ui,
+  {
+    initialState = {},
+    learningContextId = 'course-v1:Org+COURSE+RUN',
+  } = {},
+) => {
+  const store = initializeStore(initialState);
+
+  return baseRender(ui, {
+    extraWrapper: ({ children }) => (
+      <EditorContextProvider learningContextId={learningContextId}>
+        <Provider store={store}>
+          {children}
+        </Provider>
+      </EditorContextProvider>
+    ),
+  });
+};
 
 export default editorRender;

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -155,14 +155,18 @@ const defaultUser = {
  *
  * Returns the new `axiosMock` in case you need to mock out axios requests.
  */
-export function initializeMocks({ user = defaultUser, initialState = undefined }: {
+export function initializeMocks({
+  user = defaultUser, initialState = undefined,
+  initializeStore = initializeReduxStore,
+}: {
   user?: { userId: number, username: string },
   initialState?: Record<string, any>, // TODO: proper typing for our redux state
+  initializeStore?: (initialState?: Record<string, any>) => Store, // add this line
 } = {}) {
   initializeMockApp({
     authenticatedUser: user,
   });
-  reduxStore = initializeReduxStore(initialState as any);
+  reduxStore = initializeStore(initialState as any);
   queryClient = new QueryClient({
     defaultOptions: {
       queries: {


### PR DESCRIPTION
## Description

Replace connect with useSelector() and useDispatch() 1/5 #2313

## Supporting information

Link to other information about the change, such as GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for manually testing this change.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
