### PR TITLE
[Backport] fix: don't revert to advanced editor if block contains copied_from fields (#2661)

### DIFF
--- a/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
@@ -2,7 +2,7 @@
 // lint is disabled for this file due to strict spacing
 
 export const checkboxesOLXWithFeedbackAndHintsOLX = {
-  rawOLX: `<problem url_name="this_should_be_ignored">
+  rawOLX: `<problem url_name="this_should_be_ignored" copied_from_version="2" copied_from_block="some-block">
   <choiceresponse>
     <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for checkboxes with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
   <label>Add the question text, or prompt, here. This text is required.</label>

--- a/src/editors/data/constants/problem.ts
+++ b/src/editors/data/constants/problem.ts
@@ -380,6 +380,8 @@ export const ignoredOlxAttributes = [
   '@_url_name',
   '@_x-is-pointer-node',
   '@_markdown_edited',
+  '@_copied_from_block',
+  '@_copied_from_version',
 ] as const;
 
 // Useful for the block creation workflow.

--- a/src/library-authoring/components/BaseCard.tsx
+++ b/src/library-authoring/components/BaseCard.tsx
@@ -64,7 +64,7 @@ const BaseCard = ({
         <Card.Header
           className={`library-item-header ${getComponentStyleColor(itemType)}`}
           title={
-            <Icon src={itemIcon} className="library-item-header-icon" />
+            <Icon src={itemIcon} className="library-item-header-icon my-2" />
           }
           actions={(
             <div


### PR DESCRIPTION
(cherry picked from commit 2215fc53cc5df6aece84f09903d0f95272ad728c)

Backport of https://github.com/openedx/frontend-app-authoring/pull/2661#issuecomment-3572235346
