### PR TITLE
fix: scroll entire window instead of iframe

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -105,4 +105,5 @@ export const iframeMessageTypes = {
   resize: 'plugin.resize',
   videoFullScreen: 'plugin.videoFullScreen',
   xblockEvent: 'xblock-event',
+  xblockScroll: 'xblock-scroll'
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -105,5 +105,5 @@ export const iframeMessageTypes = {
   resize: 'plugin.resize',
   videoFullScreen: 'plugin.videoFullScreen',
   xblockEvent: 'xblock-event',
-  xblockScroll: 'xblock-scroll'
+  xblockScroll: 'xblock-scroll',
 };

--- a/src/generic/hooks/tests/hooks.test.tsx
+++ b/src/generic/hooks/tests/hooks.test.tsx
@@ -147,7 +147,7 @@ describe('useIframeBehavior', () => {
       window.dispatchEvent(new MessageEvent('message', message));
     });
 
-    expect(window.scrollTo).toHaveBeenCalledWith(0, 175);
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 175, left: 0, behavior: 'smooth' });
     expect(window.scrollY).toBe(100 + document.getElementsByName('xblock-iframe')[0].offsetTop + document.getElementsByName('xblock-iframe')[0]!.parentElement!.offsetTop);
   });
 

--- a/src/generic/hooks/tests/hooks.test.tsx
+++ b/src/generic/hooks/tests/hooks.test.tsx
@@ -122,6 +122,24 @@ describe('useIframeBehavior', () => {
     expect(setWindowTopOffset).toHaveBeenCalledWith(window.scrollY);
   });
 
