### PR TITLE
feat: add temporary message alert in sections settings tab in libraries (#2734)

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.scss
+++ b/src/library-authoring/LibraryAuthoringPage.scss
@@ -13,7 +13,7 @@
 
 .library-authoring-sidebar {
   z-index: 1000; // same as header
-  flex: 500px 0 0;
+  flex: 530px 0 0;
   position: sticky;
   top: 0;
   right: 0;

--- a/src/library-authoring/containers/ContainerInfo.tsx
+++ b/src/library-authoring/containers/ContainerInfo.tsx
@@ -8,10 +8,11 @@ import {
   Icon,
   IconButton,
   useToggle,
+  Alert,
 } from '@openedx/paragon';
 import React, { useCallback } from 'react';
 import { Link } from 'react-router-dom';
-import { MoreVert } from '@openedx/paragon/icons';
+import { InfoOutline, MoreVert } from '@openedx/paragon/icons';
 
 import { useClipboard } from '@src/generic/clipboard';
 import { ContainerType, getBlockType } from '@src/generic/key-utils';
@@ -149,6 +150,15 @@ const ContainerActions = ({
   );
 };
 
+/* istanbul ignore next */
+/* istanbul ignore next */
+const ContainerSettings = () => (
+  <Alert icon={InfoOutline} variant="info">
+    <p>
+      <FormattedMessage {...messages.containerSettingsMsg} />
+    </p>
+  </Alert>
+);
 const ContainerInfo = () => {
   const intl = useIntl();
   const {
@@ -222,7 +232,7 @@ const ContainerInfo = () => {
         {renderTab(
           CONTAINER_INFO_TABS.Settings,
           intl.formatMessage(messages.settingsTabTitle),
-          // TODO: container settings component
+          <ContainerSettings />,
         )}
       </Tabs>
     </Stack>

--- a/src/library-authoring/containers/messages.ts
+++ b/src/library-authoring/containers/messages.ts
@@ -66,6 +66,11 @@ const messages = defineMessages({
     defaultMessage: 'Container actions menu',
     description: 'Alt/title text for the container card menu button.',
   },
+  containerSettingsMsg: {
+    id: 'course-authoring.library-authoring.container.settings.alert.message',
+    defaultMessage: 'Section settings cannot be configured within Libraries and must be set within a course. In a future release, Libraries may support configuring some settings.',
+    description: 'Temporary message for settings tab being',
+  },
   menuOpen: {
     id: 'course-authoring.library-authoring.menu.open',
     defaultMessage: 'Open',


### PR DESCRIPTION
- add temporary message alert in sections settings tab in libraries
- increase sidebar width to remove `More` option and display all tabs
together

(cherry picked from commit 3eeca244d76d78782a155cb1a2351c78e02b321c)
