### PR TITLE
fix: Correct text direction in Course Overview field

### DIFF
--- a/src/schedule-and-details/introducing-section/index.jsx
+++ b/src/schedule-and-details/introducing-section/index.jsx
@@ -111,7 +111,7 @@ const IntroducingSection = ({
           <Form.Group className="form-group-custom">
             <Form.Label>{intl.formatMessage(messages.courseOverviewLabel)}</Form.Label>
             <WysiwygEditor
-              initialValue={overview}
+              value={overview}
               onChange={(value) => onChange(value, 'overview')}
             />
             <Form.Control.Feedback>{overviewHelpText}</Form.Control.Feedback>
@@ -120,7 +120,7 @@ const IntroducingSection = ({
             <Form.Group className="form-group-custom">
               <Form.Label>{intl.formatMessage(messages.courseAboutSidebarLabel)}</Form.Label>
               <WysiwygEditor
-                initialValue={aboutSidebarHtml}
+                value={aboutSidebarHtml}
                 onChange={(value) => onChange(value, 'aboutSidebarHtml')}
               />
               <Form.Control.Feedback>{aboutSidebarHelpText}</Form.Control.Feedback>


### PR DESCRIPTION
## Description

In Course Overview field we can see incorrect text typing direction

https://github.com/user-attachments/assets/b8a7341a-e1b3-4e32-883b-eec2b507b8d9

Fix was found in [tinymce-react](https://github.com/tinymce/tinymce-react) issues section - https://github.com/tinymce/tinymce-react/issues/267