### PR TITLE
fix: localize rerun button text

### DIFF
--- a/src/studio-home/card-item/index.tsx
+++ b/src/studio-home/card-item/index.tsx
@@ -146,7 +146,7 @@ const CardMenu = ({
             as={Link}
             to={rerunLink ?? ''}
           >
-            {intl.formatMessage(messages.btnReRunText)}
+            <FormattedMessage {...messages.btnReRunText} />
           </Dropdown.Item>
         )}
         <Dropdown.Item href={lmsLink}>


### PR DESCRIPTION
In this PR, wrapping Re-run course button text into intl as this string is missing as we translate to different language.