### PR TITLE
refactor: convert <UnitButton> and <UnitIcon> to TSX

### DIFF
--- a/src/course-unit/course-sequence/sequence-navigation/UnitButton.tsx
+++ b/src/course-unit/course-sequence/sequence-navigation/UnitButton.tsx
@@ -1,21 +1,29 @@
-import PropTypes from 'prop-types';
+import { type FC } from 'react';
 import { useSelector } from 'react-redux';
 import { Button } from '@openedx/paragon';
 import { Link } from 'react-router-dom';
 
+import { DeprecatedReduxState } from '@src/store';
+import { getCourseId, getSequenceId } from '@src/course-unit/data/selectors';
 import UnitIcon from './UnitIcon';
-import { getCourseId, getSequenceId } from '../../data/selectors';
 
-const UnitButton = ({
+interface Props {
+  unitId: string;
+  className?: string;
+  showTitle?: boolean;
+  isActive?: boolean;
+}
+
+const UnitButton: FC<Props> = ({
   unitId,
   className,
-  showTitle,
   isActive, // passed from parent (SequenceNavigationTabs)
+  showTitle = false,
 }) => {
   const courseId = useSelector(getCourseId);
   const sequenceId = useSelector(getSequenceId);
 
-  const unit = useSelector((state) => state.models.units[unitId]);
+  const unit = useSelector((state: DeprecatedReduxState) => state.models.units[unitId]);
   const { title, contentType } = unit || {};
 
   return (
@@ -31,19 +39,6 @@ const UnitButton = ({
       {showTitle && <span className="unit-title">{title}</span>}
     </Button>
   );
-};
-
-UnitButton.propTypes = {
-  className: PropTypes.string,
-  showTitle: PropTypes.bool,
-  unitId: PropTypes.string.isRequired,
-  isActive: PropTypes.bool,
-};
-
-UnitButton.defaultProps = {
-  className: undefined,
-  showTitle: false,
-  isActive: false,
 };
 
 export default UnitButton;

--- a/src/course-unit/course-sequence/sequence-navigation/UnitIcon.tsx
+++ b/src/course-unit/course-sequence/sequence-navigation/UnitIcon.tsx
@@ -1,17 +1,17 @@
-import PropTypes from 'prop-types';
+import { type FC } from 'react';
 import { Icon } from '@openedx/paragon';
 import { BookOpen as BookOpenIcon } from '@openedx/paragon/icons';
 
-import { UNIT_TYPE_ICONS_MAP, UNIT_ICON_TYPES } from '../../../generic/block-type-utils/constants';
+import { UNIT_TYPE_ICONS_MAP } from '@src/generic/block-type-utils/constants';
 
-const UnitIcon = ({ type }) => {
+interface Props {
+  type: keyof typeof UNIT_TYPE_ICONS_MAP;
+}
+
+const UnitIcon: FC<Props> = ({ type }) => {
   const icon = UNIT_TYPE_ICONS_MAP[type] || BookOpenIcon;
 
   return <Icon src={icon} screenReaderText={type} />;
-};
-
-UnitIcon.propTypes = {
-  type: PropTypes.oneOf(UNIT_ICON_TYPES).isRequired,
 };
 
 export default UnitIcon;

--- a/src/generic/block-type-utils/constants.ts
+++ b/src/generic/block-type-utils/constants.ts
@@ -21,8 +21,6 @@ import {
 } from '@openedx/paragon/icons';
 import NewsstandIcon from '../NewsstandIcon';
 
-export const UNIT_ICON_TYPES = ['video', 'other', 'vertical', 'problem', 'lock'];
-
 export const COMPONENT_TYPES = {
   advanced: 'advanced',
   discussion: 'discussion',


### PR DESCRIPTION
## Description

Small PR to convert `<UnitButton>` and `<UnitIcon>` to TypeScript.

## Supporting information

Private ref MNG-4670

## Testing instructions

Make sure the unit nav bar works:

<img width="1433" height="63" alt="Screenshot 2025-11-13 at 12 18 10 PM" src="https://github.com/user-attachments/assets/247406b9-ac0f-462b-93cb-e70a6229b609" />

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
