### PR TITLE
chore: fix no-base-to-string

### DIFF
--- a/src/editors/data/redux/thunkActions/requests.js
+++ b/src/editors/data/redux/thunkActions/requests.js
@@ -164,7 +164,7 @@ export const removeTemporalLink = (response, asset, content, resolve) => {
   const imagePath = `/${response.data.asset.portableUrl}`;
   const reader = new FileReader();
   reader.addEventListener('load', () => {
-    const imageBS64 = reader.result.toString();
+    const imageBS64 = /** @type {string} */(reader.result);
     const parsedContent = typeof content === 'string' ? content.replace(imageBS64, imagePath) : { ...content, olx: content.olx.replace(imageBS64, imagePath) };
     URL.revokeObjectURL(asset);
     resolve(parsedContent);

--- a/src/editors/utils/StrictDict.test.js
+++ b/src/editors/utils/StrictDict.test.js
@@ -39,7 +39,9 @@ describe('StrictDict', () => {
     expect(Object.values(dict)).toEqual([value1, value2]);
   });
   it('allows stringification', () => {
-    expect(dict.toString()).toEqual(rawDict.toString());
+    // Note: StrictDict stringifies as '[object Object]' which isn't stringification in any meaningful sense.
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string
+    expect(dict.toString()).toEqual('[object Object]');
     expect({ ...dict }).toEqual({ ...rawDict });
   });
   it('allows entry listing', () => {

--- a/src/library-authoring/LibraryAuthoringPage.test.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.test.tsx
@@ -71,7 +71,7 @@ describe('<LibraryAuthoringPage />', () => {
     // The Meilisearch client-side API uses fetch, not Axios.
     fetchMock.mockReset();
     fetchMock.post(searchEndpoint, (_url, req) => {
-      const requestData = JSON.parse(req.body?.toString() ?? '');
+      const requestData = JSON.parse((req.body ?? '') as string);
       const query = requestData?.queries[0]?.q ?? '';
       // We have to replace the query (search keywords) in the mock results with the actual query,
       // because otherwise Instantsearch will update the UI and change the query,

--- a/src/library-authoring/collections/LibraryCollectionPage.test.tsx
+++ b/src/library-authoring/collections/LibraryCollectionPage.test.tsx
@@ -59,7 +59,7 @@ describe('<LibraryCollectionPage />', () => {
 
     // The Meilisearch client-side API uses fetch, not Axios.
     fetchMock.post(searchEndpoint, (_url, req) => {
-      const requestData = JSON.parse(req.body?.toString() ?? '');
+      const requestData = JSON.parse((req.body ?? '') as string);
       const query = requestData?.queries[0]?.q ?? '';
       const mockResultCopy = cloneDeep(mockResult);
       // We have to replace the query (search keywords) in the mock results with the actual query,

--- a/src/library-authoring/generic/manage-collections/ManageCollections.test.tsx
+++ b/src/library-authoring/generic/manage-collections/ManageCollections.test.tsx
@@ -45,7 +45,7 @@ describe('<ManageCollections />', () => {
     // The Meilisearch client-side API uses fetch, not Axios.
     fetchMock.mockReset();
     fetchMock.post(searchEndpoint, (_url, req) => {
-      const requestData = JSON.parse(req.body?.toString() ?? '');
+      const requestData = JSON.parse((req.body ?? '') as string);
       const query = requestData?.queries[0]?.q ?? '';
       // We have to replace the query (search keywords) in the mock results with the actual query,
       // because otherwise Instantsearch will update the UI and change the query,

--- a/src/library-authoring/routes.test.tsx
+++ b/src/library-authoring/routes.test.tsx
@@ -35,7 +35,7 @@ describe('Library Authoring routes', () => {
     // The Meilisearch client-side API uses fetch, not Axios.
     fetchMock.mockReset();
     fetchMock.post(searchEndpoint, (_url, req) => {
-      const requestData = JSON.parse(req.body?.toString() ?? '');
+      const requestData = JSON.parse((req.body ?? '') as string);
       const query = requestData?.queries[0]?.q ?? '';
       // We have to replace the query (search keywords) in the mock results with the actual query,
       // because otherwise Instantsearch will update the UI and change the query,

--- a/src/search-manager/data/api.mock.ts
+++ b/src/search-manager/data/api.mock.ts
@@ -34,7 +34,7 @@ export function mockSearchResult(
   filterFn?: (requestData: any) => MultiSearchResponse,
 ) {
   fetchMock.post(mockContentSearchConfig.multisearchEndpointUrl, (_url, req) => {
-    const requestData = JSON.parse(req.body?.toString() ?? '');
+    const requestData = JSON.parse((req.body ?? '') as string);
     const query = requestData?.queries[0]?.q ?? '';
     // We have to replace the query (search keywords) in the mock results with the actual query,
     // because otherwise Instantsearch will update the UI and change the query,

--- a/src/search-modal/SearchUI.test.tsx
+++ b/src/search-modal/SearchUI.test.tsx
@@ -90,7 +90,7 @@ describe('<SearchUI />', () => {
 
     // The Meilisearch client-side API uses fetch, not Axios.
     fetchMock.post(searchEndpoint, (_url, req) => {
-      const requestData = JSON.parse(req.body?.toString() ?? '');
+      const requestData = JSON.parse((req.body ?? '') as string);
       const query = requestData?.queries[0]?.q ?? '';
       // We have to replace the query (search keywords) in the mock results with the actual query,
       // because otherwise Instantsearch will update the UI and change the query,
@@ -168,7 +168,7 @@ describe('<SearchUI />', () => {
     await waitFor(() => { expect(fetchMock).toHaveFetchedTimes(1, searchEndpoint, 'post'); });
     // And make sure the request was limited to this course:
     expect(fetchMock).toHaveLastFetched((_url, req) => {
-      const requestData = JSON.parse(req.body?.toString() ?? '');
+      const requestData = JSON.parse((req.body ?? '') as string);
       const requestedFilter = requestData?.queries[0].filter;
       return requestedFilter?.[1] === 'type = "course_block"'
         && requestedFilter?.[2] === 'context_key = "course-v1:org+test+123"';
@@ -337,7 +337,7 @@ describe('<SearchUI />', () => {
     let rendered: RenderResult;
     beforeEach(async () => {
       fetchMock.post(facetSearchEndpoint, (_path, req) => {
-        const requestData = JSON.parse(req.body?.toString() ?? '');
+        const requestData = JSON.parse((req.body ?? '') as string);
         switch (requestData.facetName) {
           case 'tags.taxonomy': return mockTagsFacetResult;
           case 'tags.level0': return mockTagsFacetResultLevel0;
@@ -356,7 +356,7 @@ describe('<SearchUI />', () => {
       await waitFor(() => { expect(fetchMock).toHaveFetchedTimes(1, searchEndpoint, 'post'); });
       // And make sure the request was limited to this course:
       expect(fetchMock).toHaveLastFetched((_url, req) => {
-        const requestData = JSON.parse(req.body?.toString() ?? '');
+        const requestData = JSON.parse((req.body ?? '') as string);
         const requestedFilter = requestData?.queries[0].filter;
         // the filter is:
         // ['', 'type = "course_block"', 'context_key = "course-v1:org+test+123"']
@@ -393,7 +393,7 @@ describe('<SearchUI />', () => {
       // Because we're mocking the results, there's no actual changes to the mock results,
       // but we can verify that the filter was sent in the request
       expect(fetchMock).toHaveLastFetched((_url, req) => {
-        const requestData = JSON.parse(req.body?.toString() ?? '');
+        const requestData = JSON.parse((req.body ?? '') as string);
         const requestedFilter = requestData?.queries[0].filter;
         return JSON.stringify(requestedFilter) === JSON.stringify([
           [
@@ -426,7 +426,7 @@ describe('<SearchUI />', () => {
       // Because we're mocking the results, there's no actual changes to the mock results,
       // but we can verify that the filter was sent in the request
       expect(fetchMock).toHaveLastFetched((_url, req) => {
-        const requestData = JSON.parse(req.body?.toString() ?? '');
+        const requestData = JSON.parse((req.body ?? '') as string);
         const requestedFilter = requestData?.queries?.[0]?.filter;
         return JSON.stringify(requestedFilter) === JSON.stringify([
           [],
@@ -461,7 +461,7 @@ describe('<SearchUI />', () => {
       // Because we're mocking the results, there's no actual changes to the mock results,
       // but we can verify that the filter was sent in the request
       expect(fetchMock).toHaveLastFetched((_url, req) => {
-        const requestData = JSON.parse(req.body?.toString() ?? '');
+        const requestData = JSON.parse((req.body ?? '') as string);
         const requestedFilter = requestData?.queries?.[0]?.filter;
         return JSON.stringify(requestedFilter) === JSON.stringify([
           [],
@@ -502,7 +502,7 @@ describe('<SearchUI />', () => {
       fireEvent.change(searchBox, { target: { value: 'test search' } });
       await waitFor(() => {
         expect(fetchMock).toHaveLastFetched((_url, req) => {
-          const requestData = JSON.parse(req.body?.toString() ?? '');
+          const requestData = JSON.parse((req.body ?? '') as string);
           // Check both the first and second query.q
           return requestData?.queries[0]?.q === 'test search'
             && requestData?.queries[1]?.q === 'test search';


### PR DESCRIPTION
## Description

In a few places on in the code we are calling `.toString()` on an object with a type like `ReadableStream<Uint8Array<ArrayBuffer>> | BodyInit | null | undefined`. Because this _could_ be an object, oxlint is warning us against using `.toString()` which will just return a string like `[object Object]` or `[object ArrayBuffer]`. However, it turns out that in each case the type is already a `string` so we don't need to be calling `.toString()` at all.

Rule documentation:
* https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-base-to-string.html#typescript-no-base-to-string

Part of https://github.com/openedx/frontend-app-authoring/issues/2559

Private ref MNG-4763