### PR TITLE
Backport- fix: self-closing script tag fixed for TinyMceEditor

### DIFF
--- a/src/editors/sharedComponents/TinyMceWidget/hooks.ts
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.ts
@@ -457,7 +457,8 @@ export const editorConfig = ({
       valid_elements: '*[*]',
       // FIXME: this is passing 'utf-8', which is not a valid entity_encoding value. It should be 'named' etc.
       entity_encoding: 'utf-8' as any,
-      // Protect self-closing <script /> tags from being mangled, to preserve backwards compatibility with content that relied on this behavior
+      // Protect self-closing <script /> tags from being mangled,
+      // to preserve backwards compatibility with content that relied on this behavior
       protect: [/<script[^>]*\/>/g],
     },
   };


### PR DESCRIPTION
## Description

Backport PR for: https://github.com/openedx/frontend-app-authoring/pull/2510