### PR TITLE
feat: add library v2 alert [FC-0097]

### DIFF
--- a/src/generic/alert-error/AlertError.test.tsx
+++ b/src/generic/alert-error/AlertError.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import AlertError from '.';
@@ -33,7 +33,6 @@ describe('<AlertMessage />', () => {
       },
     };
     const { getByText } = render(<RootWrapper error={error} />);
-    screen.logTestingPlaygroundURL();
     expect(getByText(/this is an error message/i)).toBeInTheDocument();
     expect(getByText(/\{ "message": "this is a response body" \}/i)).toBeInTheDocument();
   });

--- a/src/library-authoring/generic/manage-collections/ManageCollections.test.tsx
+++ b/src/library-authoring/generic/manage-collections/ManageCollections.test.tsx
@@ -121,7 +121,6 @@ describe('<ManageCollections />', () => {
       collections={[]}
       useUpdateCollectionsHook={useUpdateComponentCollections}
     />);
-    screen.logTestingPlaygroundURL();
     const manageBtn = await screen.findByRole('button', { name: 'Add to Collection' });
     await user.click(manageBtn);
     await waitFor(() => { expect(fetchMock).toHaveFetchedTimes(1, searchEndpoint, 'post'); });

--- a/src/library-authoring/units/LibraryUnitPage.test.tsx
+++ b/src/library-authoring/units/LibraryUnitPage.test.tsx
@@ -177,7 +177,6 @@ describe('<LibraryUnitPage />', () => {
     const textBox = screen.getByRole('textbox', { name: /text input/i });
     expect(textBox).toBeInTheDocument();
     expect(textBox).toHaveValue('Test Unit');
-    screen.logTestingPlaygroundURL();
     fireEvent.change(textBox, { target: { value: 'New Unit Title' } });
     fireEvent.keyDown(textBox, { key: 'Enter', code: 'Enter', charCode: 13 });
 

--- a/src/studio-home/data/apiHooks.ts
+++ b/src/studio-home/data/apiHooks.ts
@@ -12,7 +12,7 @@ export const studioHomeQueryKeys = {
 export const useLibrariesV1Data = (enabled: boolean = true) => (
   useQuery({
     queryKey: studioHomeQueryKeys.librariesV1(),
-    queryFn: () => getStudioHomeLibraries(),
+    queryFn: getStudioHomeLibraries,
     enabled,
   })
 );

--- a/src/studio-home/tabs-section/libraries-tab/MigrateLegacyLibrariesAlert.tsx
+++ b/src/studio-home/tabs-section/libraries-tab/MigrateLegacyLibrariesAlert.tsx
@@ -11,7 +11,7 @@ export const MigrateLegacyLibrariesAlert = () => (
     </Alert.Heading>
     <div className="row">
       <div className="col-8">
-        <FormattedMessage {...messages.alertDescription} />
+        <FormattedMessage {...messages.alertDescriptionV1} />
       </div>
       <div className="col-4 d-flex justify-content-center align-items-start">
         <Button>

--- a/src/studio-home/tabs-section/libraries-v2-tab/WelcomeLibrariesV2Alert.tsx
+++ b/src/studio-home/tabs-section/libraries-v2-tab/WelcomeLibrariesV2Alert.tsx
@@ -1,0 +1,51 @@
+import { Alert, Button, Hyperlink } from '@openedx/paragon';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+
+import { useLibrariesV1Data } from '@src/studio-home/data/apiHooks';
+
+import messages from '../messages';
+
+const libraryDocsLink = (
+  <Hyperlink
+    target="_blank"
+    showLaunchIcon={false}
+    destination="https://docs.openedx.org/en/latest/educators/how-tos/course_development/create_new_library.html"
+  >
+    <FormattedMessage {...messages.alertLibrariesDocLinkText} />
+  </Hyperlink>
+);
+
+export const WelcomeLibrariesV2Alert = () => {
+  const { data, isPending, isError } = useLibrariesV1Data();
+
+  // Does not show the alert if we are still loading or if there was an error fetching libraries
+  if (isPending || isError) {
+    return null;
+  }
+
+  const hasPendingV1Migrations = data.libraries.some(library => !library.isMigrated);
+  return (
+    <Alert variant="info">
+      {hasPendingV1Migrations ? (
+        <>
+          <Alert.Heading>
+            <FormattedMessage {...messages.alertTitle} />
+          </Alert.Heading>
+          <div className="row">
+            <div className="col-8">
+              <FormattedMessage {...messages.alertDescriptionV2} values={{ link: libraryDocsLink }} />
+              <FormattedMessage {...messages.alertDescriptionV2MigrationPending} />
+            </div>
+            <div className="col-4 d-flex justify-content-center align-items-start">
+              <Button>
+                <FormattedMessage {...messages.alertReviewButton} />
+              </Button>
+            </div>
+          </div>
+        </>
+      ) : (
+        <FormattedMessage {...messages.alertDescriptionV2} values={{ link: libraryDocsLink }} />
+      )}
+    </Alert>
+  );
+};

--- a/src/studio-home/tabs-section/libraries-v2-tab/libraries-v2-filters/index.test.tsx
+++ b/src/studio-home/tabs-section/libraries-v2-tab/libraries-v2-filters/index.test.tsx
@@ -115,13 +115,13 @@ describe('LibrariesV2Filters', () => {
   });
 
   it('should display the loading spinner when isLoading is true', () => {
-    renderComponent({ isLoading: true });
+    renderComponent({ isPending: true });
     const spinner = screen.getByText('Loading...');
     expect(spinner).toBeInTheDocument();
   });
 
   it('should not display the loading spinner when isLoading is false', () => {
-    renderComponent({ isLoading: false });
+    renderComponent({ isPending: false });
     const spinner = screen.queryByText('Loading...');
     expect(spinner).not.toBeInTheDocument();
   });

--- a/src/studio-home/tabs-section/libraries-v2-tab/libraries-v2-filters/index.tsx
+++ b/src/studio-home/tabs-section/libraries-v2-tab/libraries-v2-filters/index.tsx
@@ -7,7 +7,7 @@ import LibrariesV2OrderFilterMenu from './libraries-v2-order-filter-menu';
 import messages from '../../messages';
 
 export interface LibrariesV2FiltersProps {
-  isLoading?: boolean;
+  isPending?: boolean;
   isFiltered?: boolean;
   filterParams: { search?: string | undefined, order?: string };
   setFilterParams: React.Dispatch<React.SetStateAction<{ search: string | undefined, order: string }>>;
@@ -15,7 +15,7 @@ export interface LibrariesV2FiltersProps {
 }
 
 const LibrariesV2Filters: React.FC<LibrariesV2FiltersProps> = ({
-  isLoading = false,
+  isPending = false,
   isFiltered = false,
   filterParams,
   setFilterParams,
@@ -93,7 +93,7 @@ const LibrariesV2Filters: React.FC<LibrariesV2FiltersProps> = ({
           className="mr-4"
           placeholder={intl.formatMessage(messages.librariesV2TabLibrarySearchPlaceholder)}
         />
-        {isLoading && (
+        {isPending && (
           <span className="search-field-loading">
             <LoadingSpinner size="sm" />
           </span>

--- a/src/studio-home/tabs-section/messages.ts
+++ b/src/studio-home/tabs-section/messages.ts
@@ -63,19 +63,6 @@ const messages = defineMessages({
     defaultMessage: 'Beta',
     description: 'Text used to mark the Libraries v2 feature as "in beta"',
   },
-  librariesV2TabBetaText: {
-    id: 'course-authoring.studio-home.libraries.tab.library.beta-text',
-    defaultMessage: 'Welcome to the new Beta Libraries experience! Libraries have been redesigned from the ground up,'
-      + ' making it much easier to reuse and remix course content. The new Libraries space lets you create, organize and'
-      + ' manage new content; reuse your content in as many courses as you\'d like; sync updates centrally; and create'
-      + ' and randomize problem sets. See {link} for details.',
-    description: 'Explanatory text shown on the Libraries v2 tab during the beta release.',
-  },
-  librariesV2TabBetaTutorialLinkText: {
-    id: 'course-authoring.studio-home.libraries.tab.library.beta-link-text',
-    defaultMessage: 'Libraries v2 tutorial',
-    description: 'Text to use as the link in the "course-authoring.studio-home.libraries.tab.library.beta-text" message',
-  },
   librariesV2TabLibrarySearchPlaceholder: {
     id: 'course-authoring.studio-home.libraries.tab.library.search-placeholder',
     defaultMessage: 'Search',
@@ -89,17 +76,17 @@ const messages = defineMessages({
     defaultMessage: 'There are no libraries with the current filters.',
   },
   alertTitle: {
-    id: 'studio-home.legacy-libraries.migrate-alert.title',
+    id: 'studio-home.libraries.migrate-alert.title',
     defaultMessage: 'Migrate Legacy Libraries',
     description: 'Title for the alert message to migrate legacy libraries',
   },
-  alertDescription: {
-    id: 'studio-home.legacy-libraries.migrate-alert.description',
+  alertDescriptionV1: {
+    id: 'studio-home.libraries.migrate-alert.description-v1',
     defaultMessage: 'In a future release, legacy libraries will no longer be supported.'
       + ' The new libraries experience allows you to author sections, subsections, units,'
       + ' and components to reuse across your courses. Content from legacy libraries can be'
       + ' migrated to the new experience.',
-    description: 'Description for the alert message to migrate legacy libraries',
+    description: 'Description for the alert message to migrate legacy libraries on legacy libraries tab.',
   },
   alertReviewButton: {
     id: 'studio-home.legacy-libraries.migrate-alert.review-button',
@@ -120,6 +107,24 @@ const messages = defineMessages({
     id: 'course-authoring.studio-home.libraries.tab.migration.filter.item.unmigrated.label',
     description: 'Label text for unmigrated migration filter menu item in legacy libraries tab',
     defaultMessage: 'Unmigrated',
+  },
+  alertDescriptionV2: {
+    id: 'studio-home.libraries.migrate-alert.description-v2',
+    defaultMessage: 'Welcome to the new Content Libraries experience! Libraries have been redesigned'
+      + ' from the ground up, making it much easier to reuse content. You can create, organize and manage'
+      + ' new content, reuse your content in as many courses as you\'d like, publish updates, and create/randomize'
+      + ' problem sets. See {link} for details.',
+    description: 'Description for the alert message while there are no libraries pending migration on v2 tab.',
+  },
+  alertDescriptionV2MigrationPending: {
+    id: 'studio-home.libraries.migrate-alert.description-v2.migration-pending',
+    defaultMessage: ' Legacy libraries can be migrated using the migration tool.',
+    description: 'Complementary description for the alert message while there are libraries pending migration.',
+  },
+  alertLibrariesDocLinkText: {
+    id: 'studio-home.libraries.migrate-alert.docs',
+    defaultMessage: 'Libraries documentation',
+    description: 'Link text for the libraries documentation link.',
   },
 });
 


### PR DESCRIPTION
## Description

This PR adds an Alert to the Legacy Library Page to notify the user of the process of deprecating Legacy Libraries and a Button to open the Migrate Library interface.

### Before
<img width="1079" height="473" alt="image" src="https://github.com/user-attachments/assets/3618b7da-ff4f-4d17-99e7-51aad7bff1e9" />

### After (with pending migrations)
<img width="2134" height="1030" alt="image" src="https://github.com/user-attachments/assets/d4ef2b27-777c-4036-b16c-8e49e653f53e" />

### After (without pending migrations)
<img width="2142" height="912" alt="image" src="https://github.com/user-attachments/assets/14a5680d-ddf4-4908-afda-0b8c38dc65c7" />


- Which user roles will this change impact? 
"Course Author",


## Supporting information
- Related to https://github.com/openedx/frontend-app-authoring/issues/2169
- Depends on https://github.com/openedx/frontend-app-authoring/pull/2417

## Testing instructions

The alert has two states, so uncomment the code below and switch `isMigrated` to `true`/`false` to check both states.
https://github.com/openedx/frontend-app-authoring/blob/62b329431fcd45bdb5295d17d66a4274d6ecb14c/src/studio-home/data/apiHooks.ts#L17-L20

- Open the Legacy Library tab and check the Alert

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`

___
Private ref: [FAL-4234](https://tasks.opencraft.com/browse/FAL-4234)