### PR TITLE
chore: don't name unused errors in catch expressions

### DIFF
--- a/plugins/course-apps/xpert_unit_summary/data/thunks.js
+++ b/plugins/course-apps/xpert_unit_summary/data/thunks.js
@@ -19,7 +19,7 @@ export function updateXpertSettings(courseId, state) {
       }
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       return false;
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       return false;
     }
@@ -33,7 +33,7 @@ export function fetchXpertPluginConfigurable(courseId) {
     try {
       const { response } = await getXpertPluginConfigurable(courseId);
       enabled = response?.enabled;
-    } catch (e) {
+    } catch {
       enabled = undefined;
     }
 
@@ -55,7 +55,7 @@ export function fetchXpertSettings(courseId) {
     try {
       const { response } = await getXpertSettings(courseId);
       enabled = response?.enabled;
-    } catch (e) {
+    } catch {
       enabled = undefined;
     }
 
@@ -86,7 +86,7 @@ export function removeXpertSettings(courseId) {
       }
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       return false;
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       return false;
     }
@@ -105,7 +105,7 @@ export function resetXpertSettings(courseId, state) {
       }
       dispatch(updateResetStatus({ status: RequestStatus.FAILED }));
       return false;
-    } catch (error) {
+    } catch {
       dispatch(updateResetStatus({ status: RequestStatus.FAILED }));
       return false;
     }

--- a/src/advanced-settings/data/thunks.js
+++ b/src/advanced-settings/data/thunks.js
@@ -58,7 +58,7 @@ export function updateCourseAppSetting(courseId, settings) {
       try {
         const { customAttributes: { httpErrorResponseData } } = error;
         errorData = JSON.parse(httpErrorResponseData);
-      } catch (err) {
+      } catch {
         errorData = {};
       }
 
@@ -77,7 +77,7 @@ export function fetchProctoringExamErrors(courseId) {
       const settingValues = await getProctoringExamErrors(courseId);
       dispatch(fetchProctoringExamErrorsSuccess(settingValues));
       return true;
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       return false;
     }

--- a/src/advanced-settings/utils.js
+++ b/src/advanced-settings/utils.js
@@ -17,7 +17,7 @@ export default function validateAdvancedSettingsData(settingObj, setErrorFields,
   Object.entries(settingObj).forEach(([settingName, settingValue]) => {
     try {
       JSON.parse(settingValue);
-    } catch (e) {
+    } catch {
       let targetSettingValue = settingValue;
       const firstNonWhite = settingValue.substring(0, 1);
       const isValid = !['{', '[', "'"].includes(firstNonWhite);
@@ -30,7 +30,7 @@ export default function validateAdvancedSettingsData(settingObj, setErrorFields,
             ...prevEditedSettings,
             [settingName]: targetSettingValue,
           }));
-        } catch (quotedE) { /* empty */ }
+        } catch { /* empty */ }
       }
 
       pushDataToErrorArray(settingName);

--- a/src/course-checklist/data/thunks.js
+++ b/src/course-checklist/data/thunks.js
@@ -43,7 +43,7 @@ export function fetchCourseBestPracticesQuery({
       const data = await getCourseBestPractices({ courseId, excludeGraded, all });
       dispatch(fetchBestPracticeChecklistSuccess({ data }));
       dispatch(updateBestPracticeChecklisttStatus({ status: RequestStatus.SUCCESSFUL }));
-    } catch (error) {
+    } catch {
       dispatch(updateBestPracticeChecklisttStatus({ status: RequestStatus.FAILED }));
     }
   };

--- a/src/course-libraries/ReviewTabContent.tsx
+++ b/src/course-libraries/ReviewTabContent.tsx
@@ -224,7 +224,7 @@ const ItemReviewList = ({
         messages.updateSingleBlockSuccess,
         { name: info.displayName },
       ));
-    } catch (e) {
+    } catch {
       showToast(intl.formatMessage(previewChangesMessages.acceptChangesFailure));
     }
   }, []);
@@ -243,7 +243,7 @@ const ItemReviewList = ({
         messages.ignoreSingleBlockSuccess,
         { name: blockData.displayName },
       ));
-    } catch (e) {
+    } catch {
       showToast(intl.formatMessage(previewChangesMessages.ignoreChangesFailure));
     } finally {
       closeConfirmModal();

--- a/src/course-outline/data/thunk.ts
+++ b/src/course-outline/data/thunk.ts
@@ -148,7 +148,7 @@ export function fetchCourseBestPracticesQuery({
       dispatch(fetchStatusBarChecklistSuccess(getCourseBestPracticesChecklist(data)));
 
       return true;
-    } catch (error) {
+    } catch {
       return false;
     }
   };
@@ -165,7 +165,7 @@ export function enableCourseHighlightsEmailsQuery(courseId: string) {
 
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       dispatch(hideProcessingNotification());
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
   };
@@ -182,7 +182,7 @@ export function setVideoSharingOptionQuery(courseId: string, option: string) {
 
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       dispatch(hideProcessingNotification());
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       dispatch(hideProcessingNotification());
     }
@@ -260,7 +260,7 @@ export function updateCourseSectionHighlightsQuery(sectionId: string, highlights
           dispatch(hideProcessingNotification());
         }
       });
