### PR TITLE
refactor: Replace of injectIntl with useIntl() part 6 - remaining files

### DIFF
--- a/src/files-and-videos/generic/EditFileErrors.jsx
+++ b/src/files-and-videos/generic/EditFileErrors.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { Alert } from '@openedx/paragon';
 import ErrorAlert from '../../editors/sharedComponents/ErrorAlerts/ErrorAlert';
 import { RequestStatus } from '../../data/constants';
@@ -13,71 +13,72 @@ const EditFileErrors = ({
   deleteFileStatus,
   updateFileStatus,
   loadingStatus,
-  // injected
-  intl,
-}) => (
-  <>
-    <ErrorAlert
-      hideHeading={false}
-      dismissError={() => resetErrors({ errorType: 'loading' })}
-      isError={loadingStatus === RequestStatus.FAILED || loadingStatus === RequestStatus.PARTIAL_FAILURE}
-    >
-      {intl.formatMessage(messages.errorAlertMessage, { message: errorMessages.loading })}
-    </ErrorAlert>
-    <ErrorAlert
-      hideHeading
-      dismissError={() => resetErrors({ errorType: 'add' })}
-      isError={addFileStatus === RequestStatus.FAILED}
-    >
-      <Alert.Heading>
-        {intl.formatMessage(messages.uploadErrorAlertTitle)}
-      </Alert.Heading>
-      <ul className="p-0">
-        {errorMessages.add.map(message => (
-          <li key={`add-error-${message}`} style={{ listStyle: 'none' }}>
-            {intl.formatMessage(messages.errorAlertMessage, { message })}
-          </li>
-        ))}
-      </ul>
-    </ErrorAlert>
-    <ErrorAlert
-      hideHeading={false}
-      dismissError={() => resetErrors({ errorType: 'delete' })}
-      isError={deleteFileStatus === RequestStatus.FAILED}
-    >
-      <ul className="p-0">
-        {errorMessages.delete.map(message => (
-          <li key={`delete-error-${message}`} style={{ listStyle: 'none' }}>
-            {intl.formatMessage(messages.errorAlertMessage, { message })}
-          </li>
-        ))}
-      </ul>
-    </ErrorAlert>
-    <ErrorAlert
-      hideHeading={false}
-      dismissError={() => resetErrors({ errorType: 'update' })}
-      isError={updateFileStatus === RequestStatus.FAILED}
-    >
-      <ul className="p-0">
-        {errorMessages.lock?.map(message => (
-          <li key={`lock-error-${message}`} style={{ listStyle: 'none' }}>
-            {intl.formatMessage(messages.errorAlertMessage, { message })}
-          </li>
-        ))}
-        {errorMessages.download.map(message => (
-          <li key={`download-error-${message}`} style={{ listStyle: 'none' }}>
-            {intl.formatMessage(messages.errorAlertMessage, { message })}
-          </li>
-        ))}
-        {errorMessages.thumbnail?.map(message => (
-          <li key={`add-thumbnail-error-${message}`} style={{ listStyle: 'none' }}>
-            {intl.formatMessage(messages.errorAlertMessage, { message })}
-          </li>
-        ))}
-      </ul>
-    </ErrorAlert>
-  </>
-);
+}) => {
+  const intl = useIntl();
+  return (
+    <>
+      <ErrorAlert
+        hideHeading={false}
+        dismissError={/* istanbul ignore next */ () => resetErrors({ errorType: 'loading' })}
+        isError={loadingStatus === RequestStatus.FAILED || loadingStatus === RequestStatus.PARTIAL_FAILURE}
+      >
+        {intl.formatMessage(messages.errorAlertMessage, { message: errorMessages.loading })}
+      </ErrorAlert>
+      <ErrorAlert
+        hideHeading
+        dismissError={/* istanbul ignore next */ () => resetErrors({ errorType: 'add' })}
+        isError={addFileStatus === RequestStatus.FAILED}
+      >
+        <Alert.Heading>
+          {intl.formatMessage(messages.uploadErrorAlertTitle)}
+        </Alert.Heading>
+        <ul className="p-0">
+          {errorMessages.add.map(message => (
+            <li key={`add-error-${message}`} style={{ listStyle: 'none' }}>
+              {intl.formatMessage(messages.errorAlertMessage, { message })}
+            </li>
+          ))}
+        </ul>
+      </ErrorAlert>
+      <ErrorAlert
+        hideHeading={false}
+        dismissError={/* istanbul ignore next */ () => resetErrors({ errorType: 'delete' })}
+        isError={deleteFileStatus === RequestStatus.FAILED}
+      >
+        <ul className="p-0">
+          {errorMessages.delete.map(message => (
+            <li key={`delete-error-${message}`} style={{ listStyle: 'none' }}>
+              {intl.formatMessage(messages.errorAlertMessage, { message })}
+            </li>
+          ))}
+        </ul>
+      </ErrorAlert>
+      <ErrorAlert
+        hideHeading={false}
+        dismissError={/* istanbul ignore next */ () => resetErrors({ errorType: 'update' })}
+        isError={updateFileStatus === RequestStatus.FAILED}
+      >
+        <ul className="p-0">
+          {errorMessages.lock?.map(message => (
+            <li key={`lock-error-${message}`} style={{ listStyle: 'none' }}>
+              {intl.formatMessage(messages.errorAlertMessage, { message })}
+            </li>
+          ))}
+          {errorMessages.download.map(message => (
+            <li key={`download-error-${message}`} style={{ listStyle: 'none' }}>
+              {intl.formatMessage(messages.errorAlertMessage, { message })}
+            </li>
+          ))}
+          {errorMessages.thumbnail?.map(message => (
+            <li key={`add-thumbnail-error-${message}`} style={{ listStyle: 'none' }}>
+              {intl.formatMessage(messages.errorAlertMessage, { message })}
+            </li>
+          ))}
+        </ul>
+      </ErrorAlert>
+    </>
+  );
+};
 
 EditFileErrors.propTypes = {
   resetErrors: PropTypes.func.isRequired,
@@ -93,8 +94,6 @@ EditFileErrors.propTypes = {
   deleteFileStatus: PropTypes.string.isRequired,
   updateFileStatus: PropTypes.string.isRequired,
   loadingStatus: PropTypes.string.isRequired,
-  // injected
-  intl: intlShape.isRequired,
 };
 
-export default injectIntl(EditFileErrors);
+export default EditFileErrors;


### PR DESCRIPTION
## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be linked here.

Useful information to include:
- Which user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).

## Supporting information

Link to other information about the change, such as GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for manually testing this change.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
