### PR TITLE
refactor: update relative path to absolute path alias

### DIFF
--- a/src/generic/modal-dropzone/ModalDropzone.jsx
+++ b/src/generic/modal-dropzone/ModalDropzone.jsx
@@ -13,9 +13,9 @@ import {
 } from '@openedx/paragon';
 import { FileUpload as FileUploadIcon } from '@openedx/paragon/icons';
 
+import { UPLOAD_FILE_MAX_SIZE } from '@src/constants';
 import useModalDropzone from './useModalDropzone';
 import messages from './messages';
-import { UPLOAD_FILE_MAX_SIZE } from '@src/constants';
 
 const ModalDropzone = ({
   fileTypes,


### PR DESCRIPTION
## Description

refactor of `UPLOAD_FILE_MAX_SIZE` import statement in `src/generic/modal-dropzone/ModalDropzone.jsx` to use absolute path (`@src` path alias) instead of relative path, in line with current best practices
No change in functionality for operators or users