### PR TITLE
chore: fix unnecessary 'undefined' types

### DIFF
--- a/src/course-libraries/CourseLibraries.test.tsx
+++ b/src/course-libraries/CourseLibraries.test.tsx
@@ -28,7 +28,7 @@ mockUseLibBlockMetadata.applyMock();
 
 const searchParamsGetMock = jest.fn();
 let axiosMock: MockAdapter;
-let mockShowToast: (message: string, action?: ToastActionData | undefined) => void;
+let mockShowToast: (message: string, action?: ToastActionData) => void;
 let queryClient: QueryClient;
 
 jest.mock('../studio-home/hooks', () => ({

--- a/src/course-unit/preview-changes/index.test.tsx
+++ b/src/course-unit/preview-changes/index.test.tsx
@@ -48,7 +48,7 @@ const render = (eventData?: LibraryChangesMessageData) => {
 };
 
 let axiosMock: MockAdapter;
-let mockShowToast: (message: string, action?: ToastActionData | undefined) => void;
+let mockShowToast: (message: string, action?: ToastActionData) => void;
 
 describe('<IframePreviewLibraryXBlockChanges />', () => {
   beforeEach(() => {

--- a/src/library-authoring/add-content/AddContent.test.tsx
+++ b/src/library-authoring/add-content/AddContent.test.tsx
@@ -68,7 +68,7 @@ const renderWithContainer = (containerId: string, containerType: 'unit' | 'secti
 };
 
 let axiosMock: MockAdapter;
-let mockShowToast: (message: string, action?: ToastActionData | undefined) => void;
+let mockShowToast: (message: string, action?: ToastActionData) => void;
 
 describe('<AddContent />', () => {
   beforeEach(() => {

--- a/src/library-authoring/components/ComponentDeleter.test.tsx
+++ b/src/library-authoring/components/ComponentDeleter.test.tsx
@@ -35,7 +35,7 @@ const renderArgs = {
   ),
 };
 
-let mockShowToast: { (message: string, action?: ToastActionData | undefined): void; mock?: any; };
+let mockShowToast: { (message: string, action?: ToastActionData): void; mock?: any; };
 
 describe('<ComponentDeleter />', () => {
   beforeEach(() => {

--- a/src/library-authoring/containers/ContainerDeleter.test.tsx
+++ b/src/library-authoring/containers/ContainerDeleter.test.tsx
@@ -51,7 +51,7 @@ const renderArgs = {
   ),
 };
 
-let mockShowToast: { (message: string, action?: ToastActionData | undefined): void; mock?: any; };
+let mockShowToast: { (message: string, action?: ToastActionData): void; mock?: any; };
 
 [
   'unit' as const,

--- a/src/library-authoring/containers/ContainerInfo.test.tsx
+++ b/src/library-authoring/containers/ContainerInfo.test.tsx
@@ -128,7 +128,7 @@ const render = (
   });
 };
 let axiosMock: MockAdapter;
-let mockShowToast: { (message: string, action?: ToastActionData | undefined): void; mock?: any; };
+let mockShowToast: { (message: string, action?: ToastActionData): void; mock?: any; };
 
 [
   {

--- a/src/library-authoring/section-subsections/LibrarySectionSubsectionPage.test.tsx
+++ b/src/library-authoring/section-subsections/LibrarySectionSubsectionPage.test.tsx
@@ -34,7 +34,7 @@ const libraryTitle = mockContentLibrary.libraryData.title;
 
 let axiosMock: MockAdapter;
 let queryClient: QueryClient;
-let mockShowToast: (message: string, action?: ToastActionData | undefined) => void;
+let mockShowToast: (message: string, action?: ToastActionData) => void;
 
 mockClipboardEmpty.applyMock();
 mockGetContainerMetadata.applyMock();

--- a/src/library-authoring/units/LibraryUnitPage.test.tsx
+++ b/src/library-authoring/units/LibraryUnitPage.test.tsx
@@ -33,7 +33,7 @@ const path = '/library/:libraryId/*';
 const libraryTitle = mockContentLibrary.libraryData.title;
 
 let axiosMock: MockAdapter;
-let mockShowToast: (message: string, action?: ToastActionData | undefined) => void;
+let mockShowToast: (message: string, action?: ToastActionData) => void;
 
 mockClipboardEmpty.applyMock();
 mockGetContainerMetadata.applyMock();


### PR DESCRIPTION
Found using oxlint. This removes unnecessary `undefined` type annotations on optional parameters.

```
  ⚠ typescript-eslint(no-duplicate-type-constituents): Explicit undefined is unnecessary on an optional parameter.
    ╭─[src/library-authoring/units/LibraryUnitPage.test.tsx:36:65]
 35 │ let axiosMock: MockAdapter;
 36 │ let mockShowToast: (message: string, action?: ToastActionData) => void;
```

Part of https://github.com/openedx/frontend-app-authoring/issues/2559

Private ref MNG-4763