### PR TITLE
fix: Rename builtin discussion providers, "edX" -> "Open edX" [ulmo]

### DIFF
--- a/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
@@ -147,7 +147,7 @@ describe('DiscussionsSettings', () => {
       // content has been loaded - prior to proceeding with our expectations.
       await waitForElementToBeRemoved(screen.queryByRole('status'));
 
-      await user.click(queryByLabelText(container, 'Select edX'));
+      await user.click(queryByLabelText(container, 'Select Open edX (legacy)'));
       await user.click(queryByText(container, messages.nextButton.defaultMessage));
 
       expect(queryByTestId(container, 'appList')).not.toBeInTheDocument();

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -107,13 +107,13 @@ const messages = defineMessages({
   },
   'appName-legacy': {
     id: 'authoring.discussions.appConfigForm.appName-legacy',
-    defaultMessage: 'edX',
-    description: 'The name of the Legacy edX Discussions app.',
+    defaultMessage: 'Open edX (legacy)',
+    description: 'The name of the Legacy Open edX Discussions app.',
   },
   'appName-openedx': {
     id: 'authoring.discussions.appConfigForm.appName-openedx',
-    defaultMessage: 'edX (new)',
-    description: 'The name of the new edX Discussions app.',
+    defaultMessage: 'Open edX',
+    description: 'The name of the new Open edX Discussions app.',
   },
   divisionByGroup: {
     id: 'authoring.discussions.builtIn.divisionByGroup',


### PR DESCRIPTION
Backport of https://github.com/openedx/frontend-app-authoring/pull/2660