### PR TITLE
fix: support "in progress" status for lib upload

### DIFF
--- a/src/library-authoring/create-library/CreateLibrary.tsx
+++ b/src/library-authoring/create-library/CreateLibrary.tsx
@@ -253,7 +253,8 @@ export const CreateLibrary = ({
 
         {(restoreTaskId || isError || restoreMutation.isError) && (
           <div className="mb-4">
-            {restoreStatus?.state === LibraryRestoreStatus.Pending && (
+            {(restoreStatus?.state === LibraryRestoreStatus.Pending
+            || restoreStatus?.state === LibraryRestoreStatus.InProgress) && (
               <Alert variant="info">
                 {intl.formatMessage(messages.restoreInProgress)}
               </Alert>

--- a/src/library-authoring/create-library/data/apiHooks.test.tsx
+++ b/src/library-authoring/create-library/data/apiHooks.test.tsx
@@ -173,6 +173,34 @@ describe('create library apiHooks', () => {
       expect(axiosMock.history.get[0].url).toEqual(`http://localhost:18010/api/libraries/v2/restore/?task_id=${taskId}`);
     });
 
+    it('should handle in-progress status with refetch interval', async () => {
+      const taskId = 'in-progress-task-id';
+      const inProgressResult = {
+        state: LibraryRestoreStatus.InProgress,
+        result: null,
+        error: null,
+        error_log: null,
+      };
+
+      const expectedResult = {
+        state: LibraryRestoreStatus.InProgress,
+        result: null,
+        error: null,
+        errorLog: null,
+      };
+
+      axiosMock.onGet(`http://localhost:18010/api/libraries/v2/restore/?task_id=${taskId}`).reply(200, inProgressResult);
+
+      const { result } = renderHook(() => useGetLibraryRestoreStatus(taskId), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBeFalsy();
+      });
+
+      expect(result.current.data).toEqual(expectedResult);
+      expect(axiosMock.history.get[0].url).toEqual(`http://localhost:18010/api/libraries/v2/restore/?task_id=${taskId}`);
+    });
+
     it('should handle failed status', async () => {
       const taskId = 'failed-task-id';
       const failedResult = {

--- a/src/library-authoring/create-library/data/apiHooks.ts
+++ b/src/library-authoring/create-library/data/apiHooks.ts
@@ -41,7 +41,10 @@ export const useGetLibraryRestoreStatus = (taskId: string) => useQuery<GetLibrar
   queryKey: libraryRestoreQueryKeys.restoreStatus(taskId),
   queryFn: () => getLibraryRestoreStatus(taskId),
   enabled: !!taskId, // Only run the query if taskId is provided
-  refetchInterval: (query) => (query.state.data?.state === LibraryRestoreStatus.Pending ? 2000 : false),
+  refetchInterval: (query) => (
+    (query.state.data?.state === LibraryRestoreStatus.Pending
+      || query.state.data?.state === LibraryRestoreStatus.InProgress
+    ) ? 2000 : false),
 });
 
 export const useCreateLibraryRestore = () => useMutation<CreateLibraryRestoreResponse, Error, File>({

--- a/src/library-authoring/create-library/data/restoreConstants.ts
+++ b/src/library-authoring/create-library/data/restoreConstants.ts
@@ -32,6 +32,7 @@ export interface GetLibraryRestoreStatusResponse {
 
 export enum LibraryRestoreStatus {
   Pending = 'Pending',
+  InProgress = 'In Progress',
   Succeeded = 'Succeeded',
   Failed = 'Failed',
 }


### PR DESCRIPTION
## Description

When uploading a library archive file during the creation of a new
library, the code prior to this commit did not properly handle the "In
Progress" state, which is when the celery task doing the archive
processing is actively running. Note that this is distinct from the
"Pending" state, which is when the task is waiting in the queue to be
run (which in practice should almost never happen unless there is an
operational issue).

Since celery tasks run in-process during local development, the task
was always finished by the time that the browser made a call to check
on the status. The problem only happened on slower sandboxes, where
processing truly runs asynchronously and might take a few seconds.
Because this case wasn't handled, the frontend would never poll for
updates either, so the upload was basically lost as far as the user
was concerned.

## Testing instructions

This is difficult to test locally, but I just hardcoded the task status [GET view](https://github.com/openedx/edx-platform/blob/b76595d610115d4cfd43f260c2af00f6b143fe91/openedx/core/djangoapps/content_libraries/rest_api/libraries.py#L885) so that it always returned the "In Progress" or "Pending" states, to make sure the frontend did the right thing.

This is the original bug:

https://github.com/user-attachments/assets/30258795-9033-4622-96b6-f783072c9955

This is hacky testing, where I hardcode my view to send back the "In Progress" JSON to demonstrate display and polling behavior, and then later remove that hardcoded bit so that the real completion status comes through:

https://github.com/user-attachments/assets/a47d63c6-3e3e-4d00-a0f6-46afa9ab7b38

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [X] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [X] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [X] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [X] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [X] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [X] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [X] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`

(None of this are applicable to the changes I've made.)
