### PR TITLE
fix: migrate library alert text (backport of #2651)

### DIFF
--- a/src/legacy-libraries-migration/ConfirmationView.tsx
+++ b/src/legacy-libraries-migration/ConfirmationView.tsx
@@ -74,6 +74,7 @@ export const ConfirmationView = ({
         {...messages.confirmationViewAlert}
         values={{
           count: legacyLibraries.length,
+          libraryName: destination.title,
           b: BoldText,
         }}
       />

--- a/src/legacy-libraries-migration/LegacyLibMigrationPage.test.tsx
+++ b/src/legacy-libraries-migration/LegacyLibMigrationPage.test.tsx
@@ -185,7 +185,7 @@ describe('<LegacyLibMigrationPage />', () => {
     nextButton.click();
 
     // Should show alert of SelectDestinationView
-    expect(await screen.findByText(/you selected will be migrated to this new library/i)).toBeInTheDocument();
+    expect(await screen.findByText(/you selected will be migrated to the Content Library you/)).toBeInTheDocument();
 
     const backButton = screen.getByRole('button', { name: /back/i });
     backButton.click();
@@ -211,7 +211,7 @@ describe('<LegacyLibMigrationPage />', () => {
     nextButton.click();
 
     // Should show alert of SelectDestinationView
-    expect(await screen.findByText(/you selected will be migrated to this new library/i)).toBeInTheDocument();
+    expect(await screen.findByText(/you selected will be migrated to the Content Library you/)).toBeInTheDocument();
 
     // The next button is disabled
     expect(nextButton).toBeDisabled();
@@ -237,7 +237,7 @@ describe('<LegacyLibMigrationPage />', () => {
     await user.click(nextButton);
 
     // Should show alert of SelectDestinationView
-    expect(await screen.findByText(/you selected will be migrated to this new library/i)).toBeInTheDocument();
+    expect(await screen.findByText(/you selected will be migrated to the Content Library you/)).toBeInTheDocument();
     expect(await screen.findByText('Test Library 1')).toBeInTheDocument();
     const radioButton = screen.getByRole('radio', { name: /test library 1/i });
     await user.click(radioButton);
@@ -245,7 +245,7 @@ describe('<LegacyLibMigrationPage />', () => {
     await user.click(nextButton);
     const alert = await screen.findByRole('alert');
     expect(await within(alert).findByText(
-      /All content from the legacy library you selected will be migrated to the Content Library you select/i,
+      /All content from the legacy library you selected will be migrated to/,
     )).toBeInTheDocument();
 
     const backButton = screen.getByRole('button', { name: /back/i });
@@ -274,7 +274,7 @@ describe('<LegacyLibMigrationPage />', () => {
     nextButton.click();
 
     // Should show alert of SelectDestinationView
-    expect(await screen.findByText(/you selected will be migrated to this new library/i)).toBeInTheDocument();
+    expect(await screen.findByText(/you selected will be migrated to the Content Library you/)).toBeInTheDocument();
 
     const createButton = await screen.findByRole('button', { name: /create new library/i });
     expect(createButton).toBeInTheDocument();
@@ -344,7 +344,7 @@ describe('<LegacyLibMigrationPage />', () => {
     await user.click(nextButton);
 
     // Should show alert of SelectDestinationView
-    expect(await screen.findByText(/you selected will be migrated to this new library/i)).toBeInTheDocument();
+    expect(await screen.findByText(/you selected will be migrated to the Content Library you/)).toBeInTheDocument();
     expect(await screen.findByText('Test Library 1')).toBeInTheDocument();
     const radioButton = screen.getByRole('radio', { name: /test library 1/i });
     await user.click(radioButton);
@@ -354,7 +354,7 @@ describe('<LegacyLibMigrationPage />', () => {
     // Should show alert of ConfirmationView
     const alert = await screen.findByRole('alert');
     expect(await within(alert).findByText(
-      /All content from the 3 legacy libraries you selected will be migrated to the Content Library you select/i,
+      /All content from the 3 legacy libraries you selected will be migrated to/,
     )).toBeInTheDocument();
     expect(screen.getByText('MBA')).toBeInTheDocument();
     expect(screen.getByText('Legacy library 1')).toBeInTheDocument();
@@ -401,7 +401,7 @@ describe('<LegacyLibMigrationPage />', () => {
     await user.click(nextButton);
 
     // Should show alert of SelectDestinationView
-    expect(await screen.findByText(/you selected will be migrated to this new library/i)).toBeInTheDocument();
+    expect(await screen.findByText(/you selected will be migrated to the Content Library you/)).toBeInTheDocument();
     expect(await screen.findByText('Test Library 1')).toBeInTheDocument();
     const radioButton = screen.getByRole('radio', { name: /test library 1/i });
     await user.click(radioButton);
@@ -411,7 +411,7 @@ describe('<LegacyLibMigrationPage />', () => {
     // Should show alert of ConfirmationView
     const alert = await screen.findByRole('alert');
     expect(await within(alert).findByText(
-      /All content from the 3 legacy libraries you selected will be migrated to the Content Library you select/i,
+      /All content from the 3 legacy libraries you selected will be migrated to/,
       { exact: false },
     )).toBeInTheDocument();
     expect(screen.getByText('MBA')).toBeInTheDocument();

--- a/src/legacy-libraries-migration/messages.ts
+++ b/src/legacy-libraries-migration/messages.ts
@@ -65,24 +65,24 @@ const messages = defineMessages({
     id: 'legacy-libraries-migration.select-destination.alert.text',
     defaultMessage: 'All content from the'
       + ' {count, plural, one {legacy library} other {{count} legacy libraries}} you selected will'
-      + ' be migrated to this new library, organized into collections. Legacy library content used in courses will'
-      + ' continue to work as-is. To receive any future changes to migrated content, you must update these'
-      + ' references within your course.',
+      + ' be migrated to the Content Library you select, organized into collections. Legacy library content used'
+      + ' in courses will continue to work as-is. To receive any future changes to migrated content,'
+      + ' you must update these references within your course.',
     description: 'Alert text in the select destination step of the legacy libraries migration page.',
   },
   confirmationViewAlert: {
     id: 'legacy-libraries-migration.select-destination.alert.text',
     defaultMessage: 'All content from the'
       + ' {count, plural, one {legacy library} other {{count} legacy libraries}} you selected will'
-      + ' be migrated to the Content Library you select, organized into collections. Legacy library content used in courses will'
-      + ' continue to work as-is. To receive any future changes to migrated content, you must update these'
-      + ' references within your course.',
+      + ' be migrated to <b>{libraryName}</b> and organized into collections. Legacy library content used'
+      + ' in courses will continue to work as-is. To receive any future changes to migrated content,'
+      + ' you must update these references within your course.',
     description: 'Alert text in the confirmation step of the legacy libraries migration page.',
   },
   previouslyMigratedAlert: {
     id: 'legacy-libraries-migration.confirmation-step.card.previously-migrated.text',
     defaultMessage: 'Previously migrated library. Any problem bank links were already'
-    + ' moved will be migrated to <b>{libraryName}</b>',
+      + ' moved will be migrated to <b>{libraryName}</b>',
     description: 'Alert text when the legacy library is already migrated.',
   },
   helpAndSupportTitle: {
@@ -98,8 +98,8 @@ const messages = defineMessages({
   helpAndSupportFirstQuestionBody: {
     id: 'legacy-libraries-migration.helpAndSupport.q1.body',
     defaultMessage: 'In the new Content Libraries experience, you can author sections,'
-    + ' subsections, units, and many types of components. Library content can be reused across many courses,'
-    + ' and kept up-to-date. Content libraries now support increased collaboration across authoring teams.',
+      + ' subsections, units, and many types of components. Library content can be reused across many courses,'
+      + ' and kept up-to-date. Content libraries now support increased collaboration across authoring teams.',
     description: 'Body of the first question in the Help & Support sidebar',
   },
   helpAndSupportSecondQuestionTitle: {
@@ -110,9 +110,9 @@ const messages = defineMessages({
   helpAndSupportSecondQuestionBody: {
     id: 'legacy-libraries-migration.helpAndSupport.q2.body',
     defaultMessage: 'All legacy library content is supported in the new experience.'
-    + ' Content from legacy libraries will be migrated to its own collection in the new Content Libraries experience.'
-    + ' This collection will have the same name as your original library. Courses that use legacy library content will'
-    + ' continue to function as usual, linked to the migrated version within the new libraries experience.',
+      + ' Content from legacy libraries will be migrated to its own collection in the new Content Libraries experience.'
+      + ' This collection will have the same name as your original library. Courses that use legacy library content will'
+      + ' continue to function as usual, linked to the migrated version within the new libraries experience.',
     description: 'Body of the second question in the Help & Support sidebar',
   },
   helpAndSupportThirdQuestionTitle: {
@@ -123,18 +123,18 @@ const messages = defineMessages({
   helpAndSupportThirdQuestionBody: {
     id: 'legacy-libraries-migration.helpAndSupport.q3.body.2',
     defaultMessage: '<p>There are three steps to migrating legacy libraries:</p>'
-    + '<p><div>1 - Select Legacy Libraries</div>'
-    + 'You can select up to 50 legacy libraries for migration in this step. By default, only libraries that have'
-    + ' not yet been migrated are shown. To see all libraries, remove the filter.'
-    + ' You can select up to 50 legacy libraries for migration, but only one destination'
-    + ' v2 Content Library per migration.</p>'
-    + '<p><div>2 - Select Destination</div>'
-    + 'You can migrate legacy libraries to an existing Content Library in the new experience,'
-    + ' or you can create a new destination. You can only select one v2 Content Library per migration.'
-    + ' All your content will be migrated, and kept organized in collections.</p>'
-    + '<p><div>3 - Confirm</div>'
-    + 'In this step, review your migration. Once you confirm, migration will begin.'
-    + ' It may take some time to complete.</p>',
+      + '<p><div>1 - Select Legacy Libraries</div>'
+      + 'You can select up to 50 legacy libraries for migration in this step. By default, only libraries that have'
+      + ' not yet been migrated are shown. To see all libraries, remove the filter.'
+      + ' You can select up to 50 legacy libraries for migration, but only one destination'
+      + ' v2 Content Library per migration.</p>'
+      + '<p><div>2 - Select Destination</div>'
+      + 'You can migrate legacy libraries to an existing Content Library in the new experience,'
+      + ' or you can create a new destination. You can only select one v2 Content Library per migration.'
+      + ' All your content will be migrated, and kept organized in collections.</p>'
+      + '<p><div>3 - Confirm</div>'
+      + 'In this step, review your migration. Once you confirm, migration will begin.'
+      + ' It may take some time to complete.</p>',
     description: 'Part 2 of the Body of the third question in the Help & Support sidebar',
   },
   migrationInProgress: {


### PR DESCRIPTION
## Description

Backport of https://github.com/openedx/frontend-app-authoring/pull/2651

## Supporting information

Check https://github.com/openedx/frontend-app-authoring/pull/2651

## Testing instructions

Check https://github.com/openedx/frontend-app-authoring/pull/2651

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
