### PR TITLE
Fix parsing of OLX "correct" attribute

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -257,7 +257,7 @@ export class OLXParser {
         if (isComplexAnswer && preservedAnswer) {
           title = this.richTextBuilder.build(preservedAnswer);
         }
-        const correct = eval(element['@_correct'].toLowerCase());
+        const correct = element['@_correct'].toLowerCase() === 'true';
         const id = indexToLetterMap[index];
         const feedback = this.getAnswerFeedback(preservedFeedback, `${option}hint`);
         answers.push(
@@ -279,7 +279,7 @@ export class OLXParser {
       }
       const feedback = this.getAnswerFeedback(preservedFeedback, `${option}hint`);
       answers.push({
-        correct: eval(choice['@_correct'].toLowerCase()),
+        correct: choice['@_correct'].toLowerCase() === 'true',
         id: indexToLetterMap[answers.length],
         title,
         ...feedback,


### PR DESCRIPTION
## Description

The Problem editor UI only supports values of `correct="true"` and `correct="false"` so the parsing can be simplified; it shouldn't be using `eval()`. In general, using `eval(...)` on user input is very dangerous and shouldn't ever be used!

## Security Analysis

This seems like it fixes a moderate security vulnerability: authors can put arbitrary JS into the `correctness` OLX field, and then when other others open the problem in the advanced editor, it will run that code as the other user. However, we already allow authors to put arbitrary HTML in so many other places that this bug would actually be one of the most difficult ways to achieve that. Authors can simply put arbitrary JS in "Text" XBlocks anywhere they want or, for example, put code like `<img src="https://placehold.co/1" onload="alert('test')" />` in the OLX `<choice>` element of the multiple choice problem, and it will run for all users, not just instructors. So what I'm saying is we already trust authors and closing one door for arbitrary JS is not a significant change when there are so many others still open.

## Supporting information

This was caught by oxlint: https://github.com/openedx/frontend-app-authoring/issues/2559

## Testing instructions

Ensure the problem editor still works for saving changes to which answer is correct on "Single Select" (multiple choice) problems. Can be tested in a course or a library. 

Private ref: MNG-4763
