### PR TITLE
test: run additional lint checks only on modified files

### DIFF
--- a/.eslintrc.diff.js
+++ b/.eslintrc.diff.js
@@ -1,0 +1,39 @@
+const path = require('path');
+
+// Additional eslint rules specific to the Authoring MFE, which only run on modified files.
+
+module.exports = {
+  rules: {
+    'no-restricted-imports': ['error', {
+      patterns: [
+        {
+          // Ban injectIntl() HOC
+          group: ['@edx/frontend-platform/i18n'],
+          importNames: ['injectIntl'],
+          message: "Use 'useIntl' hook instead of injectIntl.",
+        },
+        {
+          // Ban connect()/mapStateToProps/mapDispatchToProps HOC pattern
+          group: ['react-redux'],
+          importNames: ['connect'],
+          message: "Use 'useDispatch' and 'useSelector' hooks instead of 'connect'.",
+        },
+        // In the near future we will require 'propTypes' to be removed from all modified code too:
+        // {
+        //   group: ['prop-types'],
+        //   message: 'Use TypeScript types instead of propTypes.',
+        // },
+      ],
+    }],
+    // Ban 'defaultProps' from any modified code.
+    'react/require-default-props': ['error', { functions: 'defaultArguments' }],
+  },
+  settings: {
+    // Import URLs should be resolved using aliases
+    'import/resolver': {
+      webpack: {
+        config: path.resolve(__dirname, 'webpack.dev.config.js'),
+      },
+    },
+  },
+};

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ validate:
 	make validate-no-uncommitted-package-lock-changes
 	npm run i18n_extract
 	npm run lint -- --max-warnings 0
+	npm run lint:diff
 	npm run types
 	npm run test:ci
 	npm run build

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "stylelint": "stylelint \"plugins/**/*.scss\" \"src/**/*.scss\" \"scss/**/*.scss\" --config .stylelintrc.json",
     "lint": "npm run stylelint && fedx-scripts eslint --ext .js --ext .jsx --ext .ts --ext .tsx .",
     "lint:fix": "npm run stylelint -- --fix && fedx-scripts eslint --fix --ext .js --ext .jsx --ext .ts --ext .tsx .",
+    "lint:diff": "git diff --name-only master | grep -E '^src/.*(\\.jsx?$|\\.tsx?)$' | xargs fedx-scripts eslint --config .eslintrc.diff.js",
     "start": "fedx-scripts webpack-dev-server --progress",
     "start:with-theme": "paragon install-theme && npm start && npm install",
     "dev": "PUBLIC_PATH=/authoring/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "include": [
       "*.js",
       ".eslintrc.js",
+      ".eslintrc.diff.js",
       "src/**/*",
       "plugins/**/*"
     ],


### PR DESCRIPTION
## Description

We've had a "Best Practices Checklist" in our PR template for a while, but I'd like to start using linters to enforce the best practices more. However, that is tough with such a huge codebase where there's a lot of code to refactor.

This PR introduces a new way of running **additional, stricter lint rules** that only apply to modified files. The idea is that contributors will be expected to make these refactors as they go, improving any code that they happen to touch in their PRs.

For this initial version, the diff check only rejects `injectIntl`, `defaultProps`, and `connect()` as they are all quite easy to refactor. Later, I'd also like to ban `propTypes` from modified code, although that can require a more significant refactor (to TypeScript) so I'm holding off on it for now.

If this experiment is successful, we may wish to extend it to all repos.

## Testing instructions

Check out this branch, modify some files (including .jsx files with `defaultProps`), then run `npm run lint:diff`

## Other information

Private ref MNG-4670.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] **Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.**
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
