### PR TITLE
fix: files page web url missing #2409

### DIFF
--- a/src/files-and-videos/files-page/FileInfoModalSidebar.jsx
+++ b/src/files-and-videos/files-page/FileInfoModalSidebar.jsx
@@ -7,7 +7,6 @@ import {
   IconButton,
   ActionRow,
   Icon,
-  Truncate,
   IconButtonWithTooltip,
   CheckboxControl,
 } from '@openedx/paragon';
@@ -15,6 +14,7 @@ import { ContentCopy, InfoOutline } from '@openedx/paragon/icons';
 
 import { getFileSizeToClosestByte } from '../../utils';
 import messages from './messages';
+import './FileInfoModalSidebar.scss';
 
 const FileInfoModalSidebar = ({
   asset,
@@ -28,7 +28,6 @@ const FileInfoModalSidebar = ({
     handleLockedAsset(asset?.id, locked);
   };
   const fileSize = getFileSizeToClosestByte(asset?.fileSize);
-
   return (
     <Stack>
       <div className="font-weight-bold">
@@ -50,10 +49,11 @@ const FileInfoModalSidebar = ({
         <FormattedMessage {...messages.studioUrlTitle} />
       </div>
       <ActionRow>
-        <div style={{ wordBreak: 'break-word' }}>
-          <Truncate.Deprecated lines={1}>
-            {asset?.portableUrl}
-          </Truncate.Deprecated>
+        <div
+          className="files-page-url-truncate"
+          style={{ wordBreak: 'break-word' }}
+        >
+          {asset?.portableUrl}
         </div>
         <ActionRow.Spacer />
         <IconButton
@@ -67,10 +67,8 @@ const FileInfoModalSidebar = ({
         <FormattedMessage {...messages.webUrlTitle} />
       </div>
       <ActionRow>
-        <div style={{ wordBreak: 'break-word' }}>
-          <Truncate lines={1}>
-            {asset?.externalUrl}
-          </Truncate>
+        <div className="files-page-url-truncate" style={{ wordBreak: 'break-word' }}>
+          {asset?.externalUrl}
         </div>
         <ActionRow.Spacer />
         <IconButton

--- a/src/files-and-videos/files-page/FileInfoModalSidebar.scss
+++ b/src/files-and-videos/files-page/FileInfoModalSidebar.scss
@@ -1,0 +1,16 @@
+/* stylelint-disable value-no-vendor-prefix */
+.files-page-url-truncate {
+  max-width: 200px;
+
+  /* Firefox + others fallback (single line ellipsis) */
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  /* WebKit multiline clamp */
+  display: -webkit-box;
+  -webkit-line-clamp: 1; // adjust number of lines
+  line-clamp: 1; /* Standard property */
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+/* stylelint-enable value-no-vendor-prefix */


### PR DESCRIPTION
## Description

- files page web url missing #2409
- Add css based truncate approach because paragon's Truncate has been deprecated 

## Supporting information
### After
<img width="1764" height="1034" alt="image" src="https://github.com/user-attachments/assets/7a3537f4-a6ad-4088-9c6d-8dad17fba886" />
 

## Testing instructions

Please provide detailed step-by-step instructions for manually testing this change.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
