### PR TITLE
feat: settings component for section, subsection and unit

### DIFF
--- a/src/library-authoring/containers/ContainerInfo.tsx
+++ b/src/library-authoring/containers/ContainerInfo.tsx
@@ -24,6 +24,7 @@ import {
 } from '../common/context/SidebarContext';
 import ContainerOrganize from './ContainerOrganize';
 import ContainerUsage from './ContainerUsage';
+import { SettingsPanel } from './SettingsPanel';
 import { useLibraryRoutes } from '../routes';
 import { LibraryUnitBlocks } from '../units/LibraryUnitBlocks';
 import { LibraryContainerChildren } from '../section-subsections/LibraryContainerChildren';
@@ -225,7 +226,7 @@ const ContainerInfo = () => {
             <ContainerUsage />
           </Tab.Pane>
           <Tab.Pane eventKey={CONTAINER_INFO_TABS.Settings}>
-            {/* TODO: Container settings component */}
+            <SettingsPanel containerType={containerType} />
           </Tab.Pane>
         </Tab.Content>
       </Tab.Container>

--- a/src/library-authoring/containers/SettingsPanel.scss
+++ b/src/library-authoring/containers/SettingsPanel.scss
@@ -1,0 +1,3 @@
+.text-muted-override{
+    color: #DEDBDB !important;
+}

--- a/src/library-authoring/containers/SettingsPanel.test.tsx
+++ b/src/library-authoring/containers/SettingsPanel.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { ContainerType } from '@src/generic/key-utils';
+import { SettingsPanel } from './SettingsPanel';
+import messages from './messages';
+
+const renderWithIntl = (ui: React.ReactNode) => render(
+  <IntlProvider locale="en" messages={{}}>
+    {ui}
+  </IntlProvider>,
+);
+
+describe('SettingsPanel', () => {
+  describe('Section container', () => {
+    test('renders section default info text', () => {
+      renderWithIntl(<SettingsPanel containerType={ContainerType.Section} />);
+      expect(
+        screen.getByText(messages.settingsSectionDefaultText.defaultMessage),
+      ).toBeInTheDocument();
+    });
+
+    test('does not render grading or results visibility', () => {
+      renderWithIntl(<SettingsPanel containerType={ContainerType.Section} />);
+      expect(
+        screen.queryByText(messages.settingsSectionGradingLabel.defaultMessage),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          messages.settingsSectionAssessmentResultsVisibilityLabel.defaultMessage,
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    test('renders visibility controls', () => {
+      renderWithIntl(<SettingsPanel containerType={ContainerType.Section} />);
+      expect(
+        screen.getByText(messages.settingsSectionVisibilityLabel.defaultMessage),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {
+          name: messages.settingsSectionDefaultVisibilityButton.defaultMessage,
+        }),
+      ).toBeDisabled();
+    });
+  });
+
+  describe('Subsection container', () => {
+    test('renders subsection default info text', () => {
+      renderWithIntl(<SettingsPanel containerType={ContainerType.Subsection} />);
+      expect(
+        screen.getByText(messages.settingsSubSectionDefaultText.defaultMessage),
+      ).toBeInTheDocument();
+    });
+
+    test('renders grading buttons (disabled)', () => {
+      renderWithIntl(<SettingsPanel containerType={ContainerType.Subsection} />);
+      expect(
+        screen.getByRole('button', {
+          name: messages.settingsSectionUpgradeButton.defaultMessage,
+        }),
+      ).toBeDisabled();
+      expect(
+        screen.getByRole('button', {
+          name: messages.settingsSectionGradeButton.defaultMessage,
+        }),
+      ).toBeDisabled();
+    });
+
+    test('renders visibility + hide content checkbox', () => {
+      renderWithIntl(<SettingsPanel containerType={ContainerType.Subsection} />);
+      expect(
+        screen.getByLabelText(
+          messages.settingsSectionHideContentAfterDueDateLabel.defaultMessage,
+        ),
+      ).toBeDisabled();
+    });
+
+    test('renders results visibility controls', () => {
+      renderWithIntl(<SettingsPanel containerType={ContainerType.Subsection} />);
+      expect(
+        screen.getByRole('button', {
+          name: messages.settingsSectionShowButton.defaultMessage,
+        }),
+      ).toBeDisabled();
+      expect(
+        screen.getByRole('button', {
+          name: messages.settingsSectionHideButton.defaultMessage,
+        }),
+      ).toBeDisabled();
+      expect(
+        screen.getByLabelText(
+          messages.settingsSectionOnlyShowResultsAfterDueDateLabel.defaultMessage,
+        ),
+      ).toBeDisabled();
+    });
+  });
+
+  describe('Unit container', () => {
+    test('renders unit default info text', () => {
+      renderWithIntl(<SettingsPanel containerType={ContainerType.Unit} />);
+      expect(
+        screen.getByText(messages.settingsUnitDefaultText.defaultMessage),
+      ).toBeInTheDocument();
+    });
+
+    test('renders discussion settings', () => {
+      renderWithIntl(<SettingsPanel containerType={ContainerType.Unit} />);
+      expect(
+        screen.getByText(messages.settingsSectionDiscussionLabel.defaultMessage),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText(
+          messages.settingsSectionEnableDiscussionLabel.defaultMessage,
+        ),
+      ).toBeChecked();
+      expect(
+        screen.getByText(messages.settingsSectionUnpublishedUnitsLabel.defaultMessage),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/library-authoring/containers/SettingsPanel.tsx
+++ b/src/library-authoring/containers/SettingsPanel.tsx
@@ -1,0 +1,133 @@
+import React, { useState } from 'react';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { Button, ButtonGroup, Form } from '@openedx/paragon';
+import { ContainerType } from '@src/generic/key-utils';
+import messages from './messages';
+
+import './SettingsPanel.scss';
+
+interface SettingsPanelProps {
+  containerType: string;
+}
+
+export const SettingsPanel: React.FC<SettingsPanelProps> = ({ containerType }) => {
+  const [grading] = useState('ungraded');
+  const [visibility] = useState('default');
+  const [resultsVisibility] = useState('show');
+
+  const disableAll = true; // 👈 set to false to re-enable
+
+  return (
+    <>
+      <div className="pb-2 pl-4 pr-4 space-y-4">
+        <p className="text-muted small mb-4">
+          { containerType === ContainerType.Section && (
+            <FormattedMessage {...messages.settingsSectionDefaultText} />
+          )}
+          { containerType === ContainerType.Subsection && (
+            <FormattedMessage {...messages.settingsSubSectionDefaultText} />
+          )}
+          { containerType === ContainerType.Unit && (
+            <FormattedMessage {...messages.settingsUnitDefaultText} />
+          )}
+        </p>
+      </div>
+      <div className="pb-4 pl-4 pr-4 space-y-4">
+        {containerType === ContainerType.Subsection && (
+        <>
+          <h6 className="text-muted small font-weight-bold mb-3">
+            <FormattedMessage {...messages.settingsSectionGradingLabel} />
+          </h6>
+          <ButtonGroup className="d-flex w-100 mb-4.5">
+            <Button
+              className="flex-fill"
+              variant={grading === 'ungraded' ? 'dark' : 'outline-secondary'}
+              size="sm"
+              disabled={disableAll}
+            >
+              <FormattedMessage {...messages.settingsSectionUpgradeButton} />
+            </Button>
+            <Button
+              className="flex-fill"
+              variant={grading === 'graded' ? 'dark' : 'outline-secondary'}
+              size="sm"
+              disabled={disableAll}
+            >
+              <FormattedMessage {...messages.settingsSectionGradeButton} />
+            </Button>
+          </ButtonGroup>
+        </>
+        )}
+
+        <h6 className="text-muted small font-weight-bold mt-3 mb-3">
+          <FormattedMessage {...messages.settingsSectionVisibilityLabel} />
+        </h6>
+        <ButtonGroup className="d-flex w-100">
+          <Button
+            className="flex-fill"
+            variant={visibility === 'default' ? 'dark' : 'outline-secondary'}
+            size="sm"
+            disabled={disableAll}
+          >
+            <FormattedMessage {...messages.settingsSectionDefaultVisibilityButton} />
+          </Button>
+          <Button
+            className="flex-fill"
+            variant={visibility === 'staff' ? 'dark' : 'outline-secondary'}
+            size="sm"
+            disabled={disableAll}
+          >
+            <FormattedMessage {...messages.settingsSectionStaffOnlyButton} />
+          </Button>
+        </ButtonGroup>
+        {containerType === ContainerType.Subsection && (
+          <Form.Checkbox className="mt-3 text-muted mb-4.5" disabled>
+            <FormattedMessage {...messages.settingsSectionHideContentAfterDueDateLabel} />
+          </Form.Checkbox>
+        )}
+
+        {containerType === ContainerType.Subsection && (
+          <>
+            <h6 className="text-muted small font-weight-bold mt-1 mb-3">
+              <FormattedMessage {...messages.settingsSectionAssessmentResultsVisibilityLabel} />
+            </h6>
+            <ButtonGroup className="d-flex w-100">
+              <Button
+                className="flex-fill"
+                variant={resultsVisibility === 'show' ? 'dark' : 'outline-secondary'}
+                size="sm"
+                disabled={disableAll}
+              >
+                <FormattedMessage {...messages.settingsSectionShowButton} />
+              </Button>
+              <Button
+                className="flex-fill"
+                variant={resultsVisibility === 'hide' ? 'dark' : 'outline-secondary'}
+                size="sm"
+                disabled={disableAll}
+              >
+                <FormattedMessage {...messages.settingsSectionHideButton} />
+              </Button>
+            </ButtonGroup>
+            <Form.Checkbox className="mt-3 text-muted mb-4.5" disabled>
+              <FormattedMessage {...messages.settingsSectionOnlyShowResultsAfterDueDateLabel} />
+            </Form.Checkbox>
+          </>
+        )}
+        {containerType === ContainerType.Unit && (
+          <>
+            <h6 className="text-muted small font-weight-bold mt-3 mb-3">
+              <FormattedMessage {...messages.settingsSectionDiscussionLabel} />
+            </h6>
+            <Form.Checkbox className="mt-3 text-muted" disabled checked>
+              <FormattedMessage {...messages.settingsSectionEnableDiscussionLabel} />
+            </Form.Checkbox>
+            <p className="text-muted small mb-4 text-muted-override">
+              <FormattedMessage {...messages.settingsSectionUnpublishedUnitsLabel} />
+            </p>
+          </>
+        )}
+      </div>
+    </>
+  );
+};

--- a/src/library-authoring/containers/messages.ts
+++ b/src/library-authoring/containers/messages.ts
@@ -216,6 +216,91 @@ const messages = defineMessages({
     defaultMessage: 'Failed to publish changes',
     description: 'Popup text seen if publishing a container fails',
   },
+  settingsSectionDefaultText: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-default-text',
+    defaultMessage: 'Section settings cannot be configured within Libraries and must be set within a course. In a future release, Libraries may support configuring some settings.',
+    description: 'Settings section tab default text',
+  },
+  settingsSubSectionDefaultText: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-subsection-default-text',
+    defaultMessage: 'Subsection settings cannot be configured within Libraries and must be set within a course. In a future release, Libraries may support configuring some settings.',
+    description: 'Settings subsection tab default text',
+  },
+  settingsUnitDefaultText: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-unit-default-text',
+    defaultMessage: 'Unit settings cannot be configured within Libraries and must be set within a course. In a future release, Libraries may support configuring some settings',
+    description: 'Settings unit tab default text',
+  },
+  settingsSectionGradingLabel: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-grading-label',
+    defaultMessage: 'Subsection Grading',
+    description: 'Label for the grading section in settings',
+  },
+  settingsSectionVisibilityLabel: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-visibility-label',
+    defaultMessage: 'Visibility',
+    description: 'Label for the visibility in settings',
+  },
+  settingsSectionAssessmentResultsVisibilityLabel: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-assessment-results-visibility-label',
+    defaultMessage: 'Assessment Results Visibility',
+    description: 'Label for the Assessment Results Visibility in settings',
+  },
+  settingsSectionUpgradeButton: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-upgrade-button',
+    defaultMessage: 'Upgraded',
+    description: 'Label for the upgrade button in settings',
+  },
+  settingsSectionGradeButton: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-grade-button',
+    defaultMessage: 'Graded',
+    description: 'Label for the grade button in settings',
+  },
+  settingsSectionDefaultVisibilityButton: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-default-visibility-button',
+    defaultMessage: 'Default Visibility',
+    description: 'Label for the default visibility button in settings',
+  },
+  settingsSectionStaffOnlyButton: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-staff-only-button',
+    defaultMessage: 'Staff Only',
+    description: 'Label for the staff only button in settings',
+  },
+  settingsSectionShowButton: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-show-button',
+    defaultMessage: 'Show',
+    description: 'Label for the show button in settings',
+  },
+  settingsSectionHideButton: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-hide-button',
+    defaultMessage: 'Hide',
+    description: 'Label for the hide button in settings',
+  },
+  settingsSectionHideContentAfterDueDateLabel: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-hide-content-after-due-date',
+    defaultMessage: 'Hide content after due date',
+    description: 'Label for the hide content after due date checkbox in settings',
+  },
+  settingsSectionOnlyShowResultsAfterDueDateLabel: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-only-show-results-after-due-date',
+    defaultMessage: 'Only show results after due date',
+    description: 'Label for the only show results after due date checkbox in settings',
+  },
+  settingsSectionDiscussionLabel: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-discussion-label',
+    defaultMessage: 'Discussion',
+    description: 'Label for the discussion in settings',
+  },
+  settingsSectionEnableDiscussionLabel: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-enable-discussion-label',
+    defaultMessage: 'Enable Discussion',
+    description: 'Label for the enable discussion checkbox in settings',
+  },
+  settingsSectionUnpublishedUnitsLabel: {
+    id: 'course-authoring.library-authoring.container-sidebar.publisher.settings-section-unpublished-units-label',
+    defaultMessage: 'Topics for unpublished units will not be created',
+    description: 'Label for the unpublished units in settings',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description

Settings component for section, subsection and unit
https://github.com/openedx/frontend-app-authoring/issues/1976
## Supporting information

<img width="2828" height="1400" alt="image" src="https://github.com/user-attachments/assets/19b8ffb7-2a67-457d-86f7-d1088a29d4df" />


<img width="2844" height="1398" alt="image" src="https://github.com/user-attachments/assets/fa04f4f4-035c-48f2-b9bb-deb223127c90" />


<img width="2858" height="1414" alt="image" src="https://github.com/user-attachments/assets/46b59745-180a-467a-a4bd-f24e4fd0ce1e" />

