### PR TITLE
feat: dock buttons to the bottom in import course stepper [FC-0112]

### DIFF
--- a/src/library-authoring/import-course/index.scss
+++ b/src/library-authoring/import-course/index.scss
@@ -17,3 +17,22 @@
 .text-decoration-underline {
   text-decoration: underline;
 }
+
+.import-course-stepper {
+  .import-container {
+    // Calculate all the screen size subtracting the height of the header and title and top/bottom margins
+    min-height: calc(calc(100vh - 60px - 61px) - calc(var(--pgn-spacing-spacer-base) * 6));
+  }
+
+  .content-buttons {
+    width: 100%;
+    position: sticky;
+    bottom: 0;
+  }
+
+  [class*="col-"] {
+    // To avoid create an empty gray space between the main content and the sidebar
+    padding-right: 0;
+    padding-left: 0;
+  }
+}

--- a/src/library-authoring/import-course/stepper/ImportStepperPage.tsx
+++ b/src/library-authoring/import-course/stepper/ImportStepperPage.tsx
@@ -112,7 +112,7 @@ export const ImportStepperPage = () => {
   }
 
   return (
-    <div className="d-flex">
+    <div className="import-course-stepper d-flex">
       <div className="flex-grow-1">
         <Helmet>
           <title>{libraryData.title} | {process.env.SITE_NAME}</title>
@@ -128,7 +128,7 @@ export const ImportStepperPage = () => {
             size: undefined,
           }}
         />
-        <Container className="mt-4 mb-5">
+        <Container className="mt-4">
           <div className="px-4 bg-light-200 border-bottom">
             <SubHeader
               title={intl.formatMessage(messages.importCourseStepperTitle)}
@@ -137,29 +137,31 @@ export const ImportStepperPage = () => {
           </div>
           <Layout xs={[{ span: 9 }, { span: 3 }]}>
             <Layout.Element>
-              <Stepper activeKey={currentStep}>
-                <Stepper.Header />
-                <Stepper.Step
-                  eventKey="select-course"
-                  title={intl.formatMessage(messages.importCourseSelectCourseStep)}
-                >
-                  <CoursesList
-                    selectedCourseId={selectedCourseId}
-                    handleSelect={setSelectedCourseId}
-                    cardMigrationStatusWidget={MigrationStatus}
-                  />
-                </Stepper.Step>
-                <Stepper.Step
-                  eventKey="review-details"
-                  title={intl.formatMessage(messages.importCourseReviewDetailsStep)}
-                >
-                  <ReviewImportDetails
-                    markAnalysisComplete={setAnalysisCompleted}
-                    courseId={selectedCourseId}
-                  />
-                </Stepper.Step>
-              </Stepper>
-              <div className="mt-4">
+              <div className="import-container px-4">
+                <Stepper activeKey={currentStep}>
+                  <Stepper.Header />
+                  <Stepper.Step
+                    eventKey="select-course"
+                    title={intl.formatMessage(messages.importCourseSelectCourseStep)}
+                  >
+                    <CoursesList
+                      selectedCourseId={selectedCourseId}
+                      handleSelect={setSelectedCourseId}
+                      cardMigrationStatusWidget={MigrationStatus}
+                    />
+                  </Stepper.Step>
+                  <Stepper.Step
+                    eventKey="review-details"
+                    title={intl.formatMessage(messages.importCourseReviewDetailsStep)}
+                  >
+                    <ReviewImportDetails
+                      markAnalysisComplete={setAnalysisCompleted}
+                      courseId={selectedCourseId}
+                    />
+                  </Stepper.Step>
+                </Stepper>
+              </div>
+              <div className="content-buttons mt-5 px-5 py-2 bg-white box-shadow-up-1">
                 {currentStep === 'select-course' ? (
                   <ActionRow className="d-flex justify-content-between">
                     <Button variant="outline-primary" onClick={() => navigate('../import')}>


### PR DESCRIPTION
## Description

- Docks buttons to the button in import course stepper
- Which user roles will this change impact? "Course Author"

<img width="1919" height="927" alt="image" src="https://github.com/user-attachments/assets/434b1e10-3175-4bcc-b3cb-9d5a3acdff98" />
<img width="1919" height="927" alt="image" src="https://github.com/user-attachments/assets/baa8c033-a691-4274-9121-8b821f2752f9" />


## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/2524#issuecomment-3543294726
- Internal ticket: [FAL-4270](https://tasks.opencraft.com/browse/FAL-4270)

## Testing instructions

- Go to the Library Home of a library.
- Go to Import menu in the header.
- Click on `Import Course` button.
- Verify that the buttons are docked to the button in all steps

## Other information

N/A

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [X] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [X] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [X] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [X] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [X] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [X] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [X] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
