### PR TITLE
fix: unit button active state

### DIFF
--- a/src/course-unit/course-sequence/sequence-navigation/UnitButton.jsx
+++ b/src/course-unit/course-sequence/sequence-navigation/UnitButton.jsx
@@ -37,7 +37,7 @@ UnitButton.propTypes = {
   className: PropTypes.string,
   showTitle: PropTypes.bool,
   unitId: PropTypes.string.isRequired,
-  isActive: PropTypes.bool.isRequired,
+  isActive: PropTypes.bool,
 };
 
 UnitButton.defaultProps = {


### PR DESCRIPTION
## Description

Unit buttons were checking unit.isActive from Redux, but the units in state never had an isActive field. That meant isActive was always undefined and the active tab styling broke. This PR fixes the issue by using the isActive prop, which was already being passed in the props.

Useful information to include:
- Which user roles will this change impact? "Course Author"
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
Before

https://github.com/user-attachments/assets/dd8800a2-9fae-48fc-8195-d012d040e4ca

After

https://github.com/user-attachments/assets/eb862aea-6fbc-4d46-a4bf-7d5409d370f4

## Supporting information

Link to other information about the change, such as GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

- Verify that the unit button's color is blue when active as shown in the after screen recording above

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
