### PR TITLE
fix: "Back up" is two words when used as a verb [ulmo]

### DIFF
--- a/src/header/messages.js
+++ b/src/header/messages.js
@@ -103,8 +103,8 @@ const messages = defineMessages({
   },
   'header.links.exportLibrary': {
     id: 'header.links.exportLibrary',
-    defaultMessage: 'Backup to local archive',
-    description: 'Link to Studio Backup Library page',
+    defaultMessage: 'Back up to local archive',
+    description: 'Link to Studio Library Backup page',
   },
   'header.links.optimizer': {
     id: 'header.links.optimizer',


### PR DESCRIPTION
Backports https://github.com/openedx/frontend-app-authoring/pull/2696