### PR TITLE
fix: answer range format validation and error message in Numerical input

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
@@ -49,7 +49,7 @@ const AnswerOption = ({
     ? `${getConfig().STUDIO_BASE_URL}/library_assets/blocks/${blockId}/`
     : undefined;
 
-  const validateAnswerTitle = (value) => {
+  const validateAnswerRange = (value) => {
     const cleanedValue = value.replace(/^\s+|\s+$/g, '');
     return !cleanedValue.length || answerRangeFormatRegex.test(cleanedValue);
   };
@@ -83,7 +83,7 @@ const AnswerOption = ({
       );
     }
     // Return Answer Range View
-    const isValidValue = validateAnswerTitle(answer.title);
+    const isValidValue = validateAnswerRange(answer.title);
     return (
       <Form.Group isInvalid={!isValidValue}>
         <Form.Control

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
@@ -18,6 +18,7 @@ import { FeedbackBox } from './components/Feedback';
 import * as hooks from './hooks';
 import { ProblemTypeKeys } from '../../../../../data/constants/problem';
 import ExpandableTextArea from '../../../../../sharedComponents/ExpandableTextArea';
+import { answerRangeFormatRegex } from '../../../data/OLXParser';
 
 const AnswerOption = ({
   answer,
@@ -48,6 +49,11 @@ const AnswerOption = ({
     ? `${getConfig().STUDIO_BASE_URL}/library_assets/blocks/${blockId}/`
     : undefined;
 
+  const validateAnswerTitle = (value) => {
+    const cleanedValue = value.replace(/^\s+|\s+$/g, '');
+    return !cleanedValue.length || answerRangeFormatRegex.test(cleanedValue);
+  };
+
   const getInputArea = () => {
     if ([ProblemTypeKeys.SINGLESELECT, ProblemTypeKeys.MULTISELECT].includes(problemType)) {
       return (
@@ -77,8 +83,9 @@ const AnswerOption = ({
       );
     }
     // Return Answer Range View
+    const isValidValue = validateAnswerTitle(answer.title);
     return (
-      <div>
+      <Form.Group isInvalid={!isValidValue}>
         <Form.Control
           as="textarea"
           className="answer-option-textarea text-gray-500 small"
@@ -88,10 +95,15 @@ const AnswerOption = ({
           onChange={setAnswerTitle}
           placeholder={intl.formatMessage(messages.answerRangeTextboxPlaceholder)}
         />
+        {!isValidValue && (
+          <Form.Control.Feedback type="invalid">
+            <FormattedMessage {...messages.answerRangeErrorText} />
+          </Form.Control.Feedback>
+        )}
         <div className="pgn__form-switch-helper-text">
           <FormattedMessage {...messages.answerRangeHelperText} />
         </div>
-      </div>
+      </Form.Group>
     );
   };
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/messages.js
@@ -77,6 +77,11 @@ const messages = defineMessages({
     defaultMessage: 'Enter min and max values separated by a comma. Use a bracket to include the number next to it in the range, or a parenthesis to exclude the number. For example, to identify the correct answers as 5, 6, or 7, but not 8, specify [5,8).',
     description: 'Helper text describing usage of answer ranges',
   },
+  answerRangeErrorText: {
+    id: 'authoring.answerwidget.answer.answerRangeErrorText',
+    defaultMessage: 'Error: Invalid range format. Use brackets or parentheses with values separated by a comma.',
+    description: 'Error text describing wrong format of answer ranges',
+  },
 });
 
 export default messages;

--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -57,6 +57,8 @@ export const responseKeys = [
   'choicetextresponse',
 ];
 
+export const answerRangeFormatRegex = /^[([]\s*\d+(\.\d+)?\s*,\s*\d+(\.\d+)?\s*[)\]]$/m;
+
 export const stripNonTextTags = ({ input, tag }) => {
   const stripedTags = {};
   Object.entries(input).forEach(([key, value]) => {
@@ -432,7 +434,7 @@ export class OLXParser {
         [type]: defaultValue,
       };
     }
-    const isAnswerRange = /[([]\s*\d*,\s*\d*\s*[)\]]/gm.test(numericalresponse['@_answer']);
+    const isAnswerRange = answerRangeFormatRegex.test(numericalresponse['@_answer']);
     answers.push({
       id: indexToLetterMap[answers.length],
       title: numericalresponse['@_answer'],

--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -57,6 +57,29 @@ export const responseKeys = [
   'choicetextresponse',
 ];
 
+/**
+ * Regular expression to validate numeric answer ranges in OLX format.
+ * Matches ranges in the form of (min, max) or [min, max] where:
+ * - min and max are numbers (integers or decimals)
+ * - Whitespace around numbers and comma is optional
+ * - Parentheses () indicate exclusive bounds
+ * - Square brackets [] indicate inclusive bounds
+ *
+ * @example
+ * // Valid patterns:
+ * (1, 5)    // Numbers 2, 3, 4
+ * [1, 5]    // Numbers 1, 2, 3, 4, 5
+ * (1.5, 5.5) // Decimal numbers between 1.5 and 5.5
+ * [0, 100]  // Numbers 0 through 100 (inclusive)
+ * ( 0 , 1 ) // With spaces
+ *
+ * @example
+ * // Invalid patterns:
+ * (5, 1)    // Min > Max
+ * (1, )     // Missing max value
+ * [1 5]     // Missing comma
+ * {1, 5}    // Invalid brackets
+ */
 export const answerRangeFormatRegex = /^[([]\s*\d+(\.\d+)?\s*,\s*\d+(\.\d+)?\s*[)\]]$/m;
 
 export const stripNonTextTags = ({ input, tag }) => {

--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
@@ -413,16 +413,18 @@ class ReactStateOLXParser {
             const lowerBoundFloat = Number(numerator) / Number(denominator);
             lowerBoundInt = lowerBoundFloat;
           } else {
-            // these regex replaces remove everything that is not a decimal or positive/negative numer
+            // these regex replaces remove everything that is not a decimal or positive/negative number
             lowerBoundInt = Number(rawLowerBound.replace(/[^0-9-.]/gm, ''));
           }
-          if (rawUpperBound.includes('/')) {
+          if (!rawUpperBound) {
+            upperBoundInt = lowerBoundInt;
+          } else if (rawUpperBound.includes('/')) {
             upperBoundFraction = rawUpperBound.replace(/[^0-9-/]/gm, '');
             const [numerator, denominator] = upperBoundFraction.split('/');
             const upperBoundFloat = Number(numerator) / Number(denominator);
             upperBoundInt = upperBoundFloat;
           } else {
-            // these regex replaces remove everything that is not a decimal or positive/negative numer
+            // these regex replaces remove everything that is not a decimal or positive/negative number
             upperBoundInt = Number(rawUpperBound.replace(/[^0-9-.]/gm, ''));
           }
           if (lowerBoundInt > upperBoundInt) {

--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.test.js
@@ -18,6 +18,10 @@ import {
   numericInputWithAnswerRange,
   textInputWithFeedbackAndHintsWithMultipleAnswers,
   numberParseTest,
+  numericInputWithFractionBounds,
+  numericInputWithEmptyUpperBound,
+  numericInputWithSwappedBounds,
+  numericInputWithMissingUpperBound,
 } from './mockData/editorTestData';
 import ReactStateOLXParser from './ReactStateOLXParser';
 
@@ -145,6 +149,43 @@ describe('Check React State OLXParser problem', () => {
       expect(buildOLX).toEqual(
         '<problem><optionresponse>\n<pre>  1  a<br/>  2  b<br/></pre><optioninput></optioninput></optionresponse>\n</problem>',
       );
+    });
+  });
+  describe('ReactStateOLXParser numerical response range parsing', () => {
+    test('handles empty upper bound as same as lower', () => {
+      const parser = new ReactStateOLXParser({
+        problem: numericInputWithEmptyUpperBound,
+        editorObject: numericInputWithEmptyUpperBound,
+      });
+      const result = parser.buildNumericalResponse();
+      expect(result[':@']['@_answer']).toBe('[0,1.5]');
+    });
+
+    test('handles swapped bounds and corrects order', () => {
+      const parser = new ReactStateOLXParser({
+        problem: numericInputWithSwappedBounds,
+        editorObject: numericInputWithSwappedBounds,
+      });
+      const result = parser.buildNumericalResponse();
+      expect(result[':@']['@_answer']).toBe('[2,5]');
+    });
+
+    test('fixes swapped fraction bounds and preserves brackets', () => {
+      const parser = new ReactStateOLXParser({
+        problem: numericInputWithFractionBounds,
+        editorObject: numericInputWithFractionBounds,
+      });
+      const result = parser.buildNumericalResponse();
+      expect(result[':@']['@_answer']).toBe('(1/2,3/2)');
+    });
+
+    test('sets upper bound = lower bound if upper bound missing', () => {
+      const parser = new ReactStateOLXParser({
+        problem: numericInputWithMissingUpperBound,
+        editorObject: numericInputWithMissingUpperBound,
+      });
+      const result = parser.buildNumericalResponse();
+      expect(result[':@']['@_answer']).toBe('[,2.5]');
     });
   });
 });

--- a/src/editors/containers/ProblemEditor/data/mockData/editorTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/editorTestData.js
@@ -130,3 +130,51 @@ export const numberParseTest = {
   hints: [],
   question: '<p>What is the content of the register x2 after executing the following three lines of instructions?</p>',
 };
+
+export const numericInputWithEmptyUpperBound = {
+  answers: [
+    {
+      id: 'a1',
+      title: '[1.5,]',
+      correct: true,
+    },
+  ],
+  problemType: 'numericalresponse',
+  settings: {},
+};
+
+export const numericInputWithSwappedBounds = {
+  answers: [
+    {
+      id: 'a1',
+      title: '[5,2]',
+      correct: true,
+    },
+  ],
+  problemType: 'numericalresponse',
+  settings: {},
+};
+
+export const numericInputWithFractionBounds = {
+  answers: [
+    {
+      id: 'a1',
+      title: '(3/2,1/2)',
+      correct: true,
+    },
+  ],
+  problemType: 'numericalresponse',
+  settings: {},
+};
+
+export const numericInputWithMissingUpperBound = {
+  answers: [
+    {
+      id: 'a1',
+      title: '[,2.5]',
+      correct: true,
+    },
+  ],
+  problemType: 'numericalresponse',
+  settings: {},
+};


### PR DESCRIPTION
Backport Pull Requests to frontend-lib-content-components: https://github.com/openedx/frontend-lib-content-components/pull/511

### Description
These fixes validate input range format; it accepts the following response forms: `[1,10]`, `[1, 10]`, `[ 1,10 ]`, `[ 1, 10 ]`, `[1, 10 ] `, `[ 1, 10]`, `[1.1,10]`, `[1.1,10.1]`, `[1.1,10.1]` and display error on incorrect format like: `[1.10]`, `[1;10]`, `[1/10]`, etc.

### Steps to reproduce
1) Go to studio -> unit -> problem -> Numerical input
2) In answers click on Add answer button -> Add answer range
3) Fill in value [5.8), click Save (like user set dot instead of comma by mistake)

### Actual result
Nothing happened, in console there's error
<img width="1295" alt="000" src="https://github.com/user-attachments/assets/2fd191c9-9d40-47fd-a79e-a620a792ef76">
Note: the same when user print additional bracket

### Expected result
Some validation should be for field or some error message for user should be shown
Before save:
<img width="1727" alt="0001" src="https://github.com/user-attachments/assets/d6bb42e2-c257-4ce7-af9a-a13ab7ce6aa8">
After save:
<img width="1727" alt="0002" src="https://github.com/user-attachments/assets/7f22e2a8-8d38-41ba-b4fa-7d427419fea8">

### Note
Old closed MR https://github.com/openedx/frontend-app-authoring/pull/1557