### PR TITLE
feat: enable to select collections as components in problems picker

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -316,12 +316,11 @@ const LibraryAuthoringPage = ({
 
   const activeTypeFilters = {
     components: 'type = "library_block"',
-    collections: 'type = "collection"',
     units: 'block_type = "unit"',
     subsections: 'block_type = "subsection"',
     sections: 'block_type = "section"',
   };
-  if (activeKey !== ContentType.home) {
+  if (activeKey !== ContentType.home && activeKey !== ContentType.collections) {
     extraFilter.push(activeTypeFilters[activeKey]);
   }
 

--- a/src/library-authoring/LibraryContent.tsx
+++ b/src/library-authoring/LibraryContent.tsx
@@ -45,6 +45,13 @@ const LibraryContent = ({ contentType = ContentType.home }: LibraryContentProps)
   const { libraryId, openCreateCollectionModal, collectionId } = useOptionalLibraryContext();
   const { openAddContentSidebar, openComponentInfoSidebar } = useSidebarContext();
   const { insideCollection } = useLibraryRoutes();
+  /**
+   * Filter collections on the frontend to display only collection cards in the Collections tab.
+   * This approach is used instead of backend filtering to ensure that all components (including those
+   * within collections) remain available in the 'hits' array. This is necessary for the component
+   * selection workflow when adding components to xblocks by choosing the while collection in Collections tab.
+   * Note: LibraryAuthoringPage.tsx has been modified to skip backend filtering for this purpose.
+   */
   const filteredHits = contentType === ContentType.collections
     ? hits.filter((hit) => hit.type === 'collection')
     : hits;

--- a/src/library-authoring/LibraryContent.tsx
+++ b/src/library-authoring/LibraryContent.tsx
@@ -45,6 +45,10 @@ const LibraryContent = ({ contentType = ContentType.home }: LibraryContentProps)
   const { libraryId, openCreateCollectionModal, collectionId } = useOptionalLibraryContext();
   const { openAddContentSidebar, openComponentInfoSidebar } = useSidebarContext();
   const { insideCollection } = useLibraryRoutes();
+  const filteredHits = contentType === ContentType.collections
+    ? hits.filter((hit) => hit.type === 'collection')
+    : hits;
+
   /**
   * Placeholder blocks represent fake blocks for failed imports from other sources, such as courses.
   * They should only be displayed when viewing all components in the home tab of the library and the
@@ -103,7 +107,7 @@ const LibraryContent = ({ contentType = ContentType.home }: LibraryContentProps)
 
   return (
     <div className="library-cards-grid">
-      {hits.map((contentHit) => {
+      {filteredHits.map((contentHit) => {
         const CardComponent = LibraryItemCard[contentHit.type] || ComponentCard;
 
         return <CardComponent key={contentHit.id} hit={contentHit} />;

--- a/src/library-authoring/__mocks__/library-search.json
+++ b/src/library-authoring/__mocks__/library-search.json
@@ -67,6 +67,7 @@
         },
         {
           "display_name": "Collection 2",
+          "block_id": "col2",
           "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et mi ac nisi accumsan imperdiet vitae at odio. Vivamus tempor nec lorem eget lacinia. Vivamus efficitur lacus non dapibus porta. Nulla venenatis luctus nisi id posuere. Sed sollicitudin magna a sem ultrices accumsan. Praesent volutpat tortor vitae luctus rutrum. Integer. Descrition 58",
           "id": 2,
           "type": "collection",
@@ -99,6 +100,7 @@
         },
         {
           "display_name": "Collection 3",
+          "block_id": "col3",
           "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et mi ac nisi accumsan imperdiet vitae at odio. Vivamus tempor nec lorem eget lacinia. Vivamus efficitur lacus non dapibus porta. Nulla venenatis luctus nisi id posuere. Sed sollicitudin magna a sem ultrices accumsan. Praesent volutpat tortor vitae luctus rutrum. Integer. Descrition 57",
           "id": 3,
           "type": "collection",
@@ -131,6 +133,7 @@
         },
         {
           "display_name": "Collection 4",
+          "block_id": "col4",
           "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et mi ac nisi accumsan imperdiet vitae at odio. Vivamus tempor nec lorem eget lacinia. Vivamus efficitur lacus non dapibus porta. Nulla venenatis luctus nisi id posuere. Sed sollicitudin magna a sem ultrices accumsan. Praesent volutpat tortor vitae luctus rutrum. Integer. Descrition 56",
           "id": 4,
           "type": "collection",
@@ -163,6 +166,7 @@
         },
         {
           "display_name": "Collection 5",
+          "block_id": "col5",
           "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et mi ac nisi accumsan imperdiet vitae at odio. Vivamus tempor nec lorem eget lacinia. Vivamus efficitur lacus non dapibus porta. Nulla venenatis luctus nisi id posuere. Sed sollicitudin magna a sem ultrices accumsan. Praesent volutpat tortor vitae luctus rutrum. Integer. Descrition 55",
           "id": 5,
           "type": "collection",
@@ -195,6 +199,7 @@
         },
         {
           "display_name": "Collection 6",
+          "block_id": "col6",
           "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et mi ac nisi accumsan imperdiet vitae at odio. Vivamus tempor nec lorem eget lacinia. Vivamus efficitur lacus non dapibus porta. Nulla venenatis luctus nisi id posuere. Sed sollicitudin magna a sem ultrices accumsan. Praesent volutpat tortor vitae luctus rutrum. Integer. Descrition 54",
           "id": 6,
           "type": "collection",

--- a/src/library-authoring/collections/LibraryCollectionComponents.tsx
+++ b/src/library-authoring/collections/LibraryCollectionComponents.tsx
@@ -4,7 +4,6 @@ import { useSearchContext } from '../../search-manager';
 import messages from './messages';
 import { useSidebarContext } from '../common/context/SidebarContext';
 import LibraryContent from '../LibraryContent';
-import { ContentType } from '../routes';
 
 const LibraryCollectionComponents = () => {
   const { totalHits: componentCount, isFiltered } = useSearchContext();
@@ -25,7 +24,7 @@ const LibraryCollectionComponents = () => {
   return (
     <Stack direction="vertical" gap={3}>
       <h3 className="text-gray">Content ({componentCount})</h3>
-      <LibraryContent contentType={ContentType.collections} />
+      <LibraryContent />
     </Stack>
   );
 };

--- a/src/library-authoring/common/context/ComponentPickerContext.tsx
+++ b/src/library-authoring/common/context/ComponentPickerContext.tsx
@@ -146,8 +146,15 @@ export const ComponentPickerProvider = ({
     if (!componentKeys?.length || !components.length) {
       return undefined;
     }
-    const firstComponentKeys = components[0].collectionKeys;
-    return firstComponentKeys?.find((key) => componentKeys.includes(key));
+
+    for (const component of components) {
+      const commonKey = component.collectionKeys?.find((key) => componentKeys.includes(key));
+      if (commonKey) {
+        return commonKey;
+      }
+    }
+
+    return undefined;
   }, []);
 
   const addComponentToSelectedComponents = useCallback<ComponentSelectedEvent>((
@@ -170,16 +177,11 @@ export const ComponentPickerProvider = ({
 
       // Handle collection selection (when selecting entire collection)
       if (Array.isArray(collectionComponents) && collectionComponents.length) {
-        const selectedKeys = new Set(newSelectedComponents.map((c) => c.usageKey));
-        const allComponentsSelected = collectionComponents.every((c) => selectedKeys.has(c.usageKey));
-
-        if (allComponentsSelected) {
-          updateCollectionStatus(
-            selectedComponent.usageKey,
-            collectionComponents.length,
-            collectionComponents.length,
-          );
-        }
+        updateCollectionStatus(
+          selectedComponent.usageKey,
+          collectionComponents.length,
+          collectionComponents.length,
+        );
       }
 
       // Handle individual component selection (with total count)
@@ -208,7 +210,7 @@ export const ComponentPickerProvider = ({
       onChangeComponentSelection?.(newSelectedComponents);
       return newSelectedComponents;
     });
-  }, [onChangeComponentSelection, updateCollectionStatus, findCommonCollectionKey]);
+  }, []);
 
   const removeComponentFromSelectedComponents = useCallback<ComponentSelectedEvent>((
     selectedComponent: SelectedComponent,
@@ -225,9 +227,8 @@ export const ComponentPickerProvider = ({
       );
 
       if (typeof collectionComponents === 'number') {
-        // Update collection status based on remaining components
         const componentCollectionKeys = selectedComponent.collectionKeys;
-        const collectionKey = componentCollectionKeys?.[0];
+        const collectionKey = findCommonCollectionKey(componentCollectionKeys, componentsToRemove);
 
         if (collectionKey) {
           const remainingCollectionComponents = newSelectedComponents.filter(
@@ -251,7 +252,7 @@ export const ComponentPickerProvider = ({
       onChangeComponentSelection?.(newSelectedComponents);
       return newSelectedComponents;
     });
-  }, [onChangeComponentSelection, updateCollectionStatus]);
+  }, []);
 
   const context = useMemo<ComponentPickerContextData>(() => {
     switch (componentPickerMode) {

--- a/src/library-authoring/component-picker/ComponentPicker.test.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.test.tsx
@@ -312,7 +312,7 @@ describe('<LibraryAndComponentPicker />', () => {
     onChange.mockClear();
 
     // Select another component
-    fireEvent.click(screen.queryAllByRole('button', { name: 'Select' })[1]);
+    fireEvent.click(screen.queryAllByRole('button', { name: 'Select' })[7]);
     await waitFor(() => expect(onChange).toHaveBeenCalledWith([
       {
         usageKey: 'lb:Axim:TEST:html:571fe018-f3ce-45c9-8f53-5dafcb422fdd',

--- a/src/library-authoring/components/AddComponentWidget.tsx
+++ b/src/library-authoring/components/AddComponentWidget.tsx
@@ -64,12 +64,13 @@ const AddComponentWidget = ({
 
   const { hits } = useSearchContext();
 
-  // Memoize collection data to avoid recalculating on every render
   const collectionData = useMemo(() => {
+    // When selecting a collection: retrieve all its components to enable bulk selection
     if (isCollection) {
       return buildCollectionComponents(hits, usageKey);
     }
-    // For individual components, get the collection key and count sibling hits
+    // When selecting an individual component: get the total count of components in its collection
+    // This count is used to determine if the entire collection should be marked as selected
     const componentCollectionKey = (hits.find((hit) => hit.usageKey === usageKey) as ContentHit)?.collections?.key;
     return countCollectionHits(hits, componentCollectionKey);
   }, [hits, usageKey, isCollection]);

--- a/src/library-authoring/components/AddComponentWidget.tsx
+++ b/src/library-authoring/components/AddComponentWidget.tsx
@@ -27,9 +27,9 @@ const buildCollectionComponents = (
   collectionUsageKey: string,
 ): SelectedComponent[] => hits
   .filter((hit) => hit.type === 'library_block' && hit.collections?.key?.includes(collectionUsageKey))
-  .map((hit) => ({
+  .map((hit: ContentHit) => ({
     usageKey: hit.usageKey,
-    blockType: hit.type,
+    blockType: hit.blockType,
     collectionKeys: (hit as ContentHit).collections?.key,
   }));
 

--- a/src/library-authoring/components/AddComponentWidget.tsx
+++ b/src/library-authoring/components/AddComponentWidget.tsx
@@ -1,20 +1,56 @@
+import { useMemo } from 'react';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { Button } from '@openedx/paragon';
 import {
   AddCircleOutline,
   CheckBoxIcon,
+  IndeterminateCheckBox,
   CheckBoxOutlineBlank,
 } from '@openedx/paragon/icons';
 
-import { useComponentPickerContext } from '../common/context/ComponentPickerContext';
+import { ContentHit, useSearchContext } from '@src/search-manager';
+import { SelectedComponent, useComponentPickerContext } from '../common/context/ComponentPickerContext';
 import messages from './messages';
 
 interface AddComponentWidgetProps {
   usageKey: string;
   blockType: string;
+  collectionKeys?: string[];
+  isCollection?: boolean;
 }
 
-const AddComponentWidget = ({ usageKey, blockType }: AddComponentWidgetProps) => {
+/**
+ * Builds an array of SelectedComponent from collection hits.
+ */
+const buildCollectionComponents = (
+  hits: ReturnType<typeof useSearchContext>['hits'],
+  collectionUsageKey: string,
+): SelectedComponent[] => hits
+  .filter((hit) => hit.type === 'library_block' && hit.collections?.key?.includes(collectionUsageKey))
+  .map((hit) => ({
+    usageKey: hit.usageKey,
+    blockType: hit.type,
+    collectionKeys: (hit as ContentHit).collections?.key,
+  }));
+
+/**
+ * Counts the number of hits that share a collection key with the given component.
+ */
+const countCollectionHits = (
+  hits: ReturnType<typeof useSearchContext>['hits'],
+  componentCollectionKey: string[] | undefined,
+): number => {
+  if (!componentCollectionKey?.length) {
+    return 0;
+  }
+  return hits.filter(
+    (hit) => (hit as ContentHit).collections?.key?.some((key) => componentCollectionKey.includes(key)),
+  ).length;
+};
+
+const AddComponentWidget = ({
+  usageKey, blockType, collectionKeys, isCollection,
+}: AddComponentWidgetProps) => {
   const intl = useIntl();
 
   const {
@@ -23,7 +59,20 @@ const AddComponentWidget = ({ usageKey, blockType }: AddComponentWidgetProps) =>
     addComponentToSelectedComponents,
     removeComponentFromSelectedComponents,
     selectedComponents,
+    selectedCollections,
   } = useComponentPickerContext();
+
+  const { hits } = useSearchContext();
+
+  // Memoize collection data to avoid recalculating on every render
+  const collectionData = useMemo(() => {
+    if (isCollection) {
+      return buildCollectionComponents(hits, usageKey);
+    }
+    // For individual components, get the collection key and count sibling hits
+    const componentCollectionKey = (hits.find((hit) => hit.usageKey === usageKey) as ContentHit)?.collections?.key;
+    return countCollectionHits(hits, componentCollectionKey);
+  }, [hits, usageKey, isCollection]);
 
   // istanbul ignore if: this should never happen
   if (!usageKey) {
@@ -50,24 +99,37 @@ const AddComponentWidget = ({ usageKey, blockType }: AddComponentWidgetProps) =>
   }
 
   if (componentPickerMode === 'multiple') {
-    const isChecked = selectedComponents.some((component) => component.usageKey === usageKey);
+    const collectionStatus = selectedCollections.find((c) => c.key === usageKey)?.status;
+
+    const isChecked = isCollection
+      ? collectionStatus === 'selected'
+      : selectedComponents.some((component) => component.usageKey === usageKey);
+
+    const isIndeterminate = isCollection && collectionStatus === 'indeterminate';
+
+    const getIcon = () => {
+      if (isChecked) { return CheckBoxIcon; }
+      if (isIndeterminate) { return IndeterminateCheckBox; }
+      return CheckBoxOutlineBlank;
+    };
 
     const handleChange = () => {
-      const selectedComponent = {
+      const selectedComponent: SelectedComponent = {
         usageKey,
         blockType,
+        collectionKeys,
       };
       if (!isChecked) {
-        addComponentToSelectedComponents(selectedComponent);
+        addComponentToSelectedComponents(selectedComponent, collectionData);
       } else {
-        removeComponentFromSelectedComponents(selectedComponent);
+        removeComponentFromSelectedComponents(selectedComponent, collectionData);
       }
     };
 
     return (
       <Button
         variant="outline-primary"
-        iconBefore={isChecked ? CheckBoxIcon : CheckBoxOutlineBlank}
+        iconBefore={getIcon()}
         onClick={handleChange}
       >
         {intl.formatMessage(messages.componentPickerMultipleSelectTitle)}

--- a/src/library-authoring/components/CollectionCard.tsx
+++ b/src/library-authoring/components/CollectionCard.tsx
@@ -20,6 +20,7 @@ import { useLibraryRoutes } from '../routes';
 import BaseCard from './BaseCard';
 import { useDeleteCollection, useRestoreCollection } from '../data/apiHooks';
 import messages from './messages';
+import AddComponentWidget from './AddComponentWidget';
 
 type CollectionMenuProps = {
   hit: CollectionHit,
@@ -169,9 +170,16 @@ const CollectionCard = ({ hit } : CollectionCardProps) => {
       description={description}
       tags={tags}
       numChildren={numChildrenCount}
-      actions={!componentPickerMode && (
+      actions={(
         <ActionRow>
-          <CollectionMenu hit={hit} />
+          {componentPickerMode ? (
+            <AddComponentWidget
+              isCollection
+              usageKey={collectionId}
+              blockType={itemType}
+            />
+          ) : (
+            <CollectionMenu hit={hit} />)}
         </ActionRow>
       )}
       onSelect={selectCollection}

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -25,6 +25,7 @@ const ComponentCard = ({ hit }: ComponentCardProps) => {
     formatted,
     tags,
     usageKey,
+    collections,
     publishStatus,
   } = hit;
   const componentDescription: string = (
@@ -56,7 +57,11 @@ const ComponentCard = ({ hit }: ComponentCardProps) => {
       actions={(
         <ActionRow>
           {componentPickerMode ? (
-            <AddComponentWidget usageKey={usageKey} blockType={blockType} />
+            <AddComponentWidget
+              usageKey={usageKey}
+              blockType={blockType}
+              collectionKeys={collections?.key ?? undefined}
+            />
           ) : (
             <ComponentMenu usageKey={usageKey} />
           )}


### PR DESCRIPTION
This pull request introduces enhanced support for bulk selection and management of collections and their components in the library authoring interface. The main changes add the ability to select entire collections, track selection status (selected/indeterminate), and ensure consistent UI feedback when interacting with collections and their components. Filtering logic has also been updated to ensure all relevant items remain available for selection workflows.

**Bulk selection and collection management:**

* Added new types and state management in `ComponentPickerContext.tsx` to track selected collections and their status (`selected` or `indeterminate`). Also introduced logic for updating collection selection status when components are added or removed, supporting both individual and bulk operations. [[1]](diffhunk://#diff-56a2caa7a3a665d1608eada6aec67fa79983bf8879d0b1a90d4eb719b3725e11R12-R25) [[2]](diffhunk://#diff-56a2caa7a3a665d1608eada6aec67fa79983bf8879d0b1a90d4eb719b3725e11R102-R242)
* Updated the `AddComponentWidget` to support bulk selection of all components in a collection, including logic to build component lists and count collection membership. The widget now displays checkboxes that reflect collection selection status and supports indeterminate states. [[1]](diffhunk://#diff-54a0059de43d8f5598c86295e8f8395d1102e83c952a7b4936a1f775d416104eR1-R53) [[2]](diffhunk://#diff-54a0059de43d8f5598c86295e8f8395d1102e83c952a7b4936a1f775d416104eR62-R77) [[3]](diffhunk://#diff-54a0059de43d8f5598c86295e8f8395d1102e83c952a7b4936a1f775d416104eL53-R133)

**UI integration and feedback:**

* Modified `CollectionCard` and `ComponentCard` to use the updated `AddComponentWidget`, enabling bulk selection on collection cards and correct checkbox display for both collections and components. [[1]](diffhunk://#diff-e5eaa334df2d12ae99abaec10fa351e88bc07e1151cb72686bd1edd8741c7f74R23) [[2]](diffhunk://#diff-e5eaa334df2d12ae99abaec10fa351e88bc07e1151cb72686bd1edd8741c7f74L158-R168) [[3]](diffhunk://#diff-49e613dfd8b3d4c99b6cb27fe426de4977f8701af3c3c262fcf4e72d3d5346a0R29) [[4]](diffhunk://#diff-49e613dfd8b3d4c99b6cb27fe426de4977f8701af3c3c262fcf4e72d3d5346a0L59-R64)

**Filtering logic improvements:**

* Changed backend and frontend filtering logic in `LibraryAuthoringPage.tsx` and `LibraryContent.tsx` to ensure all components remain available for selection, even when viewing the Collections tab. This supports workflows where components are added to xblocks by selecting an entire collection. [[1]](diffhunk://#diff-b607a6130d15e58997aa9499ad9dfa67e094b17d966b5750e86f5bb7cadaaa73L236-R238) [[2]](diffhunk://#diff-2dbf7689e2e92c3beb107328d77b772213ee3f75445da9e4a92d2c06ffaabf32R46-R56) [[3]](diffhunk://#diff-2dbf7689e2e92c3beb107328d77b772213ee3f75445da9e4a92d2c06ffaabf32L79-R90)

**Context and provider updates:**

* Updated context provider return values and memoization to include the new `selectedCollections` state, ensuring all components have access to the latest selection data. [[1]](diffhunk://#diff-56a2caa7a3a665d1608eada6aec67fa79983bf8879d0b1a90d4eb719b3725e11R260) [[2]](diffhunk://#diff-56a2caa7a3a665d1608eada6aec67fa79983bf8879d0b1a90d4eb719b3725e11L146-R276)

### How to test
Make sure you have a collection in your Libraries ( http://apps.local.openedx.io:2001/authoring/libraries ) with questions in it
1. Have a Teak environment
2. Mount this MFE and switch to this branch
3. Install https://github.com/eduNEXT-collab/xblock-exam-question-bank in the CMS
4. Go to the Authoring MFE ( http://apps.local.openedx.io:2001/authoring/ ), create a new course or use any existing one, go to `Settings > Advanced Settings` and add ` "examquestionbank"` to the list of `Advanced module list`
5. Go to the content outline and access a unit
6. Click `Advanced` in the component selector and add an `Exam Question Bank`
7. Click `Add Problems` and select a collection; it should be selected and deselected properly, and once you click `Add Selected Components`, they should be displayed in the xblock as will be shown in the following screencast

### Screencast

[Screencast from 09-01-26 14:40:43.webm](https://github.com/user-attachments/assets/fd476fb4-0fe3-4160-96a5-441bfc756b36)
