### PR TITLE
docs: update course_unit_sidebar slot ID to v2 in plugin-slots README

### DIFF
--- a/src/plugin-slots/README.md
+++ b/src/plugin-slots/README.md
@@ -8,7 +8,7 @@
 
 ## Course Unit page
 * [`org.openedx.frontend.authoring.course_unit_header_actions.v1`](./CourseUnitHeaderActionsSlot/)
-* [`org.openedx.frontend.authoring.course_unit_sidebar.v1`](./CourseAuthoringUnitSidebarSlot/)
+* [`org.openedx.frontend.authoring.course_unit_sidebar.v2`](./CourseAuthoringUnitSidebarSlot/)
 
 ## Other Slots
 * [`org.openedx.frontend.authoring.additional_course_content_plugin.v1`](./AdditionalCourseContentPluginSlot/)


### PR DESCRIPTION
The `CourseAuthoringUnitSidebarSlot` README defines the slot ID as `org.openedx.frontend.authoring.course_unit_sidebar.v2`, but the top-level plugin-slots README was referencing it as `v1`. This fixes that inconsistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)