### PR TITLE
Fix: Refresh search token after library creation for course creator access

### DIFF
--- a/src/library-authoring/create-library/data/apiHooks.test.tsx
+++ b/src/library-authoring/create-library/data/apiHooks.test.tsx
@@ -63,6 +63,9 @@ describe('create library apiHooks', () => {
       expect(invalidateQueriesSpy).toHaveBeenCalledWith({
         queryKey: libraryAuthoringQueryKeys.contentLibraryList(),
       });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ['content_search'],
+      });
     });
   });
 

--- a/src/library-authoring/create-library/data/apiHooks.ts
+++ b/src/library-authoring/create-library/data/apiHooks.ts
@@ -23,6 +23,8 @@ export const useCreateLibraryV2 = () => {
     mutationFn: createLibraryV2,
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibraryList() });
+      // Invalidate the search token to refresh with the new library's access_id
+      queryClient.invalidateQueries({ queryKey: ['content_search'] });
     },
   });
 };


### PR DESCRIPTION
## Description
- When a course creator creates a new library, the cached JWT token for Meilisearch needs to be refreshed to include the new library's access_id. Without this, newly added components won't appear in search results until the page is refreshed.
- This works in conjunction with the backend fix that creates SearchAccess records immediately on library creation.
- The fix invalidates the content_search query, triggering React Query to refetch the token with updated access permissions.
- Check openedx-platform for further details