### PR TITLE
fix: "Back up" is two words when used as a verb

### DIFF
--- a/src/header/hooks.test.ts
+++ b/src/header/hooks.test.ts
@@ -174,7 +174,7 @@ describe('header utils', () => {
       const items = renderHook(() => useLibraryToolsMenuItems('course-123')).result.current;
       expect(items).toContainEqual({
         href: '/library/course-123/backup',
-        title: 'Backup to local archive',
+        title: 'Back up to local archive',
       });
       expect(items).toContainEqual({ href: '/library/course-123/import', title: 'Import' });
     });

--- a/src/header/messages.ts
+++ b/src/header/messages.ts
@@ -108,8 +108,8 @@ const messages = defineMessages({
   },
   'header.links.exportLibrary': {
     id: 'header.links.exportLibrary',
-    defaultMessage: 'Backup to local archive',
-    description: 'Link to Studio Backup Library page',
+    defaultMessage: 'Back up to local archive',
+    description: 'Link to Studio Library Backup page',
   },
   'header.menu.teamAccess': {
     id: 'header.links.teamAccess',


### PR DESCRIPTION
## Description

There is a new menu item "Backup to local archive". _Backup_ is the correct spelling when using it as a noun or adjective, but the menu item uses as a verb, so it should be two words, _back up_, i.e. "Back up to local archive"

Note: alternatively, if we want to stick with the spelling "backup", the menu item could be rephrased. For example, "Create local backup" or "Local backup archive" use the noun and adjective forms, respectively.

If accepted I'll backport (back port?) this to Ulmo.

### Before

<img width="757" height="223" alt="Screenshot 2025-11-25 at 12 07 14 PM" src="https://github.com/user-attachments/assets/b53532ec-960f-426e-b27e-430834b01b97" />

### After

<img width="757" height="223" alt="Screenshot 2025-11-25 at 12 10 25 PM" src="https://github.com/user-attachments/assets/d3b85f19-8ec2-425c-a8be-edf780d36b0a" />

## Supporting information

https://www.merriam-webster.com/dictionary/backup#dictionary-entry-2

## Best Practices Checklist

N/A