### PR TITLE
fix: Bug when adding spaces to containers names in course outline

### DIFF
--- a/src/course-outline/card-header/CardHeader.tsx
+++ b/src/course-outline/card-header/CardHeader.tsx
@@ -178,9 +178,14 @@ const CardHeader = ({
               onChange={(e) => setTitleValue(e.target.value)}
               aria-label={intl.formatMessage(messages.editFieldAriaLabel)}
               onBlur={() => onEditSubmit(titleValue)}
-              onKeyDown={(e) => {
+              onKeyDown={/* istanbul ignore next */ (e) => {
                 if (e.key === 'Enter') {
                   onEditSubmit(titleValue);
+                } else if (e.key === ' ') {
+                  // Avoid passing propagation to the `SortableItem` in the card,
+                  // which executes a `preventDefault`. If propagation is not prevented,
+                  // spaces cannot be added to names.
+                  e.stopPropagation();
                 }
               }}
               disabled={isSaving}


### PR DESCRIPTION

## Description

- Fixes the bug introduced in https://github.com/openedx/frontend-app-authoring/pull/2732
- Removes the unnecessary `preventDefault`

## Supporting information

- Related comment: https://github.com/openedx/frontend-app-authoring/pull/2732#issuecomment-3750618728

## Testing instructions

- Go to the course outline of a course.
- Add a section, subsection, or unit.
- Rename the title of the container and verify that you can add spaces.
- Also verify that you can select containers using the keyboard.

## Other information

N/A

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [X] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [X] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [X] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [X] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [X] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [X] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [X] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
