### PR TITLE
test: Remove support for Node 20

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [20, 24]
 
     steps:
     - uses: actions/checkout@v5
@@ -22,7 +19,7 @@ jobs:
     - name: Archive code coverage results
       uses: actions/upload-artifact@v4
       with:
-        name: code-coverage-report-${{ matrix.node }}
+        name: code-coverage-report
         path: coverage/*.*
   coverage:
     runs-on: ubuntu-latest
@@ -32,7 +29,7 @@ jobs:
     - name: Download code coverage results
       uses: actions/download-artifact@v5
       with:
-        pattern: code-coverage-report-*
+        pattern: code-coverage-report
         path: coverage
         merge-multiple: true
     - name: Upload coverage


### PR DESCRIPTION
### Description

Complete the upgrade to Node 24 by removing the Node 20 CI check and going back to using `.nvmrc` as the source of truth for which version to use.

See [the tracking issue](https://github.com/openedx/frontend-app-authoring/issues/2177) for further information.
