### PR TITLE
Fix: Duplicate max file size const

### DIFF
--- a/src/files-and-videos/files-page/CourseFilesTable.tsx
+++ b/src/files-and-videos/files-page/CourseFilesTable.tsx
@@ -76,7 +76,7 @@ export const CourseFilesTable = () => {
     usageErrorMessages: errorMessages.usageMetrics,
     fileType: 'file',
   };
-  const maxFileSize = UPLOAD_FILE_MAX_SIZE * 1024 * 1024;
+  const maxFileSize = UPLOAD_FILE_MAX_SIZE;
 
   const activeColumn = {
     id: 'activeStatus',


### PR DESCRIPTION
## Description

File `src/files-and-videos/files-page/CourseFilesTable.tsx` contained a duplication of the constant maxFileSize that already existed in `src/constants.ts` (and is already consumed elsewhere).
Updated to import and reuse existing value `UPLOAD_FILE_MAX_SIZE`  from `@src/constants`


Useful information to include:
- Which user roles will this change impact? "Operator"