-    } catch (error) {
+    } catch {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
@@ -280,7 +280,7 @@ export function publishCourseItemQuery(itemId: string, sectionId: string) {
           dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
         }
       });
-    } catch (error) {
+    } catch {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
@@ -300,7 +300,7 @@ export function configureCourseItemQuery(sectionId: string, configureFn: () => P
           dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
         }
       });
-    } catch (error) {
+    } catch {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
@@ -390,7 +390,7 @@ export function editCourseItemQuery(itemId: string, sectionId: string, displayNa
           dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
         }
       });
-    } catch (error) {
+    } catch {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
@@ -412,7 +412,7 @@ function deleteCourseItemQuery(itemId: string, deleteItemFn: () => {}) {
       dispatch(deleteItemFn());
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
-    } catch (error) {
+    } catch {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
@@ -469,7 +469,7 @@ function duplicateCourseItemQuery(
           dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
         }
       });
-    } catch (error) {
+    } catch {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
@@ -541,7 +541,7 @@ function addNewCourseItemQuery(
           dispatch(hideProcessingNotification());
         }
       });
-    } catch (error) {
+    } catch {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
@@ -612,7 +612,7 @@ export function addUnitFromLibrary(body: {
           callback(result.locator);
         }
       });
-    } catch (error) /* istanbul ignore next */ {
+    } catch /* istanbul ignore next */ {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
@@ -643,7 +643,7 @@ function setBlockOrderListQuery(
           dispatch(hideProcessingNotification());
         }
       });
-    } catch (error) {
+    } catch {
       restoreCallback();
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
@@ -728,7 +728,7 @@ export function pasteClipboardContent(parentLocator: string, sectionId: string) 
           dispatch(setPasteFileNotices(result?.staticFileNotices));
         }
       });
-    } catch (error) {
+    } catch {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
@@ -743,7 +743,7 @@ export function dismissNotificationQuery(url: string) {
       await dismissNotification(url).then(async () => {
         dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       });
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
   };

--- a/src/course-outline/hooks.jsx
+++ b/src/course-outline/hooks.jsx
@@ -159,7 +159,7 @@ const useCourseOutline = ({ courseId }) => {
       data.shouldScroll = true;
       // Page should scroll to newly added subsection.
       dispatch(addSubsection({ parentLocator, data }));
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
   });
@@ -174,7 +174,7 @@ const useCourseOutline = ({ courseId }) => {
       // Page should scroll to newly added section.
       data.shouldScroll = true;
       dispatch(addSection(data));
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
   });

--- a/src/course-team/data/thunk.js
+++ b/src/course-team/data/thunk.js
@@ -66,7 +66,7 @@ export function changeRoleTeamUserQuery(courseId, email, role) {
 
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       return true;
-    } catch ({ message }) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       return false;
     }
@@ -83,7 +83,7 @@ export function deleteCourseTeamQuery(courseId, email) {
 
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       return true;
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       return false;
     }

--- a/src/course-unit/data/thunk.js
+++ b/src/course-unit/data/thunk.js
@@ -58,7 +58,7 @@ export function fetchCourseSectionVerticalData(courseId, sequenceId) {
       localStorage.removeItem('staticFileNotices');
       dispatch(fetchSequenceSuccess({ sequenceId }));
       return true;
-    } catch (error) {
+    } catch {
       dispatch(updateLoadingCourseSectionVerticalDataStatus({ status: RequestStatus.FAILED }));
       dispatch(fetchSequenceFailure({ sequenceId }));
       return false;
@@ -204,7 +204,7 @@ export function fetchCourseVerticalChildrenData(itemId, isSplitTestType, skipPag
       }
       dispatch(updateCourseVerticalChildren(courseVerticalChildrenData));
       dispatch(updateCourseVerticalChildrenLoadingStatus({ status: RequestStatus.SUCCESSFUL }));
-    } catch (error) {
+    } catch {
       dispatch(updateCourseVerticalChildrenLoadingStatus({ status: RequestStatus.FAILED }));
     }
   };

--- a/src/course-unit/preview-changes/index.tsx
+++ b/src/course-unit/preview-changes/index.tsx
@@ -177,7 +177,7 @@ export const PreviewLibraryXBlockChanges = ({
         overrideCustomizations,
       });
       postChange(accept);
-    } catch (e) {
+    } catch {
       showToast(intl.formatMessage(failureMsg));
     } finally {
       closeModal();

--- a/src/course-updates/data/thunk.js
+++ b/src/course-updates/data/thunk.js
@@ -58,7 +58,7 @@ export function createCourseUpdateQuery(courseId, data) {
         status: { createCourseUpdateQuery: RequestStatus.SUCCESSFUL },
         error: { creatingUpdate: false },
       }));
