### PR TITLE
feat: container library-course sync diff prevew [FC-0097]

### DIFF
--- a/src/container-comparison/ChildrenPreview.tsx
+++ b/src/container-comparison/ChildrenPreview.tsx
@@ -1,19 +1,17 @@
-import { Stack } from "@openedx/paragon";
+import { Stack } from '@openedx/paragon';
 
 interface Props {
   title: React.ReactNode;
   children: React.ReactNode;
-  side: "Before" | "After";
+  side: 'Before' | 'After';
 }
 
-const ChildrenPreview = ({ title, children, side }: Props) => {
-  return (
-    <Stack direction="vertical">
-      <span className="text-center">{side}</span>
-      <span className={`mt-2 mb-3 text-md text-gray-800`}>{title}</span>
-      {children}
-    </Stack>
-  )
-}
+const ChildrenPreview = ({ title, children, side }: Props) => (
+  <Stack direction="vertical">
+    <span className="text-center">{side}</span>
+    <span className="mt-2 mb-3 text-md text-gray-800">{title}</span>
+    {children}
+  </Stack>
+);
 
-export default ChildrenPreview
+export default ChildrenPreview;

--- a/src/container-comparison/ChildrenPreview.tsx
+++ b/src/container-comparison/ChildrenPreview.tsx
@@ -1,7 +1,7 @@
 import { Stack } from "@openedx/paragon";
 
 interface Props {
-  title: string;
+  title: React.ReactNode;
   children: React.ReactNode;
   side: "Before" | "After";
 }

--- a/src/container-comparison/ChildrenPreview.tsx
+++ b/src/container-comparison/ChildrenPreview.tsx
@@ -10,9 +10,9 @@ interface Props {
 
 const ChildrenPreview = ({ title, children, side }: Props) => {
   const intl = useIntl();
-  const sideTitle = side === 'Before' ?
-    intl.formatMessage(messages.diffBeforeTitle) :
-    intl.formatMessage(messages.diffAfterTitle);
+  const sideTitle = side === 'Before'
+    ? intl.formatMessage(messages.diffBeforeTitle)
+    : intl.formatMessage(messages.diffAfterTitle);
 
   return (
     <Stack direction="vertical">

--- a/src/container-comparison/ChildrenPreview.tsx
+++ b/src/container-comparison/ChildrenPreview.tsx
@@ -1,4 +1,6 @@
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { Stack } from '@openedx/paragon';
+import messages from './messages';
 
 interface Props {
   title: React.ReactNode;
@@ -6,12 +8,19 @@ interface Props {
   side: 'Before' | 'After';
 }
 
-const ChildrenPreview = ({ title, children, side }: Props) => (
-  <Stack direction="vertical">
-    <span className="text-center">{side}</span>
-    <span className="mt-2 mb-3 text-md text-gray-800">{title}</span>
-    {children}
-  </Stack>
-);
+const ChildrenPreview = ({ title, children, side }: Props) => {
+  const intl = useIntl();
+  const sideTitle = side === 'Before' ?
+    intl.formatMessage(messages.diffBeforeTitle) :
+    intl.formatMessage(messages.diffAfterTitle);
+
+  return (
+    <Stack direction="vertical">
+      <span className="text-center">{sideTitle}</span>
+      <span className="mt-2 mb-3 text-md text-gray-800">{title}</span>
+      {children}
+    </Stack>
+  );
+};
 
 export default ChildrenPreview;

--- a/src/container-comparison/ChildrenPreview.tsx
+++ b/src/container-comparison/ChildrenPreview.tsx
@@ -1,0 +1,19 @@
+import { Stack } from "@openedx/paragon";
+
+interface Props {
+  title: string;
+  children: React.ReactNode;
+  side: "Before" | "After";
+}
+
+const ChildrenPreview = ({ title, children, side }: Props) => {
+  return (
+    <Stack direction="vertical">
+      <span className="text-center">{side}</span>
+      <span className={`mt-2 mb-3 text-md text-gray-800`}>{title}</span>
+      {children}
+    </Stack>
+  )
+}
+
+export default ChildrenPreview

--- a/src/container-comparison/CompareContainersWidget.test.tsx
+++ b/src/container-comparison/CompareContainersWidget.test.tsx
@@ -1,8 +1,8 @@
-import userEvent from "@testing-library/user-event";
-import { mockGetContainerChildren, mockGetContainerMetadata } from "../library-authoring/data/api.mocks";
-import { initializeMocks, render, screen } from "../testUtils";
-import { CompareContainersWidget } from "./CompareContainersWidget";
-import { mockGetCourseContainerChildren } from "./data/api.mock";
+import userEvent from '@testing-library/user-event';
+import { mockGetContainerChildren, mockGetContainerMetadata } from '../library-authoring/data/api.mocks';
+import { initializeMocks, render, screen } from '../testUtils';
+import { CompareContainersWidget } from './CompareContainersWidget';
+import { mockGetCourseContainerChildren } from './data/api.mock';
 
 mockGetCourseContainerChildren.applyMock();
 mockGetContainerChildren.applyMock();
@@ -47,13 +47,13 @@ describe('CompareContainersWidget', () => {
       downstreamBlockId={mockGetCourseContainerChildren.sectionId}
     />);
     expect((await screen.findAllByText('Test Title')).length).toEqual(2);
-    const blocks =  await screen.findAllByText('subsection block 0');
+    const blocks = await screen.findAllByText('subsection block 0');
     expect(blocks.length).toEqual(2);
     await user.click(blocks[0]);
     // Breadcrumbs
-    const breadcrumbs = await screen.findAllByRole('button', {name: 'subsection block 0'});
+    const breadcrumbs = await screen.findAllByRole('button', { name: 'subsection block 0' });
     expect(breadcrumbs.length).toEqual(2);
-    const backbtns = await screen.findAllByRole('button', {name: 'Back'});
+    const backbtns = await screen.findAllByRole('button', { name: 'Back' });
     expect(backbtns.length).toEqual(2);
     await user.click(backbtns[0]);
     expect((await screen.findAllByText('Test Title')).length).toEqual(2);

--- a/src/container-comparison/CompareContainersWidget.test.tsx
+++ b/src/container-comparison/CompareContainersWidget.test.tsx
@@ -1,0 +1,62 @@
+import userEvent from "@testing-library/user-event";
+import { mockGetContainerChildren, mockGetContainerMetadata } from "../library-authoring/data/api.mocks";
+import { initializeMocks, render, screen } from "../testUtils";
+import { CompareContainersWidget } from "./CompareContainersWidget";
+import { mockGetCourseContainerChildren } from "./data/api.mock";
+
+mockGetCourseContainerChildren.applyMock();
+mockGetContainerChildren.applyMock();
+
+describe('CompareContainersWidget', () => {
+  beforeEach(() => {
+    initializeMocks();
+  });
+
+  test('renders the component with a title', async () => {
+    render(<CompareContainersWidget
+      title="Test Title"
+      upstreamBlockId={mockGetContainerMetadata.sectionId}
+      downstreamBlockId={mockGetCourseContainerChildren.sectionId}
+    />);
+    expect((await screen.findAllByText('Test Title')).length).toEqual(2);
+    expect((await screen.findAllByText('subsection block 0')).length).toEqual(2);
+    expect((await screen.findAllByText('This subsection will be modified')).length).toEqual(3);
+    expect((await screen.findAllByText('This subsection was modified')).length).toEqual(3);
+    expect((await screen.findAllByText('subsection block 1')).length).toEqual(2);
+    expect((await screen.findAllByText('subsection block 2')).length).toEqual(2);
+  });
+
+  test('renders loading spinner when data is pending', async () => {
+    render(<CompareContainersWidget
+      title="Test Title"
+      upstreamBlockId={mockGetContainerMetadata.sectionIdLoading}
+      downstreamBlockId={mockGetCourseContainerChildren.sectionIdLoading}
+    />);
+    expect((await screen.findAllByText('Test Title')).length).toEqual(2);
+    const spinner = await screen.findAllByRole('status');
+    expect(spinner.length).toEqual(2);
+    expect(spinner[0].textContent).toEqual('Loading...');
+    expect(spinner[1].textContent).toEqual('Loading...');
+  });
+
+  test('calls onRowClick when a row is clicked and updates diff view', async () => {
+    const user = userEvent.setup();
+    render(<CompareContainersWidget
+      title="Test Title"
+      upstreamBlockId={mockGetContainerMetadata.sectionId}
+      downstreamBlockId={mockGetCourseContainerChildren.sectionId}
+    />);
+    expect((await screen.findAllByText('Test Title')).length).toEqual(2);
+    const blocks =  await screen.findAllByText('subsection block 0');
+    expect(blocks.length).toEqual(2);
+    await user.click(blocks[0]);
+    // Breadcrumbs
+    const breadcrumbs = await screen.findAllByRole('button', {name: 'subsection block 0'});
+    expect(breadcrumbs.length).toEqual(2);
+    const backbtns = await screen.findAllByRole('button', {name: 'Back'});
+    expect(backbtns.length).toEqual(2);
+    await user.click(backbtns[0]);
+    expect((await screen.findAllByText('Test Title')).length).toEqual(2);
+    expect((await screen.findAllByText('subsection block 0')).length).toEqual(2);
+  });
+});

--- a/src/container-comparison/CompareContainersWidget.test.tsx
+++ b/src/container-comparison/CompareContainersWidget.test.tsx
@@ -47,16 +47,31 @@ describe('CompareContainersWidget', () => {
       downstreamBlockId={mockGetCourseContainerChildren.sectionId}
     />);
     expect((await screen.findAllByText('Test Title')).length).toEqual(2);
-    const blocks = await screen.findAllByText('subsection block 0');
+    let blocks = await screen.findAllByText('subsection block 0');
     expect(blocks.length).toEqual(2);
     await user.click(blocks[0]);
     // Breadcrumbs
     const breadcrumbs = await screen.findAllByRole('button', { name: 'subsection block 0' });
     expect(breadcrumbs.length).toEqual(2);
+
+    const removedRows = await screen.findAllByText('This unit was removed');
+    // clicking on removed or added rows does not updated the page.
+    await user.click(removedRows[0]);
+    // Still in same page
+    expect((await screen.findAllByRole('button', { name: 'subsection block 0' })).length).toEqual(2);
+
+    // Back breadcrumb
     const backbtns = await screen.findAllByRole('button', { name: 'Back' });
     expect(backbtns.length).toEqual(2);
+
+    // Go back
     await user.click(backbtns[0]);
     expect((await screen.findAllByText('Test Title')).length).toEqual(2);
-    expect((await screen.findAllByText('subsection block 0')).length).toEqual(2);
+    blocks = await screen.findAllByText('subsection block 0');
+    expect(blocks.length).toEqual(2);
+
+    // After side click also works
+    await user.click(blocks[1]);
+    expect((await screen.findAllByRole('button', { name: 'subsection block 0' })).length).toEqual(2);
   });
 });

--- a/src/container-comparison/CompareContainersWidget.tsx
+++ b/src/container-comparison/CompareContainersWidget.tsx
@@ -1,0 +1,199 @@
+import { Stack } from "@openedx/paragon";
+import { UseQueryResult } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { UpstreamInfo } from "../data/types";
+import { ContainerType } from "../generic/key-utils";
+import { LoadingSpinner } from "../generic/Loading";
+import { Container } from "../library-authoring/data/api";
+import { useContainerChildren } from "../library-authoring/data/apiHooks";
+import ChildrenPreview from "./ChildrenPreview";
+import ContainerRow, { ContainerState } from "./ContainerRow";
+import { useCourseContainerChildren } from "./data/apiHooks";
+
+interface Props {
+  title: string;
+  upstreamBlockId: string;
+  downstreamBlockId: string;
+}
+
+type WithState<T> = T & { state?: ContainerState };
+
+type CourseContainerChildBase = {
+  name: string;
+  id: string;
+  upstreamLink: UpstreamInfo;
+  blockType: ContainerType;
+}
+
+type ContainerChildBase = {
+  displayName: string;
+  id: string;
+  containerType: ContainerType;
+}
+
+function checkIsReadyToSync(link: UpstreamInfo): boolean {
+  return (link.versionSynced < (link.versionAvailable || 0))
+    || (link.versionSynced < (link.versionDeclined || 0))
+}
+
+/**
+ * Stable-merge two lists while preserving relative order from both.
+ * Returns [updatedA, updatedB] where both arrays have the same length
+ * and are aligned index-by-index.
+ *
+ * Assumes each object has a unique identifier field `idKey`.
+ */
+function stableMergeWithState<A extends CourseContainerChildBase, B extends ContainerChildBase>(
+  a: A[],
+  b: B[],
+  idKey: string = "id"
+): [WithState<A>[], WithState<B>[]] {
+  const mapA = new Map<any, A>();
+  const mapB = new Map<any, B>();
+  for (const x of a) mapA.set(x.upstreamLink?.upstreamRef, x);
+  for (const x of b) mapB.set(x[idKey], x);
+
+  // Build sequences of ids preserving order
+  const idsA = a.map(x => x.upstreamLink?.upstreamRef);
+  const idsB = b.map(x => x[idKey]);
+
+  // We'll perform a stable merge of idsA and idsB producing mergedIds.
+  // When an id appears in both, include it once at the point we encounter it
+  // in either sequence while preserving relative order of remaining items.
+  const mergedIds: string[] = [];
+  const seen = new Set<string>();
+  let i = 0, j = 0;
+  while (i < idsA.length || j < idsB.length) {
+    if (i < idsA.length && j < idsB.length) {
+      const idA = idsA[i];
+      const idB = idsB[j];
+      if (idA === idB) {
+        if (!seen.has(idA)) {
+          mergedIds.push(idA);
+          seen.add(idA);
+        }
+        i++; j++;
+      } else {
+        // Lookahead: prefer whichever id occurs earlier in the other list to avoid
+        // reordering common elements. If idA appears later in idsB, we should take idB now,
+        // and vice versa. If neither appears later, take idA to preserve A's order.
+        const nextIndexOfAinB = idsB.indexOf(idA, j);
+        const nextIndexOfBinA = idsA.indexOf(idB, i);
+
+        if (nextIndexOfAinB === -1 && nextIndexOfBinA === -1) {
+          // distinct remaining sequences — take from A to preserve A order
+          if (!seen.has(idA)) { mergedIds.push(idA); seen.add(idA); }
+          i++;
+        } else if (nextIndexOfAinB === -1) {
+          // idA not in remaining B, prefer idA (keeps A relative)
+          if (!seen.has(idA)) { mergedIds.push(idA); seen.add(idA); }
+          i++;
+        } else if (nextIndexOfBinA === -1) {
+          // idB not in remaining A, prefer idB
+          if (!seen.has(idB)) { mergedIds.push(idB); seen.add(idB); }
+          j++;
+        } else {
+          // both appear later in the opposite lists: take the one with smaller next index
+          if (nextIndexOfAinB <= nextIndexOfBinA) {
+            if (!seen.has(idA)) { mergedIds.push(idA); seen.add(idA); }
+            i++;
+          } else {
+            if (!seen.has(idB)) { mergedIds.push(idB); seen.add(idB); }
+            j++;
+          }
+        }
+      }
+    } else if (i < idsA.length) {
+      const idA = idsA[i++];
+      if (!seen.has(idA)) { mergedIds.push(idA); seen.add(idA); }
+    } else {
+      const idB = idsB[j++];
+      if (!seen.has(idB)) { mergedIds.push(idB); seen.add(idB); }
+    }
+  }
+
+  const updatedA: WithState<A>[] = [];
+  const updatedB: WithState<B>[] = [];
+
+  for (const id of mergedIds) {
+    const itemA = mapA.get(id);
+    const itemB = mapB.get(id);
+    if (itemA && itemB) {
+      let state: ContainerState | undefined;
+      const newDisplayName = itemA?.upstreamLink?.isModified ? itemA?.name : itemB.displayName;
+      if (checkIsReadyToSync(itemA.upstreamLink!)) {
+        state = "modified";
+      }
+      updatedA.push({ ...itemA, state });
+      updatedB.push({ ...itemB, displayName: newDisplayName, state });
+    } else if (itemA && !itemB) {
+      updatedA.push({ ...itemA, state: "removed" });
+      updatedB.push({
+        displayName: itemA.name,
+        id: itemA.id,
+        containerType: itemA.blockType,
+        state: "removed",
+      } as WithState<B>);
+    } else if (!itemA && itemB) {
+      updatedA.push({
+        name: itemB.displayName,
+        id: itemB.id,
+        blockType: itemB.containerType,
+        state: "added",
+      } as WithState<A>);
+      updatedB.push({ ...itemB, state: "added" });
+    }
+  }
+
+  return [updatedA, updatedB];
+}
+
+
+export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBlockId }: Props) => {
+  const { data, isLoading } = useCourseContainerChildren(downstreamBlockId);
+  const { data: libData, isLoading: libLoading } = useContainerChildren(upstreamBlockId, true) as UseQueryResult<Container[], Error>;;
+
+  const result = useCallback(
+    () => stableMergeWithState(data?.children || [], libData || []),
+    [data, libData]
+  );
+
+  const renderBeforeChildren = useCallback(() => {
+    if (isLoading) {
+      return <div className="m-auto"><LoadingSpinner /></div>
+    }
+
+    return result()[0].map((child) => (
+      <ContainerRow
+        title={child.name}
+        containerType={child.blockType}
+        state={child.state}
+      />
+    ))
+  }, [isLoading, result]);
+
+  const renderAfterChildren = useCallback(() => {
+    if (libLoading || isLoading) {
+      return <div className="m-auto"><LoadingSpinner /></div>
+    }
+
+    return result()[1].map((child) => (
+      <ContainerRow
+        title={child.displayName}
+        containerType={child.containerType}
+        state={child.state}
+      />
+    ))
+  }, [libLoading, isLoading, result]);
+
+  return (
+    <Stack direction="horizontal" gap={3}>
+      <ChildrenPreview title={title} side="Before">
+        {renderBeforeChildren()}
+      </ChildrenPreview>
+      <ChildrenPreview title={title} side="After">
+        {renderAfterChildren()}
+      </ChildrenPreview>
+    </Stack>
+  )
+}

--- a/src/container-comparison/CompareContainersWidget.tsx
+++ b/src/container-comparison/CompareContainersWidget.tsx
@@ -3,14 +3,16 @@ import {
 } from '@openedx/paragon';
 import { ArrowBack } from '@openedx/paragon/icons';
 import { useCallback, useMemo, useState } from 'react';
