### PR TITLE
Clean up editor tests

### DIFF
--- a/src/editors/VideoSelector.test.tsx
+++ b/src/editors/VideoSelector.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import * as reactRedux from 'react-redux';
 import * as hooks from './hooks';
 import VideoSelector from './VideoSelector';
-import editorRender from './editorTestRender';
+import { editorRender } from './editorTestRender';
 import { initializeMocks, screen } from '../testUtils';
 
 const defaultProps = {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
@@ -37,8 +37,7 @@ const EditProblemView = ({ returnFunction }) => {
   const lmsEndpointUrl = useSelector(selectors.app.lmsEndpointUrl);
   const returnUrl = useSelector(selectors.app.returnUrl);
   const problemType = useSelector(selectors.problem.problemType);
-  const problemState = useSelector(selectors.problem.completeState)?.completeState;
-  const problemStateWithoutComplete = useSelector(selectors.problem.completeState);
+  const problemState = useSelector(selectors.problem.completeState);
   const isDirty = useSelector(selectors.problem.isDirty);
 
   const isMarkdownEditorEnabledSelector = useSelector(selectors.problem.isMarkdownEditorEnabled);
@@ -60,7 +59,7 @@ const EditProblemView = ({ returnFunction }) => {
   return (
     <EditorContainer
       getContent={() => getContent({
-        problemState: problemStateWithoutComplete,
+        problemState,
         openSaveWarningModal,
         isAdvancedProblemType,
         isMarkdownEditorEnabled,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.test.tsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { screen, fireEvent, initializeMocks } from '../../../../../testUtils';
-import editorRender from '../../../../editorTestRender';
+import { screen, fireEvent, initializeMocks } from '@src/testUtils';
+import { editorRender, type PartialEditorState } from '@src/editors/editorTestRender';
+import { ProblemTypeKeys } from '@src/editors/data/constants/problem';
 import EditProblemView from './index';
-import { initializeStore } from '../../../../data/redux';
-import { ProblemTypeKeys } from '../../../../data/constants/problem';
 
 const { saveBlock } = require('../../../../hooks');
 const { saveWarningModalToggle } = require('./hooks');
@@ -41,20 +40,16 @@ jest.mock('./hooks', () => ({
 }));
 
 // 🗂️ Initial state based on baseProps
-const initialState = {
+const initialState: PartialEditorState = {
   app: {
-    analytics: {},
     lmsEndpointUrl: null,
-    returnUrl: '/return',
     isMarkdownEditorEnabledForCourse: false,
   },
   problem: {
-    problemType: 'standard',
+    problemType: null,
     isMarkdownEditorEnabled: false,
-    completeState: {
-      rawOLX: '<problem></problem>',
-      rawMarkdown: '## Problem',
-    },
+    rawOLX: '<problem></problem>',
+    rawMarkdown: '## Problem',
     isDirty: false,
   },
 };
@@ -63,11 +58,11 @@ describe('EditProblemView', () => {
   const returnFunction = jest.fn();
 
   beforeEach(() => {
-    initializeMocks({ initialState, initializeStore });
+    initializeMocks();
   });
 
   it('renders standard problem widgets', () => {
-    editorRender(<EditProblemView returnFunction={returnFunction} />);
+    editorRender(<EditProblemView returnFunction={returnFunction} />, { initialState });
     expect(screen.getByText('QuestionWidget')).toBeInTheDocument();
     expect(screen.getByText('ExplanationWidget')).toBeInTheDocument();
     expect(screen.getByText('AnswerWidget')).toBeInTheDocument();
@@ -77,14 +72,6 @@ describe('EditProblemView', () => {
   });
 
   it('renders advanced problem with RawEditor', () => {
-    initializeMocks({
-      initializeStore,
-      ...initialState,
-      problem: {
-        ...initialState.problem,
-        problemType: ProblemTypeKeys.ADVANCED,
-      },
-    });
     editorRender(<EditProblemView returnFunction={returnFunction} />, {
       initialState: {
         ...initialState,
@@ -99,27 +86,19 @@ describe('EditProblemView', () => {
   });
 
   it('renders markdown editor with RawEditor', () => {
-    const modifiedInitialState = {
+    const modifiedInitialState: PartialEditorState = {
       app: {
-        analytics: {},
         lmsEndpointUrl: null,
-        returnUrl: '/return',
         isMarkdownEditorEnabledForCourse: true,
       },
       problem: {
-        problemType: 'standard',
+        problemType: null,
         isMarkdownEditorEnabled: true,
-        completeState: {
-          rawOLX: '<problem></problem>',
-          rawMarkdown: '## Problem',
-        },
+        rawOLX: '<problem></problem>',
+        rawMarkdown: '## Problem',
         isDirty: false,
       },
     };
-    initializeMocks({
-      initializeStore,
-      initialState: modifiedInitialState,
-    });
     editorRender(<EditProblemView returnFunction={returnFunction} />, { initialState: modifiedInitialState });
     expect(screen.getByText('markdown:## Problem')).toBeInTheDocument();
   });

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/index.test.tsx
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/index.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {
   screen, fireEvent, initializeMocks,
-} from '../../../../../../testUtils';
-import editorRender from '../../../../../editorTestRender';
+} from '@src/testUtils';
+import { editorRender } from '@src/editors/editorTestRender';
 import SelectTypeWrapper from './index';
 import * as hooks from '../hooks';
 

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/index.test.tsx
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/index.test.tsx
@@ -2,8 +2,8 @@ import {
   fireEvent,
   screen,
   initializeMocks,
-} from '../../../../../testUtils';
-import editorRender from '../../../../editorTestRender';
+} from '@src/testUtils';
+import { editorRender } from '@src/editors/editorTestRender';
 import * as hooks from './hooks';
 import SelectTypeModal from '.';
 

--- a/src/editors/containers/ProblemEditor/index.tsx
+++ b/src/editors/containers/ProblemEditor/index.tsx
@@ -42,7 +42,7 @@ const ProblemEditor: React.FC<Props> = ({
         <Spinner
           animation="border"
           className="m-3"
-          screenreadertext="Loading Problem Editor"
+          screenReaderText="Loading Problem Editor"
         />
       </div>
     );

--- a/src/editors/data/store.ts
+++ b/src/editors/data/store.ts
@@ -10,7 +10,7 @@ export const createStore = () => {
 
   const middleware = [thunkMiddleware, loggerMiddleware];
 
-  const store = redux.createStore<EditorState, any, any, any>(
+  const store: redux.Store<EditorState> = redux.createStore<EditorState, any, any, any>(
     reducer as any,
     composeWithDevToolsLogOnlyInProduction(redux.applyMiddleware(...middleware)),
   );

--- a/src/editors/editorTestRender.tsx
+++ b/src/editors/editorTestRender.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render as baseRender } from '../testUtils';
+import { render as baseRender, WrapperOptions } from '../testUtils';
 import { EditorContextProvider } from './EditorContext';
-import { initializeStore } from './data/redux'; // adjust path if needed
+import { type EditorState, initializeStore } from './data/redux'; // adjust path if needed
+
+type RecursivePartial<T> = {
+  [P in keyof T]?: RecursivePartial<T[P]>;
+};
+
+export type PartialEditorState = RecursivePartial<EditorState>;
 
 /**
  * Custom render function for testing React components with the editor context and Redux store.
@@ -10,22 +16,19 @@ import { initializeStore } from './data/redux'; // adjust path if needed
  * Wraps the provided UI in both the EditorContextProvider and Redux Provider,
  * ensuring that components under test have access to the necessary context and store.
  *
- * @param {React.ReactElement} ui - The React element to render.
- * @param {object} [options] - Optional parameters.
- * @param {object} [options.initialState] - Optional initial state for the store.
- * @param {string} [options.learningContextId] - Optional learning context ID.
- * @returns {RenderResult} The result of the render, as returned by RTL render.
  */
-const editorRender = (
-  ui,
+export const editorRender = (
+  ui: React.ReactElement,
   {
     initialState = {},
     learningContextId = 'course-v1:Org+COURSE+RUN',
-  } = {},
+    ...options
+  }: Omit<WrapperOptions, 'extraWrapper'> & { initialState?: PartialEditorState, learningContextId?: string } = {},
 ) => {
-  const store = initializeStore(initialState);
+  const store = initializeStore(initialState as any);
 
   return baseRender(ui, {
+    ...options,
     extraWrapper: ({ children }) => (
       <EditorContextProvider learningContextId={learningContextId}>
         <Provider store={store}>
@@ -35,5 +38,3 @@ const editorRender = (
     ),
   });
 };
-
-export default editorRender;

--- a/src/editors/editorTestRender.tsx
+++ b/src/editors/editorTestRender.tsx
@@ -25,6 +25,8 @@ export const editorRender = (
     ...options
   }: Omit<WrapperOptions, 'extraWrapper'> & { initialState?: PartialEditorState, learningContextId?: string } = {},
 ) => {
+  // We might need a way for the test cases to access this store directly. In that case we could allow either an
+  // initialState parameter OR an editorStore parameter.
   const store = initializeStore(initialState as any);
 
   return baseRender(ui, {

--- a/src/editors/sharedComponents/TinyMceWidget/index.test.tsx
+++ b/src/editors/sharedComponents/TinyMceWidget/index.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   screen, initializeMocks,
 } from '@src/testUtils';
-import editorRender from '@src/editors/editorTestRender';
+import { editorRender } from '@src/editors/editorTestRender';
 import * as hooks from './hooks';
 import TinyMceWidget from '.';
 

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -155,18 +155,14 @@ const defaultUser = {
  *
  * Returns the new `axiosMock` in case you need to mock out axios requests.
  */
-export function initializeMocks({
-  user = defaultUser, initialState = undefined,
-  initializeStore = initializeReduxStore,
-}: {
+export function initializeMocks({ user = defaultUser, initialState = undefined }: {
   user?: { userId: number, username: string },
   initialState?: Record<string, any>, // TODO: proper typing for our redux state
-  initializeStore?: (initialState?: Record<string, any>) => Store, // add this line
 } = {}) {
   initializeMockApp({
     authenticatedUser: user,
   });
-  reduxStore = initializeStore(initialState as any);
+  reduxStore = initializeReduxStore(initialState as any);
   queryClient = new QueryClient({
     defaultOptions: {
       queries: {


### PR DESCRIPTION
## Description

This fixes some bugs and cleans up redundant code introduced by https://github.com/openedx/frontend-app-authoring/pull/2326 .

## Supporting information

This is part of the broader effort to clean up our test suite and [remove `useSelector` and `useDispatch`](https://github.com/openedx/frontend-app-authoring/issues/2312).

## Testing instructions

This mostly changes test code, but it does make one fix to the problem editor, so make sure the (capa) problem editor is working normally.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
