### PR TITLE
fix: enable publish button after component edit

### DIFF
--- a/src/course-unit/data/selectors.js
+++ b/src/course-unit/data/selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { RequestStatus } from 'CourseAuthoring/data/constants';
 
-export const getCourseUnitData = (state) => state.courseUnit.unit;
+export const getCourseUnitData = (state) => state.courseUnit.courseSectionVertical.xblockInfo ?? {};
 export const getCanEdit = (state) => state.courseUnit.canEdit;
 export const getStaticFileNotices = (state) => state.courseUnit.staticFileNotices;
 export const getCourseUnit = (state) => state.courseUnit;

--- a/src/course-unit/data/thunk.js
+++ b/src/course-unit/data/thunk.js
@@ -146,8 +146,8 @@ export function editCourseUnitVisibilityAndData(
           if (callback) {
             callback();
           }
-          const courseUnit = await getCourseUnitData(blockId);
-          dispatch(fetchCourseItemSuccess(courseUnit));
+          const courseSectionVerticalData = await getCourseSectionVerticalData(blockId);
+          dispatch(fetchCourseSectionVerticalDataSuccess(courseSectionVerticalData));
           const courseVerticalChildrenData = await getCourseVerticalChildren(blockId);
           dispatch(updateCourseVerticalChildren(courseVerticalChildrenData));
           dispatch(hideProcessingNotification());


### PR DESCRIPTION
This was fixed in master in commit https://github.com/openedx/frontend-app-authoring/commit/ad62519af75ffcd797dc8356fff28badfda72f7a but at that time, the changes of current PR also contributed to the fix. We backported the fix to release/teak but that didn't work because of additional changes that this commit adds. We avoided the backport of the original [PR](https://github.com/openedx/frontend-app-authoring/pull/1867) due to additional refactoring.

## Description

This PR fixes an issue with the course unit sidebar. When we edit any component, the publish button doesn't show.

In master, this is working fine due to the changes in https://github.com/openedx/frontend-app-authoring/pull/1867 and https://github.com/openedx/frontend-app-authoring/pull/2227.

We backported https://github.com/openedx/frontend-app-authoring/pull/2227 to release/teak in https://github.com/openedx/frontend-app-authoring/pull/2392 but it didn't fix the issue and eventually it turned out that we need extra changes that we made in master in https://github.com/openedx/frontend-app-authoring/pull/1867 and skipped backport to release/teak.

## Testing instructions

- Checkout release/teak
- Go to any unit and edit any component
- Notice that the publish button does not show up
- Checkout this branch and repeat.