### PR TITLE
refactor: Update title in ImportStepperModal

### DIFF
--- a/src/library-authoring/import-course/messages.ts
+++ b/src/library-authoring/import-course/messages.ts
@@ -151,8 +151,8 @@ const messages = defineMessages({
   },
   importCourseDetailsTitle: {
     id: 'course-authoring.library-authoring.import-course.review-details.import-details.title',
-    defaultMessage: 'Import Details',
-    description: 'Title of the card for the import details of a imported course.',
+    defaultMessage: 'Analysis Details',
+    description: 'Title of the card for the analysis details of a imported course.',
   },
   importCourseDetailsLoadingBody: {
     id: 'course-authoring.library-authoring.import-course.review-details.import-details.loading.body',

--- a/src/library-authoring/import-course/stepper/ImportStepperPage.test.tsx
+++ b/src/library-authoring/import-course/stepper/ImportStepperPage.test.tsx
@@ -126,7 +126,7 @@ describe('<ImportStepperModal />', () => {
     )).toBeInTheDocument());
 
     expect(screen.getByText('Analysis Summary')).toBeInTheDocument();
-    expect(screen.getByText('Import Details')).toBeInTheDocument();
+    expect(screen.getByText('Analysis Details')).toBeInTheDocument();
     // The import details is loading
     expect(screen.getByText('The selected course is being analyzed for import and review')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Description

- Updates the title of one card from "Import Details" to "Analysis Details"

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/2524#issuecomment-3533189957
- Internal ticket: [FAL-4266](https://tasks.opencraft.com/browse/FAL-4266)

## Testing instructions

- Follow the testing instructions in https://github.com/openedx/frontend-app-authoring/pull/2567, and verify the change in the title.

## Other information

N/A

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [X] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [X] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [X] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [X] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [X] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [X] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [X] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