+  it('handles xblockScroll message correctly', () => {
+    document.body.innerHTML = '<div id="window" top: 25px;"><div id="xblock-iframe" style="position: absolute; top: 50px;"></div></div>';
+    renderHook(() => useIframeBehavior({ id, iframeUrl, iframeRef }));
+
+    const message = {
+      type: iframeMessageTypes.xblockScroll,
+      data: { offset: 100 },
+    };
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', message));
+    });
+
+    expect(window.scrollY).toBe(100
+      + (document.getElementById('xblock-iframe') as HTMLElement).offsetTop
+      + (document.getElementById('xblock-iframe')?.parentElement as HTMLElement).offsetTop);
+  });
+
   it('handles offset message correctly', () => {
     document.body.innerHTML = '<div id="unit-iframe" style="position: absolute; top: 50px;"></div>';
     renderHook(() => useIframeBehavior({ id, iframeUrl, iframeRef }));

--- a/src/generic/hooks/tests/hooks.test.tsx
+++ b/src/generic/hooks/tests/hooks.test.tsx
@@ -124,38 +124,38 @@ describe('useIframeBehavior', () => {
 
   it('handles xblockScroll message correctly', () => {
     const iframeElement = document.createElement('iframe');
-    iframeElement.setAttribute('name','xblock-iframe');
+    iframeElement.setAttribute('name', 'xblock-iframe');
     Object.defineProperty(iframeElement, 'offsetTop', { writable: true, configurable: true, value: 50 });
 
     const iframeParentElement = document.createElement('div');
-    iframeParentElement.setAttribute('id','div0');
+    iframeParentElement.setAttribute('id', 'div0');
     Object.defineProperty(iframeParentElement, 'offsetTop', { writable: true, configurable: true, value: 25 });
 
     iframeParentElement.appendChild(iframeElement);
     document.body.appendChild(iframeParentElement);
 
-    renderHook(() => useIframeBehavior({ id, iframeUrl, iframeRef}));
+    renderHook(() => useIframeBehavior({ id, iframeUrl, iframeRef }));
 
     const message = {
       data: {
         type: iframeMessageTypes.xblockScroll,
         offset: 100,
-      }
+      },
     };
 
     act(() => {
       window.dispatchEvent(new MessageEvent('message', message));
     });
 
-    expect(window.scrollTo).toHaveBeenCalledWith(0,175);
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 175);
     expect(window.scrollY).toBe(100 + document.getElementsByName('xblock-iframe')[0].offsetTop + document.getElementsByName('xblock-iframe')[0]!.parentElement!.offsetTop);
   });
 
   it('handles offset message correctly', () => {
     const iframeElement = document.createElement('iframe');
-    iframeElement.setAttribute('id','unit-iframe');
-    Object.defineProperty(iframeElement, 'offsetTop', { writable: true, configurable: true, value: 50 });;
-    
+    iframeElement.setAttribute('id', 'unit-iframe');
+    Object.defineProperty(iframeElement, 'offsetTop', { writable: true, configurable: true, value: 50 });
+
     document.body.appendChild(iframeElement);
 
     renderHook(() => useIframeBehavior({ id, iframeUrl, iframeRef }));
@@ -168,7 +168,7 @@ describe('useIframeBehavior', () => {
       window.dispatchEvent(new MessageEvent('message', message));
     });
 
-    expect(window.scrollTo).toHaveBeenCalledWith(0,150);
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 150);
     expect(window.scrollY).toBe(100 + (document.getElementById('unit-iframe') as HTMLElement).offsetTop);
   });
 

--- a/src/generic/hooks/tests/hooks.test.tsx
+++ b/src/generic/hooks/tests/hooks.test.tsx
@@ -123,25 +123,41 @@ describe('useIframeBehavior', () => {
   });
 
   it('handles xblockScroll message correctly', () => {
-    document.body.innerHTML = '<div id="window" top: 25px;"><div id="xblock-iframe" style="position: absolute; top: 50px;"></div></div>';
-    renderHook(() => useIframeBehavior({ id, iframeUrl, iframeRef }));
+    const iframeElement = document.createElement('iframe');
+    iframeElement.setAttribute('name','xblock-iframe');
+    Object.defineProperty(iframeElement, 'offsetTop', { writable: true, configurable: true, value: 50 });
+
+    const iframeParentElement = document.createElement('div');
+    iframeParentElement.setAttribute('id','div0');
+    Object.defineProperty(iframeParentElement, 'offsetTop', { writable: true, configurable: true, value: 25 });
+
+    iframeParentElement.appendChild(iframeElement);
+    document.body.appendChild(iframeParentElement);
+
+    renderHook(() => useIframeBehavior({ id, iframeUrl, iframeRef}));
 
     const message = {
-      type: iframeMessageTypes.xblockScroll,
-      data: { offset: 100 },
+      data: {
+        type: iframeMessageTypes.xblockScroll,
+        offset: 100,
+      }
     };
 
     act(() => {
       window.dispatchEvent(new MessageEvent('message', message));
     });
 
-    expect(window.scrollY).toBe(100
-      + (document.getElementById('xblock-iframe') as HTMLElement).offsetTop
-      + (document.getElementById('xblock-iframe')?.parentElement as HTMLElement).offsetTop);
+    expect(window.scrollTo).toHaveBeenCalledWith(0,175);
+    expect(window.scrollY).toBe(100 + document.getElementsByName('xblock-iframe')[0].offsetTop + document.getElementsByName('xblock-iframe')[0]!.parentElement!.offsetTop);
   });
 
   it('handles offset message correctly', () => {
-    document.body.innerHTML = '<div id="unit-iframe" style="position: absolute; top: 50px;"></div>';
+    const iframeElement = document.createElement('iframe');
+    iframeElement.setAttribute('id','unit-iframe');
+    Object.defineProperty(iframeElement, 'offsetTop', { writable: true, configurable: true, value: 50 });;
+    
+    document.body.appendChild(iframeElement);
+
     renderHook(() => useIframeBehavior({ id, iframeUrl, iframeRef }));
 
     const message = {
@@ -152,6 +168,7 @@ describe('useIframeBehavior', () => {
       window.dispatchEvent(new MessageEvent('message', message));
     });
 
+    expect(window.scrollTo).toHaveBeenCalledWith(0,150);
     expect(window.scrollY).toBe(100 + (document.getElementById('unit-iframe') as HTMLElement).offsetTop);
   });
 

--- a/src/generic/hooks/useIframeBehavior.tsx
+++ b/src/generic/hooks/useIframeBehavior.tsx
@@ -83,6 +83,12 @@ export const useIframeBehavior = ({
           });
         }
         break;
+      case iframeMessageTypes.xblockScroll:
+        if(document.getElementsByName('xblock-iframe')){
+          const iframeElement = document.getElementsByName('xblock-iframe')[0];
+          window.scrollTo(0, data.offset + iframeElement!.offsetTop + iframeElement.parentElement!.offsetTop);
+        }
+        break;
       default:
         if (data.offset) {
           // We listen for this message from LMS to know when the page needs to

--- a/src/generic/hooks/useIframeBehavior.tsx
+++ b/src/generic/hooks/useIframeBehavior.tsx
@@ -86,7 +86,11 @@ export const useIframeBehavior = ({
       case iframeMessageTypes.xblockScroll:
         if (document.getElementsByName('xblock-iframe')) {
           const iframeElement = document.getElementsByName('xblock-iframe')[0];
-          window.scrollTo(0, data.offset + iframeElement!.offsetTop + iframeElement.parentElement!.offsetTop);
+          window.scrollTo({
+            top: data.offset + iframeElement!.offsetTop + iframeElement.parentElement!.offsetTop,
+            left: 0,
+            behavior: 'smooth',
+          });
         }
         break;
       default:

--- a/src/generic/hooks/useIframeBehavior.tsx
+++ b/src/generic/hooks/useIframeBehavior.tsx
@@ -84,7 +84,7 @@ export const useIframeBehavior = ({
         }
         break;
       case iframeMessageTypes.xblockScroll:
-        if(document.getElementsByName('xblock-iframe')){
+        if (document.getElementsByName('xblock-iframe')) {
           const iframeElement = document.getElementsByName('xblock-iframe')[0];
           window.scrollTo(0, data.offset + iframeElement!.offsetTop + iframeElement.parentElement!.offsetTop);
         }


### PR DESCRIPTION
## Description

Fixes https://github.com/openedx/openedx-aspects/issues/316 by scrolling window to the xblock location instead of scrolling within the iFrame

## Supporting information

Link to other information about the change, such as GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Test with https://github.com/openedx/edx-platform/pull/37152
Need to enable Aspects in-context metrics (https://github.com/openedx/frontend-plugin-aspects)

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`


**Settings**

```yaml
EDX_PLATFORM_REPOSITORY: https://github.com/openedx/edx-platform.git
EDX_PLATFORM_VERSION: sburns_unit_iframe_cutoff
```