-    } catch (error) {
+    } catch {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatuses({
         status: { createCourseUpdateQuery: RequestStatus.FAILED },
@@ -80,7 +80,7 @@ export function editCourseUpdateQuery(courseId, data) {
         status: { createCourseUpdateQuery: RequestStatus.SUCCESSFUL },
         error: { savingUpdates: false },
       }));
-    } catch (error) {
+    } catch {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatuses({
         status: { createCourseUpdateQuery: RequestStatus.FAILED },
@@ -102,7 +102,7 @@ export function deleteCourseUpdateQuery(courseId, updateId) {
         status: { createCourseUpdateQuery: RequestStatus.SUCCESSFUL },
         error: { deletingUpdates: false },
       }));
-    } catch (error) {
+    } catch {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatuses({
         status: { createCourseUpdateQuery: RequestStatus.FAILED },
@@ -150,7 +150,7 @@ export function editCourseHandoutsQuery(courseId, data) {
         status: { createCourseUpdateQuery: RequestStatus.SUCCESSFUL },
         error: { savingHandouts: false },
       }));
-    } catch (error) {
+    } catch {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatuses({
         status: { createCourseUpdateQuery: RequestStatus.FAILED },

--- a/src/custom-pages/data/thunks.js
+++ b/src/custom-pages/data/thunks.js
@@ -132,7 +132,7 @@ export function updateCustomPageVisibility({ blockId, metadata }) {
         },
       }));
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }
   };
@@ -154,7 +154,7 @@ export const updateSingleCustomPage = ({
     }));
     setCurrentPage(null);
     dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
-  } catch (error) {
+  } catch {
     dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
   }
 };

--- a/src/export-page/data/thunks.ts
+++ b/src/export-page/data/thunks.ts
@@ -49,7 +49,7 @@ export function startExportingCourse(courseId) {
 
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       return true;
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       return false;
     }

--- a/src/files-and-videos/files-page/data/api.js
+++ b/src/files-and-videos/files-page/data/api.js
@@ -59,7 +59,7 @@ export async function getDownload(selectedRows, courseId) {
             throw new Error();
           }
           return await res.blob();
-        } catch (error) {
+        } catch {
           downloadErrors.push(`Failed to download ${asset?.displayName}.`);
           return null;
         }
@@ -78,7 +78,7 @@ export async function getDownload(selectedRows, courseId) {
     const asset = selectedRows[0].original;
     try {
       saveAs(`${getApiBaseUrl()}/${asset.id}`, asset.displayName);
-    } catch (error) {
+    } catch {
       downloadErrors.push(`Failed to download ${asset?.displayName}.`);
     }
   } else {

--- a/src/files-and-videos/files-page/data/thunks.js
+++ b/src/files-and-videos/files-page/data/thunks.js
@@ -48,7 +48,7 @@ export function fetchAdditionalAssets(courseId, totalCount) {
         }));
         remainingAssetCount -= 50;
         page += 1;
-      } catch (error) {
+      } catch {
         remainingAssetCount = 0;
         dispatch(updateErrors({ error: 'loading', message: 'Failed to load remaining files.' }));
         dispatch(updateLoadingStatus({ status: RequestStatus.PARTIAL_FAILURE }));
@@ -101,7 +101,7 @@ export function deleteAssetFile(courseId, id) {
       dispatch(deleteAssetSuccess({ assetId: id }));
       dispatch(removeModel({ modelType: 'assets', id }));
       dispatch(updateEditStatus({ editType: 'delete', status: RequestStatus.SUCCESSFUL }));
-    } catch (error) {
+    } catch {
       dispatch(updateErrors({ error: 'delete', message: `Failed to delete file id ${id}.` }));
       dispatch(updateEditStatus({ editType: 'delete', status: RequestStatus.FAILED }));
     }
@@ -154,7 +154,7 @@ export function validateAssetFiles(courseId, files) {
           dispatch(updateDuplicateFiles({ files: conflicts }));
         }
       });
-    } catch (error) {
+    } catch {
       files.forEach(file => dispatch(updateErrors({ error: 'add', message: `Failed to validate ${file.name}.` })));
       dispatch(updateEditStatus({ editType: 'add', status: RequestStatus.FAILED }));
     }
@@ -177,7 +177,7 @@ export function updateAssetLock({ assetId, courseId, locked }) {
         },
       }));
       dispatch(updateEditStatus({ editType: 'lock', status: RequestStatus.SUCCESSFUL }));
-    } catch (error) {
+    } catch {
       const lockStatus = locked ? 'lock' : 'unlock';
       dispatch(updateErrors({ error: 'lock', message: `Failed to ${lockStatus} file id ${assetId}.` }));
       dispatch(updateEditStatus({ editType: 'lock', status: RequestStatus.FAILED }));
@@ -205,7 +205,7 @@ export function getUsagePaths({ asset, courseId }) {
         },
       }));
       dispatch(updateEditStatus({ editType: 'usageMetrics', status: RequestStatus.SUCCESSFUL }));
-    } catch (error) {
+    } catch {
       dispatch(updateErrors({ error: 'usageMetrics', message: `Failed to get usage metrics for ${asset.displayName}.` }));
       dispatch(updateEditStatus({ editType: 'usageMetrics', status: RequestStatus.FAILED }));
     }

