### PR TITLE
fix: tinyMCE images previews in image selection modal

### DIFF
--- a/src/editors/sharedComponents/SelectionModal/GalleryCard.jsx
+++ b/src/editors/sharedComponents/SelectionModal/GalleryCard.jsx
@@ -28,11 +28,7 @@ const GalleryCard = ({
     >
       <div className="card-div d-flex flex-row flex-nowrap align-items-center">
         <div
-          className="position-relative"
-          style={{
-            width: '200px',
-            height: '100px',
-          }}
+          className="row justify-content-center align-itmes-center p-2"
         >
           {(thumbnailError && thumbnailFallback) ? (
             <div style={{ width: '200px', height: '100px' }}>
@@ -40,7 +36,7 @@ const GalleryCard = ({
             </div>
           ) : (
             <Image
-              style={{ border: 'none', width: '200px', height: '100px' }}
+              className="selection-modal-image-thumbnail"
               src={asset.externalUrl}
               onError={thumbnailFallback && (() => setThumbnailError(true))}
             />

--- a/src/editors/sharedComponents/SelectionModal/index.scss
+++ b/src/editors/sharedComponents/SelectionModal/index.scss
@@ -30,3 +30,11 @@
     margin-bottom: .4375rem;
     margin-top: .4375rem;
 }
+
+.selection-modal-image-thumbnail {
+    width: 180px;
+    height: 101.25px;
+    object-fit: contain;
+    max-width: 100%;
+    max-height: 100%;
+}


### PR DESCRIPTION
Ticket: [TNL2-54](https://2u-internal.atlassian.net/browse/TNL2-54)
This PR fixes tinyMCE images previews in image selection modal.

**Before:**
<video src="https://github.com/user-attachments/assets/613504bd-fb1f-41b6-8c11-97073a71762e" controls></video>

**After:**
<video src="https://github.com/user-attachments/assets/7a4e4802-c966-4ffb-9616-904deccf5c6c" controls></video>

