### PR TITLE
feat: frontend-component-header to 8.0.0, to rm Maintenance link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@edx/browserslist-config": "1.5.0",
         "@edx/frontend-component-footer": "^14.9.0",
-        "@edx/frontend-component-header": "^6.2.0",
+        "@edx/frontend-component-header": "^8.0.0",
         "@edx/frontend-enterprise-hotjar": "^7.2.0",
         "@edx/frontend-platform": "^8.4.0",
         "@edx/openedx-atlas": "^0.7.0",
@@ -2591,9 +2591,9 @@
       }
     },
     "node_modules/@edx/frontend-component-header": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-6.6.1.tgz",
-      "integrity": "sha512-ETGIpCyXq1YWR/wvc4fGzPUtGsdYfXKDtuH45sgiRx7Zt9spgNm0KYO1tah1TF1UrPjIkQErm+8LFh8me/kJCg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-8.0.0.tgz",
+      "integrity": "sha512-AD6ImSI2APSKBOA1a3P4/Uy6YlpEYlSePpKbNNr2YjmY5nB5yWcNjE38sBBIBHLbC2/b+AwgGrv+m1bxej5xTQ==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "6.7.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
     "@edx/browserslist-config": "1.5.0",
     "@edx/frontend-component-footer": "^14.9.0",
-    "@edx/frontend-component-header": "^6.2.0",
+    "@edx/frontend-component-header": "^8.0.0",
     "@edx/frontend-enterprise-hotjar": "^7.2.0",
     "@edx/frontend-platform": "^8.4.0",
     "@edx/openedx-atlas": "^0.7.0",


### PR DESCRIPTION
BREAKING CHANGE: Removes Maintenance link in header, part of https://github.com/openedx/edx-platform/issues/36263 (the immediate purpose of this upgrade)

BREAKING CHANGE: Consuming applications must support typescript

Full diff:
https://github.com/openedx/frontend-component-header/compare/v6.2.0...v8.0.0

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
