### PR TITLE
feat: add support for origin server and user info

### DIFF
--- a/src/library-authoring/create-library/CreateLibrary.test.tsx
+++ b/src/library-authoring/create-library/CreateLibrary.test.tsx
@@ -528,15 +528,10 @@ describe('<CreateLibrary />', () => {
 
       // Upload a file to trigger the restore process
       const file = new File(['test content'], 'test-archive.zip', { type: 'application/zip' });
-      const dropzone = screen.getByTestId('library-archive-dropzone');
+      const dropzone = screen.getByRole('presentation', { hidden: true });
       const input = dropzone.querySelector('input[type="file"]') as HTMLInputElement;
 
-      Object.defineProperty(input, 'files', {
-        value: [file],
-        writable: false,
-      });
-
-      fireEvent.change(input);
+      await user.upload(input, file);
 
       // Wait for the restore to complete and archive details to be shown
       await waitFor(() => {

--- a/src/library-authoring/create-library/CreateLibrary.tsx
+++ b/src/library-authoring/create-library/CreateLibrary.tsx
@@ -211,7 +211,7 @@ export const CreateLibrary = ({
                     </div>
                     <div className="d-flex flex-column gap-2 align-items-md-start">
                       <div className="d-flex align-items-md-center gap-2">
-                        <Icon src={Widgets} style={{ width: '20px', height: '20px', marginRight: '8px' }} />
+                        <Icon src={Widgets} className="mr-2" style={{ width: '20px', height: '20px' }} />
                         <span className="x-small">
                           {intl.formatMessage(messages.archiveComponentsCount, {
                             countSections: restoreStatus.result.sections,
@@ -224,7 +224,7 @@ export const CreateLibrary = ({
                       {
                         (restoreStatus.result.createdBy?.email && restoreStatus.result.createdOnServer) && (
                           <div className="d-flex align-items-md-center gap-2">
-                            <Icon src={PersonOutline} style={{ width: '20px', height: '20px', marginRight: '8px' }} />
+                            <Icon src={PersonOutline} className="mr-2" style={{ width: '20px', height: '20px' }} />
                             <span className="x-small">
                               {intl.formatMessage(messages.archiveRestoredCreatedBy, {
                                 createdBy: restoreStatus.result.createdBy?.email,
@@ -235,7 +235,7 @@ export const CreateLibrary = ({
                         )
                       }
                       <div className="d-flex align-items-md-center gap-2">
-                        <Icon src={AccessTime} style={{ width: '20px', height: '20px', marginRight: '8px' }} />
+                        <Icon src={AccessTime} className="mr-2" style={{ width: '20px', height: '20px' }} />
                         <span className="x-small">
                           {intl.formatMessage(messages.archiveBackupDate, {
                             date: new Date(restoreStatus.result.createdAt).toLocaleDateString(),

--- a/src/library-authoring/create-library/messages.ts
+++ b/src/library-authoring/create-library/messages.ts
@@ -121,7 +121,7 @@ const messages = defineMessages({
   archiveComponentsCount: {
     id: 'course-authoring.library-authoring.create-library.form.archive.components-count',
     defaultMessage: 'Contains {countSections} sections, {countSubsections} subsections, {countUnits} units, {countComponents} components',
-    description: 'Text showing the number of components in the restored archive.',
+    description: 'Text showing the number of sections, subsections, units, and components in the restored archive.',
   },
   archiveRestoredCreatedBy: {
     id: 'course-authoring.library-authoring.create-library.form.archive.restored-created-by',


### PR DESCRIPTION
## Description

Resolves: https://github.com/openedx/frontend-app-authoring/issues/2596

This PR introduces the following improvements:

- Display of the number of sections, subsections, and units.
- Display of the instance name where the archive was created.
- Display of the email of the user who generated the archive.

**Before**:

<img width="983" height="213" alt="image" src="https://github.com/user-attachments/assets/0d22f563-2fc1-46dc-a025-d290e2c8c60e" />

<img width="521" height="774" alt="image" src="https://github.com/user-attachments/assets/f017dd23-ab1b-4520-9e1b-b8165348f534" />


**Now**:
 
<img width="1068" height="224" alt="image" src="https://github.com/user-attachments/assets/0bf53633-684e-46f8-8b2c-11eba26a1cf6" />

<img width="567" height="853" alt="image" src="https://github.com/user-attachments/assets/917dd949-c580-4073-8fa9-2b44f5917e87" />


## Where can I find this section?

This UI appears when creating a new V2 library using the “Create from archive” option.

## Testing instructions

1. Create a new V2 library.
2. Select the **Create from archive** option.
3. Upload a backup archive .zip file.
4. Review the summary section and confirm the displayed information.

## Other information

Related backend PR: https://github.com/openedx/edx-platform/pull/37626

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
