### PR TITLE
refactor: minor typing improvements

### DIFF
--- a/src/course-outline/section-card/SectionCard.test.tsx
+++ b/src/course-outline/section-card/SectionCard.test.tsx
@@ -36,8 +36,8 @@ const subsection = {
     children: [{
       id: unit.id,
     }],
-  },
-} as XBlock;
+  } as any, // 'as any' because we are omitting a lot of fields from 'childInfo'
+} satisfies Partial<XBlock> as XBlock;
 
 const section = {
   id: '123',
@@ -63,13 +63,14 @@ const section = {
         }],
       },
     }],
-  },
+  } as any, // 'as any' because we are omitting a lot of fields from 'childInfo'
   upstreamInfo: {
     readyToSync: true,
     upstreamRef: 'lct:org1:lib1:section:1',
     versionSynced: 1,
+    errorMessage: null,
   },
-} as XBlock;
+} satisfies Partial<XBlock> as XBlock;
 
 const onEditSectionSubmit = jest.fn();
 

--- a/src/course-outline/subsection-card/SubsectionCard.test.tsx
+++ b/src/course-outline/subsection-card/SubsectionCard.test.tsx
@@ -66,13 +66,14 @@ const subsection: XBlock = {
     children: [{
       id: unit.id,
     }],
-  },
+  } as any, // 'as any' because we are omitting a lot of fields from 'childInfo'
   upstreamInfo: {
     readyToSync: true,
     upstreamRef: 'lct:org1:lib1:subsection:1',
     versionSynced: 1,
+    errorMessage: null,
   },
-} as XBlock;
+} satisfies Partial<XBlock> as XBlock;
 
 const section: XBlock = {
   id: '123',
@@ -85,14 +86,14 @@ const section: XBlock = {
     children: [{
       id: subsection.id,
     }],
-  },
+  } as any, // 'as any' because we are omitting a lot of fields from 'childInfo'
   actions: {
     draggable: true,
     childAddable: true,
     deletable: true,
     duplicable: true,
   },
-} as XBlock;
+} satisfies Partial<XBlock> as XBlock;
 
 const onEditSubectionSubmit = jest.fn();
 

--- a/src/course-outline/unit-card/UnitCard.test.tsx
+++ b/src/course-outline/unit-card/UnitCard.test.tsx
@@ -31,7 +31,7 @@ const section = {
     deletable: true,
     duplicable: true,
   },
-} as XBlock;
+} satisfies Partial<XBlock> as XBlock;
 
 const subsection = {
   id: '12',
@@ -45,7 +45,7 @@ const subsection = {
     deletable: true,
     duplicable: true,
   },
-} as XBlock;
+} satisfies Partial<XBlock> as XBlock;
 
 const unit = {
   id: '123',
@@ -65,8 +65,9 @@ const unit = {
     readyToSync: true,
     upstreamRef: 'lct:org1:lib1:unit:1',
     versionSynced: 1,
+    errorMessage: null,
   },
-} as XBlock;
+} satisfies Partial<XBlock> as XBlock;
 
 const renderComponent = (props?: object) => render(
   <UnitCard

--- a/src/library-authoring/collections/CollectionDetails.test.tsx
+++ b/src/library-authoring/collections/CollectionDetails.test.tsx
@@ -142,7 +142,7 @@ describe('<CollectionDetails />', () => {
       { blockType: 'Problem', count: 1 },
       { blockType: 'Video', count: 0 },
     ].forEach(({ blockType, count }) => {
-      const blockCount = screen.getByText(blockType).closest('div') as HTMLDivElement;
+      const blockCount = screen.getByText(blockType).closest('div')!;
       expect(within(blockCount).getByText(count.toString())).toBeInTheDocument();
     });
   });

--- a/src/library-authoring/component-info/ComponentPreview.test.tsx
+++ b/src/library-authoring/component-info/ComponentPreview.test.tsx
@@ -39,7 +39,7 @@ describe('<ComponentPreview />', () => {
   it('renders a preview of the component', async () => {
     initializeMocks();
     render();
-    const iframe = (await screen.findByTitle('Preview')) as HTMLIFrameElement;
+    const iframe = (await screen.findByTitle<HTMLIFrameElement>('Preview'));
     expect(iframe.src).toEqual(`http://localhost:18010/xblocks/v2/${usageKey}/embed/student_view/`);
   });
 


### PR DESCRIPTION
## Description

This makes some minor typing improvements in our test code, seen while reviewing https://github.com/openedx/frontend-app-authoring/pull/2324

Specifically instead of just `{...} as XBlock` which is an unsafe cast, we can use `{...} satisfies Partial<XBlock> as XBlock` which is a safer cast that lets you omit fields but requires that the fields you do include have the correct type.

## Supporting information

Private ref FAL-4228 

## Testing instructions

No runtime changes so no manual testing needed; make sure tests are green.
