### PR TITLE
fix: Generalize a couple remaining Proctortrack references

### DIFF
--- a/src/course-checklist/ChecklistSection/messages.js
+++ b/src/course-checklist/ChecklistSection/messages.js
@@ -103,13 +103,13 @@ const messages = defineMessages({
   },
   proctoringEmailShortDescription: {
     id: 'proctoringEmailShortDescription',
-    defaultMessage: 'Add a proctortrack escalation email',
+    defaultMessage: 'Add an escalation email for this proctoring provider',
     description: 'Label for a section that describes proctoring escalation email',
   },
   proctoringEmailLongDescription: {
     id: 'proctoringEmailLongDescription',
-    defaultMessage: 'Courses using Proctortrack require an escalation email. Ensure learners and Support can contact your course team regarding proctoring issues (e.g. appeals, exam resets, etc).',
-    description: 'Description for a section that prompts the user to add a Proctortrack escalation email for the course',
+    defaultMessage: 'The selected proctoring provider requires an escalation email. Ensure learners and Support can contact your course team regarding proctoring issues (e.g. appeals, exam resets, etc).',
+    description: 'Description for a section that prompts the user to add a proctoring escalation email for the course',
   },
   updateLinkLabel: {
     id: 'updateLinkLabel',


### PR DESCRIPTION
## Description & Supporting info

Just a few leftovers from: https://github.com/openedx/frontend-app-authoring/pull/2645

See https://github.com/openedx/edx-platform/issues/36329 for full context. Basically: The platform no longer assumes that Proctortrack exists. Instead, it just has an idea that some proctoring providers require an escalation email, which operators can configure on a per-provider basis.

## Testing instructions

Ensure ENABLE_PROCTORED_EXAMS is true site-wide.

Configure a PROCTORING_BACKEND with option `requires_escalation_email: true`. Ensure the backend is installed.

In a studio course, go to Pages and Resources -> Proctored Exam Settings. Select the provider you just configured.

Observe these new strings in the UI.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

(I confirmed that none of these apply)