--- a/src/files-and-videos/videos-page/data/api.js
+++ b/src/files-and-videos/videos-page/data/api.js
@@ -105,7 +105,7 @@ export async function getDownload(selectedRows, courseId) {
         const url = video.downloadLink;
         const name = video.displayName;
         return { url, name };
-      } catch (error) {
+      } catch {
         downloadErrors.push(`Cannot find download file for ${video?.displayName || 'video'}.`);
         return null;
       }
@@ -129,7 +129,7 @@ export async function getDownload(selectedRows, courseId) {
       } else {
         downloadErrors.push(`Cannot find download file for ${video?.displayName}.`);
       }
-    } catch (error) {
+    } catch {
       downloadErrors.push('Failed to download video.');
     }
   } else {

--- a/src/files-and-videos/videos-page/data/thunks.js
+++ b/src/files-and-videos/videos-page/data/thunks.js
@@ -160,7 +160,7 @@ export function deleteVideoFile(courseId, id) {
           status: RequestStatus.SUCCESSFUL,
         }),
       );
-    } catch (error) {
+    } catch {
       dispatch(
         updateErrors({
           error: 'delete',
@@ -184,7 +184,7 @@ export function markVideoUploadsInProgressAsFailed({ uploadingIdsRef, courseId }
           'Upload failed',
           'upload_failed',
         );
-      } catch (error) {
+      } catch {
         // eslint-disable-next-line no-console
         console.error(`Failed to send "Failed" upload status for ${edxVideoId} onbeforeunload`);
       }
@@ -207,7 +207,7 @@ const addVideoToEdxVal = async (courseId, file, dispatch) => {
       createUrlResponse.data,
     ).files;
     return { uploadUrl, edxVideoId };
-  } catch (error) {
+  } catch {
     dispatch(failAddVideo({ fileName: file.name }));
     return {};
   }
@@ -471,7 +471,7 @@ export function deleteVideoTranscript({
           status: RequestStatus.SUCCESSFUL,
         }),
       );
-    } catch (error) {
+    } catch {
       dispatch(
         updateErrors({
           error: 'transcript',
@@ -515,7 +515,7 @@ export function downloadVideoTranscript({
           status: RequestStatus.SUCCESSFUL,
         }),
       );
-    } catch (error) {
+    } catch {
       dispatch(
         updateErrors({
           error: 'transcript',
@@ -638,7 +638,7 @@ export function getUsagePaths({ video, courseId }) {
           status: RequestStatus.SUCCESSFUL,
         }),
       );
-    } catch (error) {
+    } catch {
       dispatch(
         updateErrors({
           error: 'usageMetrics',
@@ -682,7 +682,7 @@ export function fetchVideoDownload({ selectedRows, courseId }) {
           }),
         );
       }
-    } catch (error) {
+    } catch {
       dispatch(
         updateErrors({
           error: 'download',
@@ -717,7 +717,7 @@ export function clearAutomatedTranscript({ courseId }) {
           status: RequestStatus.SUCCESSFUL,
         }),
       );
-    } catch (error) {
+    } catch {
       dispatch(
         updateErrors({
           error: 'transcript',
@@ -756,7 +756,7 @@ export function updateTranscriptCredentials({ courseId, data }) {
           status: RequestStatus.SUCCESSFUL,
         }),
       );
-    } catch (error) {
+    } catch {
       dispatch(
         updateErrors({
           error: 'transcript',

--- a/src/generic/clipboard/hooks/useClipboard.ts
+++ b/src/generic/clipboard/hooks/useClipboard.ts
@@ -59,7 +59,7 @@ const useClipboard = (canEdit: boolean = true) => {
         // If we don't have new data, invalidate the query
         queryClient.invalidateQueries({ queryKey: CLIPBOARD_QUERY_KEY });
       }
-    } catch (error) {
+    } catch {
       showToast(intl.formatMessage(messages.error));
       return;
     }

--- a/src/generic/data/thunks.js
+++ b/src/generic/data/thunks.js
@@ -19,7 +19,7 @@ export function fetchOrganizationsQuery() {
       const organizations = await getOrganizations();
       dispatch(fetchOrganizations(organizations));
       dispatch(updateLoadingStatuses({ organizationLoadingStatus: RequestStatus.SUCCESSFUL }));
-    } catch (error) {
+    } catch {
       dispatch(updateLoadingStatuses({ organizationLoadingStatus: RequestStatus.FAILED }));
     }
   };
@@ -31,7 +31,7 @@ export function fetchCourseRerunQuery(courseId) {
       const courseRerun = await getCourseRerun(courseId);
       dispatch(updateCourseRerunData(courseRerun));
       dispatch(updateLoadingStatuses({ courseRerunLoadingStatus: RequestStatus.SUCCESSFUL }));
-    } catch (error) {
+    } catch {
       dispatch(updateLoadingStatuses({ courseRerunLoadingStatus: RequestStatus.FAILED }));
     }
   };
@@ -47,7 +47,7 @@ export function updateCreateOrRerunCourseQuery(courseData) {
       dispatch(updatePostErrors('errMsg' in response ? response : {}));
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       return true;
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       return false;
     }

--- a/src/generic/loading-button/index.tsx
+++ b/src/generic/loading-button/index.tsx
@@ -59,7 +59,7 @@ const LoadingButton: React.FC<LoadingButtonProps> = ({
     setState('pending');
     try {
       await onClick(e);
-    } catch (err) {
+    } catch {
       // Do nothing
     } finally {
       if (componentMounted.current) {

--- a/src/generic/modal-dropzone/useModalDropzone.jsx
+++ b/src/generic/modal-dropzone/useModalDropzone.jsx
@@ -106,7 +106,7 @@ const useModalDropzone = ({
         onSavingStatus({ status: RequestStatus.SUCCESSFUL });
         onClose();
       }
-    } catch (error) {
+    } catch {
       onSavingStatus({ status: RequestStatus.FAILED });
     } finally {
       setDisabledUploadBtn(true);

--- a/src/generic/saving-error-alert/utils.js
+++ b/src/generic/saving-error-alert/utils.js
@@ -9,7 +9,7 @@ const handleResponseErrors = (error, dispatch, savingStatusFunction) => {
     } = error;
     const parsedData = JSON.parse(httpErrorResponseData);
     errorMessage = parsedData?.error || errorMessage;
-  } catch (err) {
+  } catch {
     errorMessage = '';
   }
 

--- a/src/help-urls/data/thunks.js
+++ b/src/help-urls/data/thunks.js
@@ -14,7 +14,7 @@ export function fetchHelpUrls() {
 
       dispatch(updateLoadingHelpUrlsStatus({ status: RequestStatus.SUCCESSFUL }));
       return true;
-    } catch (error) {
+    } catch {
       dispatch(updateLoadingHelpUrlsStatus({ status: RequestStatus.FAILED }));
 
       return false;

--- a/src/legacy-libraries-migration/LegacyLibMigrationPage.tsx
+++ b/src/legacy-libraries-migration/LegacyLibMigrationPage.tsx
@@ -98,7 +98,7 @@ export const LegacyLibMigrationPage = () => {
           count: legacyLibraries.length,
         }));
         navigate(`/library/${destinationLibrary.id}?migration_task=${migrationTask.uuid}`);
-      } catch (error) {
+      } catch {
         showToast(intl.formatMessage(messages.migrationFailed));
       }
     }

--- a/src/library-authoring/add-content/AddContent.tsx
+++ b/src/library-authoring/add-content/AddContent.tsx
@@ -297,7 +297,7 @@ export const parseErrorMsg = (
     if (detail) {
       return intl.formatMessage(detailedMessage, { detail });
     }
-  } catch (_err) {
+  } catch {
     // ignore
   }
   return intl.formatMessage(defaultMessage);

--- a/src/library-authoring/backup-restore/LibraryBackupPage.tsx
+++ b/src/library-authoring/backup-restore/LibraryBackupPage.tsx
@@ -49,7 +49,7 @@ export const LibraryBackupPage = () => {
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
-    } catch (error) {
+    } catch {
       // Fallback to window.location.href if the above fails
       window.location.href = url;
     }

--- a/src/library-authoring/collections/CollectionInfoHeader.tsx
+++ b/src/library-authoring/collections/CollectionInfoHeader.tsx
@@ -32,7 +32,7 @@ const CollectionInfoHeader = () => {
         title: newTitle,
       });
       showToast(intl.formatMessage(messages.updateCollectionSuccessMsg));
-    } catch (err) {
+    } catch {
       showToast(intl.formatMessage(messages.updateCollectionErrorMsg));
     }
   };

--- a/src/library-authoring/component-info/ComponentInfoHeader.tsx
+++ b/src/library-authoring/component-info/ComponentInfoHeader.tsx
@@ -34,7 +34,7 @@ const ComponentInfoHeader = () => {
         },
       });
       showToast(intl.formatMessage(messages.updateComponentSuccessMsg));
-    } catch (err) {
+    } catch {
       showToast(intl.formatMessage(messages.updateComponentErrorMsg));
     }
   };

