### PR TITLE
test: fix warnings when StrictDict values are checked with propTypes

### DIFF
--- a/src/editors/utils/StrictDict.ts
+++ b/src/editors/utils/StrictDict.ts
@@ -4,7 +4,9 @@ const strictGet = (target, name) => {
     return target;
   }
 
-  if (name in target || name === '_reactFragment') {
+  // '@@toStringTag' is used by propTypes in its internal `isSymbol()` function.
+  // We can probably remove this exception once we get rid of propTypes.
+  if (name in target || name === '_reactFragment' || name === '@@toStringTag') {
     return target[name];
   }
 


### PR DESCRIPTION
## Description

This fixes this warning that can be seen when running some tests:

```
    Error: invalid property "@@toStringTag"
        at Object.strictGet [as get] (src/editors/utils/StrictDict.ts:17:13)
        at isSymbol (node_modules/prop-types/factoryWithTypeCheckers.js:533:18)
        at getPropType (node_modules/prop-types/factoryWithTypeCheckers.js:557:9)
        at validate (node_modules/prop-types/factoryWithTypeCheckers.js:423:22)
        at checkType (node_modules/prop-types/factoryWithTypeCheckers.js:219:16)
        at checkPropTypes (node_modules/react/cjs/react-jsx-runtime.development.js:612:44)
        at validatePropTypes (node_modules/react/cjs/react-jsx-runtime.development.js:1164:7)
        at jsxWithValidation (node_modules/react/cjs/react-jsx-runtime.development.js:1303:7)
        at jsxWithValidationDynamic (node_modules/react/cjs/react-jsx-runtime.development.js:1320:12)
        at getComponent (src/editors/sharedComponents/SelectionModal/SearchSort.test.jsx:46:9)
        at Object.getComponent (src/editors/sharedComponents/SelectionModal/SearchSort.test.jsx:52:27)
        at Promise.then.completed (node_modules/@openedx/frontend-build/node_modules/jest-circus/build/utils.js:298:28)
        at new Promise (<anonymous>)
        ...
        at runTestInternal (node_modules/@openedx/frontend-build/node_modules/jest-runner/build/runTest.js:367:16)
        at runTest (node_modules/@openedx/frontend-build/node_modules/jest-runner/build/runTest.js:444:34)
```

## Supporting information

Private ref MNG-4670

## Testing instructions

Run `npm test -- --coverage=no --bail -- src/editors/sharedComponents/SelectionModal/SearchSort.test.jsx` before and after checking out this PR. You will see the warnings (among many others) before only.
