### PR TITLE
fix: Using the correct branch for openedx/.github

### DIFF
--- a/.github/workflows/add-to-cc-board.yml
+++ b/.github/workflows/add-to-cc-board.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   add-to-cc-board:
     if: github.event.label.name == 'Core Contributor assignee'
-    uses: openedx/.github/.github/workflows/add-to-cc-board.yml@main
+    uses: openedx/.github/.github/workflows/add-to-cc-board.yml@master
     with:
       board_name: cc-frontend-apps
     secrets:


### PR DESCRIPTION
## Description

- Fix this [issue](https://github.com/openedx/frontend-app-authoring/actions/runs/17628158668) of `add-to-cc-board` created in https://github.com/openedx/frontend-app-authoring/pull/2302

## Supporting information

- Related to: https://github.com/openedx/frontend-app-authoring/pull/2302
- Github issue: https://github.com/openedx/wg-coordination/issues/157
- Epic: https://github.com/openedx/wg-coordination/issues/138
- Internal ticket: SE-6387

## Testing instructions

- There is no way to test this in the organization without being merged.

## Other information

N/A

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [X] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [X] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [X] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [X] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [X] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [X] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [X] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