--- a/src/library-authoring/component-info/ComponentPublisher.tsx
+++ b/src/library-authoring/component-info/ComponentPublisher.tsx
@@ -30,7 +30,7 @@ export const ComponentPublisher = ({
     try {
       await publishComponent.mutateAsync();
       showToast(intl.formatMessage(messages.publishSuccessMsg));
-    } catch (error) {
+    } catch {
       showToast(intl.formatMessage(messages.publishErrorMsg));
     }
     handleClose();

--- a/src/library-authoring/components/CollectionCard.tsx
+++ b/src/library-authoring/components/CollectionCard.tsx
@@ -63,7 +63,7 @@ const CollectionMenu = ({ hit } : CollectionMenuProps) => {
           onClick: restoreCollection,
         },
       );
-    } catch (e) {
+    } catch {
       showToast(intl.formatMessage(messages.deleteCollectionFailed));
     } finally {
       closeDeleteModal();

--- a/src/library-authoring/components/ComponentDeleter.tsx
+++ b/src/library-authoring/components/ComponentDeleter.tsx
@@ -36,7 +36,7 @@ const ComponentDeleter = ({ usageKey, close }: Props) => {
     try {
       await restoreComponentMutation.mutateAsync({ usageKey });
       showToast(intl.formatMessage(messages.undoDeleteComponentToastSuccess));
-    } catch (e) {
+    } catch {
       showToast(intl.formatMessage(messages.undoDeleteComponentToastFailed));
     }
   }, []);

