### PR TITLE
style: Update some texts in legacy libraries migration flow [FC-0112]

### DIFF
--- a/src/legacy-libraries-migration/ConfirmationView.tsx
+++ b/src/legacy-libraries-migration/ConfirmationView.tsx
@@ -74,7 +74,6 @@ export const ConfirmationView = ({
         {...messages.confirmationViewAlert}
         values={{
           count: legacyLibraries.length,
-          libraryName: destination.title,
           b: BoldText,
         }}
       />

--- a/src/legacy-libraries-migration/LegacyLibMigrationPage.test.tsx
+++ b/src/legacy-libraries-migration/LegacyLibMigrationPage.test.tsx
@@ -245,14 +245,11 @@ describe('<LegacyLibMigrationPage />', () => {
     await user.click(nextButton);
     const alert = await screen.findByRole('alert');
     expect(await within(alert).findByText(
-      /All content from the 1 legacy library you selected will be migrated to/i,
-    )).toBeInTheDocument();
-    expect(await within(alert).findByText(
-      /test library 1/i,
+      /All content from the legacy library you selected will be migrated to the Content Library you select/i,
     )).toBeInTheDocument();
 
     const backButton = screen.getByRole('button', { name: /back/i });
-    backButton.click();
+    await user.click(backButton);
 
     expect(await screen.findByText('Test Library 1')).toBeInTheDocument();
     // The selected v2 library remains checked
@@ -357,10 +354,7 @@ describe('<LegacyLibMigrationPage />', () => {
     // Should show alert of ConfirmationView
     const alert = await screen.findByRole('alert');
     expect(await within(alert).findByText(
-      /All content from the 3 legacy libraries you selected will be migrated to/i,
-    )).toBeInTheDocument();
-    expect(await within(alert).findByText(
-      /test library 1/i,
+      /All content from the 3 legacy libraries you selected will be migrated to the Content Library you select/i,
     )).toBeInTheDocument();
     expect(screen.getByText('MBA')).toBeInTheDocument();
     expect(screen.getByText('Legacy library 1')).toBeInTheDocument();
@@ -417,11 +411,7 @@ describe('<LegacyLibMigrationPage />', () => {
     // Should show alert of ConfirmationView
     const alert = await screen.findByRole('alert');
     expect(await within(alert).findByText(
-      /All content from the 3 legacy libraries you selected will be migrated to /i,
-      { exact: false },
-    )).toBeInTheDocument();
-    expect(await within(alert).findByText(
-      /test library 1/i,
+      /All content from the 3 legacy libraries you selected will be migrated to the Content Library you select/i,
       { exact: false },
     )).toBeInTheDocument();
     expect(screen.getByText('MBA')).toBeInTheDocument();

--- a/src/legacy-libraries-migration/messages.ts
+++ b/src/legacy-libraries-migration/messages.ts
@@ -64,7 +64,7 @@ const messages = defineMessages({
   selectDestinationAlert: {
     id: 'legacy-libraries-migration.select-destination.alert.text',
     defaultMessage: 'All content from the'
-      + ' {count, plural, one {{count} legacy library} other {{count} legacy libraries}} you selected will'
+      + ' {count, plural, one {legacy library} other {{count} legacy libraries}} you selected will'
       + ' be migrated to this new library, organized into collections. Legacy library content used in courses will'
       + ' continue to work as-is. To receive any future changes to migrated content, you must update these'
       + ' references within your course.',
@@ -73,8 +73,8 @@ const messages = defineMessages({
   confirmationViewAlert: {
     id: 'legacy-libraries-migration.select-destination.alert.text',
     defaultMessage: 'All content from the'
-      + ' {count, plural, one {{count} legacy library} other {{count} legacy libraries}} you selected will'
-      + ' be migrated to <b>{libraryName}</b>, organized into collections. Legacy library content used in courses will'
+      + ' {count, plural, one {legacy library} other {{count} legacy libraries}} you selected will'
+      + ' be migrated to the Content Library you select, organized into collections. Legacy library content used in courses will'
       + ' continue to work as-is. To receive any future changes to migrated content, you must update these'
       + ' references within your course.',
     description: 'Alert text in the confirmation step of the legacy libraries migration page.',


### PR DESCRIPTION
## Description


- Updates the text described in https://github.com/openedx/frontend-app-authoring/issues/2582#issuecomment-3487221538
- Which user roles will this change impact? "Course Author"

<img width="1157" height="575" alt="image" src="https://github.com/user-attachments/assets/6a038205-71a0-4fb9-802e-dbd6acef3753" />
<img width="1157" height="575" alt="image" src="https://github.com/user-attachments/assets/fd7e2692-905e-40cb-893f-0007ce927c02" />

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/2582#issuecomment-3487221538
- Internal ticket: [FAL-4270](https://tasks.opencraft.com/browse/FAL-4270)

## Testing instructions

- Go to the legacy libraries migration flow.
- Select one legacy library
- On the destination view, verify the updated text in the alert.
- On the confirmation view, verify the updated text in the alert.

## Other information

N/A

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [X] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [X] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [X] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [X] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [X] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [X] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [X] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