-import { ContainerType } from '../generic/key-utils';
-import { LoadingSpinner } from '../generic/Loading';
-import { useContainerChildren } from '../library-authoring/data/apiHooks';
+import { ContainerType } from '@src/generic/key-utils';
+import { LoadingSpinner } from '@src/generic/Loading';
+import { useContainerChildren } from '@src/library-authoring/data/apiHooks';
 import ChildrenPreview from './ChildrenPreview';
 import ContainerRow from './ContainerRow';
 import { useCourseContainerChildren } from './data/apiHooks';
 import { ContainerChild, ContainerChildBase, WithState } from './types';
 import { diffPreviewContainerChildren, isRowClickable } from './utils';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import messages from './messages';
 
 interface ContainerInfoProps {
   title: string;
@@ -35,6 +37,7 @@ const CompareContainersWidgetInner = ({
   onRowClick,
   onBackBtnClick,
 }: Props) => {
+  const intl = useIntl();
   const { data, isPending } = useCourseContainerChildren(downstreamBlockId);
   const {
     data: libData,
@@ -89,7 +92,7 @@ const CompareContainersWidgetInner = ({
     }
     return (
       <Breadcrumb
-        ariaLabel="title breadcrumb"
+        ariaLabel={intl.formatMessage(messages.breadcrumbAriaLabel)}
         links={[
           {
             label: <Stack direction="horizontal" gap={1}><Icon size="xs" src={ArrowBack} />Back</Stack>,

--- a/src/container-comparison/CompareContainersWidget.tsx
+++ b/src/container-comparison/CompareContainersWidget.tsx
@@ -1,13 +1,13 @@
-import { Card } from "@openedx/paragon";
-import { UseQueryResult } from "@tanstack/react-query";
-import { useCallback } from "react";
-import { LoadingSpinner } from "../generic/Loading";
-import { Container } from "../library-authoring/data/api";
-import { useContainerChildren } from "../library-authoring/data/apiHooks";
-import ChildrenPreview from "./ChildrenPreview";
-import ContainerRow  from "./ContainerRow";
-import { useCourseContainerChildren } from "./data/apiHooks";
-import { diffPreviewContainerChildren } from "./utils";
+import { Card } from '@openedx/paragon';
+import { UseQueryResult } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { LoadingSpinner } from '../generic/Loading';
+import { Container } from '../library-authoring/data/api';
+import { useContainerChildren } from '../library-authoring/data/apiHooks';
+import ChildrenPreview from './ChildrenPreview';
+import ContainerRow from './ContainerRow';
+import { useCourseContainerChildren } from './data/apiHooks';
+import { diffPreviewContainerChildren } from './utils';
 
 interface Props {
   title: string;
@@ -17,21 +17,24 @@ interface Props {
 
 export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBlockId }: Props) => {
   const { data, isPending } = useCourseContainerChildren(downstreamBlockId);
-  const { data: libData, isPending: libPending } = useContainerChildren(upstreamBlockId, true) as UseQueryResult<Container[], Error>;;
+  const {
+    data: libData,
+    isPending: libPending,
+  } = useContainerChildren(upstreamBlockId, true) as UseQueryResult<Container[], Error>;
 
   const result = useCallback(
     () => {
       if (!data || !libData) {
         return [undefined, undefined];
       }
-      return diffPreviewContainerChildren(data.children, libData)
+      return diffPreviewContainerChildren(data.children, libData);
     },
-    [data, libData]
+    [data, libData],
   );
 
   const renderBeforeChildren = useCallback(() => {
     if (isPending) {
-      return <div className="m-auto"><LoadingSpinner /></div>
+      return <div className="m-auto"><LoadingSpinner /></div>;
     }
 
     return result()[0]?.map((child) => (
@@ -42,12 +45,12 @@ export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBloc
         originalName={child.originalName}
         side="Before"
       />
-    ))
+    ));
   }, [isPending, result]);
 
   const renderAfterChildren = useCallback(() => {
     if (libPending || isPending) {
-      return <div className="m-auto"><LoadingSpinner /></div>
+      return <div className="m-auto"><LoadingSpinner /></div>;
     }
 
     return result()[1]?.map((child) => (
@@ -57,7 +60,7 @@ export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBloc
         state={child.state}
         side="After"
       />
-    ))
+    ));
   }, [libPending, isPending, result]);
 
   return (
@@ -77,5 +80,5 @@ export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBloc
         </Card>
       </div>
     </div>
-  )
-}
+  );
+};

--- a/src/container-comparison/CompareContainersWidget.tsx
+++ b/src/container-comparison/CompareContainersWidget.tsx
@@ -1,13 +1,11 @@
 import { Card } from '@openedx/paragon';
-import { UseQueryResult } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { LoadingSpinner } from '../generic/Loading';
-import { Container } from '../library-authoring/data/api';
 import { useContainerChildren } from '../library-authoring/data/apiHooks';
 import ChildrenPreview from './ChildrenPreview';
 import ContainerRow from './ContainerRow';
 import { useCourseContainerChildren } from './data/apiHooks';
-import { diffPreviewContainerChildren } from './utils';
+import { ContainerChildBase, diffPreviewContainerChildren } from './utils';
 
 interface Props {
   title: string;
@@ -20,14 +18,14 @@ export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBloc
   const {
     data: libData,
     isPending: libPending,
-  } = useContainerChildren(upstreamBlockId, true) as UseQueryResult<Container[], Error>;
+  } = useContainerChildren(upstreamBlockId, true);
 
   const result = useCallback(
     () => {
       if (!data || !libData) {
         return [undefined, undefined];
       }
-      return diffPreviewContainerChildren(data.children, libData);
+      return diffPreviewContainerChildren(data.children, libData as ContainerChildBase[]);
     },
     [data, libData],
   );
@@ -56,7 +54,7 @@ export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBloc
     return result()[1]?.map((child) => (
       <ContainerRow
         title={child.displayName}
-        containerType={child.containerType}
+        containerType={child.containerType || child.blockType!}
         state={child.state}
         side="After"
       />

--- a/src/container-comparison/CompareContainersWidget.tsx
+++ b/src/container-comparison/CompareContainersWidget.tsx
@@ -8,7 +8,7 @@ import { useContainerChildren } from '../library-authoring/data/apiHooks';
 import ChildrenPreview from './ChildrenPreview';
 import ContainerRow from './ContainerRow';
 import { useCourseContainerChildren } from './data/apiHooks';
-import { ContainerChildBase, CourseContainerChildBase, WithState } from './types';
+import { ContainerChild, ContainerChildBase, WithState } from './types';
 import { diffPreviewContainerChildren } from './utils';
 
 interface ContainerInfoProps {
@@ -19,7 +19,7 @@ interface ContainerInfoProps {
 
 interface Props extends ContainerInfoProps {
   parent: ContainerInfoProps[];
-  onRowClick: (row: WithState<CourseContainerChildBase>) => void;
+  onRowClick: (row: WithState<ContainerChild>) => void;
   onBackBtnClick: () => void;
 }
 
@@ -71,10 +71,11 @@ const CompareContainersWidgetInner = ({
 
     return result[1]?.map((child) => (
       <ContainerRow
-        title={child.displayName}
-        containerType={child.containerType || child.blockType!}
+        title={child.name}
+        containerType={child.blockType}
         state={child.state}
         side="After"
+        onClick={() => onRowClick(child)}
       />
     ));
   }, [libPending, isPending, result]);
@@ -140,15 +141,15 @@ export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBloc
     parent: [],
   });
 
-  const onRowClick = (row: WithState<CourseContainerChildBase>) => {
-    if (!row.upstreamLink || row.state !== 'modified') {
+  const onRowClick = (row: WithState<ContainerChild>) => {
+    if (!row.downstreamId || !row.id || row.state !== 'modified') {
       return;
     }
 
     setCurrentContainerState((prev) => ({
       title: row.name,
-      upstreamBlockId: row.upstreamLink.upstreamRef,
-      downstreamBlockId: row.id,
+      upstreamBlockId: row.id!,
+      downstreamBlockId: row.downstreamId!,
       parent: [...prev.parent, {
         title,
         upstreamBlockId,

--- a/src/container-comparison/CompareContainersWidget.tsx
+++ b/src/container-comparison/CompareContainersWidget.tsx
@@ -6,12 +6,12 @@ import { useCallback, useMemo, useState } from 'react';
 import { ContainerType } from '@src/generic/key-utils';
 import { LoadingSpinner } from '@src/generic/Loading';
 import { useContainerChildren } from '@src/library-authoring/data/apiHooks';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import ChildrenPreview from './ChildrenPreview';
 import ContainerRow from './ContainerRow';
 import { useCourseContainerChildren } from './data/apiHooks';
 import { ContainerChild, ContainerChildBase, WithState } from './types';
 import { diffPreviewContainerChildren, isRowClickable } from './utils';
-import { useIntl } from '@edx/frontend-platform/i18n';
 import messages from './messages';
 
 interface ContainerInfoProps {

--- a/src/container-comparison/CompareContainersWidget.tsx
+++ b/src/container-comparison/CompareContainersWidget.tsx
@@ -1,4 +1,6 @@
-import { Breadcrumb, Button, Card, Icon, Stack } from '@openedx/paragon';
+import {
+  Breadcrumb, Button, Card, Icon, Stack,
+} from '@openedx/paragon';
 import { ArrowBack } from '@openedx/paragon/icons';
 import { useCallback, useMemo, useState } from 'react';
 import { LoadingSpinner } from '../generic/Loading';
@@ -22,68 +24,9 @@ interface Props extends ContainerInfoProps {
 }
 
 /**
- * CompareContainersWidget component. Displays a diff of set of child containers from two different sources
- * and allows the user to select the container to view. This is a wrapper component that maintains current
- * source state. Actual implementation of the diff view is done by _CompareContainersWidget.
- */
-export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBlockId }: ContainerInfoProps) => {
-  const [currentContainerState, setCurrentContainerState] = useState<ContainerInfoProps & {
-    parent: ContainerInfoProps[];
-  }>({
-    title,
-    upstreamBlockId,
-    downstreamBlockId,
-    parent: [],
-  });
-
-  const onRowClick = (row: WithState<CourseContainerChildBase>) => {
-    if (!row.upstreamLink || row.state !== "modified") {
-      return;
-    }
-
-    setCurrentContainerState((prev) => ({
-      title: row.name,
-      upstreamBlockId: row.upstreamLink.upstreamRef,
-      downstreamBlockId: row.id,
-      parent: [...prev.parent, {
-        title,
-        upstreamBlockId,
-        downstreamBlockId,
-      }]
-    }));
-  }
-
-  const onBackBtnClick = () => {
-    setCurrentContainerState((prev) => {
-      if (prev.parent.length < 1) {
-        return prev;
-      }
-      const prevParent = prev.parent[prev.parent.length-1];
-      return {
-        title: prevParent!.title,
-        upstreamBlockId: prevParent!.upstreamBlockId,
-        downstreamBlockId: prevParent!.downstreamBlockId,
-        parent: prev.parent.slice(0, -1),
-      }
-    });
-  }
-
-  return (
-    <_CompareContainersWidget
-      title={currentContainerState.title}
-      upstreamBlockId={currentContainerState.upstreamBlockId}
-      downstreamBlockId={currentContainerState.downstreamBlockId}
-      parent={currentContainerState.parent}
-      onRowClick={onRowClick}
-      onBackBtnClick={onBackBtnClick}
-    />
-  );
-};
-
-/**
  * Actual implementation of the displaying diff between children of containers.
  */
-const _CompareContainersWidget = ({
+const CompareContainersWidgetInner = ({
   title,
   upstreamBlockId,
   downstreamBlockId,
@@ -139,28 +82,28 @@ const _CompareContainersWidget = ({
   const getTitleComponent = () => {
     if (parent.length === 0) {
       return title;
-    } else {
-      return (
-        <Breadcrumb ariaLabel="title breadcrumb"
-          links={[
-            {
-              label: <Stack direction="horizontal" gap={1}><Icon size='xs' src={ArrowBack} />Back</Stack>,
-              onClick: onBackBtnClick,
-              variant: "link",
-              className: "px-0 text-gray-900",
-            },
-            {
-              label: title,
-              variant: "link",
-              className: "px-0 text-gray-900",
-              disabled: true,
-            },
-          ]}
-          linkAs={Button}
-        />
-      );
     }
-  }
+    return (
+      <Breadcrumb
+        ariaLabel="title breadcrumb"
+        links={[
+          {
+            label: <Stack direction="horizontal" gap={1}><Icon size="xs" src={ArrowBack} />Back</Stack>,
+            onClick: onBackBtnClick,
+            variant: 'link',
+            className: 'px-0 text-gray-900',
+          },
+          {
+            label: title,
+            variant: 'link',
+            className: 'px-0 text-gray-900',
+            disabled: true,
+          },
+        ]}
+        linkAs={Button}
+      />
+    );
+  };
 
   return (
     <div className="row">
@@ -179,5 +122,64 @@ const _CompareContainersWidget = ({
         </Card>
       </div>
     </div>
+  );
+};
+
+/**
+ * CompareContainersWidget component. Displays a diff of set of child containers from two different sources
+ * and allows the user to select the container to view. This is a wrapper component that maintains current
+ * source state. Actual implementation of the diff view is done by CompareContainersWidgetInner.
+ */
+export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBlockId }: ContainerInfoProps) => {
+  const [currentContainerState, setCurrentContainerState] = useState<ContainerInfoProps & {
+    parent: ContainerInfoProps[];
+  }>({
+    title,
+    upstreamBlockId,
+    downstreamBlockId,
+    parent: [],
+  });
+
+  const onRowClick = (row: WithState<CourseContainerChildBase>) => {
+    if (!row.upstreamLink || row.state !== 'modified') {
+      return;
+    }
+
+    setCurrentContainerState((prev) => ({
+      title: row.name,
+      upstreamBlockId: row.upstreamLink.upstreamRef,
+      downstreamBlockId: row.id,
+      parent: [...prev.parent, {
+        title,
+        upstreamBlockId,
+        downstreamBlockId,
+      }],
+    }));
+  };
+
+  const onBackBtnClick = () => {
+    setCurrentContainerState((prev) => {
+      if (prev.parent.length < 1) {
+        return prev;
+      }
+      const prevParent = prev.parent[prev.parent.length - 1];
+      return {
+        title: prevParent!.title,
+        upstreamBlockId: prevParent!.upstreamBlockId,
+        downstreamBlockId: prevParent!.downstreamBlockId,
+        parent: prev.parent.slice(0, -1),
+      };
+    });
+  };
+
+  return (
+    <CompareContainersWidgetInner
+      title={currentContainerState.title}
+      upstreamBlockId={currentContainerState.upstreamBlockId}
+      downstreamBlockId={currentContainerState.downstreamBlockId}
+      parent={currentContainerState.parent}
+      onRowClick={onRowClick}
+      onBackBtnClick={onBackBtnClick}
+    />
   );
 };

--- a/src/container-comparison/CompareContainersWidget.tsx
+++ b/src/container-comparison/CompareContainersWidget.tsx
@@ -55,6 +55,7 @@ const CompareContainersWidgetInner = ({
 
     return result[0]?.map((child) => (
       <ContainerRow
+        key={child.id}
         title={child.name}
         containerType={child.blockType}
         state={child.state}
@@ -72,6 +73,7 @@ const CompareContainersWidgetInner = ({
 
     return result[1]?.map((child) => (
       <ContainerRow
+        key={child.id}
         title={child.name}
         containerType={child.blockType}
         state={child.state}

--- a/src/container-comparison/CompareContainersWidget.tsx
+++ b/src/container-comparison/CompareContainersWidget.tsx
@@ -1,14 +1,13 @@
 import { Stack } from "@openedx/paragon";
 import { UseQueryResult } from "@tanstack/react-query";
 import { useCallback } from "react";
-import { UpstreamInfo } from "../data/types";
-import { ContainerType } from "../generic/key-utils";
 import { LoadingSpinner } from "../generic/Loading";
 import { Container } from "../library-authoring/data/api";
 import { useContainerChildren } from "../library-authoring/data/apiHooks";
 import ChildrenPreview from "./ChildrenPreview";
-import ContainerRow, { ContainerState } from "./ContainerRow";
+import ContainerRow  from "./ContainerRow";
 import { useCourseContainerChildren } from "./data/apiHooks";
+import { diffPreviewContainerChildren } from "./utils";
 
 interface Props {
   title: string;
@@ -16,145 +15,12 @@ interface Props {
   downstreamBlockId: string;
 }
 
-type WithState<T> = T & { state?: ContainerState };
-
-type CourseContainerChildBase = {
-  name: string;
-  id: string;
-  upstreamLink: UpstreamInfo;
-  blockType: ContainerType;
-}
-
-type ContainerChildBase = {
-  displayName: string;
-  id: string;
-  containerType: ContainerType;
-}
-
-function checkIsReadyToSync(link: UpstreamInfo): boolean {
-  return (link.versionSynced < (link.versionAvailable || 0))
-    || (link.versionSynced < (link.versionDeclined || 0))
-}
-
-/**
- * Stable-merge two lists while preserving relative order from both.
- * Returns [updatedA, updatedB] where both arrays have the same length
- * and are aligned index-by-index.
- *
- * Assumes each object has a unique identifier field `idKey`.
- */
-function stableMergeWithState<A extends CourseContainerChildBase, B extends ContainerChildBase>(
-  a: A[],
-  b: B[],
-  idKey: string = "id"
-): [WithState<A>[], WithState<B>[]] {
-  const mapA = new Map<any, A>();
-  const mapB = new Map<any, B>();
-  for (const x of a) mapA.set(x.upstreamLink?.upstreamRef, x);
-  for (const x of b) mapB.set(x[idKey], x);
-
-  // Build sequences of ids preserving order
-  const idsA = a.map(x => x.upstreamLink?.upstreamRef);
-  const idsB = b.map(x => x[idKey]);
-
-  // We'll perform a stable merge of idsA and idsB producing mergedIds.
-  // When an id appears in both, include it once at the point we encounter it
-  // in either sequence while preserving relative order of remaining items.
-  const mergedIds: string[] = [];
-  const seen = new Set<string>();
-  let i = 0, j = 0;
-  while (i < idsA.length || j < idsB.length) {
-    if (i < idsA.length && j < idsB.length) {
-      const idA = idsA[i];
-      const idB = idsB[j];
-      if (idA === idB) {
-        if (!seen.has(idA)) {
-          mergedIds.push(idA);
-          seen.add(idA);
-        }
-        i++; j++;
-      } else {
-        // Lookahead: prefer whichever id occurs earlier in the other list to avoid
-        // reordering common elements. If idA appears later in idsB, we should take idB now,
-        // and vice versa. If neither appears later, take idA to preserve A's order.
-        const nextIndexOfAinB = idsB.indexOf(idA, j);
-        const nextIndexOfBinA = idsA.indexOf(idB, i);
-
-        if (nextIndexOfAinB === -1 && nextIndexOfBinA === -1) {
-          // distinct remaining sequences — take from A to preserve A order
-          if (!seen.has(idA)) { mergedIds.push(idA); seen.add(idA); }
-          i++;
-        } else if (nextIndexOfAinB === -1) {
-          // idA not in remaining B, prefer idA (keeps A relative)
-          if (!seen.has(idA)) { mergedIds.push(idA); seen.add(idA); }
-          i++;
-        } else if (nextIndexOfBinA === -1) {
-          // idB not in remaining A, prefer idB
-          if (!seen.has(idB)) { mergedIds.push(idB); seen.add(idB); }
-          j++;
-        } else {
-          // both appear later in the opposite lists: take the one with smaller next index
-          if (nextIndexOfAinB <= nextIndexOfBinA) {
-            if (!seen.has(idA)) { mergedIds.push(idA); seen.add(idA); }
-            i++;
-          } else {
-            if (!seen.has(idB)) { mergedIds.push(idB); seen.add(idB); }
-            j++;
-          }
-        }
-      }
-    } else if (i < idsA.length) {
-      const idA = idsA[i++];
-      if (!seen.has(idA)) { mergedIds.push(idA); seen.add(idA); }
-    } else {
-      const idB = idsB[j++];
-      if (!seen.has(idB)) { mergedIds.push(idB); seen.add(idB); }
-    }
-  }
-
-  const updatedA: WithState<A>[] = [];
-  const updatedB: WithState<B>[] = [];
-
-  for (const id of mergedIds) {
-    const itemA = mapA.get(id);
-    const itemB = mapB.get(id);
-    if (itemA && itemB) {
-      let state: ContainerState | undefined;
-      const newDisplayName = itemA?.upstreamLink?.isModified ? itemA?.name : itemB.displayName;
-      if (checkIsReadyToSync(itemA.upstreamLink!)) {
-        state = "modified";
-      }
-      updatedA.push({ ...itemA, state });
-      updatedB.push({ ...itemB, displayName: newDisplayName, state });
-    } else if (itemA && !itemB) {
-      updatedA.push({ ...itemA, state: "removed" });
-      updatedB.push({
-        displayName: itemA.name,
-        id: itemA.id,
-        containerType: itemA.blockType,
-        state: "removed",
-      } as WithState<B>);
-    } else if (!itemA && itemB) {
-      updatedA.push({
-        name: itemB.displayName,
-        id: itemB.id,
-        blockType: itemB.containerType,
-        state: "added",
-      } as WithState<A>);
-      updatedB.push({ ...itemB, state: "added" });
-    }
-  }
-
-  return [updatedA, updatedB];
-}
-
-
 export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBlockId }: Props) => {
   const { data, isLoading } = useCourseContainerChildren(downstreamBlockId);
   const { data: libData, isLoading: libLoading } = useContainerChildren(upstreamBlockId, true) as UseQueryResult<Container[], Error>;;
 
   const result = useCallback(
-    () => stableMergeWithState(data?.children || [], libData || []),
+    () => diffPreviewContainerChildren(data?.children || [], libData || []),
     [data, libData]
   );
 

--- a/src/container-comparison/CompareContainersWidget.tsx
+++ b/src/container-comparison/CompareContainersWidget.tsx
@@ -163,6 +163,7 @@ export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBloc
 
   const onBackBtnClick = () => {
     setCurrentContainerState((prev) => {
+      // istanbul ignore if: this should never happen
       if (prev.parent.length < 1) {
         return prev;
       }

--- a/src/container-comparison/CompareContainersWidget.tsx
+++ b/src/container-comparison/CompareContainersWidget.tsx
@@ -1,4 +1,4 @@
-import { Stack } from "@openedx/paragon";
+import { Card } from "@openedx/paragon";
 import { UseQueryResult } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { LoadingSpinner } from "../generic/Loading";
@@ -34,6 +34,7 @@ export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBloc
         title={child.name}
         containerType={child.blockType}
         state={child.state}
+        side="Before"
       />
     ))
   }, [isLoading, result]);
@@ -48,18 +49,27 @@ export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBloc
         title={child.displayName}
         containerType={child.containerType}
         state={child.state}
+        side="After"
       />
     ))
   }, [libLoading, isLoading, result]);
 
   return (
-    <Stack direction="horizontal" gap={3}>
-      <ChildrenPreview title={title} side="Before">
-        {renderBeforeChildren()}
-      </ChildrenPreview>
-      <ChildrenPreview title={title} side="After">
-        {renderAfterChildren()}
-      </ChildrenPreview>
-    </Stack>
+    <div className="row">
+      <div className="col col-6 p-1">
+        <Card className="p-4">
+          <ChildrenPreview title={title} side="Before">
+            {renderBeforeChildren()}
+          </ChildrenPreview>
+        </Card>
+      </div>
+      <div className="col col-6 p-1">
+        <Card className="p-4">
+          <ChildrenPreview title={title} side="After">
+            {renderAfterChildren()}
+          </ChildrenPreview>
+        </Card>
+      </div>
+    </div>
   )
 }

--- a/src/container-comparison/CompareContainersWidget.tsx
+++ b/src/container-comparison/CompareContainersWidget.tsx
@@ -34,6 +34,7 @@ export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBloc
         title={child.name}
         containerType={child.blockType}
         state={child.state}
+        originalName={child.originalName}
         side="Before"
       />
     ))

--- a/src/container-comparison/CompareContainersWidget.tsx
+++ b/src/container-comparison/CompareContainersWidget.tsx
@@ -3,13 +3,14 @@ import {
 } from '@openedx/paragon';
 import { ArrowBack } from '@openedx/paragon/icons';
 import { useCallback, useMemo, useState } from 'react';
+import { ContainerType } from '../generic/key-utils';
 import { LoadingSpinner } from '../generic/Loading';
 import { useContainerChildren } from '../library-authoring/data/apiHooks';
 import ChildrenPreview from './ChildrenPreview';
 import ContainerRow from './ContainerRow';
 import { useCourseContainerChildren } from './data/apiHooks';
 import { ContainerChild, ContainerChildBase, WithState } from './types';
-import { diffPreviewContainerChildren } from './utils';
+import { diffPreviewContainerChildren, isRowClickable } from './utils';
 
 interface ContainerInfoProps {
   title: string;
@@ -142,7 +143,7 @@ export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBloc
   });
 
   const onRowClick = (row: WithState<ContainerChild>) => {
-    if (!row.downstreamId || !row.id || row.state !== 'modified') {
+    if (!isRowClickable(row.state, row.blockType as ContainerType)) {
       return;
     }
 
@@ -151,9 +152,9 @@ export const CompareContainersWidget = ({ title, upstreamBlockId, downstreamBloc
       upstreamBlockId: row.id!,
       downstreamBlockId: row.downstreamId!,
       parent: [...prev.parent, {
-        title,
-        upstreamBlockId,
-        downstreamBlockId,
+        title: prev.title,
+        upstreamBlockId: prev.upstreamBlockId,
+        downstreamBlockId: prev.downstreamBlockId,
       }],
     }));
   };

--- a/src/container-comparison/ContainerRow.test.tsx
+++ b/src/container-comparison/ContainerRow.test.tsx
@@ -1,7 +1,9 @@
-import userEvent from "@testing-library/user-event";
-import { fireEvent, initializeMocks, render, screen } from "../testUtils";
-import ContainerRow from "./ContainerRow";
-import messages from "./messages";
+import userEvent from '@testing-library/user-event';
+import {
+  fireEvent, initializeMocks, render, screen,
+} from '../testUtils';
+import ContainerRow from './ContainerRow';
+import messages from './messages';
 
 describe('<ContainerRow />', () => {
   beforeEach(() => {
@@ -16,14 +18,14 @@ describe('<ContainerRow />', () => {
   test('renders with modified state', async () => {
     render(<ContainerRow title="Test title" containerType="subsection" side="Before" state="modified" />);
     expect(await screen.findByText(
-      messages.modifiedDiffBeforeMessage.defaultMessage.replace('{blockType}', 'subsection')
+      messages.modifiedDiffBeforeMessage.defaultMessage.replace('{blockType}', 'subsection'),
     )).toBeInTheDocument();
   });
 
   test('renders with removed state', async () => {
     render(<ContainerRow title="Test title" containerType="subsection" side="After" state="removed" />);
     expect(await screen.findByText(
-      messages.removedDiffAfterMessage.defaultMessage.replace('{blockType}', 'subsection')
+      messages.removedDiffAfterMessage.defaultMessage.replace('{blockType}', 'subsection'),
     )).toBeInTheDocument();
   });
 
@@ -72,7 +74,7 @@ describe('<ContainerRow />', () => {
     const card = titleDiv.closest('.clickable');
     expect(card).not.toBe(null);
     fireEvent.select(card!);
-    await user.keyboard("{enter}");
+    await user.keyboard('{enter}');
     expect(onClick).toHaveBeenCalled();
   });
 
@@ -84,14 +86,14 @@ describe('<ContainerRow />', () => {
   test('renders with moved state', async () => {
     render(<ContainerRow title="Test title" containerType="subsection" side="After" state="moved" />);
     expect(await screen.findByText(
-      messages.movedDiffAfterMessage.defaultMessage.replace('{blockType}', 'subsection')
+      messages.movedDiffAfterMessage.defaultMessage.replace('{blockType}', 'subsection'),
     )).toBeInTheDocument();
   });
 
   test('renders with added state', async () => {
     render(<ContainerRow title="Test title" containerType="subsection" side="After" state="added" />);
     expect(await screen.findByText(
-      messages.addedDiffAfterMessage.defaultMessage.replace('{blockType}', 'subsection')
+      messages.addedDiffAfterMessage.defaultMessage.replace('{blockType}', 'subsection'),
     )).toBeInTheDocument();
   });
-})
+});

--- a/src/container-comparison/ContainerRow.test.tsx
+++ b/src/container-comparison/ContainerRow.test.tsx
@@ -1,0 +1,97 @@
+import userEvent from "@testing-library/user-event";
+import { fireEvent, initializeMocks, render, screen } from "../testUtils";
+import ContainerRow from "./ContainerRow";
+import messages from "./messages";
+
+describe('<ContainerRow />', () => {
+  beforeEach(() => {
+    initializeMocks();
+  });
+
+  test('renders with default props', async () => {
+    render(<ContainerRow title="Test title" containerType="subsection" side="Before" />);
+    expect(await screen.findByText('Test title')).toBeInTheDocument();
+  });
+
+  test('renders with modified state', async () => {
+    render(<ContainerRow title="Test title" containerType="subsection" side="Before" state="modified" />);
+    expect(await screen.findByText(
+      messages.modifiedDiffBeforeMessage.defaultMessage.replace('{blockType}', 'subsection')
+    )).toBeInTheDocument();
+  });
+
+  test('renders with removed state', async () => {
+    render(<ContainerRow title="Test title" containerType="subsection" side="After" state="removed" />);
+    expect(await screen.findByText(
+      messages.removedDiffAfterMessage.defaultMessage.replace('{blockType}', 'subsection')
+    )).toBeInTheDocument();
+  });
+
+  test('is not clickable when state !== modified', async () => {
+    const onClick = jest.fn();
+    render(<ContainerRow
+      title="Test title"
+      containerType="subsection"
+      side="Before"
+      state="removed"
+      onClick={onClick}
+    />);
+    const titleDiv = await screen.findByText('Test title');
+    const card = titleDiv.closest('.clickable');
+    expect(card).toBe(null);
+  });
+
+  test('calls onClick when clicked', async () => {
+    const onClick = jest.fn();
+    const user = userEvent.setup();
+    render(<ContainerRow
+      title="Test title"
+      containerType="subsection"
+      side="Before"
+      state="modified"
+      onClick={onClick}
+    />);
+    const titleDiv = await screen.findByText('Test title');
+    const card = titleDiv.closest('.clickable');
+    expect(card).not.toBe(null);
+    await user.click(card!);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  test('calls onClick when pressed enter or space', async () => {
+    const onClick = jest.fn();
+    const user = userEvent.setup();
+    render(<ContainerRow
+      title="Test title"
+      containerType="subsection"
+      side="Before"
+      state="modified"
+      onClick={onClick}
+    />);
+    const titleDiv = await screen.findByText('Test title');
+    const card = titleDiv.closest('.clickable');
+    expect(card).not.toBe(null);
+    fireEvent.select(card!);
+    await user.keyboard("{enter}");
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  test('renders with originalName', async () => {
+    render(<ContainerRow title="Test title" containerType="subsection" side="Before" state="locallyRenamed" originalName="Modified name" />);
+    expect(await screen.findByText(messages.renamedDiffBeforeMessage.defaultMessage.replace('{name}', 'Modified name'))).toBeInTheDocument();
+  });
+
+  test('renders with moved state', async () => {
+    render(<ContainerRow title="Test title" containerType="subsection" side="After" state="moved" />);
+    expect(await screen.findByText(
+      messages.movedDiffAfterMessage.defaultMessage.replace('{blockType}', 'subsection')
+    )).toBeInTheDocument();
+  });
+
+  test('renders with added state', async () => {
+    render(<ContainerRow title="Test title" containerType="subsection" side="After" state="added" />);
+    expect(await screen.findByText(
+      messages.addedDiffAfterMessage.defaultMessage.replace('{blockType}', 'subsection')
+    )).toBeInTheDocument();
+  });
+})

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -92,7 +92,7 @@ const ContainerRow = ({
             )}
           </Stack>
           <ActionRow.Spacer />
-          {isClickable && <Icon size='md' src={ChevronRight} />}
+          {isClickable && <Icon size="md" src={ChevronRight} />}
         </ActionRow>
       </Stack>
     </Card>

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -1,32 +1,74 @@
 import { ActionRow, Icon, Stack } from "@openedx/paragon";
+import type { MessageDescriptor } from 'react-intl';
 import { getItemIcon } from "../generic/block-type-utils";
 import { ContainerType } from "../generic/key-utils";
 import { COMPONENT_TYPES } from '@src/generic/block-type-utils/constants';
+import { useMemo } from "react";
+import { Cached, Delete, Done, Plus } from "@openedx/paragon/icons";
+import messages from './messages';
+import { FormattedMessage } from "@edx/frontend-platform/i18n";
 
-export type ContainerState = "removed" | "added" | "modified" | "moved";
+export type ContainerState = "removed" | "added" | "modified" | "renamed" | "moved";
 
 export interface ContainerRowProps {
   title: string;
   containerType: ContainerType | keyof typeof COMPONENT_TYPES;
   state?: ContainerState;
-  tense?: "past" | "future";
+  side: "Before" | "After";
   onClick?: () => void;
 }
 
-const ContainerRow = ({ title, containerType, state, tense, onClick }: ContainerRowProps) => {
+const ContainerRow = ({ title, containerType, state, side, onClick }: ContainerRowProps) => {
+  const stateContext = useMemo(() => {
+    let message: MessageDescriptor | undefined;
+    switch (state) {
+      case "added":
+        message = side === "Before" ? messages.addedDiffBeforeMessage : messages.addedDiffAfterMessage;
+        return ["text-white bg-success-500", Plus, message];
+      case "modified":
+        message = side === "Before" ? messages.modifiedDiffBeforeMessage : messages.modifiedDiffAfterMessage;
+        return ["text-white bg-warning-800", Cached, message];
+      case "removed":
+        message = side === "Before" ? messages.removedDiffBeforeMessage : messages.removedDiffAfterMessage;
+        return ["text-white bg-danger-600", Delete, message];
+      case "renamed":
+        message = side === "Before" ? messages.renamedDiffBeforeMessage : messages.renamedDiffAfterMessage;
+        return ["bg-light-300 text-light-300", Done, message];
+      case "moved":
+        message = side === "Before" ? messages.movedDiffBeforeMessage : messages.movedDiffAfterMessage;
+        return ["bg-light-300 text-light-300", Done, message];
+      default:
+        return ["bg-light-300 text-light-300", Done, message];
+    }
+  }, [state, side]);
+
   return (
-    <ActionRow onClick={onClick}>
-      {state}
-      <Stack direction="horizontal" gap={2}>
-        <Icon
-          src={getItemIcon(containerType.toString())}
-          screenReaderText={containerType.toString()}
-          title={title}
-        />
-        <span>{title}</span>
-      </Stack>
-      {tense}
+    <Stack direction="horizontal" gap={0} className="mb-2 rounded shadow-sm border border-light-100">
+      <div
+        className={`px-1 align-self-stretch align-content-center rounded-left ${stateContext[0]}`}
+      >
+        <Icon size="sm" src={stateContext[1]} />
+      </div>
+      <ActionRow onClick={onClick} className="p-2">
+        <Stack direction="vertical" gap={3}>
+          <Stack direction="horizontal" gap={2}>
+            <Icon
+              src={getItemIcon(containerType)}
+              screenReaderText={containerType}
+              title={title}
+            />
+            <span className="small font-weight-bold">{title}</span>
+          </Stack>
+          {stateContext[2] && <span className="micro">
+          <FormattedMessage {...stateContext[2]} values={{
+            blockType: containerType,
+            name: title,
+          }} />
+          </span>}
+        </Stack>
+        <ActionRow.Spacer />
     </ActionRow>
+    </Stack>
   )
 }
 

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -7,10 +7,10 @@ import {
   Cached, Delete, Done, Plus,
 } from '@openedx/paragon/icons';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { getItemIcon } from '@src/generic/block-type-utils';
+import { ContainerType } from '@src/generic/key-utils';
+import { COMPONENT_TYPES } from '@src/generic/block-type-utils/constants';
 import messages from './messages';
-import { getItemIcon } from '../generic/block-type-utils';
-import { ContainerType } from '../generic/key-utils';
-import { COMPONENT_TYPES } from '../generic/block-type-utils/constants';
 import { ContainerState } from './types';
 import { isRowClickable } from './utils';
 

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -1,16 +1,15 @@
-import { ActionRow, Icon, Stack } from '@openedx/paragon';
+import { ActionRow, Card, Icon, Stack } from '@openedx/paragon';
 import type { MessageDescriptor } from 'react-intl';
-import { COMPONENT_TYPES } from '@src/generic/block-type-utils/constants';
 import { useMemo } from 'react';
 import {
   Cached, Delete, Done, Plus,
 } from '@openedx/paragon/icons';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import messages from './messages';
-import { ContainerType } from '../generic/key-utils';
 import { getItemIcon } from '../generic/block-type-utils';
-
-export type ContainerState = 'removed' | 'added' | 'modified' | 'renamed' | 'moved';
+import { ContainerType } from '../generic/key-utils';
+import { COMPONENT_TYPES } from '../generic/block-type-utils/constants';
+import { ContainerState } from './types';
 
 export interface ContainerRowProps {
   title: string;
@@ -48,39 +47,50 @@ const ContainerRow = ({
   }, [state, side]);
 
   return (
-    <Stack onClick={onClick} direction="horizontal" gap={0} className="mb-2 rounded shadow-sm border border-light-100">
-      <div
-        className={`px-1 align-self-stretch align-content-center rounded-left ${stateContext[0]}`}
-      >
-        <Icon size="sm" src={stateContext[1]} />
-      </div>
-      <ActionRow className="p-2">
-        <Stack direction="vertical" gap={3}>
-          <Stack direction="horizontal" gap={2}>
-            <Icon
-              src={getItemIcon(containerType)}
-              screenReaderText={containerType}
-              title={title}
-            />
-            <span className="small font-weight-bold">{title}</span>
-          </Stack>
-          {stateContext[2] ? (
-            <span className="micro">
-              <FormattedMessage
-                {...stateContext[2]}
-                values={{
-                  blockType: containerType,
-                  name: originalName,
-                }}
+    <Card
+      isClickable={state==="modified"}
+      onClick={onClick}
+      onKeyDown={(e: KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          onClick?.();
+        }
+      }}
+      className="mb-2 rounded shadow-sm border border-light-100"
+    >
+      <Stack direction="horizontal" gap={0}>
+        <div
+          className={`px-1 align-self-stretch align-content-center rounded-left ${stateContext[0]}`}
+        >
+          <Icon size="sm" src={stateContext[1]} />
+        </div>
+        <ActionRow className="p-2">
+          <Stack direction="vertical" gap={3}>
+            <Stack direction="horizontal" gap={2}>
+              <Icon
+                src={getItemIcon(containerType)}
+                screenReaderText={containerType}
+                title={title}
               />
-            </span>
-          ) : (
-            <span className="micro">&nbsp;</span>
-          )}
-        </Stack>
-        <ActionRow.Spacer />
-      </ActionRow>
-    </Stack>
+              <span className="small font-weight-bold">{title}</span>
+            </Stack>
+            {stateContext[2] ? (
+              <span className="micro">
+                <FormattedMessage
+                  {...stateContext[2]}
+                  values={{
+                    blockType: containerType,
+                    name: originalName,
+                  }}
+                />
+              </span>
+            ) : (
+                <span className="micro">&nbsp;</span>
+              )}
+          </Stack>
+          <ActionRow.Spacer />
+        </ActionRow>
+      </Stack>
+    </Card>
   );
 };
 

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -15,10 +15,11 @@ export interface ContainerRowProps {
   containerType: ContainerType | keyof typeof COMPONENT_TYPES;
   state?: ContainerState;
   side: "Before" | "After";
+  originalName?: string;
   onClick?: () => void;
 }
 
-const ContainerRow = ({ title, containerType, state, side, onClick }: ContainerRowProps) => {
+const ContainerRow = ({ title, containerType, state, side, originalName, onClick }: ContainerRowProps) => {
   const stateContext = useMemo(() => {
     let message: MessageDescriptor | undefined;
     switch (state) {
@@ -33,7 +34,7 @@ const ContainerRow = ({ title, containerType, state, side, onClick }: ContainerR
         return ["text-white bg-danger-600", Delete, message];
       case "renamed":
         message = side === "Before" ? messages.renamedDiffBeforeMessage : messages.renamedDiffAfterMessage;
-        return ["bg-light-300 text-light-300", Done, message];
+        return ["bg-light-300 text-light-300 ", Done, message];
       case "moved":
         message = side === "Before" ? messages.movedDiffBeforeMessage : messages.movedDiffAfterMessage;
         return ["bg-light-300 text-light-300", Done, message];
@@ -43,13 +44,13 @@ const ContainerRow = ({ title, containerType, state, side, onClick }: ContainerR
   }, [state, side]);
 
   return (
-    <Stack direction="horizontal" gap={0} className="mb-2 rounded shadow-sm border border-light-100">
+    <Stack onClick={onClick} direction="horizontal" gap={0} className="mb-2 rounded shadow-sm border border-light-100">
       <div
         className={`px-1 align-self-stretch align-content-center rounded-left ${stateContext[0]}`}
       >
         <Icon size="sm" src={stateContext[1]} />
       </div>
-      <ActionRow onClick={onClick} className="p-2">
+      <ActionRow className="p-2">
         <Stack direction="vertical" gap={3}>
           <Stack direction="horizontal" gap={2}>
             <Icon
@@ -62,7 +63,7 @@ const ContainerRow = ({ title, containerType, state, side, onClick }: ContainerR
           {stateContext[2] && <span className="micro">
           <FormattedMessage {...stateContext[2]} values={{
             blockType: containerType,
-            name: title,
+            name: originalName,
           }} />
           </span>}
         </Stack>

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -1,45 +1,49 @@
-import { ActionRow, Icon, Stack } from "@openedx/paragon";
+import { ActionRow, Icon, Stack } from '@openedx/paragon';
 import type { MessageDescriptor } from 'react-intl';
-import { getItemIcon } from "../generic/block-type-utils";
-import { ContainerType } from "../generic/key-utils";
 import { COMPONENT_TYPES } from '@src/generic/block-type-utils/constants';
-import { useMemo } from "react";
-import { Cached, Delete, Done, Plus } from "@openedx/paragon/icons";
+import { useMemo } from 'react';
+import {
+  Cached, Delete, Done, Plus,
+} from '@openedx/paragon/icons';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import messages from './messages';
-import { FormattedMessage } from "@edx/frontend-platform/i18n";
+import { ContainerType } from '../generic/key-utils';
+import { getItemIcon } from '../generic/block-type-utils';
 
-export type ContainerState = "removed" | "added" | "modified" | "renamed" | "moved";
+export type ContainerState = 'removed' | 'added' | 'modified' | 'renamed' | 'moved';
 
 export interface ContainerRowProps {
   title: string;
   containerType: ContainerType | keyof typeof COMPONENT_TYPES;
   state?: ContainerState;
-  side: "Before" | "After";
+  side: 'Before' | 'After';
   originalName?: string;
   onClick?: () => void;
 }
 
-const ContainerRow = ({ title, containerType, state, side, originalName, onClick }: ContainerRowProps) => {
+const ContainerRow = ({
+  title, containerType, state, side, originalName, onClick,
+}: ContainerRowProps) => {
   const stateContext = useMemo(() => {
     let message: MessageDescriptor | undefined;
     switch (state) {
-      case "added":
-        message = side === "Before" ? messages.addedDiffBeforeMessage : messages.addedDiffAfterMessage;
-        return ["text-white bg-success-500", Plus, message];
-      case "modified":
-        message = side === "Before" ? messages.modifiedDiffBeforeMessage : messages.modifiedDiffAfterMessage;
-        return ["text-white bg-warning-800", Cached, message];
-      case "removed":
-        message = side === "Before" ? messages.removedDiffBeforeMessage : messages.removedDiffAfterMessage;
-        return ["text-white bg-danger-600", Delete, message];
-      case "renamed":
-        message = side === "Before" ? messages.renamedDiffBeforeMessage : messages.renamedDiffAfterMessage;
-        return ["bg-light-300 text-light-300 ", Done, message];
-      case "moved":
-        message = side === "Before" ? messages.movedDiffBeforeMessage : messages.movedDiffAfterMessage;
-        return ["bg-light-300 text-light-300", Done, message];
+      case 'added':
+        message = side === 'Before' ? messages.addedDiffBeforeMessage : messages.addedDiffAfterMessage;
+        return ['text-white bg-success-500', Plus, message];
+      case 'modified':
+        message = side === 'Before' ? messages.modifiedDiffBeforeMessage : messages.modifiedDiffAfterMessage;
+        return ['text-white bg-warning-800', Cached, message];
+      case 'removed':
+        message = side === 'Before' ? messages.removedDiffBeforeMessage : messages.removedDiffAfterMessage;
+        return ['text-white bg-danger-600', Delete, message];
+      case 'renamed':
+        message = side === 'Before' ? messages.renamedDiffBeforeMessage : messages.renamedDiffAfterMessage;
+        return ['bg-light-300 text-light-300 ', Done, message];
+      case 'moved':
+        message = side === 'Before' ? messages.movedDiffBeforeMessage : messages.movedDiffAfterMessage;
+        return ['bg-light-300 text-light-300', Done, message];
       default:
-        return ["bg-light-300 text-light-300", Done, message];
+        return ['bg-light-300 text-light-300', Done, message];
     }
   }, [state, side]);
 
@@ -62,19 +66,22 @@ const ContainerRow = ({ title, containerType, state, side, originalName, onClick
           </Stack>
           {stateContext[2] ? (
             <span className="micro">
-              <FormattedMessage {...stateContext[2]} values={{
-                blockType: containerType,
-                name: originalName,
-              }} />
+              <FormattedMessage
+                {...stateContext[2]}
+                values={{
+                  blockType: containerType,
+                  name: originalName,
+                }}
+              />
             </span>
-          ): (
+          ) : (
             <span className="micro">&nbsp;</span>
           )}
         </Stack>
         <ActionRow.Spacer />
-    </ActionRow>
+      </ActionRow>
     </Stack>
-  )
-}
+  );
+};
 
-export default ContainerRow
+export default ContainerRow;

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -3,11 +3,11 @@ import { getItemIcon } from "../generic/block-type-utils";
 import { ContainerType } from "../generic/key-utils";
 import { COMPONENT_TYPES } from '@src/generic/block-type-utils/constants';
 
-export type ContainerState = "removed" | "added" | "modified";
+export type ContainerState = "removed" | "added" | "modified" | "moved";
 
 export interface ContainerRowProps {
   title: string;
-  containerType: ContainerType | typeof COMPONENT_TYPES;
+  containerType: ContainerType | keyof typeof COMPONENT_TYPES;
   state?: ContainerState;
   tense?: "past" | "future";
   onClick?: () => void;

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -14,7 +14,7 @@ export type ContainerState = 'removed' | 'added' | 'modified' | 'renamed' | 'mov
 
 export interface ContainerRowProps {
   title: string;
-  containerType: ContainerType | keyof typeof COMPONENT_TYPES;
+  containerType: ContainerType | keyof typeof COMPONENT_TYPES | string;
   state?: ContainerState;
   side: 'Before' | 'After';
   originalName?: string;

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -12,6 +12,7 @@ import { getItemIcon } from '../generic/block-type-utils';
 import { ContainerType } from '../generic/key-utils';
 import { COMPONENT_TYPES } from '../generic/block-type-utils/constants';
 import { ContainerState } from './types';
+import { isRowClickable } from './utils';
 
 export interface ContainerRowProps {
   title: string;
@@ -37,7 +38,7 @@ const ContainerRow = ({
       case 'removed':
         message = side === 'Before' ? messages.removedDiffBeforeMessage : messages.removedDiffAfterMessage;
         return ['text-white bg-danger-600', Delete, message];
-      case 'renamed':
+      case 'locallyRenamed':
         message = side === 'Before' ? messages.renamedDiffBeforeMessage : messages.renamedDiffAfterMessage;
         return ['bg-light-300 text-light-300 ', Done, message];
       case 'moved':
@@ -50,7 +51,7 @@ const ContainerRow = ({
 
   return (
     <Card
-      isClickable={state === 'modified'}
+      isClickable={isRowClickable(state, containerType)}
       onClick={onClick}
       onKeyDown={(e: KeyboardEvent) => {
         if (e.key === 'Enter' || e.key === ' ') {

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -1,0 +1,33 @@
+import { ActionRow, Icon, Stack } from "@openedx/paragon";
+import { getItemIcon } from "../generic/block-type-utils";
+import { ContainerType } from "../generic/key-utils";
+import { COMPONENT_TYPES } from '@src/generic/block-type-utils/constants';
+
+export type ContainerState = "removed" | "added" | "modified";
+
+export interface ContainerRowProps {
+  title: string;
+  containerType: ContainerType | typeof COMPONENT_TYPES;
+  state?: ContainerState;
+  tense?: "past" | "future";
+  onClick?: () => void;
+}
+
+const ContainerRow = ({ title, containerType, state, tense, onClick }: ContainerRowProps) => {
+  return (
+    <ActionRow onClick={onClick}>
+      {state}
+      <Stack direction="horizontal" gap={2}>
+        <Icon
+          src={getItemIcon(containerType.toString())}
+          screenReaderText={containerType.toString()}
+          title={title}
+        />
+        <span>{title}</span>
+      </Stack>
+      {tense}
+    </ActionRow>
+  )
+}
+
+export default ContainerRow

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -4,7 +4,7 @@ import {
 import type { MessageDescriptor } from 'react-intl';
 import { useMemo } from 'react';
 import {
-  Cached, Delete, Done, Plus,
+  Cached, ChevronRight, Delete, Done, Plus,
 } from '@openedx/paragon/icons';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { getItemIcon } from '@src/generic/block-type-utils';
@@ -26,6 +26,7 @@ export interface ContainerRowProps {
 const ContainerRow = ({
   title, containerType, state, side, originalName, onClick,
 }: ContainerRowProps) => {
+  const isClickable = isRowClickable(state, containerType as ContainerType);
   const stateContext = useMemo(() => {
     let message: MessageDescriptor | undefined;
     switch (state) {
@@ -34,7 +35,7 @@ const ContainerRow = ({
         return ['text-white bg-success-500', Plus, message];
       case 'modified':
         message = side === 'Before' ? messages.modifiedDiffBeforeMessage : messages.modifiedDiffAfterMessage;
-        return ['text-white bg-warning-800', Cached, message];
+        return ['text-white bg-warning-900', Cached, message];
       case 'removed':
         message = side === 'Before' ? messages.removedDiffBeforeMessage : messages.removedDiffAfterMessage;
         return ['text-white bg-danger-600', Delete, message];
@@ -51,7 +52,7 @@ const ContainerRow = ({
 
   return (
     <Card
-      isClickable={isRowClickable(state, containerType as ContainerType)}
+      isClickable={isClickable}
       onClick={onClick}
       onKeyDown={(e: KeyboardEvent) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -67,7 +68,7 @@ const ContainerRow = ({
           <Icon size="sm" src={stateContext[1]} />
         </div>
         <ActionRow className="p-2">
-          <Stack direction="vertical" gap={3}>
+          <Stack direction="vertical" gap={2}>
             <Stack direction="horizontal" gap={2}>
               <Icon
                 src={getItemIcon(containerType)}
@@ -91,6 +92,7 @@ const ContainerRow = ({
             )}
           </Stack>
           <ActionRow.Spacer />
+          {isClickable && <Icon size='md' src={ChevronRight} />}
         </ActionRow>
       </Stack>
     </Card>

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -51,7 +51,7 @@ const ContainerRow = ({
 
   return (
     <Card
-      isClickable={isRowClickable(state, containerType)}
+      isClickable={isRowClickable(state, containerType as ContainerType)}
       onClick={onClick}
       onKeyDown={(e: KeyboardEvent) => {
         if (e.key === 'Enter' || e.key === ' ') {

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -1,4 +1,6 @@
-import { ActionRow, Card, Icon, Stack } from '@openedx/paragon';
+import {
+  ActionRow, Card, Icon, Stack,
+} from '@openedx/paragon';
 import type { MessageDescriptor } from 'react-intl';
 import { useMemo } from 'react';
 import {
@@ -48,7 +50,7 @@ const ContainerRow = ({
 
   return (
     <Card
-      isClickable={state==="modified"}
+      isClickable={state === 'modified'}
       onClick={onClick}
       onKeyDown={(e: KeyboardEvent) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -84,8 +86,8 @@ const ContainerRow = ({
                 />
               </span>
             ) : (
-                <span className="micro">&nbsp;</span>
-              )}
+              <span className="micro">&nbsp;</span>
+            )}
           </Stack>
           <ActionRow.Spacer />
         </ActionRow>

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -60,12 +60,16 @@ const ContainerRow = ({ title, containerType, state, side, originalName, onClick
             />
             <span className="small font-weight-bold">{title}</span>
           </Stack>
-          {stateContext[2] && <span className="micro">
-          <FormattedMessage {...stateContext[2]} values={{
-            blockType: containerType,
-            name: originalName,
-          }} />
-          </span>}
+          {stateContext[2] ? (
+            <span className="micro">
+              <FormattedMessage {...stateContext[2]} values={{
+                blockType: containerType,
+                name: originalName,
+              }} />
+            </span>
+          ): (
+            <span className="micro">&nbsp;</span>
+          )}
         </Stack>
         <ActionRow.Spacer />
     </ActionRow>

--- a/src/container-comparison/data/api.mock.ts
+++ b/src/container-comparison/data/api.mock.ts
@@ -1,5 +1,5 @@
-import { CourseContainerChildrenData } from '../../course-unit/data/types';
-import * as unitApi from '../../course-unit/data/api';
+import { CourseContainerChildrenData } from '@src/course-unit/data/types';
+import * as unitApi from '@src/course-unit/data/api';
 
 /**
  * Mock for `getLibraryContainerChildren()`

--- a/src/container-comparison/data/api.mock.ts
+++ b/src/container-comparison/data/api.mock.ts
@@ -1,0 +1,71 @@
+import { CourseContainerChildrenData } from '../../course-unit/data/types';
+import * as unitApi from '../../course-unit/data/api';
+
+/**
+ * Mock for `getLibraryContainerChildren()`
+ *
+ * This mock returns a fixed response for the given container ID.
+ */
+export async function mockGetCourseContainerChildren(containerId: string): Promise<CourseContainerChildrenData> {
+  let numChildren: number = 3;
+  let blockType: string;
+  switch (containerId) {
+    case mockGetCourseContainerChildren.unitId:
+      blockType = "text";
+      break;
+    case mockGetCourseContainerChildren.sectionId:
+      blockType = "subsection";
+      break;
+    case mockGetCourseContainerChildren.subsectionId:
+      blockType = "unit";
+      break;
+    case mockGetCourseContainerChildren.unitIdLoading:
+    case mockGetCourseContainerChildren.sectionIdLoading:
+    case mockGetCourseContainerChildren.subsectionIdLoading:
+      return new Promise(() => { });
+  }
+  const children = Array(numChildren).fill(mockGetCourseContainerChildren.childTemplate).map((child, idx) => (
+    {
+      ...child,
+      // Generate a unique ID for each child block to avoid "duplicate key" errors in tests
+      id: `block-v1:UNIX+UX1+2025_T3+type@${blockType}+block@${idx}`,
+      name: `${blockType} block ${idx}`,
+      blockType,
+      upstreamLink: {
+        upstreamRef: `lct:org1:Demo_course_generated:${blockType}:${blockType}-${idx}`,
+        versionSynced: 1,
+        versionAvailable: 2,
+        versionDeclined: null,
+        isModified: false,
+      },
+    }
+  ));
+  return Promise.resolve({
+    canPasteComponent:  true,
+    isPublished: false,
+    children,
+  });
+}
+mockGetCourseContainerChildren.unitId = 'block-v1:UNIX+UX1+2025_T3+type@unit+block@0';
+mockGetCourseContainerChildren.subsectionId = 'block-v1:UNIX+UX1+2025_T3+type@subsection+block@0';
+mockGetCourseContainerChildren.sectionId = 'block-v1:UNIX+UX1+2025_T3+type@section+block@0';
+mockGetCourseContainerChildren.unitIdLoading = 'block-v1:UNIX+UX1+2025_T3+type@unit+block@loading';
+mockGetCourseContainerChildren.subsectionIdLoading = 'block-v1:UNIX+UX1+2025_T3+type@subsection+block@loading';
+mockGetCourseContainerChildren.sectionIdLoading = 'block-v1:UNIX+UX1+2025_T3+type@section+block@loading';
+mockGetCourseContainerChildren.childTemplate = {
+  id: 'block-v1:UNIX+UX1+2025_T3+type@unit+block@1',
+  name: 'Unit 1 remote edit - local edit',
+  blockType: 'unit',
+  upstreamLink: {
+    upstreamRef: 'lct:UNIX:CS1:unit:unit-1-2a1741',
+    versionSynced: 1,
+    versionAvailable: 2,
+    versionDeclined: null,
+    isModified: false,
+  },
+};
+/** Apply this mock. Returns a spy object that can tell you if it's been called. */
+mockGetCourseContainerChildren.applyMock = () => {
+  jest.spyOn(unitApi, 'getCourseContainerChildren').mockImplementation(mockGetCourseContainerChildren);
+};
+

--- a/src/container-comparison/data/api.mock.ts
+++ b/src/container-comparison/data/api.mock.ts
@@ -7,22 +7,25 @@ import * as unitApi from '../../course-unit/data/api';
  * This mock returns a fixed response for the given container ID.
  */
 export async function mockGetCourseContainerChildren(containerId: string): Promise<CourseContainerChildrenData> {
-  let numChildren: number = 3;
+  const numChildren: number = 3;
   let blockType: string;
   switch (containerId) {
     case mockGetCourseContainerChildren.unitId:
-      blockType = "text";
+      blockType = 'text';
       break;
     case mockGetCourseContainerChildren.sectionId:
-      blockType = "subsection";
+      blockType = 'subsection';
       break;
     case mockGetCourseContainerChildren.subsectionId:
-      blockType = "unit";
+      blockType = 'unit';
       break;
     case mockGetCourseContainerChildren.unitIdLoading:
     case mockGetCourseContainerChildren.sectionIdLoading:
     case mockGetCourseContainerChildren.subsectionIdLoading:
       return new Promise(() => { });
+    default:
+      blockType = 'unit';
+      break;
   }
   const children = Array(numChildren).fill(mockGetCourseContainerChildren.childTemplate).map((child, idx) => (
     {
@@ -41,7 +44,7 @@ export async function mockGetCourseContainerChildren(containerId: string): Promi
     }
   ));
   return Promise.resolve({
-    canPasteComponent:  true,
+    canPasteComponent: true,
     isPublished: false,
     children,
   });
@@ -68,4 +71,3 @@ mockGetCourseContainerChildren.childTemplate = {
 mockGetCourseContainerChildren.applyMock = () => {
   jest.spyOn(unitApi, 'getCourseContainerChildren').mockImplementation(mockGetCourseContainerChildren);
 };
-

--- a/src/container-comparison/data/apiHooks.ts
+++ b/src/container-comparison/data/apiHooks.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { getCourseContainerChildren } from "../../course-unit/data/api";
+import { getCourseKey } from "../../generic/key-utils";
+
+export const containerComparisonQueryKeys = {
+  all: ['containerComparison'],
+  /**
+   * Base key for a course
+   */
+  course: (courseKey: string) => [...containerComparisonQueryKeys.all, courseKey],
+  /**
+   * Key for a single container
+   */
+  container: (usageKey: string) => {
+    const courseKey = getCourseKey(usageKey);
+    return [...containerComparisonQueryKeys.course(courseKey), usageKey];
+  },
+}
+
+export const useCourseContainerChildren = (usageKey?: string) => (
+  useQuery({
+    enabled: !!usageKey,
+    queryFn: () => getCourseContainerChildren(usageKey!),
+    queryKey: containerComparisonQueryKeys.container(usageKey!),
+  })
+);

--- a/src/container-comparison/data/apiHooks.ts
+++ b/src/container-comparison/data/apiHooks.ts
@@ -1,6 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
-import { getCourseContainerChildren } from "../../course-unit/data/api";
-import { getCourseKey } from "../../generic/key-utils";
+import { useQuery } from '@tanstack/react-query';
+import { getCourseContainerChildren } from '../../course-unit/data/api';
+import { getCourseKey } from '../../generic/key-utils';
 
 export const containerComparisonQueryKeys = {
   all: ['containerComparison'],
@@ -15,7 +15,7 @@ export const containerComparisonQueryKeys = {
     const courseKey = getCourseKey(usageKey);
     return [...containerComparisonQueryKeys.course(courseKey), usageKey];
   },
-}
+};
 
 export const useCourseContainerChildren = (usageKey?: string) => (
   useQuery({

--- a/src/container-comparison/data/apiHooks.ts
+++ b/src/container-comparison/data/apiHooks.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { getCourseContainerChildren } from '../../course-unit/data/api';
-import { getCourseKey } from '../../generic/key-utils';
+import { getCourseContainerChildren } from '@src/course-unit/data/api';
+import { getCourseKey } from '@src/generic/key-utils';
 
 export const containerComparisonQueryKeys = {
   all: ['containerComparison'],

--- a/src/container-comparison/index.scss
+++ b/src/container-comparison/index.scss
@@ -1,3 +1,0 @@
-.diff-container-row {
-  border-left: 14px solid gray !important;
-}

--- a/src/container-comparison/index.scss
+++ b/src/container-comparison/index.scss
@@ -1,0 +1,3 @@
+.diff-container-row {
+  border-left: 14px solid gray !important;
+}

--- a/src/container-comparison/messages.ts
+++ b/src/container-comparison/messages.ts
@@ -51,6 +51,21 @@ const messages = defineMessages({
     defaultMessage: 'This {blockType} was moved',
     description: 'Description for moved component in after section of diff preview',
   },
+  breadcrumbAriaLabel: {
+    id: 'course-authoring.container-comparison.diff.breadcrumb.ariaLabel',
+    defaultMessage: 'Title breadcrumb',
+    description: 'Aria label text for breadcrumb in diff preview',
+  },
+  diffBeforeTitle: {
+    id: 'course-authoring.container-comparison.diff.before.title',
+    defaultMessage: 'Before',
+    description: 'Before section title text',
+  },
+  diffAfterTitle: {
+    id: 'course-authoring.container-comparison.diff.after.title',
+    defaultMessage: 'After',
+    description: 'After section title text',
+  },
 });
 
 export default messages;

--- a/src/container-comparison/messages.ts
+++ b/src/container-comparison/messages.ts
@@ -1,0 +1,56 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  removedDiffBeforeMessage: {
+    id: 'course-authoring.container-comparison.diff.before.removed-message',
+    defaultMessage: 'This {blockType} will be removed in the new version',
+    description: 'Description for removed component in before section of diff preview',
+  },
+  removedDiffAfterMessage: {
+    id: 'course-authoring.container-comparison.diff.after.removed-message',
+    defaultMessage: 'This {blockType} was removed',
+    description: 'Description for removed component in after section of diff preview',
+  },
+  modifiedDiffBeforeMessage: {
+    id: 'course-authoring.container-comparison.diff.before.modified-message',
+    defaultMessage: 'This {blockType} will be modified',
+    description: 'Description for modified component in before section of diff preview',
+  },
+  modifiedDiffAfterMessage: {
+    id: 'course-authoring.container-comparison.diff.after.modified-message',
+    defaultMessage: 'This {blockType} was modified',
+    description: 'Description for modified component in after section of diff preview',
+  },
+  addedDiffBeforeMessage: {
+    id: 'course-authoring.container-comparison.diff.before.added-message',
+    defaultMessage: 'This {blockType} will be added in the new version',
+    description: 'Description for added component in before section of diff preview',
+  },
+  addedDiffAfterMessage: {
+    id: 'course-authoring.container-comparison.diff.after.added-message',
+    defaultMessage: 'This {blockType} was added',
+    description: 'Description for added component in after section of diff preview',
+  },
+  renamedDiffBeforeMessage: {
+    id: 'course-authoring.container-comparison.diff.before.renamed-message',
+    defaultMessage: 'Original Library Name: {name}',
+    description: 'Description for renamed component in before section of diff preview',
+  },
+  renamedDiffAfterMessage: {
+    id: 'course-authoring.container-comparison.diff.after.renamed-message',
+    defaultMessage: 'This {blockType} will remain renamed',
+    description: 'Description for renamed component in after section of diff preview',
+  },
+  movedDiffBeforeMessage: {
+    id: 'course-authoring.container-comparison.diff.before.moved-message',
+    defaultMessage: 'This {blockType} will be moved in the new version',
+    description: 'Description for moved component in before section of diff preview',
+  },
+  movedDiffAfterMessage: {
+    id: 'course-authoring.container-comparison.diff.after.moved-message',
+    defaultMessage: 'This {blockType} was moved',
+    description: 'Description for moved component in after section of diff preview',
+  },
+});
+
+export default messages;

--- a/src/container-comparison/types.ts
+++ b/src/container-comparison/types.ts
@@ -1,4 +1,4 @@
-import { UpstreamInfo } from '../data/types';
+import { UpstreamInfo } from '@src/data/types';
 
 export type ContainerState = 'removed' | 'added' | 'modified' | 'childrenModified' | 'locallyRenamed' | 'moved';
 

--- a/src/container-comparison/types.ts
+++ b/src/container-comparison/types.ts
@@ -1,4 +1,4 @@
-import { UpstreamInfo } from "../data/types";
+import { UpstreamInfo } from '../data/types';
 
 export type ContainerState = 'removed' | 'added' | 'modified' | 'renamed' | 'moved';
 

--- a/src/container-comparison/types.ts
+++ b/src/container-comparison/types.ts
@@ -22,3 +22,10 @@ export type ContainerChildBase = {
 } | {
   blockType: string;
 });
+
+export type ContainerChild = {
+  name: string;
+  id?: string;
+  downstreamId?: string;
+  blockType: string;
+}

--- a/src/container-comparison/types.ts
+++ b/src/container-comparison/types.ts
@@ -1,0 +1,24 @@
+import { UpstreamInfo } from "../data/types";
+
+export type ContainerState = 'removed' | 'added' | 'modified' | 'renamed' | 'moved';
+
+export type WithState<T> = T & { state?: ContainerState, originalName?: string };
+export type WithIndex<T> = T & { index: number };
+
+export type CourseContainerChildBase = {
+  name: string;
+  id: string;
+  upstreamLink: UpstreamInfo;
+  blockType: string;
+};
+
+export type ContainerChildBase = {
+  displayName: string;
+  id: string;
+  containerType?: string;
+  blockType?: string;
+} & ({
+  containerType: string;
+} | {
+  blockType: string;
+});

--- a/src/container-comparison/types.ts
+++ b/src/container-comparison/types.ts
@@ -1,6 +1,6 @@
 import { UpstreamInfo } from '../data/types';
 
-export type ContainerState = 'removed' | 'added' | 'modified' | 'renamed' | 'moved';
+export type ContainerState = 'removed' | 'added' | 'modified' | 'childrenModified' | 'locallyRenamed' | 'moved';
 
 export type WithState<T> = T & { state?: ContainerState, originalName?: string };
 export type WithIndex<T> = T & { index: number };
@@ -28,4 +28,4 @@ export type ContainerChild = {
   id?: string;
   downstreamId?: string;
   blockType: string;
-}
+};

--- a/src/container-comparison/utils.test.ts
+++ b/src/container-comparison/utils.test.ts
@@ -1,0 +1,281 @@
+import { diffPreviewContainerChildren, CourseContainerChildBase, ContainerChildBase } from "./utils";
+
+const getMockCourseContainerData = (
+  type: "added|deleted" | "moved|deleted" | "all"
+): [CourseContainerChildBase[], ContainerChildBase[]] => {
+  switch (type) {
+    case "moved|deleted":
+      return [
+        [
+          {
+            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@1",
+            name: 'Unit 1 remote edit - local edit',
+            blockType: 'vertical',
+            upstreamLink: {
+              upstreamRef: 'lct:UNIX:CS1:unit:unit-1-2a1741',
+              versionSynced: 11,
+              versionAvailable: 11,
+              versionDeclined: null,
+              isModified: true
+            }
+          },
+          {
+            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@2",
+            name: 'New unit remote edit',
+            blockType: 'vertical',
+            upstreamLink: {
+              upstreamRef: 'lct:UNIX:CS1:unit:new-unit-remote-7eb9d1',
+              versionSynced: 7,
+              versionAvailable: 7,
+              versionDeclined: null,
+              isModified: false
+            }
+          },
+          {
+            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@3",
+            name: 'Unit with tags',
+            blockType: 'vertical',
+            upstreamLink: {
+              upstreamRef: 'lct:UNIX:CS1:unit:unit-with-tags-bec5f9',
+              versionSynced: 2,
+              versionAvailable: 2,
+              versionDeclined: null,
+              isModified: false
+            }
+          },
+          {
+            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@4",
+            name: 'One more unit',
+            blockType: 'vertical',
+            upstreamLink: {
+              upstreamRef: 'lct:UNIX:CS1:unit:one-more-unit-745176',
+              versionSynced: 1,
+              versionAvailable: 1,
+              versionDeclined: null,
+              isModified: false
+            }
+          }
+        ],
+        [
+          {
+            id: 'lct:UNIX:CS1:unit:unit-with-tags-bec5f9',
+            displayName: 'Unit with tags',
+            containerType: 'unit'
+          },
+          {
+            id: 'lct:UNIX:CS1:unit:unit-1-2a1741',
+            displayName: 'Unit 1 remote edit 2',
+            containerType: 'unit'
+          },
+          {
+            id: 'lct:UNIX:CS1:unit:one-more-unit-745176',
+            displayName: 'One more unit',
+            containerType: 'unit'
+          }
+        ],
+      ] as [CourseContainerChildBase[], ContainerChildBase[]];
+    case "added|deleted":
+      return [
+        [
+          {
+            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@1",
+            name: 'Unit 1 remote edit - local edit',
+            blockType: 'vertical',
+            upstreamLink: {
+              upstreamRef: 'lct:UNIX:CS1:unit:unit-1-2a1741',
+              versionSynced: 11,
+              versionAvailable: 11,
+              versionDeclined: null,
+              isModified: true
+            }
+          },
+          {
+            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@2",
+            name: 'New unit remote edit',
+            blockType: 'vertical',
+            upstreamLink: {
+              upstreamRef: 'lct:UNIX:CS1:unit:new-unit-remote-7eb9d1',
+              versionSynced: 7,
+              versionAvailable: 7,
+              versionDeclined: null,
+              isModified: false
+            }
+          },
+          {
+            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@3",
+            name: 'Unit with tags',
+            blockType: 'vertical',
+            upstreamLink: {
+              upstreamRef: 'lct:UNIX:CS1:unit:unit-with-tags-bec5f9',
+              versionSynced: 2,
+              versionAvailable: 2,
+              versionDeclined: null,
+              isModified: false
+            }
+          },
+          {
+            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@4",
+            name: 'One more unit',
+            blockType: 'vertical',
+            upstreamLink: {
+              upstreamRef: 'lct:UNIX:CS1:unit:one-more-unit-745176',
+              versionSynced: 1,
+              versionAvailable: 1,
+              versionDeclined: null,
+              isModified: false
+            }
+          }
+        ],
+        [
+          {
+            id: 'lct:UNIX:CS1:unit:unit-1-2a1741',
+            displayName: 'Unit 1 remote edit 2',
+            containerType: 'unit'
+          },
+          {
+            id: 'lct:UNIX:CS1:unit:unit-with-tags-bec5f9',
+            displayName: 'Unit with tags',
+            containerType: 'unit'
+          },
+          {
+            id: 'lct:UNIX:CS1:unit:added-unit-1',
+            displayName: 'Added unit',
+            containerType: 'unit'
+          },
+          {
+            id: 'lct:UNIX:CS1:unit:one-more-unit-745176',
+            displayName: 'One more unit',
+            containerType: 'unit'
+          }
+        ],
+      ] as [CourseContainerChildBase[], ContainerChildBase[]];
+    case "all":
+      return [
+        [
+          {
+            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@1",
+            name: 'Unit 1 remote edit - local edit',
+            blockType: 'vertical',
+            upstreamLink: {
+              upstreamRef: 'lct:UNIX:CS1:unit:unit-1-2a1741',
+              versionSynced: 11,
+              versionAvailable: 11,
+              versionDeclined: null,
+              isModified: true
+            }
+          },
+          {
+            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@2",
+            name: 'New unit remote edit',
+            blockType: 'vertical',
+            upstreamLink: {
+              upstreamRef: 'lct:UNIX:CS1:unit:new-unit-remote-7eb9d1',
+              versionSynced: 7,
+              versionAvailable: 7,
+              versionDeclined: null,
+              isModified: false
+            }
+          },
+          {
+            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@3",
+            name: 'Unit with tags',
+            blockType: 'vertical',
+            upstreamLink: {
+              upstreamRef: 'lct:UNIX:CS1:unit:unit-with-tags-bec5f9',
+              versionSynced: 2,
+              versionAvailable: 2,
+              versionDeclined: null,
+              isModified: false
+            }
+          },
+          {
+            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@4",
+            name: 'One more unit',
+            blockType: 'vertical',
+            upstreamLink: {
+              upstreamRef: 'lct:UNIX:CS1:unit:one-more-unit-745176',
+              versionSynced: 1,
+              versionAvailable: 1,
+              versionDeclined: null,
+              isModified: false
+            }
+          }
+        ],
+        [
+          {
+            id: 'lct:UNIX:CS1:unit:unit-with-tags-bec5f9',
+            displayName: 'Unit with tags',
+            containerType: 'unit'
+          },
+          {
+            id: 'lct:UNIX:CS1:unit:added-unit-1',
+            displayName: 'Added unit',
+            containerType: 'unit'
+          },
+          {
+            id: 'lct:UNIX:CS1:unit:one-more-unit-745176',
+            displayName: 'One more unit',
+            containerType: 'unit'
+          },
+          {
+            id: 'lct:UNIX:CS1:unit:unit-1-2a1741',
+            displayName: 'Unit 1 remote edit 2',
+            containerType: 'unit'
+          },
+        ],
+      ] as [CourseContainerChildBase[], ContainerChildBase[]];
+    default:
+      throw new Error();
+  }
+}
+
+describe('diffPreviewContainerChildren', () => {
+  it('should handle moved and deleted', () => {
+    const [a, b] = getMockCourseContainerData("moved|deleted");
+    const result = diffPreviewContainerChildren(a as CourseContainerChildBase[], b);
+    expect(result[0].length).toEqual(result[1].length);
+    expect(result[0][0].state).toEqual('moved');
+    expect(result[1][0].state).toEqual('moved');
+    expect(result[0][1].state).toEqual('removed');
+    expect(result[1][1].state).toEqual('removed');
+    expect(result[1][2].displayName).toEqual(a[0].name);
+  });
+
+  it('should handle add and delete', () => {
+    const [a, b] = getMockCourseContainerData("added|deleted");
+    const result = diffPreviewContainerChildren(a as CourseContainerChildBase[], b);
+    expect(result[0].length).toEqual(result[1].length);
+    // No change, state=undefined
+    expect(result[0][0].state).toEqual(undefined);
+    expect(result[1][0].state).toEqual(undefined);
+
+    // Deleted entry
+    expect(result[0][1].state).toEqual('removed');
+    expect(result[1][1].state).toEqual('removed');
+    expect(result[1][0].displayName).toEqual(a[0].name);
+    expect(result[0][3].name).toEqual(result[1][3].displayName);
+    expect(result[0][3].state).toEqual('added');
+    expect(result[1][3].state).toEqual('added');
+  });
+
+  it('should handle add, delete and moved', () => {
+    const [a, b] = getMockCourseContainerData("all");
+    const result = diffPreviewContainerChildren(a as CourseContainerChildBase[], b);
+    expect(result[0].length).toEqual(result[1].length);
+    // Moved
+    expect(result[0][0].state).toEqual("moved");
+    expect(result[1][4].state).toEqual("moved");
+    expect(result[1][4].id).toEqual(result[0][0].upstreamLink.upstreamRef);
+
+    // Deleted entry
+    expect(result[0][1].state).toEqual('removed');
+    expect(result[1][1].state).toEqual('removed');
+    expect(result[1][1].displayName).toEqual(result[0][1].name);
+
+    // added entry
+    expect(result[0][3].state).toEqual('added');
+    // Since the first element was moved, newly added elements goes up by 1 index
+    expect(result[1][2].state).toEqual('added');
+    expect(result[1][2].id).toEqual(result[0][3].id);
+  });
+});

--- a/src/container-comparison/utils.test.ts
+++ b/src/container-comparison/utils.test.ts
@@ -236,8 +236,8 @@ describe('diffPreviewContainerChildren', () => {
     const result = diffPreviewContainerChildren(a as CourseContainerChildBase[], b);
     expect(result[0].length).toEqual(result[1].length);
     // renamed takes precendence over moved
-    expect(result[0][0].state).toEqual('renamed');
-    expect(result[1][2].state).toEqual('renamed');
+    expect(result[0][0].state).toEqual('locallyRenamed');
+    expect(result[1][2].state).toEqual('locallyRenamed');
     expect(result[0][1].state).toEqual('removed');
     expect(result[1][1].state).toEqual('removed');
     expect(result[1][2].name).toEqual(a[0].name);
@@ -248,9 +248,9 @@ describe('diffPreviewContainerChildren', () => {
     const result = diffPreviewContainerChildren(a as CourseContainerChildBase[], b);
     expect(result[0].length).toEqual(result[1].length);
     // No change, state=undefined
-    expect(result[0][0].state).toEqual('renamed');
+    expect(result[0][0].state).toEqual('locallyRenamed');
     expect(result[0][0].originalName).toEqual(b[0].displayName);
-    expect(result[1][0].state).toEqual('renamed');
+    expect(result[1][0].state).toEqual('locallyRenamed');
 
     // Deleted entry
     expect(result[0][1].state).toEqual('removed');
@@ -266,8 +266,8 @@ describe('diffPreviewContainerChildren', () => {
     const result = diffPreviewContainerChildren(a as CourseContainerChildBase[], b);
     expect(result[0].length).toEqual(result[1].length);
     // renamed takes precendence over moved
-    expect(result[0][0].state).toEqual('renamed');
-    expect(result[1][4].state).toEqual('renamed');
+    expect(result[0][0].state).toEqual('locallyRenamed');
+    expect(result[1][4].state).toEqual('locallyRenamed');
     expect(result[1][4].id).toEqual(result[0][0].id);
 
     // Deleted entry

--- a/src/container-comparison/utils.test.ts
+++ b/src/container-comparison/utils.test.ts
@@ -234,8 +234,9 @@ describe('diffPreviewContainerChildren', () => {
     const [a, b] = getMockCourseContainerData("moved|deleted");
     const result = diffPreviewContainerChildren(a as CourseContainerChildBase[], b);
     expect(result[0].length).toEqual(result[1].length);
-    expect(result[0][0].state).toEqual('moved');
-    expect(result[1][0].state).toEqual('moved');
+    // renamed takes precendence over moved
+    expect(result[0][0].state).toEqual('renamed');
+    expect(result[1][2].state).toEqual('renamed');
     expect(result[0][1].state).toEqual('removed');
     expect(result[1][1].state).toEqual('removed');
     expect(result[1][2].displayName).toEqual(a[0].name);
@@ -244,10 +245,13 @@ describe('diffPreviewContainerChildren', () => {
   it('should handle add and delete', () => {
     const [a, b] = getMockCourseContainerData("added|deleted");
     const result = diffPreviewContainerChildren(a as CourseContainerChildBase[], b);
+    // __AUTO_GENERATED_PRINT_VAR_START__
+    console.log("(anon)#(anon) result: ", result); // __AUTO_GENERATED_PRINT_VAR_END__
     expect(result[0].length).toEqual(result[1].length);
     // No change, state=undefined
-    expect(result[0][0].state).toEqual(undefined);
-    expect(result[1][0].state).toEqual(undefined);
+    expect(result[0][0].state).toEqual("renamed");
+    expect(result[0][0].originalName).toEqual(b[0].displayName);
+    expect(result[1][0].state).toEqual("renamed");
 
     // Deleted entry
     expect(result[0][1].state).toEqual('removed');
@@ -262,9 +266,9 @@ describe('diffPreviewContainerChildren', () => {
     const [a, b] = getMockCourseContainerData("all");
     const result = diffPreviewContainerChildren(a as CourseContainerChildBase[], b);
     expect(result[0].length).toEqual(result[1].length);
-    // Moved
-    expect(result[0][0].state).toEqual("moved");
-    expect(result[1][4].state).toEqual("moved");
+    // renamed takes precendence over moved
+    expect(result[0][0].state).toEqual("renamed");
+    expect(result[1][4].state).toEqual("renamed");
     expect(result[1][4].id).toEqual(result[0][0].upstreamLink.upstreamRef);
 
     // Deleted entry
@@ -273,9 +277,8 @@ describe('diffPreviewContainerChildren', () => {
     expect(result[1][1].displayName).toEqual(result[0][1].name);
 
     // added entry
-    expect(result[0][3].state).toEqual('added');
-    // Since the first element was moved, newly added elements goes up by 1 index
+    expect(result[0][2].state).toEqual('added');
     expect(result[1][2].state).toEqual('added');
-    expect(result[1][2].id).toEqual(result[0][3].id);
+    expect(result[1][2].id).toEqual(result[0][2].id);
   });
 });

--- a/src/container-comparison/utils.test.ts
+++ b/src/container-comparison/utils.test.ts
@@ -1,4 +1,5 @@
-import { diffPreviewContainerChildren, CourseContainerChildBase, ContainerChildBase } from './utils';
+import { ContainerChildBase, CourseContainerChildBase } from './types';
+import { diffPreviewContainerChildren } from './utils';
 
 const getMockCourseContainerData = (
   type: 'added|deleted' | 'moved|deleted' | 'all',

--- a/src/container-comparison/utils.test.ts
+++ b/src/container-comparison/utils.test.ts
@@ -1,7 +1,7 @@
 import { ContainerChildBase, CourseContainerChildBase } from './types';
 import { diffPreviewContainerChildren } from './utils';
 
-const getMockCourseContainerData = (
+export const getMockCourseContainerData = (
   type: 'added|deleted' | 'moved|deleted' | 'all',
 ): [CourseContainerChildBase[], ContainerChildBase[]] => {
   switch (type) {

--- a/src/container-comparison/utils.test.ts
+++ b/src/container-comparison/utils.test.ts
@@ -240,7 +240,7 @@ describe('diffPreviewContainerChildren', () => {
     expect(result[1][2].state).toEqual('renamed');
     expect(result[0][1].state).toEqual('removed');
     expect(result[1][1].state).toEqual('removed');
-    expect(result[1][2].displayName).toEqual(a[0].name);
+    expect(result[1][2].name).toEqual(a[0].name);
   });
 
   it('should handle add and delete', () => {
@@ -255,8 +255,8 @@ describe('diffPreviewContainerChildren', () => {
     // Deleted entry
     expect(result[0][1].state).toEqual('removed');
     expect(result[1][1].state).toEqual('removed');
-    expect(result[1][0].displayName).toEqual(a[0].name);
-    expect(result[0][3].name).toEqual(result[1][3].displayName);
+    expect(result[1][0].name).toEqual(a[0].name);
+    expect(result[0][3].name).toEqual(result[1][3].name);
     expect(result[0][3].state).toEqual('added');
     expect(result[1][3].state).toEqual('added');
   });
@@ -268,12 +268,12 @@ describe('diffPreviewContainerChildren', () => {
     // renamed takes precendence over moved
     expect(result[0][0].state).toEqual('renamed');
     expect(result[1][4].state).toEqual('renamed');
-    expect(result[1][4].id).toEqual(result[0][0].upstreamLink.upstreamRef);
+    expect(result[1][4].id).toEqual(result[0][0].id);
 
     // Deleted entry
     expect(result[0][1].state).toEqual('removed');
     expect(result[1][1].state).toEqual('removed');
-    expect(result[1][1].displayName).toEqual(result[0][1].name);
+    expect(result[1][1].name).toEqual(result[0][1].name);
 
     // added entry
     expect(result[0][2].state).toEqual('added');

--- a/src/container-comparison/utils.test.ts
+++ b/src/container-comparison/utils.test.ts
@@ -1,14 +1,14 @@
-import { diffPreviewContainerChildren, CourseContainerChildBase, ContainerChildBase } from "./utils";
+import { diffPreviewContainerChildren, CourseContainerChildBase, ContainerChildBase } from './utils';
 
 const getMockCourseContainerData = (
-  type: "added|deleted" | "moved|deleted" | "all"
+  type: 'added|deleted' | 'moved|deleted' | 'all',
 ): [CourseContainerChildBase[], ContainerChildBase[]] => {
   switch (type) {
-    case "moved|deleted":
+    case 'moved|deleted':
       return [
         [
           {
-            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@1",
+            id: 'block-v1:UNIX+UX1+2025_T3+type@vertical+block@1',
             name: 'Unit 1 remote edit - local edit',
             blockType: 'vertical',
             upstreamLink: {
@@ -16,11 +16,11 @@ const getMockCourseContainerData = (
               versionSynced: 11,
               versionAvailable: 11,
               versionDeclined: null,
-              isModified: true
-            }
+              isModified: true,
+            },
           },
           {
-            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@2",
+            id: 'block-v1:UNIX+UX1+2025_T3+type@vertical+block@2',
             name: 'New unit remote edit',
             blockType: 'vertical',
             upstreamLink: {
@@ -28,11 +28,11 @@ const getMockCourseContainerData = (
               versionSynced: 7,
               versionAvailable: 7,
               versionDeclined: null,
-              isModified: false
-            }
+              isModified: false,
+            },
           },
           {
-            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@3",
+            id: 'block-v1:UNIX+UX1+2025_T3+type@vertical+block@3',
             name: 'Unit with tags',
             blockType: 'vertical',
             upstreamLink: {
@@ -40,11 +40,11 @@ const getMockCourseContainerData = (
               versionSynced: 2,
               versionAvailable: 2,
               versionDeclined: null,
-              isModified: false
-            }
+              isModified: false,
+            },
           },
           {
-            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@4",
+            id: 'block-v1:UNIX+UX1+2025_T3+type@vertical+block@4',
             name: 'One more unit',
             blockType: 'vertical',
             upstreamLink: {
@@ -52,33 +52,33 @@ const getMockCourseContainerData = (
               versionSynced: 1,
               versionAvailable: 1,
               versionDeclined: null,
-              isModified: false
-            }
-          }
+              isModified: false,
+            },
+          },
         ],
         [
           {
             id: 'lct:UNIX:CS1:unit:unit-with-tags-bec5f9',
             displayName: 'Unit with tags',
-            containerType: 'unit'
+            containerType: 'unit',
           },
           {
             id: 'lct:UNIX:CS1:unit:unit-1-2a1741',
             displayName: 'Unit 1 remote edit 2',
-            containerType: 'unit'
+            containerType: 'unit',
           },
           {
             id: 'lct:UNIX:CS1:unit:one-more-unit-745176',
             displayName: 'One more unit',
-            containerType: 'unit'
-          }
+            containerType: 'unit',
+          },
         ],
       ] as [CourseContainerChildBase[], ContainerChildBase[]];
-    case "added|deleted":
+    case 'added|deleted':
       return [
         [
           {
-            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@1",
+            id: 'block-v1:UNIX+UX1+2025_T3+type@vertical+block@1',
             name: 'Unit 1 remote edit - local edit',
             blockType: 'vertical',
             upstreamLink: {
@@ -86,11 +86,11 @@ const getMockCourseContainerData = (
               versionSynced: 11,
               versionAvailable: 11,
               versionDeclined: null,
-              isModified: true
-            }
+              isModified: true,
+            },
           },
           {
-            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@2",
+            id: 'block-v1:UNIX+UX1+2025_T3+type@vertical+block@2',
             name: 'New unit remote edit',
             blockType: 'vertical',
             upstreamLink: {
@@ -98,11 +98,11 @@ const getMockCourseContainerData = (
               versionSynced: 7,
               versionAvailable: 7,
               versionDeclined: null,
-              isModified: false
-            }
+              isModified: false,
+            },
           },
           {
-            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@3",
+            id: 'block-v1:UNIX+UX1+2025_T3+type@vertical+block@3',
             name: 'Unit with tags',
             blockType: 'vertical',
             upstreamLink: {
@@ -110,11 +110,11 @@ const getMockCourseContainerData = (
               versionSynced: 2,
               versionAvailable: 2,
               versionDeclined: null,
-              isModified: false
-            }
+              isModified: false,
+            },
           },
           {
-            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@4",
+            id: 'block-v1:UNIX+UX1+2025_T3+type@vertical+block@4',
             name: 'One more unit',
             blockType: 'vertical',
             upstreamLink: {
@@ -122,38 +122,38 @@ const getMockCourseContainerData = (
               versionSynced: 1,
               versionAvailable: 1,
               versionDeclined: null,
-              isModified: false
-            }
-          }
+              isModified: false,
+            },
+          },
         ],
         [
           {
             id: 'lct:UNIX:CS1:unit:unit-1-2a1741',
             displayName: 'Unit 1 remote edit 2',
-            containerType: 'unit'
+            containerType: 'unit',
           },
           {
             id: 'lct:UNIX:CS1:unit:unit-with-tags-bec5f9',
             displayName: 'Unit with tags',
-            containerType: 'unit'
+            containerType: 'unit',
           },
           {
             id: 'lct:UNIX:CS1:unit:added-unit-1',
             displayName: 'Added unit',
-            containerType: 'unit'
+            containerType: 'unit',
           },
           {
             id: 'lct:UNIX:CS1:unit:one-more-unit-745176',
             displayName: 'One more unit',
-            containerType: 'unit'
-          }
+            containerType: 'unit',
+          },
         ],
       ] as [CourseContainerChildBase[], ContainerChildBase[]];
-    case "all":
+    case 'all':
       return [
         [
           {
-            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@1",
+            id: 'block-v1:UNIX+UX1+2025_T3+type@vertical+block@1',
             name: 'Unit 1 remote edit - local edit',
             blockType: 'vertical',
             upstreamLink: {
@@ -161,11 +161,11 @@ const getMockCourseContainerData = (
               versionSynced: 11,
               versionAvailable: 11,
               versionDeclined: null,
-              isModified: true
-            }
+              isModified: true,
+            },
           },
           {
-            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@2",
+            id: 'block-v1:UNIX+UX1+2025_T3+type@vertical+block@2',
             name: 'New unit remote edit',
             blockType: 'vertical',
             upstreamLink: {
@@ -173,11 +173,11 @@ const getMockCourseContainerData = (
               versionSynced: 7,
               versionAvailable: 7,
               versionDeclined: null,
-              isModified: false
-            }
+              isModified: false,
+            },
           },
           {
-            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@3",
+            id: 'block-v1:UNIX+UX1+2025_T3+type@vertical+block@3',
             name: 'Unit with tags',
             blockType: 'vertical',
             upstreamLink: {
@@ -185,11 +185,11 @@ const getMockCourseContainerData = (
               versionSynced: 2,
               versionAvailable: 2,
               versionDeclined: null,
-              isModified: false
-            }
+              isModified: false,
+            },
           },
           {
-            id: "block-v1:UNIX+UX1+2025_T3+type@vertical+block@4",
+            id: 'block-v1:UNIX+UX1+2025_T3+type@vertical+block@4',
             name: 'One more unit',
             blockType: 'vertical',
             upstreamLink: {
@@ -197,41 +197,41 @@ const getMockCourseContainerData = (
               versionSynced: 1,
               versionAvailable: 1,
               versionDeclined: null,
-              isModified: false
-            }
-          }
+              isModified: false,
+            },
+          },
         ],
         [
           {
             id: 'lct:UNIX:CS1:unit:unit-with-tags-bec5f9',
             displayName: 'Unit with tags',
-            containerType: 'unit'
+            containerType: 'unit',
           },
           {
             id: 'lct:UNIX:CS1:unit:added-unit-1',
             displayName: 'Added unit',
-            containerType: 'unit'
+            containerType: 'unit',
           },
           {
             id: 'lct:UNIX:CS1:unit:one-more-unit-745176',
             displayName: 'One more unit',
-            containerType: 'unit'
+            containerType: 'unit',
           },
           {
             id: 'lct:UNIX:CS1:unit:unit-1-2a1741',
             displayName: 'Unit 1 remote edit 2',
-            containerType: 'unit'
+            containerType: 'unit',
           },
         ],
       ] as [CourseContainerChildBase[], ContainerChildBase[]];
     default:
       throw new Error();
   }
-}
+};
 
 describe('diffPreviewContainerChildren', () => {
   it('should handle moved and deleted', () => {
-    const [a, b] = getMockCourseContainerData("moved|deleted");
+    const [a, b] = getMockCourseContainerData('moved|deleted');
     const result = diffPreviewContainerChildren(a as CourseContainerChildBase[], b);
     expect(result[0].length).toEqual(result[1].length);
     // renamed takes precendence over moved
@@ -243,15 +243,13 @@ describe('diffPreviewContainerChildren', () => {
   });
 
   it('should handle add and delete', () => {
-    const [a, b] = getMockCourseContainerData("added|deleted");
+    const [a, b] = getMockCourseContainerData('added|deleted');
     const result = diffPreviewContainerChildren(a as CourseContainerChildBase[], b);
-    // __AUTO_GENERATED_PRINT_VAR_START__
-    console.log("(anon)#(anon) result: ", result); // __AUTO_GENERATED_PRINT_VAR_END__
     expect(result[0].length).toEqual(result[1].length);
     // No change, state=undefined
-    expect(result[0][0].state).toEqual("renamed");
+    expect(result[0][0].state).toEqual('renamed');
     expect(result[0][0].originalName).toEqual(b[0].displayName);
-    expect(result[1][0].state).toEqual("renamed");
+    expect(result[1][0].state).toEqual('renamed');
 
     // Deleted entry
     expect(result[0][1].state).toEqual('removed');
@@ -263,12 +261,12 @@ describe('diffPreviewContainerChildren', () => {
   });
 
   it('should handle add, delete and moved', () => {
-    const [a, b] = getMockCourseContainerData("all");
+    const [a, b] = getMockCourseContainerData('all');
     const result = diffPreviewContainerChildren(a as CourseContainerChildBase[], b);
     expect(result[0].length).toEqual(result[1].length);
     // renamed takes precendence over moved
-    expect(result[0][0].state).toEqual("renamed");
-    expect(result[1][4].state).toEqual("renamed");
+    expect(result[0][0].state).toEqual('renamed');
+    expect(result[1][4].state).toEqual('renamed');
     expect(result[1][4].id).toEqual(result[0][0].upstreamLink.upstreamRef);
 
     // Deleted entry

--- a/src/container-comparison/utils.ts
+++ b/src/container-comparison/utils.ts
@@ -14,8 +14,13 @@ export type CourseContainerChildBase = {
 export type ContainerChildBase = {
   displayName: string;
   id: string;
+  containerType?: string;
+  blockType?: string;
+} & ({
   containerType: string;
-};
+} | {
+  blockType: string;
+});
 
 export function checkIsReadyToSync(link: UpstreamInfo): boolean {
   return (link.versionSynced < (link.versionAvailable || 0))
@@ -48,7 +53,7 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
       addedA.push({
         id: newVersion.id,
         name: newVersion.displayName,
-        blockType: newVersion.containerType,
+        blockType: newVersion.containerType || newVersion.blockType,
         index,
       } as WithIndex<A>);
       updatedB.push({ ...newVersion, state: 'added' });

--- a/src/container-comparison/utils.ts
+++ b/src/container-comparison/utils.ts
@@ -40,14 +40,14 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
     const element = b[index];
     mapB.set(element[idKey], { ...element, index });
   }
-  const updatedA: WithState<A>[] = [];
+  const updatedA: WithState<A>[] = Array(b.length);
   const updatedB: WithState<B>[] = [];
   for (let index = 0; index < b.length; index++) {
     const newVersion = b[index];
     const oldVersion = mapA.get(newVersion.id);
     if (!oldVersion) {
       // This is a newly added component
-      updatedA.splice(index, 0, {
+      updatedA.splice(index, 1, {
         id: newVersion.id,
         name: newVersion.displayName,
         blockType: newVersion.containerType,
@@ -73,7 +73,7 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
         state = "modified";
       }
       // Insert in its original index
-      updatedA.splice(oldVersion.index, 0, {...oldVersion, state, originalName});
+      updatedA.splice(oldVersion.index, 1, {...oldVersion, state, originalName});
       updatedB.push({...newVersion, displayName, state});
       // Delete it from mapA as it is processed.
       mapA.delete(newVersion.id);

--- a/src/container-comparison/utils.ts
+++ b/src/container-comparison/utils.ts
@@ -1,5 +1,5 @@
-import { UpstreamInfo } from "../data/types";
-import { ContainerState } from "./ContainerRow";
+import { UpstreamInfo } from '../data/types';
+import { ContainerState } from './ContainerRow';
 
 type WithState<T> = T & { state?: ContainerState, originalName?: string };
 type WithIndex<T> = T & { index: number };
@@ -9,17 +9,17 @@ export type CourseContainerChildBase = {
   id: string;
   upstreamLink: UpstreamInfo;
   blockType: string;
-}
+};
 
 export type ContainerChildBase = {
   displayName: string;
   id: string;
   containerType: string;
-}
+};
 
 export function checkIsReadyToSync(link: UpstreamInfo): boolean {
   return (link.versionSynced < (link.versionAvailable || 0))
-    || (link.versionSynced < (link.versionDeclined || 0))
+    || (link.versionSynced < (link.versionDeclined || 0));
 }
 
 /**
@@ -29,7 +29,7 @@ export function checkIsReadyToSync(link: UpstreamInfo): boolean {
 export function diffPreviewContainerChildren<A extends CourseContainerChildBase, B extends ContainerChildBase>(
   a: A[],
   b: B[],
-  idKey: string = "id"
+  idKey: string = 'id',
 ): [WithState<A>[], WithState<B>[]] {
   const mapA = new Map<any, WithIndex<A>>();
   const mapB = new Map<any, WithIndex<B>>();
@@ -51,7 +51,7 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
         blockType: newVersion.containerType,
         index,
       } as WithIndex<A>);
-      updatedB.push({...newVersion, state: "added"});
+      updatedB.push({ ...newVersion, state: 'added' });
     } else {
       // It was present in previous version
       let state: ContainerState | undefined;
@@ -59,20 +59,20 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
       let originalName: string | undefined;
       if (index !== oldVersion.index) {
         // has moved from its position
-        state = "moved";
+        state = 'moved';
       }
       if (displayName !== newVersion.displayName && displayName === oldVersion.name) {
         // Has been renamed
-        state = "renamed";
+        state = 'renamed';
         originalName = newVersion.displayName;
       }
       if (checkIsReadyToSync(oldVersion.upstreamLink)) {
         // has a new version ready to sync
-        state = "modified";
+        state = 'modified';
       }
       // Insert in its original index
-      updatedA.splice(oldVersion.index, 1, {...oldVersion, state, originalName});
-      updatedB.push({...newVersion, displayName, state});
+      updatedA.splice(oldVersion.index, 1, { ...oldVersion, state, originalName });
+      updatedB.push({ ...newVersion, displayName, state });
       // Delete it from mapA as it is processed.
       mapA.delete(newVersion.id);
     }
@@ -80,12 +80,12 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
 
   // If there are remaining items in mapA, it means they were deleted in newVersion;
   mapA.forEach((oldVersion) => {
-    updatedA.splice(oldVersion.index, 1, { ...oldVersion, state: "removed" });
+    updatedA.splice(oldVersion.index, 1, { ...oldVersion, state: 'removed' });
     updatedB.splice(oldVersion.index, 0, {
       id: oldVersion.id,
       displayName: oldVersion.name,
       containerType: oldVersion.blockType,
-      state: "removed",
+      state: 'removed',
     } as WithState<B>);
   });
 
@@ -97,9 +97,8 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
 
   // Use new mapB for getting new index for added elements
   addedA.forEach((addedRow) => {
-    updatedA.splice(mapB.get(addedRow.id)?.index!, 0, { ...addedRow, state: "added" });
+    updatedA.splice(mapB.get(addedRow.id)?.index!, 0, { ...addedRow, state: 'added' });
   });
 
   return [updatedA, updatedB];
 }
-

--- a/src/container-comparison/utils.ts
+++ b/src/container-comparison/utils.ts
@@ -1,26 +1,5 @@
 import { UpstreamInfo } from '../data/types';
-import { ContainerState } from './ContainerRow';
-
-type WithState<T> = T & { state?: ContainerState, originalName?: string };
-type WithIndex<T> = T & { index: number };
-
-export type CourseContainerChildBase = {
-  name: string;
-  id: string;
-  upstreamLink: UpstreamInfo;
-  blockType: string;
-};
-
-export type ContainerChildBase = {
-  displayName: string;
-  id: string;
-  containerType?: string;
-  blockType?: string;
-} & ({
-  containerType: string;
-} | {
-  blockType: string;
-});
+import { ContainerChildBase, ContainerState, CourseContainerChildBase, WithIndex, WithState } from './types';
 
 export function checkIsReadyToSync(link: UpstreamInfo): boolean {
   return (link.versionSynced < (link.versionAvailable || 0))
@@ -77,7 +56,7 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
       }
       // Insert in its original index
       updatedA.splice(oldVersion.index, 1, { ...oldVersion, state, originalName });
-      updatedB.push({ ...newVersion, displayName, state });
+      updatedB.push({ ...newVersion, displayName, state } as WithState<B>);
       // Delete it from mapA as it is processed.
       mapA.delete(newVersion.id);
     }
@@ -87,11 +66,11 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
   mapA.forEach((oldVersion) => {
     updatedA.splice(oldVersion.index, 1, { ...oldVersion, state: 'removed' });
     updatedB.splice(oldVersion.index, 0, {
-      id: oldVersion.id,
-      displayName: oldVersion.name,
-      containerType: oldVersion.blockType,
-      state: 'removed',
-    } as WithState<B>);
+        id: oldVersion.id,
+        displayName: oldVersion.name,
+        containerType: oldVersion.blockType,
+        state: 'removed',
+    } as unknown as WithState<B>);
   });
 
   // Create a map for id with index of newly updatedB array

--- a/src/container-comparison/utils.ts
+++ b/src/container-comparison/utils.ts
@@ -62,6 +62,10 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
         // has moved from its position
         state = "moved";
       }
+      if (displayName !== newVersion.displayName && displayName === oldVersion.name) {
+        // Has been renamed
+        state = "renamed";
+      }
       if (checkIsReadyToSync(oldVersion.upstreamLink)) {
         // has a new version ready to sync
         state = "modified";

--- a/src/container-comparison/utils.ts
+++ b/src/container-comparison/utils.ts
@@ -1,5 +1,7 @@
 import { UpstreamInfo } from '../data/types';
-import { ContainerChildBase, ContainerState, CourseContainerChildBase, WithIndex, WithState } from './types';
+import {
+  ContainerChildBase, ContainerState, CourseContainerChildBase, WithIndex, WithState,
+} from './types';
 
 export function checkIsReadyToSync(link: UpstreamInfo): boolean {
   return (link.versionSynced < (link.versionAvailable || 0))
@@ -66,10 +68,10 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
   mapA.forEach((oldVersion) => {
     updatedA.splice(oldVersion.index, 1, { ...oldVersion, state: 'removed' });
     updatedB.splice(oldVersion.index, 0, {
-        id: oldVersion.id,
-        displayName: oldVersion.name,
-        containerType: oldVersion.blockType,
-        state: 'removed',
+      id: oldVersion.id,
+      displayName: oldVersion.name,
+      containerType: oldVersion.blockType,
+      state: 'removed',
     } as unknown as WithState<B>);
   });
 

--- a/src/container-comparison/utils.ts
+++ b/src/container-comparison/utils.ts
@@ -1,5 +1,5 @@
 import { UpstreamInfo } from '../data/types';
-import { ContainerType, NormalizeContainerType } from '../generic/key-utils';
+import { ContainerType, normalizeContainerType } from '../generic/key-utils';
 import {
   ContainerChild,
   ContainerChildBase,
@@ -71,7 +71,7 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
       // Insert in its original index
       updatedA.splice(oldVersion.index, 1, {
         name: oldVersion.name,
-        blockType: NormalizeContainerType(oldVersion.blockType),
+        blockType: normalizeContainerType(oldVersion.blockType),
         id: oldVersion.upstreamLink.upstreamRef,
         downstreamId: oldVersion.id,
         state,
@@ -93,7 +93,7 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
   mapA.forEach((oldVersion) => {
     updatedA.splice(oldVersion.index, 1, {
       name: oldVersion.name,
-      blockType: NormalizeContainerType(oldVersion.blockType),
+      blockType: normalizeContainerType(oldVersion.blockType),
       id: oldVersion.upstreamLink.upstreamRef,
       downstreamId: oldVersion.id,
       state: 'removed',
@@ -101,7 +101,7 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
     updatedB.splice(oldVersion.index, 0, {
       id: oldVersion.upstreamLink.upstreamRef,
       name: oldVersion.name,
-      blockType: NormalizeContainerType(oldVersion.blockType),
+      blockType: normalizeContainerType(oldVersion.blockType),
       downstreamId: oldVersion.id,
       state: 'removed',
     });

--- a/src/container-comparison/utils.ts
+++ b/src/container-comparison/utils.ts
@@ -1,0 +1,90 @@
+import { UpstreamInfo } from "../data/types";
+import { ContainerState } from "./ContainerRow";
+
+type WithState<T> = T & { state?: ContainerState };
+
+export type CourseContainerChildBase = {
+  name: string;
+  id: string;
+  upstreamLink: UpstreamInfo;
+  blockType: string;
+}
+
+export type ContainerChildBase = {
+  displayName: string;
+  id: string;
+  containerType: string;
+}
+
+export function checkIsReadyToSync(link: UpstreamInfo): boolean {
+  return (link.versionSynced < (link.versionAvailable || 0))
+    || (link.versionSynced < (link.versionDeclined || 0))
+}
+
+/**
+ * Compares two arrays of container children (`a` and `b`) to determine the differences between them.
+ * It generates two lists indicating which elements have been added, modified, moved, or removed.
+ */
+export function diffPreviewContainerChildren<A extends CourseContainerChildBase, B extends ContainerChildBase>(
+  a: A[],
+  b: B[],
+  idKey: string = "id"
+): [WithState<A>[], WithState<B>[]] {
+  const mapA = new Map<any, A & { index: number }>();
+  const mapB = new Map<any, B & { index: number }>();
+  for (let index = 0; index < a.length; index++) {
+    const element = a[index];
+    mapA.set(element.upstreamLink?.upstreamRef, { ...element, index });
+  }
+  for (let index = 0; index < b.length; index++) {
+    const element = b[index];
+    mapB.set(element[idKey], { ...element, index });
+  }
+  const updatedA: WithState<A>[] = [];
+  const updatedB: WithState<B>[] = [];
+  for (let index = 0; index < b.length; index++) {
+    const newVersion = b[index];
+    const oldVersion = mapA.get(newVersion.id);
+    if (!oldVersion) {
+      // This is a newly added component
+      updatedA.splice(index, 0, {
+        id: newVersion.id,
+        name: newVersion.displayName,
+        blockType: newVersion.containerType,
+        state: "added",
+      } as WithState<A>);
+      updatedB.push({...newVersion, state: "added"});
+    } else {
+      // It was present in previous version
+      let state: ContainerState | undefined;
+      const displayName = oldVersion.upstreamLink.isModified ? oldVersion.name : newVersion.displayName;
+      if (index !== oldVersion.index) {
+        // has moved from its position
+        state = "moved";
+      }
+      if (checkIsReadyToSync(oldVersion.upstreamLink)) {
+        // has a new version ready to sync
+        state = "modified";
+      }
+      // Insert in its original index
+      updatedA.splice(oldVersion.index, 0, {...oldVersion, state});
+      updatedB.push({...newVersion, displayName, state});
+      // Delete it from mapA as it is processed.
+      mapA.delete(newVersion.id);
+    }
+  }
+
+  // If there are remaining items in mapA, it means they were deleted in newVersion;
+  mapA.forEach((oldVersion) => {
+    updatedA.splice(oldVersion.index, 0, { ...oldVersion, state: "removed" });
+    updatedB.splice(oldVersion.index, 0, {
+      id: oldVersion.id,
+      displayName: oldVersion.name,
+      containerType: oldVersion.blockType,
+      state: "removed",
+    } as WithState<B>);
+  });
+
+  return [updatedA, updatedB];
+}
+

--- a/src/container-comparison/utils.ts
+++ b/src/container-comparison/utils.ts
@@ -1,5 +1,5 @@
-import { UpstreamInfo } from '../data/types';
-import { ContainerType, normalizeContainerType } from '../generic/key-utils';
+import { UpstreamInfo } from '@src/data/types';
+import { ContainerType, normalizeContainerType } from '@src/generic/key-utils';
 import {
   ContainerChild,
   ContainerChildBase,

--- a/src/container-comparison/utils.ts
+++ b/src/container-comparison/utils.ts
@@ -1,7 +1,7 @@
 import { UpstreamInfo } from "../data/types";
 import { ContainerState } from "./ContainerRow";
 
-type WithState<T> = T & { state?: ContainerState };
+type WithState<T> = T & { state?: ContainerState, originalName?: string };
 
 export type CourseContainerChildBase = {
   name: string;
@@ -58,6 +58,7 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
       // It was present in previous version
       let state: ContainerState | undefined;
       const displayName = oldVersion.upstreamLink.isModified ? oldVersion.name : newVersion.displayName;
+      let originalName: string | undefined;
       if (index !== oldVersion.index) {
         // has moved from its position
         state = "moved";
@@ -65,13 +66,14 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
       if (displayName !== newVersion.displayName && displayName === oldVersion.name) {
         // Has been renamed
         state = "renamed";
+        originalName = newVersion.displayName;
       }
       if (checkIsReadyToSync(oldVersion.upstreamLink)) {
         // has a new version ready to sync
         state = "modified";
       }
       // Insert in its original index
-      updatedA.splice(oldVersion.index, 0, {...oldVersion, state});
+      updatedA.splice(oldVersion.index, 0, {...oldVersion, state, originalName});
       updatedB.push({...newVersion, displayName, state});
       // Delete it from mapA as it is processed.
       mapA.delete(newVersion.id);

--- a/src/course-outline/data/apiHooks.ts
+++ b/src/course-outline/data/apiHooks.ts
@@ -22,7 +22,7 @@ export const useCreateCourseBlock = (
 ) => useMutation({
   mutationFn: createCourseXblock,
   onSettled: async (data) => {
-    callback?.(data.locator, data.parent_locator);
+    callback?.(data?.locator, data.parent_locator);
   },
 });
 

--- a/src/course-outline/hooks.jsx
+++ b/src/course-outline/hooks.jsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { useToggle } from '@openedx/paragon';
 import { getConfig } from '@edx/frontend-platform';
+import { useQueryClient } from '@tanstack/react-query';
 
 import moment from 'moment';
 import { getSavingStatus as getGenericSavingStatus } from '@src/generic/data/selectors';
@@ -64,9 +65,11 @@ import {
 } from './data/thunk';
 import { useCreateCourseBlock } from './data/apiHooks';
 import { getCourseItem } from './data/api';
+import { containerComparisonQueryKeys } from '../container-comparison/data/apiHooks';
 
 const useCourseOutline = ({ courseId }) => {
   const dispatch = useDispatch();
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const waffleFlags = useWaffleFlags(courseId);
 
@@ -245,6 +248,8 @@ const useCourseOutline = ({ courseId }) => {
 
   const handleEditSubmit = (itemId, sectionId, displayName) => {
     dispatch(editCourseItemQuery(itemId, sectionId, displayName));
+    // Invalidate container diff queries to update sync diff preview
+    queryClient.invalidateQueries({ queryKey: containerComparisonQueryKeys.course(courseId) });
   };
 
   const handleDeleteItemSubmit = () => {

--- a/src/course-outline/section-card/SectionCard.test.tsx
+++ b/src/course-outline/section-card/SectionCard.test.tsx
@@ -71,6 +71,8 @@ const section = {
     readyToSync: true,
     upstreamRef: 'lct:org1:lib1:section:1',
     versionSynced: 1,
+    versionAvailable: 2,
+    versionDeclined: null,
     errorMessage: null,
   },
 } satisfies Partial<XBlock> as XBlock;

--- a/src/course-outline/section-card/SectionCard.test.tsx
+++ b/src/course-outline/section-card/SectionCard.test.tsx
@@ -17,11 +17,11 @@ jest.mock('@src/course-unit/data/apiHooks', () => ({
 }));
 
 const unit = {
-  id: 'unit-1',
+  id: 'block-v1:UNIX+UX1+2025_T3+type@unit+block@0',
 };
 
 const subsection = {
-  id: '123',
+  id: 'block-v1:UNIX+UX1+2025_T3+type@subsection+block@0',
   displayName: 'Subsection Name',
   category: 'sequential',
   published: true,
@@ -43,7 +43,7 @@ const subsection = {
 } satisfies Partial<XBlock> as XBlock;
 
 const section = {
-  id: '123',
+  id: 'block-v1:UNIX+UX1+2025_T3+type@section+block@0',
   displayName: 'Section Name',
   category: 'chapter',
   published: true,
@@ -188,7 +188,9 @@ describe('<SectionCard />', () => {
     const collapsedSections = { ...section };
     // @ts-ignore-next-line
     collapsedSections.isSectionsExpanded = false;
-    renderComponent(collapsedSections, `/course/:courseId?show=${subsection.id}`);
+    // url encode subsection.id
+    const subsectionIdUrl = encodeURIComponent(subsection.id);
+    renderComponent(collapsedSections, `/course/:courseId?show=${subsectionIdUrl}`);
 
     const cardSubsections = await screen.findByTestId('section-card__subsections');
     const newSubsectionButton = await screen.findByRole('button', { name: 'New subsection' });
@@ -200,7 +202,9 @@ describe('<SectionCard />', () => {
     const collapsedSections = { ...section };
     // @ts-ignore-next-line
     collapsedSections.isSectionsExpanded = false;
-    renderComponent(collapsedSections, `/course/:courseId?show=${unit.id}`);
+    // url encode subsection.id
+    const unitIdUrl = encodeURIComponent(unit.id);
+    renderComponent(collapsedSections, `/course/:courseId?show=${unitIdUrl}`);
 
     const cardSubsections = await screen.findByTestId('section-card__subsections');
     const newSubsectionButton = await screen.findByRole('button', { name: 'New subsection' });
@@ -232,7 +236,6 @@ describe('<SectionCard />', () => {
 
     // Should open compare preview modal
     expect(screen.getByRole('heading', { name: /preview changes: section name/i })).toBeInTheDocument();
-    expect(screen.getByText('Preview not available for container changes at this time')).toBeInTheDocument();
 
     // Click on accept changes
     const acceptChangesButton = screen.getByText(/accept changes/i);
@@ -252,7 +255,6 @@ describe('<SectionCard />', () => {
 
     // Should open compare preview modal
     expect(screen.getByRole('heading', { name: /preview changes: section name/i })).toBeInTheDocument();
-    expect(screen.getByText('Preview not available for container changes at this time')).toBeInTheDocument();
 
     // Click on ignore changes
     const ignoreChangesButton = screen.getByRole('button', { name: /ignore changes/i });

--- a/src/course-outline/subsection-card/SubsectionCard.test.tsx
+++ b/src/course-outline/subsection-card/SubsectionCard.test.tsx
@@ -52,7 +52,7 @@ const unit = {
 };
 
 const subsection: XBlock = {
-  id: '123',
+  id: 'block-v1:UNIX+UX1+2025_T3+type@subsection+block@0',
   displayName: 'Subsection Name',
   category: 'sequential',
   published: true,
@@ -82,7 +82,7 @@ const subsection: XBlock = {
 } satisfies Partial<XBlock> as XBlock;
 
 const section: XBlock = {
-  id: '123',
+  id: 'block-v1:UNIX+UX1+2025_T3+type@section+block@0',
   displayName: 'Section Name',
   published: true,
   visibilityState: 'live',
@@ -323,7 +323,7 @@ describe('<SubsectionCard />', () => {
     expect(handleOnAddUnitFromLibrary).toHaveBeenCalled();
     expect(handleOnAddUnitFromLibrary).toHaveBeenCalledWith({
       type: COMPONENT_TYPES.libraryV2,
-      parentLocator: '123',
+      parentLocator: 'block-v1:UNIX+UX1+2025_T3+type@subsection+block@0',
       category: 'vertical',
       libraryContentKey: containerKey,
     });
@@ -340,7 +340,6 @@ describe('<SubsectionCard />', () => {
 
     // Should open compare preview modal
     expect(screen.getByRole('heading', { name: /preview changes: subsection name/i })).toBeInTheDocument();
-    expect(screen.getByText('Preview not available for container changes at this time')).toBeInTheDocument();
 
     // Click on accept changes
     const acceptChangesButton = screen.getByText(/accept changes/i);
@@ -360,7 +359,6 @@ describe('<SubsectionCard />', () => {
 
     // Should open compare preview modal
     expect(screen.getByRole('heading', { name: /preview changes: subsection name/i })).toBeInTheDocument();
-    expect(screen.getByText('Preview not available for container changes at this time')).toBeInTheDocument();
 
     // Click on ignore changes
     const ignoreChangesButton = screen.getByRole('button', { name: /ignore changes/i });

--- a/src/course-outline/subsection-card/SubsectionCard.test.tsx
+++ b/src/course-outline/subsection-card/SubsectionCard.test.tsx
@@ -75,6 +75,8 @@ const subsection: XBlock = {
     readyToSync: true,
     upstreamRef: 'lct:org1:lib1:subsection:1',
     versionSynced: 1,
+    versionAvailable: 2,
+    versionDeclined: null,
     errorMessage: null,
   },
 } satisfies Partial<XBlock> as XBlock;

--- a/src/course-outline/unit-card/UnitCard.test.tsx
+++ b/src/course-outline/unit-card/UnitCard.test.tsx
@@ -65,6 +65,8 @@ const unit = {
     readyToSync: true,
     upstreamRef: 'lct:org1:lib1:unit:1',
     versionSynced: 1,
+    versionAvailable: 2,
+    versionDeclined: null,
     errorMessage: null,
   },
 } satisfies Partial<XBlock> as XBlock;

--- a/src/course-outline/unit-card/UnitCard.test.tsx
+++ b/src/course-outline/unit-card/UnitCard.test.tsx
@@ -19,7 +19,7 @@ jest.mock('@src/course-unit/data/apiHooks', () => ({
 }));
 
 const section = {
-  id: '1',
+  id: 'block-v1:UNIX+UX1+2025_T3+type@section+block@0',
   displayName: 'Section Name',
   published: true,
   visibilityState: 'live',
@@ -34,7 +34,7 @@ const section = {
 } satisfies Partial<XBlock> as XBlock;
 
 const subsection = {
-  id: '12',
+  id: 'block-v1:UNIX+UX1+2025_T3+type@subsection+block@0',
   displayName: 'Subsection Name',
   published: true,
   visibilityState: 'live',
@@ -48,7 +48,7 @@ const subsection = {
 } satisfies Partial<XBlock> as XBlock;
 
 const unit = {
-  id: '123',
+  id: 'block-v1:UNIX+UX1+2025_T3+type@unit+block@0',
   displayName: 'unit Name',
   category: 'vertical',
   published: true,
@@ -109,7 +109,10 @@ describe('<UnitCard />', () => {
     const { findByTestId } = renderComponent();
 
     expect(await findByTestId('unit-card-header')).toBeInTheDocument();
-    expect(await findByTestId('unit-card-header__title-link')).toHaveAttribute('href', '/some/123');
+    expect(await findByTestId('unit-card-header__title-link')).toHaveAttribute(
+      'href',
+      '/some/block-v1:UNIX+UX1+2025_T3+type@unit+block@0',
+    );
   });
 
   it('hides header based on isHeaderVisible flag', async () => {
@@ -200,7 +203,6 @@ describe('<UnitCard />', () => {
 
     // Should open compare preview modal
     expect(screen.getByRole('heading', { name: /preview changes: unit name/i })).toBeInTheDocument();
-    expect(screen.getByText('Preview not available for container changes at this time')).toBeInTheDocument();
 
     // Click on accept changes
     const acceptChangesButton = screen.getByText(/accept changes/i);
@@ -220,7 +222,6 @@ describe('<UnitCard />', () => {
 
     // Should open compare preview modal
     expect(screen.getByRole('heading', { name: /preview changes: unit name/i })).toBeInTheDocument();
-    expect(screen.getByText('Preview not available for container changes at this time')).toBeInTheDocument();
 
     // Click on ignore changes
     const ignoreChangesButton = screen.getByRole('button', { name: /ignore changes/i });

--- a/src/course-unit/data/api.ts
+++ b/src/course-unit/data/api.ts
@@ -63,13 +63,13 @@ export async function createCourseXblock({
   libraryContentKey,
 }: {
   type: string,
-  category: string,
+  category?: string,
   parentLocator: string,
-  displayName: string,
-  boilerplate: string,
-  stagedContent: string,
-  libraryContentKey: string,
-}): Promise<object> {
+  displayName?: string,
+  boilerplate?: string,
+  stagedContent?: string,
+  libraryContentKey?: string,
+}): Promise<any> {
   const body = {
     type,
     boilerplate,
@@ -95,7 +95,7 @@ export async function handleCourseUnitVisibilityAndData(
   type: string,
   isVisible: boolean,
   groupAccess: boolean,
-  isDiscussionEnabled: boolean
+  isDiscussionEnabled: boolean,
 ): Promise<object> {
   const body = {
     publish: groupAccess ? null : type,

--- a/src/course-unit/data/thunk.js
+++ b/src/course-unit/data/thunk.js
@@ -3,11 +3,11 @@ import { camelCaseObject } from '@edx/frontend-platform';
 import {
   hideProcessingNotification,
   showProcessingNotification,
-} from '../../generic/processing-notification/data/slice';
-import { handleResponseErrors } from '../../generic/saving-error-alert';
-import { RequestStatus } from '../../data/constants';
-import { NOTIFICATION_MESSAGES } from '../../constants';
-import { updateModel, updateModels } from '../../generic/model-store';
+} from '@src/generic/processing-notification/data/slice';
+import { handleResponseErrors } from '@src/generic/saving-error-alert';
+import { RequestStatus } from '@src/data/constants';
+import { NOTIFICATION_MESSAGES } from '@src/constants';
+import { updateModel, updateModels } from '@src/generic/model-store';
 import { messageTypes } from '../constants';
 import {
   editUnitDisplayName,

--- a/src/course-unit/data/thunk.js
+++ b/src/course-unit/data/thunk.js
@@ -13,7 +13,7 @@ import {
   editUnitDisplayName,
   getVerticalData,
   createCourseXblock,
-  getCourseVerticalChildren,
+  getCourseContainerChildren,
   handleCourseUnitVisibilityAndData,
   deleteUnitItem,
   duplicateUnitItem,
@@ -126,7 +126,7 @@ export function editCourseUnitVisibilityAndData(
           }
           const courseSectionVerticalData = await getVerticalData(blockId);
           dispatch(fetchCourseSectionVerticalDataSuccess(courseSectionVerticalData));
-          const courseVerticalChildrenData = await getCourseVerticalChildren(blockId);
+          const courseVerticalChildrenData = await getCourseContainerChildren(blockId);
           dispatch(updateCourseVerticalChildren(courseVerticalChildrenData));
           dispatch(hideProcessingNotification());
           dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
@@ -163,7 +163,7 @@ export function createNewCourseXBlock(body, callback, blockId, sendMessageToIfra
               localStorage.removeItem('staticFileNotices');
             }
           }
-          const courseVerticalChildrenData = await getCourseVerticalChildren(blockId);
+          const courseVerticalChildrenData = await getCourseContainerChildren(blockId);
           dispatch(updateCourseVerticalChildren(courseVerticalChildrenData));
           dispatch(hideProcessingNotification());
           if (callback) {
@@ -190,11 +190,11 @@ export function fetchCourseVerticalChildrenData(itemId, isSplitTestType, skipPag
     }
 
     try {
-      const courseVerticalChildrenData = await getCourseVerticalChildren(itemId);
+      const courseVerticalChildrenData = await getCourseContainerChildren(itemId);
       if (isSplitTestType) {
         const blockIds = courseVerticalChildrenData.children.map(child => child.blockId);
         const childrenDataArray = await Promise.all(
-          blockIds.map(blockId => getCourseVerticalChildren(blockId)),
+          blockIds.map(blockId => getCourseContainerChildren(blockId)),
         );
         const allChildren = childrenDataArray.reduce(
           (acc, data) => acc.concat(data.children || []),
@@ -239,7 +239,7 @@ export function duplicateUnitItemQuery(itemId, xblockId, callback) {
       callback(courseKey, locator);
       const courseSectionVerticalData = await getVerticalData(itemId);
       dispatch(fetchCourseSectionVerticalDataSuccess(courseSectionVerticalData));
-      const courseVerticalChildrenData = await getCourseVerticalChildren(itemId);
+      const courseVerticalChildrenData = await getCourseContainerChildren(itemId);
       dispatch(updateCourseVerticalChildren(courseVerticalChildrenData));
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));

--- a/src/course-unit/data/types.ts
+++ b/src/course-unit/data/types.ts
@@ -32,7 +32,7 @@ export interface CourseOutlineData {
 
 export interface ContainerChildData {
   blockId: string;
-  blockType: ContainerType | typeof COMPONENT_TYPES;
+  blockType: ContainerType | keyof typeof COMPONENT_TYPES;
   id: string;
   name: string;
   upstreamLink: UpstreamInfo;

--- a/src/course-unit/data/types.ts
+++ b/src/course-unit/data/types.ts
@@ -1,0 +1,45 @@
+import { UpstreamInfo, XBlock } from '@src/data/types';
+import { ContainerType } from '@src/generic/key-utils';
+import { COMPONENT_TYPES } from '@src/generic/block-type-utils/constants';
+
+export interface MoveInfoData {
+  /**
+   * The locator of the source block being moved.
+   */
+  moveSourceLocator: string;
+  /**
+   * The locator of the parent block where the source is being moved to.
+   */
+  parentLocator: string;
+  /**
+   * The index position of the source block.
+   */
+  sourceIndex: number;
+}
+
+export interface CourseOutlineData {
+  id: string;
+  displayName: string;
+  category: string;
+  hasChildren: boolean;
+  unitLevelDiscussions: boolean;
+  childInfo: {
+    category: string;
+    displayName: string;
+    children: XBlock[];
+  }
+}
+
+export interface ContainerChildData {
+  blockId: string;
+  blockType: ContainerType | typeof COMPONENT_TYPES;
+  id: string;
+  name: string;
+  upstreamLink: UpstreamInfo;
+}
+
+export interface CourseContainerChildrenData {
+  canPasteComponent: boolean;
+  children: ContainerChildData[],
+  isPublished: boolean;
+}

--- a/src/course-unit/preview-changes/index.test.tsx
+++ b/src/course-unit/preview-changes/index.test.tsx
@@ -13,7 +13,7 @@ import { messageTypes } from '../constants';
 import { libraryBlockChangesUrl } from '../data/api';
 import { ToastActionData } from '../../generic/toast-context';
 
-const usageKey = 'some-id';
+const usageKey = 'block-v1:UNIX+UX1+2025_T3+type@unit+block@1';
 const defaultEventData: LibraryChangesMessageData = {
   displayName: 'Test block',
   downstreamBlockId: usageKey,

--- a/src/course-unit/preview-changes/index.tsx
+++ b/src/course-unit/preview-changes/index.tsx
@@ -16,6 +16,7 @@ import messages from './messages';
 import { ToastContext } from '../../generic/toast-context';
 import LoadingButton from '../../generic/loading-button';
 import Loading from '../../generic/Loading';
+import { CompareContainersWidget } from '@src/container-comparison/CompareContainersWidget';
 
 export interface LibraryChangesMessageData {
   displayName: string,
@@ -55,12 +56,19 @@ export const PreviewLibraryXBlockChanges = ({
     if (!blockData) {
       return <Loading />;
     }
+    if (blockData.isContainer) {
+      return <CompareContainersWidget
+        title={blockData.displayName}
+        upstreamBlockId={blockData.upstreamBlockId}
+        downstreamBlockId={blockData.downstreamBlockId}
+      />
+    }
+
     return (
       <CompareChangesWidget
         usageKey={blockData.upstreamBlockId}
         oldVersion={blockData.upstreamBlockVersionSynced || 'published'}
         newVersion="published"
-        isContainer={blockData.isContainer}
       />
     );
   }, [blockData]);
@@ -110,12 +118,12 @@ export const PreviewLibraryXBlockChanges = ({
         </ModalDialog.Title>
       </ModalDialog.Header>
       <ModalDialog.Body>
-        <AlertMessage
+        {!blockData.isContainer && <AlertMessage
           show
           variant="warning"
           icon={Warning}
           title={intl.formatMessage(messages.olderVersionPreviewAlert)}
-        />
+        />}
         {getBody()}
       </ModalDialog.Body>
       <ModalDialog.Footer>

--- a/src/course-unit/preview-changes/index.tsx
+++ b/src/course-unit/preview-changes/index.tsx
@@ -5,6 +5,7 @@ import {
 import { Warning } from '@openedx/paragon/icons';
 import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 
+import { CompareContainersWidget } from '@src/container-comparison/CompareContainersWidget';
 import { useEventListener } from '../../generic/hooks';
 import { messageTypes } from '../constants';
 import CompareChangesWidget from '../../library-authoring/component-comparison/CompareChangesWidget';
@@ -16,7 +17,6 @@ import messages from './messages';
 import { ToastContext } from '../../generic/toast-context';
 import LoadingButton from '../../generic/loading-button';
 import Loading from '../../generic/Loading';
-import { CompareContainersWidget } from '@src/container-comparison/CompareContainersWidget';
 
 export interface LibraryChangesMessageData {
   displayName: string,
@@ -57,11 +57,13 @@ export const PreviewLibraryXBlockChanges = ({
       return <Loading />;
     }
     if (blockData.isContainer) {
-      return <CompareContainersWidget
-        title={blockData.displayName}
-        upstreamBlockId={blockData.upstreamBlockId}
-        downstreamBlockId={blockData.downstreamBlockId}
-      />
+      return (
+        <CompareContainersWidget
+          title={blockData.displayName}
+          upstreamBlockId={blockData.upstreamBlockId}
+          downstreamBlockId={blockData.downstreamBlockId}
+        />
+      );
     }
 
     return (
@@ -118,12 +120,14 @@ export const PreviewLibraryXBlockChanges = ({
         </ModalDialog.Title>
       </ModalDialog.Header>
       <ModalDialog.Body className="bg-light-300">
-        {!blockData.isContainer && <AlertMessage
+        {!blockData.isContainer && (
+        <AlertMessage
           show
           variant="warning"
           icon={Warning}
           title={intl.formatMessage(messages.olderVersionPreviewAlert)}
-        />}
+        />
+        )}
         {getBody()}
       </ModalDialog.Body>
       <ModalDialog.Footer>

--- a/src/course-unit/preview-changes/index.tsx
+++ b/src/course-unit/preview-changes/index.tsx
@@ -6,17 +6,17 @@ import { Warning } from '@openedx/paragon/icons';
 import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import { CompareContainersWidget } from '@src/container-comparison/CompareContainersWidget';
-import { useEventListener } from '../../generic/hooks';
-import { messageTypes } from '../constants';
-import CompareChangesWidget from '../../library-authoring/component-comparison/CompareChangesWidget';
-import { useAcceptLibraryBlockChanges, useIgnoreLibraryBlockChanges } from '../data/apiHooks';
-import AlertMessage from '../../generic/alert-message';
-import { useIframe } from '../../generic/hooks/context/hooks';
-import DeleteModal from '../../generic/delete-modal/DeleteModal';
+import { useEventListener } from '@src/generic/hooks';
+import CompareChangesWidget from '@src/library-authoring/component-comparison/CompareChangesWidget';
+import AlertMessage from '@src/generic/alert-message';
+import { useIframe } from '@src/generic/hooks/context/hooks';
+import DeleteModal from '@src/generic/delete-modal/DeleteModal';
+import { ToastContext } from '@src/generic/toast-context';
+import LoadingButton from '@src/generic/loading-button';
+import Loading from '@src/generic/Loading';
 import messages from './messages';
-import { ToastContext } from '../../generic/toast-context';
-import LoadingButton from '../../generic/loading-button';
-import Loading from '../../generic/Loading';
+import { useAcceptLibraryBlockChanges, useIgnoreLibraryBlockChanges } from '../data/apiHooks';
+import { messageTypes } from '../constants';
 
 export interface LibraryChangesMessageData {
   displayName: string,

--- a/src/course-unit/preview-changes/index.tsx
+++ b/src/course-unit/preview-changes/index.tsx
@@ -117,7 +117,7 @@ export const PreviewLibraryXBlockChanges = ({
           {title}
         </ModalDialog.Title>
       </ModalDialog.Header>
-      <ModalDialog.Body>
+      <ModalDialog.Body className="bg-light-300">
         {!blockData.isContainer && <AlertMessage
           show
           variant="warning"

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -52,7 +52,11 @@ export interface UpstreamInfo {
   readyToSync: boolean,
   upstreamRef: string,
   versionSynced: number,
+  versionAvailable: number | null,
+  versionDeclined: number | null,
   errorMessage: string | null,
+  isModified?: boolean,
+  hasTopLevelParent?: boolean,
 }
 
 export interface XBlock {

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -48,6 +48,12 @@ export interface XBlockPrereqs {
   blockDisplayName: string;
 }
 
+export interface UpstreamChildrenInfo {
+  name: string;
+  upstream: string;
+  id: string;
+}
+
 export interface UpstreamInfo {
   readyToSync: boolean,
   upstreamRef: string,
@@ -57,6 +63,7 @@ export interface UpstreamInfo {
   errorMessage: string | null,
   isModified?: boolean,
   hasTopLevelParent?: boolean,
+  readyToSyncChildren?: UpstreamChildrenInfo[],
 }
 
 export interface XBlock {

--- a/src/generic/key-utils.test.ts
+++ b/src/generic/key-utils.test.ts
@@ -1,9 +1,11 @@
 import {
   buildCollectionUsageKey,
+  ContainerType,
   getBlockType,
   getLibraryId,
   isLibraryKey,
   isLibraryV1Key,
+  normalizeContainerType,
 } from './key-utils';
 
 describe('component utils', () => {
@@ -97,6 +99,21 @@ describe('component utils', () => {
     ] as const) {
       it(`returns '${expected}' for learning context key '${libraryKey}' and collection Id '${collectionId}'`, () => {
         expect(buildCollectionUsageKey(libraryKey, collectionId)).toStrictEqual(expected);
+      });
+    }
+  });
+
+  describe('normalizeContainerType', () => {
+    for (const [containerType, expected] of [
+      [ContainerType.Vertical, ContainerType.Unit],
+      [ContainerType.Sequential, ContainerType.Subsection],
+      [ContainerType.Chapter, ContainerType.Section],
+      [ContainerType.Unit, ContainerType.Unit],
+      [ContainerType.Section, ContainerType.Section],
+      [ContainerType.Subsection, ContainerType.Subsection],
+    ] as const) {
+      it(`returns '${expected}' for '${containerType}'`, () => {
+        expect(normalizeContainerType(containerType)).toStrictEqual(expected);
       });
     }
   });

--- a/src/generic/key-utils.ts
+++ b/src/generic/key-utils.ts
@@ -90,3 +90,19 @@ export enum ContainerType {
    */
   Components = 'components',
 }
+
+/**
+ * Normalize a container type to the standard version. For example, 'sequential' will be normalized to 'subsection'.
+ */
+export function NormalizeContainerType(containerType: ContainerType | string) {
+  switch (containerType) {
+    case ContainerType.Chapter:
+      return ContainerType.Section;
+    case ContainerType.Sequential:
+      return ContainerType.Subsection;
+    case ContainerType.Vertical:
+      return ContainerType.Unit;
+    default:
+      return containerType;
+  }
+}

--- a/src/generic/key-utils.ts
+++ b/src/generic/key-utils.ts
@@ -94,7 +94,7 @@ export enum ContainerType {
 /**
  * Normalize a container type to the standard version. For example, 'sequential' will be normalized to 'subsection'.
  */
-export function NormalizeContainerType(containerType: ContainerType | string) {
+export function normalizeContainerType(containerType: ContainerType | string) {
   switch (containerType) {
     case ContainerType.Chapter:
       return ContainerType.Section;

--- a/src/index.scss
+++ b/src/index.scss
@@ -17,7 +17,6 @@
 @import "import-page/CourseImportPage";
 @import "taxonomy";
 @import "library-authoring";
-@import "container-comparison";
 @import "files-and-videos";
 @import "content-tags-drawer";
 @import "course-outline/CourseOutline";

--- a/src/index.scss
+++ b/src/index.scss
@@ -17,6 +17,7 @@
 @import "import-page/CourseImportPage";
 @import "taxonomy";
 @import "library-authoring";
+@import "container-comparison";
 @import "files-and-videos";
 @import "content-tags-drawer";
 @import "course-outline/CourseOutline";

--- a/src/library-authoring/component-comparison/CompareChangesWidget.tsx
+++ b/src/library-authoring/component-comparison/CompareChangesWidget.tsx
@@ -28,7 +28,7 @@ const CompareChangesWidget = ({
   const intl = useIntl();
 
   return (
-    <div className='bg-white p-2'>
+    <div className="bg-white p-2">
       <Tabs variant="tabs" defaultActiveKey="new" id="preview-version-toggle" mountOnEnter>
         <Tab eventKey="old" title={intl.formatMessage(messages.oldVersionTitle)}>
           <div className="p-2 bg-white">

--- a/src/library-authoring/component-comparison/CompareChangesWidget.tsx
+++ b/src/library-authoring/component-comparison/CompareChangesWidget.tsx
@@ -1,6 +1,6 @@
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Tab, Tabs } from '@openedx/paragon';
-import { IframeProvider } from '../../generic/hooks/context/iFrameContext';
+import { IframeProvider } from '@src/generic/hooks/context/iFrameContext';
 
 import { LibraryBlock, type VersionSpec } from '../LibraryBlock';
 

--- a/src/library-authoring/component-comparison/CompareChangesWidget.tsx
+++ b/src/library-authoring/component-comparison/CompareChangesWidget.tsx
@@ -6,21 +6,10 @@ import { LibraryBlock, type VersionSpec } from '../LibraryBlock';
 
 import messages from './messages';
 
-const PreviewNotAvailable = () => {
-  const intl = useIntl();
-
-  return (
-    <div className="d-flex mt-4 justify-content-center">
-      {intl.formatMessage(messages.previewNotAvailable)}
-    </div>
-  );
-};
-
 interface Props {
   usageKey: string;
   oldVersion?: VersionSpec;
   newVersion?: VersionSpec;
-  isContainer?: boolean;
 }
 
 /**
@@ -35,7 +24,6 @@ const CompareChangesWidget = ({
   usageKey,
   oldVersion = 'published',
   newVersion = 'draft',
-  isContainer = false,
 }: Props) => {
   const intl = useIntl();
 
@@ -44,28 +32,24 @@ const CompareChangesWidget = ({
       <Tabs variant="tabs" defaultActiveKey="new" id="preview-version-toggle" mountOnEnter>
         <Tab eventKey="old" title={intl.formatMessage(messages.oldVersionTitle)}>
           <div className="p-2 bg-white">
-            {isContainer ? (<PreviewNotAvailable />) : (
-              <IframeProvider>
-                <LibraryBlock
-                  usageKey={usageKey}
-                  version={oldVersion}
-                  minHeight="50vh"
-                />
-              </IframeProvider>
-            )}
+            <IframeProvider>
+              <LibraryBlock
+                usageKey={usageKey}
+                version={oldVersion}
+                minHeight="50vh"
+              />
+            </IframeProvider>
           </div>
         </Tab>
         <Tab eventKey="new" title={intl.formatMessage(messages.newVersionTitle)}>
           <div className="p-2 bg-white">
-            {isContainer ? (<PreviewNotAvailable />) : (
-              <IframeProvider>
-                <LibraryBlock
-                  usageKey={usageKey}
-                  version={newVersion}
-                  minHeight="50vh"
-                />
-              </IframeProvider>
-            )}
+            <IframeProvider>
+              <LibraryBlock
+                usageKey={usageKey}
+                version={newVersion}
+                minHeight="50vh"
+              />
+            </IframeProvider>
           </div>
         </Tab>
       </Tabs>

--- a/src/library-authoring/component-comparison/CompareChangesWidget.tsx
+++ b/src/library-authoring/component-comparison/CompareChangesWidget.tsx
@@ -28,7 +28,7 @@ const CompareChangesWidget = ({
   const intl = useIntl();
 
   return (
-    <div>
+    <div className='bg-white p-2'>
       <Tabs variant="tabs" defaultActiveKey="new" id="preview-version-toggle" mountOnEnter>
         <Tab eventKey="old" title={intl.formatMessage(messages.oldVersionTitle)}>
           <div className="p-2 bg-white">

--- a/src/library-authoring/component-comparison/messages.ts
+++ b/src/library-authoring/component-comparison/messages.ts
@@ -17,11 +17,6 @@ const messages = defineMessages({
     defaultMessage: 'Compare Changes',
     description: 'Title used for the compare changes dialog',
   },
-  previewNotAvailable: {
-    id: 'course-authoring.library-authoring.component-comparison.preview-not-available',
-    defaultMessage: 'Preview not available for container changes at this time',
-    description: 'Message shown when preview is not available.',
-  },
 });
 
 export default messages;

--- a/src/library-authoring/data/api.mocks.ts
+++ b/src/library-authoring/data/api.mocks.ts
@@ -602,6 +602,7 @@ mockGetContainerMetadata.applyMock = () => {
  */
 export async function mockGetContainerChildren(containerId: string): Promise<api.LibraryBlockMetadata[]> {
   let numChildren: number;
+  let blockType = 'html';
   switch (containerId) {
     case mockGetContainerMetadata.unitId:
     case mockGetContainerMetadata.sectionId:
@@ -618,7 +619,6 @@ export async function mockGetContainerChildren(containerId: string): Promise<api
       numChildren = 0;
       break;
   }
-  let blockType = 'html';
   let name = 'text';
   let typeNamespace = 'lb';
   if (containerId.includes('subsection')) {
@@ -638,6 +638,7 @@ export async function mockGetContainerChildren(containerId: string): Promise<api
         id: `${typeNamespace}:org1:Demo_course_generated:${blockType}:${name}-${idx}`,
         displayName: `${name} block ${idx}`,
         publishedDisplayName: `${name} block published ${idx}`,
+        blockType,
       }
     )),
   );


### PR DESCRIPTION
## Description

Container sync preview implemented as describe in https://github.com/openedx/frontend-app-authoring/issues/2176


https://github.com/user-attachments/assets/72785f59-f993-4550-bec1-ae77e4325527


**Limitations:**

* No easy way to distinguish containers that have only their name updated vs changes in their children. The version is updated in following cases, on container name change, on children order change and addition or deletion of a child component.


Useful information to include:
- Which user roles will this change impact? Author.

## Supporting information

* https://github.com/openedx/frontend-app-authoring/issues/2176
* Depends on https://github.com/openedx/edx-platform/pull/37375
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4246

## Testing instructions

* Checkout edx-platform and this PR.
* Create sections, subsections, units and some components in a library in hierarchy.
* Imported them into a course.
* Update some components, units, subsections in library. Try different things, like adding, deleting, updating etc. and publish the library.
* Verify the preview diff in course.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