--- a/src/library-authoring/containers/ContainerDeleter.tsx
+++ b/src/library-authoring/containers/ContainerDeleter.tsx
@@ -146,7 +146,7 @@ const ContainerDeleter = ({
     try {
       await restoreContainerMutation.mutateAsync();
       showToast(intl.formatMessage(messages.undoDeleteContainerToastMessage));
-    } catch (e) {
+    } catch {
       showToast(intl.formatMessage(messageMap.undoDeleteError));
     }
   }, [messageMap]);

--- a/src/library-authoring/containers/ContainerEditableTitle.tsx
+++ b/src/library-authoring/containers/ContainerEditableTitle.tsx
@@ -27,7 +27,7 @@ export const ContainerEditableTitle = ({ containerId, textClassName }: EditableT
         displayName: newDisplayName,
       });
       showToast(intl.formatMessage(messages.updateContainerSuccessMsg));
-    } catch (err) {
+    } catch {
       showToast(intl.formatMessage(messages.updateContainerErrorMsg));
     }
   };

--- a/src/library-authoring/containers/ContainerPublisher.tsx
+++ b/src/library-authoring/containers/ContainerPublisher.tsx
@@ -30,7 +30,7 @@ export const ContainerPublisher = ({
     try {
       await publishContainer.mutateAsync();
       showToast(intl.formatMessage(messages.publishContainerSuccess));
-    } catch (error) {
+    } catch {
       showToast(intl.formatMessage(messages.publishContainerFailed));
     }
     handleClose();

--- a/src/library-authoring/containers/ContainerRemover.tsx
+++ b/src/library-authoring/containers/ContainerRemover.tsx
@@ -55,7 +55,7 @@ const ContainerRemover = ({
         closeLibrarySidebar();
       }
       showToast(removeSuccess);
-    } catch (e) {
+    } catch {
       showToast(removeError);
     } finally {
       close();

--- a/src/library-authoring/create-container/CreateContainerModal.tsx
+++ b/src/library-authoring/create-container/CreateContainerModal.tsx
@@ -94,7 +94,7 @@ const CreateContainerModal = () => {
       }
 
       showToast(labels.successMsg);
-    } catch (error) {
+    } catch {
       showToast(labels.errorMsg);
     } finally {
       handleClose();

--- a/src/library-authoring/library-info/LibraryPublishStatus.tsx
+++ b/src/library-authoring/library-info/LibraryPublishStatus.tsx
@@ -24,7 +24,7 @@ const LibraryPublishStatus = () => {
       try {
         await commitLibraryChanges.mutateAsync(libraryData.id);
         showToast(intl.formatMessage(messages.publishSuccessMsg));
-      } catch (e) {
+      } catch {
         showToast(intl.formatMessage(messages.publishErrorMsg));
       }
     }
@@ -35,7 +35,7 @@ const LibraryPublishStatus = () => {
       try {
         await revertLibraryChanges.mutateAsync(libraryData.id);
         showToast(intl.formatMessage(messages.revertSuccessMsg));
-      } catch (e) {
+      } catch {
         showToast(intl.formatMessage(messages.revertErrorMsg));
       } finally {
         closeConfirmModal();

--- a/src/library-authoring/section-subsections/LibraryContainerChildren.tsx
+++ b/src/library-authoring/section-subsections/LibraryContainerChildren.tsx
@@ -54,7 +54,7 @@ const ContainerRow = ({ containerKey, container, readOnly }: ContainerRowProps) 
         displayName: newDisplayName,
       });
       showToast(intl.formatMessage(containerMessages.updateContainerSuccessMsg));
-    } catch (err) {
+    } catch {
       showToast(intl.formatMessage(containerMessages.updateContainerErrorMsg));
     }
   };
@@ -138,7 +138,7 @@ export const LibraryContainerChildren = ({ containerKey, readOnly }: LibraryCont
     try {
       await orderMutator.mutateAsync(childrenKeys);
       showToast(intl.formatMessage(messages.orderUpdatedMsg));
-    } catch (e) {
+    } catch {
       showToast(intl.formatMessage(messages.failedOrderUpdatedMsg));
     }
   }, [orderMutator]);

--- a/src/library-authoring/units/LibraryUnitBlocks.tsx
+++ b/src/library-authoring/units/LibraryUnitBlocks.tsx
@@ -68,7 +68,7 @@ const BlockHeader = ({ block, readOnly }: ComponentBlockProps) => {
         },
       });
       showToast(intl.formatMessage(messages.updateComponentSuccessMsg));
-    } catch (err) {
+    } catch {
       showToast(intl.formatMessage(messages.updateComponentErrorMsg));
     }
   };
