### PR TITLE
fix: make sidebar (and content) fill the whole page

### DIFF
--- a/src/library-authoring/import-course/CourseImportHomePage.tsx
+++ b/src/library-authoring/import-course/CourseImportHomePage.tsx
@@ -55,53 +55,51 @@ export const CourseImportHomePage = () => {
   }
 
   return (
-    <div className="d-flex">
-      <div className="flex-grow-1">
-        <Helmet>
-          <title>{libraryData.title} | {process.env.SITE_NAME}</title>
-        </Helmet>
-        <Header
-          number={libraryData.slug}
-          title={libraryData.title}
-          org={libraryData.org}
-          contextId={libraryId}
-          isLibrary
-          readOnly={readOnly}
-          containerProps={{
-            size: undefined,
-          }}
-        />
-        <Container className="mt-4 mb-5">
-          <div className="px-4 bg-light-200 border-bottom">
-            <SubHeader
-              title={intl.formatMessage(messages.pageTitle)}
-              subtitle={intl.formatMessage(messages.pageSubtitle)}
-              hideBorder
-              headerActions={<ImportCourseButton />}
-            />
-          </div>
-          <Layout xs={[{ span: 9 }, { span: 3 }]}>
-            <Layout.Element>
-              {courseImports.length ? (
-                <Stack gap={3} className="pl-4 mt-4">
-                  <h3>
-                    <FormattedMessage {...messages.courseImportPreviousImports} />
-                  </h3>
-                  {courseImports.map((courseImport) => (
-                    <ImportedCourseCard
-                      key={courseImport.source.key}
-                      courseImport={courseImport}
-                    />
-                  ))}
-                </Stack>
-              ) : (<EmptyState />)}
-            </Layout.Element>
-            <Layout.Element>
-              <HelpSidebar />
-            </Layout.Element>
-          </Layout>
-        </Container>
-      </div>
+    <div className="d-flex flex-column vh-100 course-import">
+      <Helmet>
+        <title>{libraryData.title} | {process.env.SITE_NAME}</title>
+      </Helmet>
+      <Header
+        number={libraryData.slug}
+        title={libraryData.title}
+        org={libraryData.org}
+        contextId={libraryId}
+        isLibrary
+        readOnly={readOnly}
+        containerProps={{
+          size: undefined,
+        }}
+      />
+      <Container className="mt-4 d-flex flex-column flex-grow-1">
+        <div className="px-4 bg-light-200 border-bottom">
+          <SubHeader
+            title={intl.formatMessage(messages.pageTitle)}
+            subtitle={intl.formatMessage(messages.pageSubtitle)}
+            hideBorder
+            headerActions={<ImportCourseButton />}
+          />
+        </div>
+        <Layout xs={[{ span: 9 }, { span: 3 }]}>
+          <Layout.Element>
+            {courseImports.length ? (
+              <Stack gap={3} className="pl-4 mt-4">
+                <h3>
+                  <FormattedMessage {...messages.courseImportPreviousImports} />
+                </h3>
+                {courseImports.map((courseImport) => (
+                  <ImportedCourseCard
+                    key={courseImport.source.key}
+                    courseImport={courseImport}
+                  />
+                ))}
+              </Stack>
+            ) : (<EmptyState />)}
+          </Layout.Element>
+          <Layout.Element>
+            <HelpSidebar />
+          </Layout.Element>
+        </Layout>
+      </Container>
     </div>
   );
 };

--- a/src/library-authoring/import-course/index.scss
+++ b/src/library-authoring/import-course/index.scss
@@ -36,3 +36,10 @@
     padding-left: 0;
   }
 }
+
+.course-import {
+  .row {
+    // Make the row grow to fill the remaining vertial space
+    flex-grow: 1;
+  }
+}


### PR DESCRIPTION
## Description

This PR increases the sidebar height to fill the entire page.

- Which user roles will this change impact?
"Course Author"

### Before
<img width="1270" height="1186" alt="image" src="https://github.com/user-attachments/assets/a1a1ce87-68dd-435c-82ca-f903f57b4352" />

### After
<img width="1275" height="1187" alt="image" src="https://github.com/user-attachments/assets/f27d293b-404a-4aa3-9344-eb1a76f777ec" />

## Supporting information

Related to: https://github.com/openedx/frontend-app-authoring/issues/2523#issuecomment-3676481482

## Testing instructions

- Open a library's import page, accessing `Tools > Import` inside a library.
- Check the sidebar height

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
