### PR TITLE
Override upload file max size in mb

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -52,7 +52,7 @@ export const DECODED_ROUTES = {
   ],
 };
 
-export const UPLOAD_FILE_MAX_SIZE = 20 * 1024 * 1024; // 100mb
+export const UPLOAD_FILE_MAX_SIZE = 20 * 1024 * 1024; // 20mb
 
 export const COURSE_BLOCK_NAMES = ({
   chapter: { id: 'chapter', name: 'Section' },

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,4 @@
+import { getConfig } from '@edx/frontend-platform';
 export const DATE_FORMAT = 'MM/dd/yyyy';
 export const TIME_FORMAT = 'HH:mm';
 export const DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss\\Z';
@@ -53,14 +54,15 @@ export const DECODED_ROUTES = {
 };
 
 // FilesUpload page - Default max size: 20MB else use env override if exists and valid number
-const DEFAULT_UPLOAD_FILE_MAX_SIZE = 20 * 1024 * 1024; 
-const overrideMaxFileSizeMB = parseInt(process.env.OVERRIDE_UPLOAD_FILE_MAX_SIZE_IN_MB, 10);
-const computedUploadFileMaxSize = (
-  !isNaN(overrideMaxFileSizeMB) && overrideMaxFileSizeMB > 0
+const DEFAULT_UPLOAD_FILE_MAX_SIZE = 20 * 1024 * 1024; // 20 MB
+export const getUploadFileMaxSize = () => {
+  const config = getConfig();
+  const overrideMaxFileSizeMB = parseInt(config.OVERRIDE_UPLOAD_FILE_MAX_SIZE_IN_MB, 10);
+  return !isNaN(overrideMaxFileSizeMB) && overrideMaxFileSizeMB > 0
     ? overrideMaxFileSizeMB * 1024 * 1024
-    : DEFAULT_UPLOAD_FILE_MAX_SIZE
-);
-export const UPLOAD_FILE_MAX_SIZE = computedUploadFileMaxSize;
+    : DEFAULT_UPLOAD_FILE_MAX_SIZE;
+};
+export const UPLOAD_FILE_MAX_SIZE = getUploadFileMaxSize();
 
 export const COURSE_BLOCK_NAMES = ({
   chapter: { id: 'chapter', name: 'Section' },

--- a/src/constants.js
+++ b/src/constants.js
@@ -55,6 +55,7 @@ export const DECODED_ROUTES = {
 
 // FilesUpload page - Default max size: 20MB else use env override if exists and valid number
 const DEFAULT_UPLOAD_FILE_MAX_SIZE = 20 * 1024 * 1024; // 20 MB
+
 export const getUploadFileMaxSize = () => {
   const config = getConfig();
   const overrideMaxFileSizeMB = parseInt(config.OVERRIDE_UPLOAD_FILE_MAX_SIZE_IN_MB, 10);
@@ -62,7 +63,6 @@ export const getUploadFileMaxSize = () => {
     ? overrideMaxFileSizeMB * 1024 * 1024
     : DEFAULT_UPLOAD_FILE_MAX_SIZE;
 };
-export const UPLOAD_FILE_MAX_SIZE = getUploadFileMaxSize();
 
 export const COURSE_BLOCK_NAMES = ({
   chapter: { id: 'chapter', name: 'Section' },

--- a/src/constants.js
+++ b/src/constants.js
@@ -52,7 +52,15 @@ export const DECODED_ROUTES = {
   ],
 };
 
-export const UPLOAD_FILE_MAX_SIZE = 20 * 1024 * 1024; // 20mb
+// FilesUpload page - Default max size: 20MB else use env override if exists and valid number
+const DEFAULT_UPLOAD_FILE_MAX_SIZE = 20 * 1024 * 1024; 
+const overrideMaxFileSizeMB = parseInt(process.env.OVERRIDE_UPLOAD_FILE_MAX_SIZE_IN_MB, 10);
+const computedUploadFileMaxSize = (
+  !isNaN(overrideMaxFileSizeMB) && overrideMaxFileSizeMB > 0
+    ? overrideMaxFileSizeMB * 1024 * 1024
+    : DEFAULT_UPLOAD_FILE_MAX_SIZE
+);
+export const UPLOAD_FILE_MAX_SIZE = computedUploadFileMaxSize;
 
 export const COURSE_BLOCK_NAMES = ({
   chapter: { id: 'chapter', name: 'Section' },

--- a/src/files-and-videos/files-page/FilesPage.jsx
+++ b/src/files-and-videos/files-page/FilesPage.jsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { CheckboxFilter, Container } from '@openedx/paragon';
 import Placeholder from '../../editors/Placeholder';
-import { UPLOAD_FILE_MAX_SIZE } from '../../constants';
+import { getUploadFileMaxSize } from '../../constants';
 
 import { RequestStatus } from '../../data/constants';
 import { useModels, useModel } from '../../generic/model-store';
@@ -92,7 +92,7 @@ const FilesPage = ({
     fileType: 'file',
   };
 
-  const maxFileSize = UPLOAD_FILE_MAX_SIZE;
+  const maxFileSize = getUploadFileMaxSize();
 
   const activeColumn = {
     id: 'activeStatus',

--- a/src/files-and-videos/files-page/FilesPage.jsx
+++ b/src/files-and-videos/files-page/FilesPage.jsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { CheckboxFilter, Container } from '@openedx/paragon';
 import Placeholder from '../../editors/Placeholder';
-import { getUploadFileMaxSize } from '../../constants';
+import { getUploadFileMaxSize } from '@src/constants';
 
 import { RequestStatus } from '../../data/constants';
 import { useModels, useModel } from '../../generic/model-store';

--- a/src/files-and-videos/files-page/FilesPage.jsx
+++ b/src/files-and-videos/files-page/FilesPage.jsx
@@ -91,13 +91,8 @@ const FilesPage = ({
     usageErrorMessages: errorMessages.usageMetrics,
     fileType: 'file',
   };
-  
-  // MaxFileSize used in Files upload page
-  // checks if OVERRIDE_UPLOAD_FILE_MAX_SIZE_IN_MB env variable exists and is a valid number, else uses default from constants
-  const overrideMaxFileSize = parseInt(process.env.OVERRIDE_UPLOAD_FILE_MAX_SIZE_IN_MB, 10);
-  const maxFileSize = !isNaN(overrideMaxFileSize) && overrideMaxFileSize > 0
-  ? overrideMaxFileSize * 1024 * 1024
-  : UPLOAD_FILE_MAX_SIZE;
+
+  const maxFileSize = UPLOAD_FILE_MAX_SIZE;
 
   const activeColumn = {
     id: 'activeStatus',

--- a/src/files-and-videos/files-page/FilesPage.jsx
+++ b/src/files-and-videos/files-page/FilesPage.jsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { CheckboxFilter, Container } from '@openedx/paragon';
 import Placeholder from '../../editors/Placeholder';
+import { UPLOAD_FILE_MAX_SIZE } from '../../constants';
 
 import { RequestStatus } from '../../data/constants';
 import { useModels, useModel } from '../../generic/model-store';
@@ -90,7 +91,13 @@ const FilesPage = ({
     usageErrorMessages: errorMessages.usageMetrics,
     fileType: 'file',
   };
-  const maxFileSize = 20 * 1048576;
+  
+  // MaxFileSize used in Files upload page
+  // checks if OVERRIDE_UPLOAD_FILE_MAX_SIZE_IN_MB env variable exists and is a valid number, else uses default from constants
+  const overrideMaxFileSize = parseInt(process.env.OVERRIDE_UPLOAD_FILE_MAX_SIZE_IN_MB, 10);
+  const maxFileSize = !isNaN(overrideMaxFileSize) && overrideMaxFileSize > 0
+  ? overrideMaxFileSize * 1024 * 1024
+  : UPLOAD_FILE_MAX_SIZE;
 
   const activeColumn = {
     id: 'activeStatus',

--- a/src/generic/modal-dropzone/ModalDropzone.jsx
+++ b/src/generic/modal-dropzone/ModalDropzone.jsx
@@ -16,6 +16,7 @@ import { FileUpload as FileUploadIcon } from '@openedx/paragon/icons';
 import useModalDropzone from './useModalDropzone';
 import messages from './messages';
 import { getUploadFileMaxSize } from '@src/constants';
+const UPLOAD_FILE_MAX_SIZE = getUploadFileMaxSize();
 
 const ModalDropzone = ({
   fileTypes,
@@ -30,7 +31,7 @@ const ModalDropzone = ({
   onChange,
   onSavingStatus,
   onSelectFile,
-  maxSize = getUploadFileMaxSize(),
+  maxSize = UPLOAD_FILE_MAX_SIZE,
 }) => {
   const {
     intl,
@@ -48,7 +49,7 @@ const ModalDropzone = ({
 
   const invalidSizeMore = invalidFileSizeMore || intl.formatMessage(
     messages.uploadImageDropzoneInvalidSizeMore,
-    { maxSize: maxSize / (1000 * 1000) },
+    { maxSize: maxSize / (1024 * 1024) },
   );
 
   const inputComponent = previewUrl ? (
@@ -129,7 +130,7 @@ ModalDropzone.defaultProps = {
   imageHelpText: '',
   previewComponent: null,
   imageDropzoneText: '',
-  maxSize: getUploadFileMaxSize(),
+  maxSize: UPLOAD_FILE_MAX_SIZE,
   invalidFileSizeMore: '',
   onSelectFile: null,
 };

--- a/src/generic/modal-dropzone/ModalDropzone.jsx
+++ b/src/generic/modal-dropzone/ModalDropzone.jsx
@@ -16,7 +16,6 @@ import { FileUpload as FileUploadIcon } from '@openedx/paragon/icons';
 import useModalDropzone from './useModalDropzone';
 import messages from './messages';
 import { getUploadFileMaxSize } from '@src/constants';
-const UPLOAD_FILE_MAX_SIZE = getUploadFileMaxSize();
 
 const ModalDropzone = ({
   fileTypes,
@@ -31,7 +30,7 @@ const ModalDropzone = ({
   onChange,
   onSavingStatus,
   onSelectFile,
-  maxSize = UPLOAD_FILE_MAX_SIZE,
+  maxSize,
 }) => {
   const {
     intl,
@@ -47,9 +46,10 @@ const ModalDropzone = ({
     onChange, onCancel, onClose, fileTypes, onSavingStatus, onSelectFile,
   });
 
+  
   const invalidSizeMore = invalidFileSizeMore || intl.formatMessage(
     messages.uploadImageDropzoneInvalidSizeMore,
-    { maxSize: maxSize / (1024 * 1024) },
+    { maxSize: (maxSize || getUploadFileMaxSize()) / (1024 * 1024) },
   );
 
   const inputComponent = previewUrl ? (
@@ -130,7 +130,7 @@ ModalDropzone.defaultProps = {
   imageHelpText: '',
   previewComponent: null,
   imageDropzoneText: '',
-  maxSize: UPLOAD_FILE_MAX_SIZE,
+  maxSize: '',
   invalidFileSizeMore: '',
   onSelectFile: null,
 };

--- a/src/generic/modal-dropzone/ModalDropzone.jsx
+++ b/src/generic/modal-dropzone/ModalDropzone.jsx
@@ -130,7 +130,7 @@ ModalDropzone.defaultProps = {
   imageHelpText: '',
   previewComponent: null,
   imageDropzoneText: '',
-  maxSize: '',
+  maxSize: 'undefined',
   invalidFileSizeMore: '',
   onSelectFile: null,
 };

--- a/src/generic/modal-dropzone/ModalDropzone.jsx
+++ b/src/generic/modal-dropzone/ModalDropzone.jsx
@@ -15,7 +15,7 @@ import { FileUpload as FileUploadIcon } from '@openedx/paragon/icons';
 
 import useModalDropzone from './useModalDropzone';
 import messages from './messages';
-import { UPLOAD_FILE_MAX_SIZE } from '../../constants';
+import { getUploadFileMaxSize } from '@src/constants';
 
 const ModalDropzone = ({
   fileTypes,
@@ -30,7 +30,7 @@ const ModalDropzone = ({
   onChange,
   onSavingStatus,
   onSelectFile,
-  maxSize = UPLOAD_FILE_MAX_SIZE,
+  maxSize = getUploadFileMaxSize(),
 }) => {
   const {
     intl,
@@ -129,7 +129,7 @@ ModalDropzone.defaultProps = {
   imageHelpText: '',
   previewComponent: null,
   imageDropzoneText: '',
-  maxSize: UPLOAD_FILE_MAX_SIZE,
+  maxSize: getUploadFileMaxSize(),
   invalidFileSizeMore: '',
   onSelectFile: null,
 };

--- a/src/textbooks/textbook-form/TextbookForm.jsx
+++ b/src/textbooks/textbook-form/TextbookForm.jsx
@@ -180,7 +180,7 @@ const TextbookForm = ({
                   <span className="modal-preview-text">{selectedFile}</span>
                 </div>
               )}
-              maxSize={UPLOAD_FILE_MAX_SIZE}
+              maxSize={getUploadFileMaxSize()}
             />
             <PromptIfDirty dirty={dirty} />
           </>

--- a/src/textbooks/textbook-form/TextbookForm.jsx
+++ b/src/textbooks/textbook-form/TextbookForm.jsx
@@ -25,6 +25,7 @@ import { getUploadFileMaxSize } from '@src/constants';
 import textbookFormValidationSchema from './validations';
 import messages from './messages';
 
+const UPLOAD_FILE_MAX_SIZE = getUploadFileMaxSize();
 const TextbookForm = ({
   closeTextbookForm,
   initialFormValues,
@@ -171,7 +172,7 @@ const TextbookForm = ({
               onSavingStatus={onSavingStatus}
               invalidFileSizeMore={intl.formatMessage(
                 messages.uploadModalFileInvalidSizeText,
-                { maxSize: getUploadFileMaxSize() / (1000 * 1000) },
+                { maxSize: UPLOAD_FILE_MAX_SIZE / (1024 * 1024) },
               )}
               onSelectFile={setSelectedFile}
               previewComponent={(
@@ -180,7 +181,7 @@ const TextbookForm = ({
                   <span className="modal-preview-text">{selectedFile}</span>
                 </div>
               )}
-              maxSize={getUploadFileMaxSize()}
+              maxSize={UPLOAD_FILE_MAX_SIZE}
             />
             <PromptIfDirty dirty={dirty} />
           </>

--- a/src/textbooks/textbook-form/TextbookForm.jsx
+++ b/src/textbooks/textbook-form/TextbookForm.jsx
@@ -21,7 +21,7 @@ import FormikControl from '../../generic/FormikControl';
 import PromptIfDirty from '../../generic/prompt-if-dirty/PromptIfDirty';
 import ModalDropzone from '../../generic/modal-dropzone/ModalDropzone';
 import { useModel } from '../../generic/model-store';
-import { UPLOAD_FILE_MAX_SIZE } from '../../constants';
+import { getUploadFileMaxSize } from '@src/constants';
 import textbookFormValidationSchema from './validations';
 import messages from './messages';
 
@@ -171,7 +171,7 @@ const TextbookForm = ({
               onSavingStatus={onSavingStatus}
               invalidFileSizeMore={intl.formatMessage(
                 messages.uploadModalFileInvalidSizeText,
-                { maxSize: UPLOAD_FILE_MAX_SIZE / (1000 * 1000) },
+                { maxSize: getUploadFileMaxSize() / (1000 * 1000) },
               )}
               onSelectFile={setSelectedFile}
               previewComponent={(

--- a/src/textbooks/textbook-form/TextbookForm.jsx
+++ b/src/textbooks/textbook-form/TextbookForm.jsx
@@ -172,7 +172,7 @@ const TextbookForm = ({
               onSavingStatus={onSavingStatus}
               invalidFileSizeMore={intl.formatMessage(
                 messages.uploadModalFileInvalidSizeText,
-                { maxSize: UPLOAD_FILE_MAX_SIZE / (1024 * 1024) },
+                { maxSize: getUploadFileMaxSize() / (1024 * 1024) },
               )}
               onSelectFile={setSelectedFile}
               previewComponent={(
@@ -181,7 +181,7 @@ const TextbookForm = ({
                   <span className="modal-preview-text">{selectedFile}</span>
                 </div>
               )}
-              maxSize={UPLOAD_FILE_MAX_SIZE}
+              maxSize={getUploadFileMaxSize()}
             />
             <PromptIfDirty dirty={dirty} />
           </>

--- a/src/textbooks/textbook-form/TextbookForm.jsx
+++ b/src/textbooks/textbook-form/TextbookForm.jsx
@@ -25,7 +25,6 @@ import { getUploadFileMaxSize } from '@src/constants';
 import textbookFormValidationSchema from './validations';
 import messages from './messages';
 
-const UPLOAD_FILE_MAX_SIZE = getUploadFileMaxSize();
 const TextbookForm = ({
   closeTextbookForm,
   initialFormValues,


### PR DESCRIPTION
For attention to @bradenmacdonald to review if this PR meets requirements.

## Description

This update makes the following changes:
`constants.js`:
- Fix incorrect comment for 20MB default file upload limit
- Retain the default 20MB limit but use an override (if exists) from GetConfig, allowing users to specify an override value via MFE_CONFIG API
- Validation that the value entered is a valid and positive integer (use default in case something goes horribly wrong)
- Written as a function allowing it to be called by other components

`FilePage.jsx`:
- Remove the hardcoded `maxFileSize` value and instead import it from constants.js

`ModalDropzone.jsx`:
- Removed `UPLOAD_FILE_MAX_SIZE` constants that were defined and replaced with a call to the new function in `constants.js`

`TextbookForm.jsx`:
- Removed `UPLOAD_FILE_MAX_SIZE` constants that were defined and replaced with a call to the new function in `constants.js`

Imports from constants now use the updated new format `'@src/constants'` instead of the old  `'../../constants'`
## Supporting information
this is an improvement to my [previous attempt](https://github.com/openedx/frontend-app-authoring/pull/2322) before i really knew what i was doing, now I only know a little bit of what I'm doing :)

## Testing instructions
1) Replace this MFE using a plugin:
```
from tutormfe.hooks import MFE_APPS

@MFE_APPS.add()
def _override_authoring_mfe(mfes):
    mfes["authoring"] = {
        "repository": "https://github.com/MuPp3t33r/frontend-app-authoring.git",
        "version": "OVERRIDE_UPLOAD_FILE_MAX_SIZE_IN_MB", 
        "port": 2001, 
    }
    return mfes

```
2) Rebuild your MFE
- tutor images build mfe

3) Apply the patched values to override the config.
Note that this must be done in MFE_CONFIG and in the CaddyFile to allow Caddy to process your larger requests
Here is a sample plugin allowing user to provide one input for the value and it applies in both locations
```
from tutor import hooks

# Instructions / info
# override_value is defined as a string so bad formats (incorrectly entered values) don't crash Python immediately
# User MUST enter only digits as a POSITIVE integer representing a value in MegaBytes (MB), e.g. "1024" for 1GB
# This adds the value to the MFE_Config API as well as the CaddyFile CMS block

override_value = "1024"  

# --- Validation ---
try:
    override_int = int(override_value)
    if override_int <= 0:
        raise ValueError
except ValueError:
    raise ValueError(
        f"Invalid override_value: {override_value}. "
        "It must be a positive integer without units (e.g., 1048)."
    )

# --- Config patches ---
hooks.Filters.ENV_PATCHES.add_items([
    (
        "openedx-lms-production-settings",
        f"""
MFE_CONFIG["OVERRIDE_UPLOAD_FILE_MAX_SIZE_IN_MB"] = "{override_int}"
"""
    ),
])

hooks.Filters.ENV_PATCHES.add_item(
    (
        "caddyfile-cms",
        f"""
# Maximum asset upload size in CMS/Studio
handle /assets/* {{
    request_body {{
        max_size {override_int}MB
    }}
}}
        """
    )
)

```
4) Finally - enable the override plugin and restart your instance:
- `tutor plugins enable override_max_asset_upload_size`
- `tutor local stop && tutor local start -d`

Now, under the following menus:

-  Content -> Files
-  Content -> Pages & Resources -> Textbooks
You will find that you can upload files up to whatever maximum defined in the `override_max_asset_upload_size` plugin