@@ -246,7 +246,7 @@ export const LibraryUnitBlocks = ({ unitId, readOnly: componentReadOnly }: Libra
     try {
       await orderMutator.mutateAsync(usageKeys);
       showToast(intl.formatMessage(messages.orderUpdatedMsg));
-    } catch (e) {
+    } catch {
       showToast(intl.formatMessage(messages.failedOrderUpdatedMsg));
     }
   }, [orderMutator]);

--- a/src/optimizer-page/data/thunks.test.js
+++ b/src/optimizer-page/data/thunks.test.js
@@ -235,7 +235,7 @@ describe('updateAllPreviousRunLinks', () => {
 
       try {
         await updateAllPreviousRunLinks(courseId)(dispatch, getState);
-      } catch (error) {
+      } catch {
         // Expected to throw
       }
 
@@ -292,7 +292,7 @@ describe('updateSinglePreviousRunLink', () => {
 
       try {
         await updateSinglePreviousRunLink(courseId, linkUrl, blockId, contentType)(dispatch, getState);
-      } catch (error) {
+      } catch {
         // Expected to throw
       }
 
@@ -383,7 +383,7 @@ describe('fetchRerunLinkUpdateStatus', () => {
 
       try {
         await fetchRerunLinkUpdateStatus(courseId)(dispatch, getState);
-      } catch (error) {
+      } catch {
         // Expected to throw
       }
 
@@ -541,7 +541,7 @@ describe('updateAllPreviousRunLinks additional edge cases', () => {
 
     try {
       await updateAllPreviousRunLinks(courseId)(dispatch, getState);
-    } catch (error) {
+    } catch {
       // Expected to throw
     }
 
@@ -556,7 +556,7 @@ describe('updateAllPreviousRunLinks additional edge cases', () => {
 
     try {
       await updateAllPreviousRunLinks(courseId)(dispatch, getState);
-    } catch (error) {
+    } catch {
       // Expected to throw
     }
 
@@ -595,7 +595,7 @@ describe('updateSinglePreviousRunLink additional edge cases', () => {
 
     try {
       await updateSinglePreviousRunLink(courseId, linkUrl, blockId, 'sections')(dispatch, getState);
-    } catch (error) {
+    } catch {
       // Expected to throw
     }
 
@@ -611,7 +611,7 @@ describe('updateSinglePreviousRunLink additional edge cases', () => {
 
     try {
       await updateSinglePreviousRunLink(courseId, malformedUrl, blockId, 'sections')(dispatch, getState);
-    } catch (error) {
+    } catch {
       // Expected to throw
     }
 
@@ -664,7 +664,7 @@ describe('updateAllPreviousRunLinks with polling support', () => {
 
       try {
         await updateAllPreviousRunLinks(courseId)(dispatch, getState);
-      } catch (error) {
+      } catch {
         // Expected to throw
       }
 
@@ -759,7 +759,7 @@ describe('fetchRerunLinkUpdateStatus with polling support', () => {
 
       try {
         await fetchRerunLinkUpdateStatus(courseId)(dispatch, getState);
-      } catch (error) {
+      } catch {
         // Expected to throw
       }
 

--- a/src/optimizer-page/data/thunks.ts
+++ b/src/optimizer-page/data/thunks.ts
@@ -37,7 +37,7 @@ export function startLinkCheck(courseId: string) {
       await postLinkCheck(courseId);
       await dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       return true;
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       dispatch(updateLinkCheckInProgress(false));
       dispatch(updateCurrentStage(SCAN_STAGES[LINK_CHECK_STATUSES.CANCELED]));

--- a/src/optimizer-page/scan-results/BrokenLinkTable.test.tsx
+++ b/src/optimizer-page/scan-results/BrokenLinkTable.test.tsx
@@ -45,7 +45,7 @@ const findAllUpdateButtons = (): HTMLElement[] => {
   try {
     const updateBtn = screen.getAllByText(/^Update$/);
     return updateBtn as HTMLElement[];
-  } catch (e) {
+  } catch {
     return [];
   }
 };

--- a/src/optimizer-page/scan-results/ScanResults.tsx
+++ b/src/optimizer-page/scan-results/ScanResults.tsx
@@ -494,7 +494,7 @@ const ScanResults: FC<Props> = ({
           } else if (onErrorStateChange) {
             onErrorStateChange(null);
           }
-        } catch (error) {
+        } catch {
           setIsUpdateAllInProgress(false);
           setUpdateAllCompleted(false);
           setUpdateAllTrigger(t => t + 1);
@@ -717,7 +717,7 @@ const ScanResults: FC<Props> = ({
       };
 
       return await pollForSingleLinkResult();
-    } catch (error) {
+    } catch {
       if (onErrorStateChange) {
         onErrorStateChange(intl.formatMessage(messages.updateLinkError));
       }
@@ -758,7 +758,7 @@ const ScanResults: FC<Props> = ({
       await dispatch(updateAllPreviousRunLinks(courseId));
 
       return true;
-    } catch (error) {
+    } catch {
       setIsUpdateAllInProgress(false); // Reset on error
       if (onErrorStateChange) {
         onErrorStateChange(intl.formatMessage(messages.updateLinksError));

--- a/src/pages-and-resources/data/thunks.js
+++ b/src/pages-and-resources/data/thunks.js
@@ -61,7 +61,7 @@ export function updateAppStatus(courseId, appId, state) {
       dispatch(updateModel({ modelType: 'courseApps', model: { id: appId, enabled: state } }));
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       return true;
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       return false;
     }
@@ -95,7 +95,7 @@ export function updateCourseAppSetting(courseId, setting, value) {
       dispatch(updateCourseAppsSettingsSuccess(settingValues));
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       return true;
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       return false;
     }

--- a/src/schedule-and-details/data/thunks.js
+++ b/src/schedule-and-details/data/thunks.js
@@ -40,7 +40,7 @@ export function updateCourseDetailsQuery(courseId, details) {
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       dispatch(updateCourseDetailsSuccess(detailsValues));
       return true;
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       return false;
     }

--- a/src/search-manager/SearchManager.ts
+++ b/src/search-manager/SearchManager.ts
@@ -117,7 +117,7 @@ export const SearchContextProvider: React.FC<{
       if (getBlockType(value)) {
         return value;
       }
-    } catch (error) {
+    } catch {
       // Error thrown if value cannot be parsed into a library usage key.
       // Pass through to return below.
     }

--- a/src/studio-home/data/thunks.js
+++ b/src/studio-home/data/thunks.js
@@ -33,7 +33,7 @@ function fetchStudioHomeData(
         const studioHomeData = await getStudioHomeData();
         dispatch(fetchStudioHomeDataSuccess(studioHomeData));
         dispatch(updateLoadingStatuses({ studioHomeLoadingStatus: RequestStatus.SUCCESSFUL }));
-      } catch (error) {
+      } catch {
         dispatch(updateLoadingStatuses({ studioHomeLoadingStatus: RequestStatus.FAILED }));
         return;
       }
@@ -44,7 +44,7 @@ function fetchStudioHomeData(
         const coursesData = await getStudioHomeCoursesV2(search || '', requestParams);
         dispatch(fetchCourseDataSuccessV2(coursesData));
         dispatch(updateLoadingStatuses({ courseLoadingStatus: RequestStatus.SUCCESSFUL }));
-      } catch (error) {
+      } catch {
         dispatch(updateLoadingStatuses({ courseLoadingStatus: RequestStatus.FAILED }));
       }
     }
@@ -63,7 +63,7 @@ function handleDeleteNotificationQuery(url) {
     try {
       await handleCourseNotification(url);
       dispatch(updateSavingStatuses({ deleteNotificationSavingStatus: RequestStatus.SUCCESSFUL }));
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatuses({ deleteNotificationSavingStatus: RequestStatus.FAILED }));
     }
   };
@@ -77,7 +77,7 @@ function requestCourseCreatorQuery() {
       await sendRequestForCourseCreator();
       dispatch(updateSavingStatuses({ courseCreatorSavingStatus: RequestStatus.SUCCESSFUL }));
       return true;
-    } catch (error) {
+    } catch {
       dispatch(updateSavingStatuses({ courseCreatorSavingStatus: RequestStatus.FAILED }));
       return false;
     }

--- a/src/taxonomy/manage-orgs/ManageOrgsModal.jsx
+++ b/src/taxonomy/manage-orgs/ManageOrgsModal.jsx
@@ -100,7 +100,7 @@ const ManageOrgsModal = ({
         if (setToastMessage) {
           setToastMessage(intl.formatMessage(messages.assignOrgsSuccess));
         }
-      } catch (error) {
+      } catch {
         // ToDo: display the error to the user
       } finally {
         enableDialog();

--- a/src/textbooks/data/thunk.js
+++ b/src/textbooks/data/thunk.js
@@ -28,7 +28,7 @@ export function fetchTextbooksQuery(courseId) {
       const { textbooks } = await getTextbooks(courseId);
       dispatch(fetchTextbooks({ textbooks }));
       dispatch(updateLoadingStatus({ status: RequestStatus.SUCCESSFUL }));
-    } catch (error) {
+    } catch {
       dispatch(updateLoadingStatus({ status: RequestStatus.FAILED }));
     }
   };

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -93,7 +93,7 @@ export function parseArrayOrObjectValues(obj: { [s: string]: string; } | ArrayLi
       } else {
         result[key] = JSON.parse(value);
       }
-    } catch (e) {
+    } catch {
       result[key] = value;
     }
   });


### PR DESCRIPTION
Found using oxlint. This removes unused error variables in `catch()` expressions.

```
  ⚠ eslint(no-unused-vars): Catch parameter 'error' is caught but never used.
     ╭─[src/course-updates/data/thunk.js:153:14]
 152 │       }));
 153 │     } catch (error) {
     ·              ──┬──
     ·                ╰── 'error' is declared here
 154 │       dispatch(hideProcessingNotification());
     ╰────
  help: Consider handling this error.

```

Part of https://github.com/openedx/frontend-app-authoring/issues/2559

Private ref MNG-4763