### PR TITLE
fix: Restore styling for header title and button

### DIFF
--- a/src/course-outline/card-header/TitleButton.tsx
+++ b/src/course-outline/card-header/TitleButton.tsx
@@ -45,9 +45,10 @@ const TitleButton = ({
         data-testid={`${namePrefix}-card-header__expanded-btn`}
         className="item-card-header__title-btn"
         onClick={onTitleClick}
+        title={title}
       >
         {prefixIcon}
-        <span className="truncate-1-line">
+        <span className={`${namePrefix}-card-title mb-0 truncate-1-line`}>
           {title}
         </span>
       </Button>

--- a/src/course-outline/card-header/TitleLink.tsx
+++ b/src/course-outline/card-header/TitleLink.tsx
@@ -20,9 +20,10 @@ const TitleLink = ({
     data-testid={`${namePrefix}-card-header__title-link`}
     className="item-card-header__title-btn align-items-end"
     to={titleLink}
+    title={title}
   >
     {prefixIcon}
-    <span className="truncate-1-line">
+    <span className={`${namePrefix}-card-title mb-0 truncate-1-line`}>
       {title}
     </span>
   </Button>


### PR DESCRIPTION
## Description

In a previous PR #2374 some of the styling applied in addition to truncation was lost. This restores that.


Private-ref: https://tasks.opencraft.com/browse/BB-9925