### PR TITLE
test: run only oxlint, not eslint

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,18 +21,6 @@ jobs:
       with:
         name: code-coverage-report
         path: coverage/*.*
-  # We are trying out oxlint for a while. Please report if you ever see lint issues that eslint catches but oxlint
-  # misses. We expect the opposite (oxlint should catch more issues).
-  lint-preview:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-node@v6
-      with:
-        node-version-file: '.nvmrc'
-    - run: npm install
-    - run: npm run oxlint
   coverage:
     runs-on: ubuntu-latest
     needs: tests

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,9 @@ validate-no-uncommitted-package-lock-changes:
 validate:
 	make validate-no-uncommitted-package-lock-changes
 	npm run i18n_extract
-	npm run lint -- --max-warnings 0
+# We are trying out oxlint. Now that it's been working well for a while with both oxlint and eslint, we have disabled
+# eslint, and after a few weeks we'll evaluate whether any problems are slipping through if only oxlint is used.
+	npm run oxlint
 	npm run types
 	npm run test:ci
 	npm run build


### PR DESCRIPTION
## Description

As the next phase of testing oxlint (https://github.com/openedx/frontend-app-authoring/issues/2559), this PR removes `eslint` from CI. After a few weeks, we will see if any issues have "slipped in" to the codebase when we're actively developing with only oxlint as our linter. If we're happy at the end, we'll then proceed to remove eslint completely and make a recommendation for other repos.

Private ref: MNG-4763
