### PR TITLE
fix: grading settings save button stuck in pending state

### DIFF
--- a/src/grading-settings/GradingSettings.jsx
+++ b/src/grading-settings/GradingSettings.jsx
@@ -42,7 +42,7 @@ const GradingSettings = ({ courseId }) => {
   } = useCourseSettings(courseId);
   const {
     mutate: updateGradingSettings,
-    isLoading: savePending,
+    isPending: savePending,
     isSuccess: savingStatus,
     isError: savingFailed,
   } = useGradingSettingUpdater(courseId);


### PR DESCRIPTION
## Description

The save button on the Grading Settings page stayed in its loading state after a successful save. The effect was toggling state using stale values and watched savePending instead of savingStatus. Updated the effect to depend on savingStatus and set the UI flags explicitly (show success, hide save prompt, clear pending).

Useful information to include:
- Which user roles will this change impact? "Course Author"
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).

Before

https://github.com/user-attachments/assets/b2102710-b131-4ea2-a538-816c2009eb71

After

https://github.com/user-attachments/assets/1fd63c77-e90c-4205-b543-bc16627a052c


## Supporting information

Link to other information about the change, such as GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

- On the master branch, try to update the grading page.
- The page will keep showing the save button even after the response from the backend is received.
- Check out this branch and verify that the page states are updated properly after the response from the backend is received.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
