### PR TITLE
chore: clean up ValidationResult for NumericalInput problems

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
@@ -73,7 +73,7 @@ const AnswerOption = ({
 
     if (problemType !== ProblemTypeKeys.NUMERIC || !answer.isAnswerRange) {
       return (
-        <Form.Group isInvalid={!data?.isValid ?? true}>
+        <Form.Group isInvalid={!data?.isValid}>
           <Form.Control
             as="textarea"
             className="answer-option-textarea text-gray-500 small"
@@ -89,7 +89,7 @@ const AnswerOption = ({
             placeholder={intl.formatMessage(messages.answerTextboxPlaceholder)}
 
           />
-          {(!data?.isValid ?? true) && (
+          {(!data?.isValid) && (
           <Form.Control.Feedback type="invalid">
             <FormattedMessage {...messages.answerNumericErrorText} />
           </Form.Control.Feedback>

--- a/src/editors/containers/ProblemEditor/data/apiHooks.ts
+++ b/src/editors/containers/ProblemEditor/data/apiHooks.ts
@@ -4,8 +4,14 @@ import api from '@src/editors/data/services/cms/api';
 
 const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
 
+interface ValidationResult {
+  isValid: boolean;
+  error?: string;
+  preview?: string;
+}
+
 export const useValidateInputBlock = () => useMutation({
-  mutationFn: async (title : string) => {
+  mutationFn: async (title : string): Promise<ValidationResult> => {
     try {
       const res = await api.validateBlockNumericInput({ studioEndpointUrl: `${getApiBaseUrl()}`, data: { formula: title } });
       return camelCaseObject(res.data);


### PR DESCRIPTION
## Description

This fixes a minor issue with the code in the Numerical Input problem editor answer validation.

Specifically, the code `isInvalid={!data?.isValid ?? true}`

If you think about it:
* if `isValid` is `true`, then this evaluates to `{!true ?? true}` which is `{false ?? true}` which is `false`.
* if `isValid` is `false`, then this evaluates to `{!false ?? true}` which is `{true ?? true}` which is `true`.
* if `isValid` is `undefined`, then this evaluates to `{!undefined ?? true}` which is `{true ?? true}` which is `true`.

In any case, the `?? true` has absolutely no effect. And `oxlint` actually warns about this:

```
  ⚠ eslint(no-constant-binary-expression): Unexpected constant nullishness on the left-hand side of a "??" expression
    ╭─[src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx:92:13]
 91 │           />
 92 │           {(!data?.isValid ?? true) && (
    ·             ──────────────────────
 93 │           <Form.Control.Feedback type="invalid">
    ╰────
  help: This expression always evaluates to the constant on the left-hand side
```

As it says, "this expression always evaluates to the constant on the left-hand side", so there is no need for the right-hand side.

I also added a type definition for the validation data.

## Supporting information

This follows https://github.com/openedx/frontend-app-authoring/pull/2615 and is part of the work to test oxlint in this repo - https://github.com/openedx/frontend-app-authoring/issues/2559

## Testing instructions

Test that validation of numerical input answers is working the same as it was before.

<img width="750" height="83" alt="Screenshot 2026-01-28 at 6 01 02 PM" src="https://github.com/user-attachments/assets/ac39a6b9-c72a-42a0-9ed6-fa6d69495de0" />

<img width="603" height="111" alt="Screenshot 2026-01-28 at 5 59 48 PM" src="https://github.com/user-attachments/assets/0eabb89d-dfae-428f-8ce2-a06576bb32fa" />

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
