### PR TITLE
feat: Shows an alert in container sync if the only change is a local override to a text component []

### DIFF
--- a/src/container-comparison/ContainerRow.test.tsx
+++ b/src/container-comparison/ContainerRow.test.tsx
@@ -83,6 +83,11 @@ describe('<ContainerRow />', () => {
     expect(await screen.findByText(messages.renamedDiffBeforeMessage.defaultMessage.replace('{name}', 'Modified name'))).toBeInTheDocument();
   });
 
+  test('renders with local content update', async () => {
+    render(<ContainerRow title="Test title" containerType="html" side="Before" state="locallyContentUpdated" />);
+    expect(await screen.findByText(messages.locallyContentUpdatedBeforeMessage.defaultMessage.replace('{blockType}', 'html'))).toBeInTheDocument();
+  });
+
   test('renders with moved state', async () => {
     render(<ContainerRow title="Test title" containerType="subsection" side="After" state="moved" />);
     expect(await screen.findByText(

--- a/src/container-comparison/ContainerRow.tsx
+++ b/src/container-comparison/ContainerRow.tsx
@@ -40,7 +40,10 @@ const ContainerRow = ({
         message = side === 'Before' ? messages.removedDiffBeforeMessage : messages.removedDiffAfterMessage;
         return ['text-white bg-danger-600', Delete, message];
       case 'locallyRenamed':
-        message = side === 'Before' ? messages.renamedDiffBeforeMessage : messages.renamedDiffAfterMessage;
+        message = side === 'Before' ? messages.renamedDiffBeforeMessage : messages.renamedUpdatedDiffAfterMessage;
+        return ['bg-light-300 text-light-300 ', Done, message];
+      case 'locallyContentUpdated':
+        message = side === 'Before' ? messages.locallyContentUpdatedBeforeMessage : messages.locallyContentUpdatedAfterMessage;
         return ['bg-light-300 text-light-300 ', Done, message];
       case 'moved':
         message = side === 'Before' ? messages.movedDiffBeforeMessage : messages.movedDiffAfterMessage;

--- a/src/container-comparison/data/api.mock.ts
+++ b/src/container-comparison/data/api.mock.ts
@@ -47,6 +47,7 @@ export async function mockGetCourseContainerChildren(containerId: string): Promi
     canPasteComponent: true,
     isPublished: false,
     children,
+    upstreamReadyToSyncChildrenInfo: [],
   });
 }
 mockGetCourseContainerChildren.unitId = 'block-v1:UNIX+UX1+2025_T3+type@unit+block@0';

--- a/src/container-comparison/data/apiHooks.ts
+++ b/src/container-comparison/data/apiHooks.ts
@@ -11,16 +11,16 @@ export const containerComparisonQueryKeys = {
   /**
    * Key for a single container
    */
-  container: (usageKey: string) => {
+  container: (usageKey: string, getUpstreamInfo: boolean) => {
     const courseKey = getCourseKey(usageKey);
-    return [...containerComparisonQueryKeys.course(courseKey), usageKey];
+    return [...containerComparisonQueryKeys.course(courseKey), usageKey, getUpstreamInfo.toString()];
   },
 };
 
-export const useCourseContainerChildren = (usageKey?: string) => (
+export const useCourseContainerChildren = (usageKey?: string, getUpstreamInfo?: boolean) => (
   useQuery({
     enabled: !!usageKey,
-    queryFn: () => getCourseContainerChildren(usageKey!),
-    queryKey: containerComparisonQueryKeys.container(usageKey!),
+    queryFn: () => getCourseContainerChildren(usageKey!, getUpstreamInfo),
+    queryKey: containerComparisonQueryKeys.container(usageKey!, getUpstreamInfo || false),
   })
 );

--- a/src/container-comparison/messages.ts
+++ b/src/container-comparison/messages.ts
@@ -76,6 +76,11 @@ const messages = defineMessages({
     defaultMessage: 'After',
     description: 'After section title text',
   },
+  localChangeInTextAlert: {
+    id: 'course-authoring.container-comparison.text-with-local-change.alert',
+    defaultMessage: 'The only change is to text block <b>{blockName}</b> which has been edited in this course. Accepting will not remove local edits.',
+    description: 'Alert to show if the only change is a local override to a text component.',
+  },
 });
 
 export default messages;

--- a/src/container-comparison/messages.ts
+++ b/src/container-comparison/messages.ts
@@ -32,14 +32,24 @@ const messages = defineMessages({
     description: 'Description for added component in after section of diff preview',
   },
   renamedDiffBeforeMessage: {
-    id: 'course-authoring.container-comparison.diff.before.renamed-message',
-    defaultMessage: 'Original Library Name: {name}',
-    description: 'Description for renamed component in before section of diff preview',
+    id: 'course-authoring.container-comparison.diff.before.locally-updated-message',
+    defaultMessage: 'Library Name: {name}',
+    description: 'Description for locally updated component in before section of diff preview',
   },
-  renamedDiffAfterMessage: {
-    id: 'course-authoring.container-comparison.diff.after.renamed-message',
-    defaultMessage: 'This {blockType} will remain renamed',
-    description: 'Description for renamed component in after section of diff preview',
+  renamedUpdatedDiffAfterMessage: {
+    id: 'course-authoring.container-comparison.diff.after.locally-updated-message',
+    defaultMessage: 'Library name remains overwritten',
+    description: 'Description for locally updated component in after section of diff preview',
+  },
+  locallyContentUpdatedBeforeMessage: {
+    id: 'course-authoring.container-comparison.diff.before.locally-content-updated-message',
+    defaultMessage: 'This {blockType} was edited locally',
+    description: 'Description for locally content updated component in before section of diff preview',
+  },
+  locallyContentUpdatedAfterMessage: {
+    id: 'course-authoring.container-comparison.diff.after.locally-content-updated-message',
+    defaultMessage: 'Local edit will remain',
+    description: 'Description for locally content updated component in after section of diff preview',
   },
   movedDiffBeforeMessage: {
     id: 'course-authoring.container-comparison.diff.before.moved-message',

--- a/src/container-comparison/types.ts
+++ b/src/container-comparison/types.ts
@@ -1,6 +1,6 @@
 import { UpstreamInfo } from '@src/data/types';
 
-export type ContainerState = 'removed' | 'added' | 'modified' | 'childrenModified' | 'locallyRenamed' | 'moved';
+export type ContainerState = 'removed' | 'added' | 'modified' | 'childrenModified' | 'locallyContentUpdated' | 'locallyRenamed' | 'moved';
 
 export type WithState<T> = T & { state?: ContainerState, originalName?: string };
 export type WithIndex<T> = T & { index: number };

--- a/src/container-comparison/utils.ts
+++ b/src/container-comparison/utils.ts
@@ -36,6 +36,7 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
   for (let index = 0; index < b.length; index++) {
     const newVersion = b[index];
     const oldVersion = mapA.get(newVersion.id);
+
     if (!oldVersion) {
       // This is a newly added component
       addedA.push({
@@ -55,12 +56,19 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
       let state: ContainerState | undefined;
       const displayName = oldVersion.upstreamLink.isModified ? oldVersion.name : newVersion.displayName;
       let originalName: string | undefined;
+      const isRenamed = displayName !== newVersion.displayName && displayName === oldVersion.name;
       if (index !== oldVersion.index) {
         // has moved from its position
         state = 'moved';
       }
-      if (displayName !== newVersion.displayName && displayName === oldVersion.name) {
-        // Has been renamed
+      if (oldVersion.upstreamLink.isModified && !isRenamed) {
+        // The content is updated, not the name.
+        state = 'locallyContentUpdated';
+      }
+      if (isRenamed) {
+        // Has been renamed.
+        // TODO: At this point we can't know if the content is updated or not
+        // because `upstreamLink.isModified` is also true when renaming.
         state = 'locallyRenamed';
         originalName = newVersion.displayName;
       }

--- a/src/container-comparison/utils.ts
+++ b/src/container-comparison/utils.ts
@@ -64,15 +64,13 @@ export function diffPreviewContainerChildren<A extends CourseContainerChildBase,
       if (oldVersion.upstreamLink.isModified && !isRenamed) {
         // The content is updated, not the name.
         state = 'locallyContentUpdated';
-      }
-      if (isRenamed) {
+      } else if (isRenamed) {
         // Has been renamed.
         // TODO: At this point we can't know if the content is updated or not
         // because `upstreamLink.isModified` is also true when renaming.
         state = 'locallyRenamed';
         originalName = newVersion.displayName;
-      }
-      if (checkIsReadyToSync(oldVersion.upstreamLink)) {
+      } else if (checkIsReadyToSync(oldVersion.upstreamLink)) {
         // has a new version ready to sync
         state = 'modified';
       }

--- a/src/course-outline/section-card/SectionCard.tsx
+++ b/src/course-outline/section-card/SectionCard.tsx
@@ -144,6 +144,7 @@ const SectionCard = ({
       downstreamBlockId: id,
       upstreamBlockId: upstreamInfo.upstreamRef,
       upstreamBlockVersionSynced: upstreamInfo.versionSynced,
+      isReadyToSyncIndividually: upstreamInfo.isReadyToSyncIndividually,
       isContainer: true,
     };
   }, [upstreamInfo]);

--- a/src/course-outline/subsection-card/SubsectionCard.tsx
+++ b/src/course-outline/subsection-card/SubsectionCard.tsx
@@ -126,6 +126,7 @@ const SubsectionCard = ({
       downstreamBlockId: id,
       upstreamBlockId: upstreamInfo.upstreamRef,
       upstreamBlockVersionSynced: upstreamInfo.versionSynced,
+      isReadyToSyncIndividually: upstreamInfo.isReadyToSyncIndividually,
       isContainer: true,
     };
   }, [upstreamInfo]);

--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -103,6 +103,7 @@ const UnitCard = ({
       downstreamBlockId: id,
       upstreamBlockId: upstreamInfo.upstreamRef,
       upstreamBlockVersionSynced: upstreamInfo.versionSynced,
+      isReadyToSyncIndividually: upstreamInfo.isReadyToSyncIndividually,
       isContainer: true,
     };
   }, [upstreamInfo]);

--- a/src/course-unit/data/api.ts
+++ b/src/course-unit/data/api.ts
@@ -9,7 +9,7 @@ const getStudioBaseUrl = () => getConfig().STUDIO_BASE_URL;
 
 export const getXBlockBaseApiUrl = (itemId: string) => `${getStudioBaseUrl()}/xblock/${itemId}`;
 export const getCourseSectionVerticalApiUrl = (itemId: string) => `${getStudioBaseUrl()}/api/contentstore/v1/container_handler/${itemId}`;
-export const getCourseVerticalChildrenApiUrl = (itemId: string) => `${getStudioBaseUrl()}/api/contentstore/v1/container/${itemId}/children`;
+export const getCourseVerticalChildrenApiUrl = (itemId: string, getUpstreamInfo: boolean = false) => `${getStudioBaseUrl()}/api/contentstore/v1/container/${itemId}/children?get_upstream_info=${getUpstreamInfo}`;
 export const getCourseOutlineInfoUrl = (courseId: string) => `${getStudioBaseUrl()}/course/${courseId}?format=concise`;
 export const postXBlockBaseApiUrl = () => `${getStudioBaseUrl()}/xblock/`;
 export const libraryBlockChangesUrl = (blockId: string) => `${getStudioBaseUrl()}/api/contentstore/v2/downstreams/${blockId}/sync`;
@@ -108,9 +108,12 @@ export async function handleCourseUnitVisibilityAndData(
 /**
  * Get an object containing course vertical children data.
  */
-export async function getCourseContainerChildren(itemId: string): Promise<CourseContainerChildrenData> {
+export async function getCourseContainerChildren(
+  itemId: string,
+  getUpstreamInfo: boolean = false,
+): Promise<CourseContainerChildrenData> {
   const { data } = await getAuthenticatedHttpClient()
-    .get(getCourseVerticalChildrenApiUrl(itemId));
+    .get(getCourseVerticalChildrenApiUrl(itemId, getUpstreamInfo));
   const camelCaseData = camelCaseObject(data);
 
   return updateXBlockBlockIdToId(camelCaseData) as CourseContainerChildrenData;

--- a/src/course-unit/data/types.ts
+++ b/src/course-unit/data/types.ts
@@ -38,8 +38,17 @@ export interface ContainerChildData {
   upstreamLink: UpstreamInfo;
 }
 
+export interface UpstreamReadyToSyncChildrenInfo {
+  id: string;
+  name: string;
+  upstream: string;
+  blockType: string;
+  isModified: boolean;
+}
+
 export interface CourseContainerChildrenData {
   canPasteComponent: boolean;
-  children: ContainerChildData[],
+  children: ContainerChildData[];
   isPublished: boolean;
+  upstreamReadyToSyncChildrenInfo: UpstreamReadyToSyncChildrenInfo[];
 }

--- a/src/course-unit/preview-changes/index.tsx
+++ b/src/course-unit/preview-changes/index.tsx
@@ -105,6 +105,7 @@ export interface LibraryChangesMessageData {
   isLocallyModified?: boolean,
   isContainer: boolean,
   blockType?: string | null,
+  isReadyToSyncIndividually?: boolean,
 }
 
 export interface PreviewLibraryXBlockChangesProps {
@@ -144,6 +145,7 @@ export const PreviewLibraryXBlockChanges = ({
           title={blockData.displayName}
           upstreamBlockId={blockData.upstreamBlockId}
           downstreamBlockId={blockData.downstreamBlockId}
+          isReadyToSyncIndividually={blockData.isReadyToSyncIndividually}
         />
       );
     }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -64,6 +64,7 @@ export interface UpstreamInfo {
   isModified?: boolean,
   hasTopLevelParent?: boolean,
   readyToSyncChildren?: UpstreamChildrenInfo[],
+  isReadyToSyncIndividually?: boolean,
 }
 
 export interface XBlock {


### PR DESCRIPTION
## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be linked here.

Useful information to include:
- Which user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).

## Supporting information

Link to other information about the change, such as GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for manually testing this change.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
