### PR TITLE
fix: self-closing script tag fixed for TinyMceEditor

### DIFF
--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -362,6 +362,7 @@ export const editorConfig = ({
       valid_children: '+body[style]',
       valid_elements: '*[*]',
       entity_encoding: 'utf-8',
+      protect: [/\<script[^>]*\/\>/g], // protect self-closing script tags from being mangled
     },
   };
 };


### PR DESCRIPTION
### Related Ticket (internal)
https://github.com/mitodl/hq/issues/7208

## Description

In some scenarios the script tag is automatically enclosing other html content when used in a text component. Take for example this simple piece of html:

```html
<script type="text/javascript" src="/asset-v1:TestX+8.13_testing+2025_Spring+type@asset+block@print_styles.js"/>
<p>This is content</p>
```
if that is put into a text component using the HTML editor, then problems arise, see screenshots:

![](https://github.mit.edu/storage/user/1431/files/8347e8fd-8d19-478f-9801-8e1b540f3d77)
![](https://github.mit.edu/storage/user/1431/files/8838749a-43af-45fe-8976-fd94b20266cd)

Basically what happens is the editor is deciding that the script tag needs closed, it then saves the html as:

```html
<p>
<script type="text/javascript" src="/asset-v1:TestX+8.13_testing+2025_Spring+type@asset+block@print_styles.js">
<p>This is content</p></script>
</p>
```

## Testing instructions
1. Follow the steps from **Description** and you shouldn't see any malformed HTML now instead you should see `This is content` in the editor

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
