### PR TITLE
feat: add card in Pages and Resources to allow hiding the dates tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@edx/frontend-platform": "^8.4.0",
         "@edx/openedx-atlas": "^0.7.0",
         "@openedx-plugins/course-app-calculator": "file:plugins/course-apps/calculator",
+        "@openedx-plugins/course-app-dates": "file:plugins/course-apps/dates",
         "@openedx-plugins/course-app-edxnotes": "file:plugins/course-apps/edxnotes",
         "@openedx-plugins/course-app-learning_assistant": "file:plugins/course-apps/learning_assistant",
         "@openedx-plugins/course-app-live": "file:plugins/course-apps/live",
@@ -5157,6 +5158,10 @@
     },
     "node_modules/@openedx-plugins/course-app-calculator": {
       "resolved": "plugins/course-apps/calculator",
+      "link": true
+    },
+    "node_modules/@openedx-plugins/course-app-dates": {
+      "resolved": "plugins/course-apps/dates",
       "link": true
     },
     "node_modules/@openedx-plugins/course-app-edxnotes": {
@@ -24702,6 +24707,22 @@
     },
     "plugins/course-apps/calculator": {
       "name": "@openedx-plugins/course-app-calculator",
+      "version": "0.1.0",
+      "peerDependencies": {
+        "@edx/frontend-app-authoring": "*",
+        "@edx/frontend-platform": "*",
+        "@openedx/paragon": "*",
+        "prop-types": "*",
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edx/frontend-app-authoring": {
+          "optional": true
+        }
+      }
+    },
+    "plugins/course-apps/dates": {
+      "name": "@openedx-plugins/course-app-dates",
       "version": "0.1.0",
       "peerDependencies": {
         "@edx/frontend-app-authoring": "*",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@edx/frontend-platform": "^8.4.0",
     "@edx/openedx-atlas": "^0.7.0",
     "@openedx-plugins/course-app-calculator": "file:plugins/course-apps/calculator",
+    "@openedx-plugins/course-app-dates": "file:plugins/course-apps/dates",
     "@openedx-plugins/course-app-edxnotes": "file:plugins/course-apps/edxnotes",
     "@openedx-plugins/course-app-learning_assistant": "file:plugins/course-apps/learning_assistant",
     "@openedx-plugins/course-app-live": "file:plugins/course-apps/live",

--- a/plugins/course-apps/dates/Settings.tsx
+++ b/plugins/course-apps/dates/Settings.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useIntl } from '@edx/frontend-platform/i18n';
+
+import AppSettingsModal from 'CourseAuthoring/pages-and-resources/app-settings-modal/AppSettingsModal';
+import messages from './messages';
+
+type DatesSettingsProps = {
+  onClose: () => void;
+};
+
+const DatesSettings: React.FC<DatesSettingsProps> = ({ onClose }) => {
+  const intl = useIntl();
+
+  return (
+    <AppSettingsModal
+      appId="dates"
+      title={intl.formatMessage(messages.heading)}
+      enableAppHelp={intl.formatMessage(messages.enableAppHelp)}
+      enableAppLabel={intl.formatMessage(messages.enableAppLabel)}
+      learnMoreText={intl.formatMessage(messages.learnMore)}
+      onClose={onClose}
+      validationSchema={{}}
+      initialValues={{}}
+      onSettingsSave={async () => true}
+    />
+  );
+};
+
+export default DatesSettings;

--- a/plugins/course-apps/dates/messages.ts
+++ b/plugins/course-apps/dates/messages.ts
@@ -1,0 +1,26 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  heading: {
+    id: 'course-authoring.pages-resources.dates.heading',
+    defaultMessage: 'Configure dates',
+    description: 'Heading for the Dates settings modal shown in Pages & Resources.',
+  },
+  enableAppLabel: {
+    id: 'course-authoring.pages-resources.dates.enable-app.label',
+    defaultMessage: 'Dates',
+    description: 'Label for the toggle that enables the Dates experience.',
+  },
+  enableAppHelp: {
+    id: 'course-authoring.pages-resources.dates.enable-app.help',
+    defaultMessage: 'Show the Dates tab in course navigation, where learners can view important course dates.',
+    description: 'Helper text explaining what enabling the Dates experience does.',
+  },
+  learnMore: {
+    id: 'course-authoring.pages-resources.dates.learn-more',
+    defaultMessage: 'Learn more about dates',
+    description: 'Link text that leads to documentation about the Dates experience.',
+  },
+});
+
+export default messages;

--- a/plugins/course-apps/dates/package.json
+++ b/plugins/course-apps/dates/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "@openedx-plugins/course-app-dates",
+    "version": "0.1.0",
+    "description": "Dates configuration for courses using it",
+    "peerDependencies": {
+        "@edx/frontend-app-authoring": "*",
+        "@edx/frontend-platform": "*",
+        "@openedx/paragon": "*",
+        "prop-types": "*",
+        "react": "*"
+    },
+    "peerDependenciesMeta": {
+        "@edx/frontend-app-authoring": {
+            "optional": true
+        }
+    }
+}

--- a/src/pages-and-resources/SettingsComponent.jsx
+++ b/src/pages-and-resources/SettingsComponent.jsx
@@ -17,7 +17,7 @@ const SettingsComponent = ({ url }) => {
 
   const LazyLoadedComponent = React.useMemo(
     () => React.lazy(() =>
-      import(`@openedx-plugins/course-app-${appId}/Settings.jsx`).catch((err) => { // eslint-disable-line
+      import(`@openedx-plugins/course-app-${appId}/Settings`).catch((err) => { // eslint-disable-line
         // If we couldn't load this plugin, log the details to the console.
         console.trace(err); // eslint-disable-line no-console
         return { default: PluginLoadFailedError };


### PR DESCRIPTION
## Description

This PR adds a Date Course App card to the Pages and Resources page, enabling course authors to hide the Dates tab from learners using the authoring MFE. 

Useful information to include:
- Which user roles will this change impact? "Learner", "Course Author"
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).

https://github.com/user-attachments/assets/c05a1431-c178-4116-baf5-8ba0b5f13544

## Supporting information

https://github.com/openedx/platform-roadmap/issues/392

## Testing instructions

- Checkout to [this branch](https://github.com/mitodl/edx-platform/tree/anas/add-hide-dates-tab-option) in edx-platform.
- Make sure to restart your CMS once you switch to this branch; otherwise, the changes won't be reflected.
- Enable the ENABLE_DATES_COURSE_APP toggle in your settings.
- Navigate to the Pages and Resources page for any course in Studio.
- Confirm that the Dates card appears, as shown in the screen recording above.
- Disable the Dates app as demonstrated in the video.
- Verify that the Dates tab is no longer visible on the Learning MFE and themed pages.

## Other information

Related edx-platform PR: https://github.com/openedx/edx-platform/pull/37923

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
