### PR TITLE
fix: do not reload multiple tabs on block save

### DIFF
--- a/src/course-unit/hooks.jsx
+++ b/src/course-unit/hooks.jsx
@@ -24,6 +24,7 @@ import {
   fetchCourseVerticalChildrenData,
   getCourseOutlineInfoQuery,
   patchUnitItemQuery,
+  updateCourseUnitSidebar,
 } from './data/thunk';
 import {
   getCanEdit,
@@ -231,8 +232,7 @@ export const useCourseUnit = ({ courseId, blockId }) => {
       // edits the component using editor which has a separate store
       /* istanbul ignore next */
       if (event.key === 'courseRefreshTriggerOnComponentEditSave') {
-        dispatch(fetchCourseSectionVerticalData(blockId, sequenceId));
-        dispatch(fetchCourseVerticalChildrenData(blockId, isSplitTestType));
+        dispatch(updateCourseUnitSidebar(blockId));
         localStorage.removeItem(event.key);
       }
     };

--- a/src/editors/data/redux/thunkActions/app.js
+++ b/src/editors/data/redux/thunkActions/app.js
@@ -126,9 +126,9 @@ export const saveBlock = (content, returnToUnit) => (dispatch) => {
     onSuccess: (response) => {
       dispatch(actions.app.setSaveResponse(response));
       const parsedData = JSON.parse(response.config.data);
-      if (parsedData?.has_changes) {
+      if (parsedData?.has_changes || !('has_changes' in parsedData)) {
         const storageKey = 'courseRefreshTriggerOnComponentEditSave';
-        localStorage.setItem(storageKey, Date.now());
+        sessionStorage.setItem(storageKey, Date.now());
 
         window.dispatchEvent(new StorageEvent('storage', {
           key: storageKey,


### PR DESCRIPTION
## Description

This PR fixes the below issues:

- When a block is changed, it reloads whole page to enable the publish button. This PR fixes it to only reload the sidebar to enable the publish button.

BEFORE:

  https://github.com/user-attachments/assets/144d77ab-aa42-4b48-86af-3b9c6c2328ea

AFTER:

https://github.com/user-attachments/assets/f208c623-9424-4eec-9e2d-c803292c8098



- If there are multiple tabs open, changing a block was reloading all tabs. This PR fixes it to reload the sidebar of only the current tab.

BEFORE:

  https://github.com/user-attachments/assets/5d5e40d5-5520-436c-bc21-70f3d354fbb8

AFTER:

https://github.com/user-attachments/assets/56ab5bff-e423-418b-8fd8-18a2548b2dd0



- Video block save does not enable the Publish button when updated; This PR fixes that as well.

BEFORE:

  https://github.com/user-attachments/assets/b021a698-bdc9-4c8e-a2a6-20518a0474e2

AFTER:

https://github.com/user-attachments/assets/7628dddf-ef1d-4a94-a775-b7ff6d519b07

## Testing instructions

- Checkout master branch
- Create a course and edit any problem block in a unit. Notice that the full page will reload and enable the publish button.
- Now open another course in a new tab.
- Open the problem editor and make changes in both tabs, Keep the unsaved changes open in the editor in one of the tabs and save the other one. Notice that both tabs will reload and you lose the changes in the tab with unsaved changes.
- Now edit any video block and notice that the publish button won't be enabled and you have to reload the page to enable the publish button.
- Checkout this branch and test all cases.