### PR TITLE
fix: fix unit test and refactor the code

### DIFF
--- a/src/files-and-videos/videos-page/VideosPage.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.jsx
@@ -169,8 +169,9 @@ const VideosPage = ({
     handleAddThumbnail,
     videoImageSettings,
   });
+
   const infoModalSidebar = (video, activeTab, setActiveTab) => (
-    VideoInfoModalSidebar({ video, activeTab, setActiveTab })
+    <VideoInfoModalSidebar video={video} activeTab={activeTab} setActiveTab={setActiveTab} />
   );
   const maxFileSize = videoUploadMaxFileSize * 1073741824;
   const transcriptColumn = {

--- a/src/files-and-videos/videos-page/info-sidebar/VideoInfoModalSidebar.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/VideoInfoModalSidebar.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Tabs,
   Tab,
@@ -14,33 +14,35 @@ const VideoInfoModalSidebar = ({
   video,
   activeTab,
   setActiveTab,
-  // injected
-  intl,
-}) => (
-  <Tabs
-    id="controlled-info-sidebar-tab"
-    activeKey={activeTab}
-    onSelect={(tab) => setActiveTab(tab)}
-  >
-    <Tab eventKey="fileInfo" title={intl.formatMessage(messages.infoTabTitle)}>
-      <InfoTab {...{ video }} />
-    </Tab>
-    <Tab
-      eventKey="fileTranscripts"
-      title={intl.formatMessage(
-        messages.transcriptTabTitle,
-        { transcriptCount: video.transcripts.length },
-      )}
-      notification={TRANSCRIPT_FAILURE_STATUSES.includes(video.transcriptionStatus) && (
+}) => {
+  const intl = useIntl();
+
+  return (
+    <Tabs
+      id="controlled-info-sidebar-tab"
+      activeKey={activeTab}
+      onSelect={(tab) => setActiveTab(tab)}
+    >
+      <Tab eventKey="fileInfo" title={intl.formatMessage(messages.infoTabTitle)}>
+        <InfoTab {...{ video }} />
+      </Tab>
+      <Tab
+        eventKey="fileTranscripts"
+        title={intl.formatMessage(
+          messages.transcriptTabTitle,
+          { transcriptCount: video.transcripts.length },
+        )}
+        notification={TRANSCRIPT_FAILURE_STATUSES.includes(video.transcriptionStatus) && (
         <span>
           <span className="sr-only">{intl.formatMessage(messages.notificationScreenReaderText)}</span>
         </span>
-      )}
-    >
-      <TranscriptTab {...{ video }} />
-    </Tab>
-  </Tabs>
-);
+        )}
+      >
+        <TranscriptTab {...{ video }} />
+      </Tab>
+    </Tabs>
+  );
+};
 
 VideoInfoModalSidebar.propTypes = {
   video: PropTypes.shape({
@@ -54,12 +56,10 @@ VideoInfoModalSidebar.propTypes = {
   }),
   activeTab: PropTypes.string.isRequired,
   setActiveTab: PropTypes.func.isRequired,
-  // injected
-  intl: intlShape.isRequired,
 };
 
 VideoInfoModalSidebar.defaultProps = {
   video: null,
 };
 
-export default injectIntl(VideoInfoModalSidebar);
+export default VideoInfoModalSidebar;


### PR DESCRIPTION
## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be linked here.

Useful information to include:
- Which user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).

## Supporting information

Link to other information about the change, such as GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for manually testing this change.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
