### PR TITLE
fix: coerce multiple choice text elements to String

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -252,7 +252,7 @@ export class OLXParser {
       choice.forEach((element, index) => {
         const preservedAnswer = preservedAnswers[index].filter(answer => !Object.keys(answer).includes(`${option}hint`));
         const preservedFeedback = preservedAnswers[index].filter(answer => Object.keys(answer).includes(`${option}hint`));
-        let title = element['#text'];
+        let title = String(element['#text']);
 
         if (isComplexAnswer && preservedAnswer) {
           title = this.richTextBuilder.build(preservedAnswer);
@@ -272,7 +272,7 @@ export class OLXParser {
     } else {
       const preservedAnswer = preservedAnswers[0].filter(answer => !Object.keys(answer).includes(`${option}hint`));
       const preservedFeedback = preservedAnswers[0].filter(answer => Object.keys(answer).includes(`${option}hint`));
-      let title = choice['#text'];
+      let title = String(choice['#text']);
 
       if (isComplexAnswer && preservedAnswer) {
         title = this.richTextBuilder.build(preservedAnswer);

--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -23,6 +23,7 @@ import {
   labelDescriptionQuestionOLX,
   htmlEntityTestOLX,
   numberParseTestOLX,
+  numericTextCoercionTestOLX,
   numericalProblemPartialCredit,
   solutionExplanationTest,
   solutionExplanationWithoutDivTest,
@@ -263,6 +264,19 @@ describe('OLXParser', () => {
       const { answers } = multipleChoiceOlxParser.parseMultipleChoiceAnswers('multiplechoiceresponse', 'choicegroup', 'choice');
       it('should equal an array of objects with length three', () => {
         expect(answers).toEqual(multipleChoiceWithFeedbackAndHintsOLX.data.answers);
+        expect(answers).toHaveLength(3);
+      });
+    });
+    describe('given multiple choice olx with numeric text that needs coercion', () => {
+      const olxparser = new OLXParser(numericTextCoercionTestOLX.rawOLX);
+      const { answers } = olxparser.parseMultipleChoiceAnswers('multiplechoiceresponse', 'choicegroup', 'choice');
+      it('should coerce numeric #text values to strings', () => {
+        expect(answers).toEqual(numericTextCoercionTestOLX.data.answers);
+        answers.forEach((answer) => {
+          expect(typeof answer.title).toBe('string');
+        });
+      });
+      it('should equal an array of objects with length three', () => {
         expect(answers).toHaveLength(3);
       });
     });

--- a/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
@@ -945,6 +945,38 @@ export const numberParseTestOLX = {
   </problem>`,
 };
 
+export const numericTextCoercionTestOLX = {
+  rawOLX: `<problem>
+  <multiplechoiceresponse>
+  <p>Select the correct number:</p>
+  <choicegroup type="MultipleChoice">
+      <choice correct="false">123</choice>
+      <choice correct="true">456</choice>
+      <choice correct="false">789</choice>
+    </choicegroup>
+  </multiplechoiceresponse>
+  </problem>`,
+  data: {
+    answers: [
+      {
+        id: 'A',
+        title: '123',
+        correct: false,
+      },
+      {
+        id: 'B',
+        title: '456',
+        correct: true,
+      },
+      {
+        id: 'C',
+        title: '789',
+        correct: false,
+      },
+    ],
+  },
+};
+
 export const solutionExplanationTest = {
   rawOLX: `<problem>
       How <code class="lang-matlab">99</code> long is the array <code class="lang-matlab">q</code> after the following loop runs?


### PR DESCRIPTION
## Description

"No answer specified" confirmation window is displayed all the time after the second save for dropdown.

<img width="910" alt="234" src="https://github.com/user-attachments/assets/ac92e126-6046-49d1-aeef-e54d48f1e20c">

### Steps to Reproduce: 
1. Add new `Unit`
2. Add new component `Problem`
3. Choose `Dropdown`
4. Fill in at least question and answers (for the correct answer, enter the number)
5. Click `Save`
5. Click on `Edit` for problem again
6. Click `Save`

This PR is a possible replacement for https://github.com/openedx/frontend-app-authoring/pull/2429

@bradenmacdonald I've create a new PR based on your suggestion [here](https://github.com/openedx/frontend-app-authoring/pull/2429#discussion_r2342583158).
If this PR is good for us - I'll close the #2429 