### PR TITLE
Adding permission validations from authz for Course Updates

### DIFF
--- a/src/authz/constants.ts
+++ b/src/authz/constants.ts
@@ -24,4 +24,6 @@ export const COURSE_PERMISSIONS = {
   VIEW_SCHEDULE_AND_DETAILS: 'courses.view_schedule_and_details',
   EDIT_SCHEDULE: 'courses.edit_schedule',
   EDIT_DETAILS: 'courses.edit_details',
+  VIEW_COURSE_UPDATES: 'courses.view_course_updates',
+  MANAGE_COURSE_UPDATES: 'courses.manage_course_updates',
 };

--- a/src/authz/hooks.test.ts
+++ b/src/authz/hooks.test.ts
@@ -60,8 +60,8 @@ describe('useCourseUserPermissions', () => {
 
     expect(result.current.isLoading).toBe(true);
     expect(result.current.isAuthzEnabled).toBe(true);
-    expect(result.current.canView).toBeUndefined();
-    expect(result.current.canEdit).toBeUndefined();
+    expect(result.current.canView).toBe(false);
+    expect(result.current.canEdit).toBe(false);
   });
 
   it('falls back to false for permissions absent from server response when authz is enabled', () => {

--- a/src/authz/hooks.test.tsx
+++ b/src/authz/hooks.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import * as authzApi from '@src/authz/data/api';
+import { PermissionValidationQuery } from '@src/authz/types';
+import { mockWaffleFlags } from '@src/data/apiHooks.mock';
+import { useUserPermissionsWithAuthzCourse } from './hooks';
+
+jest.mock('@src/data/api');
+jest.mock('@src/authz/data/api');
+
+const mockedAuthzApi = jest.mocked(authzApi);
+
+describe('useUserPermissionsWithAuthzCourse', () => {
+  let queryClient: QueryClient;
+
+  const createWrapper = () =>
+    function TestWrapper({ children }: { children: React.ReactNode; }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+    };
+
+  const mockPermissions: PermissionValidationQuery = {
+    canViewFiles: {
+      action: 'course.view_files',
+      scope: 'course-v1:Test+101+2023',
+    },
+    canManageFiles: {
+      action: 'course.manage_files',
+      scope: 'course-v1:Test+101+2023',
+    },
+  };
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+    jest.clearAllMocks();
+  });
+
+  it('returns all permissions as true when authz is disabled', async () => {
+    mockWaffleFlags({
+      enableAuthzCourseAuthoring: false,
+    });
+
+    const { result } = renderHook(
+      () => useUserPermissionsWithAuthzCourse('course-v1:Test+101+2023', mockPermissions),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isAuthzEnabled).toBe(false);
+    expect(result.current.permissions.canViewFiles).toBe(true);
+    expect(result.current.permissions.canManageFiles).toBe(true);
+  });
+
+  it('returns loading state when authz is enabled and permissions are loading', async () => {
+    mockWaffleFlags({
+      enableAuthzCourseAuthoring: true,
+    });
+
+    mockedAuthzApi.validateUserPermissions.mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    const { result } = renderHook(
+      () => useUserPermissionsWithAuthzCourse('course-v1:Test+101+2023', mockPermissions),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isAuthzEnabled).toBe(true);
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns actual permission values when authz is enabled and permissions loaded', async () => {
+    mockWaffleFlags({
+      enableAuthzCourseAuthoring: true,
+    });
+
+    mockedAuthzApi.validateUserPermissions.mockResolvedValue({
+      canViewFiles: true,
+      canManageFiles: false,
+    });
+
+    const { result } = renderHook(
+      () => useUserPermissionsWithAuthzCourse('course-v1:Test+101+2023', mockPermissions),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isAuthzEnabled).toBe(true);
+    expect(result.current.permissions.canViewFiles).toBe(true);
+    expect(result.current.permissions.canManageFiles).toBe(false);
+  });
+
+  it('falls back to false for undefined permissions when authz is enabled', async () => {
+    mockWaffleFlags({
+      enableAuthzCourseAuthoring: true,
+    });
+
+    mockedAuthzApi.validateUserPermissions.mockResolvedValue({
+      canViewFiles: true,
+    });
+
+    const { result } = renderHook(
+      () => useUserPermissionsWithAuthzCourse('course-v1:Test+101+2023', mockPermissions),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isAuthzEnabled).toBe(true);
+    expect(result.current.permissions.canViewFiles).toBe(true);
+    expect(result.current.permissions.canManageFiles).toBe(false);
+  });
+});

--- a/src/authz/hooks.test.tsx
+++ b/src/authz/hooks.test.tsx
@@ -5,14 +5,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as authzApi from '@src/authz/data/api';
 import { PermissionValidationQuery } from '@src/authz/types';
 import { mockWaffleFlags } from '@src/data/apiHooks.mock';
-import { useUserPermissionsWithAuthzCourse } from './hooks';
+import { useCourseUserPermissions } from './hooks';
 
 jest.mock('@src/data/api');
 jest.mock('@src/authz/data/api');
 
 const mockedAuthzApi = jest.mocked(authzApi);
 
-describe('useUserPermissionsWithAuthzCourse', () => {
+describe('useCourseUserPermissions', () => {
   let queryClient: QueryClient;
 
   const createWrapper = () =>
@@ -50,7 +50,7 @@ describe('useUserPermissionsWithAuthzCourse', () => {
     });
 
     const { result } = renderHook(
-      () => useUserPermissionsWithAuthzCourse('course-v1:Test+101+2023', mockPermissions),
+      () => useCourseUserPermissions('course-v1:Test+101+2023', mockPermissions),
       { wrapper: createWrapper() },
     );
 
@@ -59,8 +59,8 @@ describe('useUserPermissionsWithAuthzCourse', () => {
     });
 
     expect(result.current.isAuthzEnabled).toBe(false);
-    expect(result.current.permissions.canViewFiles).toBe(true);
-    expect(result.current.permissions.canManageFiles).toBe(true);
+    expect(result.current.canViewFiles).toBe(true);
+    expect(result.current.canManageFiles).toBe(true);
   });
 
   it('returns loading state when authz is enabled and permissions are loading', async () => {
@@ -73,7 +73,7 @@ describe('useUserPermissionsWithAuthzCourse', () => {
     );
 
     const { result } = renderHook(
-      () => useUserPermissionsWithAuthzCourse('course-v1:Test+101+2023', mockPermissions),
+      () => useCourseUserPermissions('course-v1:Test+101+2023', mockPermissions),
       { wrapper: createWrapper() },
     );
 
@@ -82,6 +82,8 @@ describe('useUserPermissionsWithAuthzCourse', () => {
     });
 
     expect(result.current.isLoading).toBe(true);
+    expect(result.current.canViewFiles).toBe(false);
+    expect(result.current.canManageFiles).toBe(false);
   });
 
   it('returns actual permission values when authz is enabled and permissions loaded', async () => {
@@ -95,7 +97,7 @@ describe('useUserPermissionsWithAuthzCourse', () => {
     });
 
     const { result } = renderHook(
-      () => useUserPermissionsWithAuthzCourse('course-v1:Test+101+2023', mockPermissions),
+      () => useCourseUserPermissions('course-v1:Test+101+2023', mockPermissions),
       { wrapper: createWrapper() },
     );
 
@@ -104,8 +106,8 @@ describe('useUserPermissionsWithAuthzCourse', () => {
     });
 
     expect(result.current.isAuthzEnabled).toBe(true);
-    expect(result.current.permissions.canViewFiles).toBe(true);
-    expect(result.current.permissions.canManageFiles).toBe(false);
+    expect(result.current.canViewFiles).toBe(true);
+    expect(result.current.canManageFiles).toBe(false);
   });
 
   it('falls back to false for undefined permissions when authz is enabled', async () => {
@@ -118,7 +120,7 @@ describe('useUserPermissionsWithAuthzCourse', () => {
     });
 
     const { result } = renderHook(
-      () => useUserPermissionsWithAuthzCourse('course-v1:Test+101+2023', mockPermissions),
+      () => useCourseUserPermissions('course-v1:Test+101+2023', mockPermissions),
       { wrapper: createWrapper() },
     );
 
@@ -127,7 +129,7 @@ describe('useUserPermissionsWithAuthzCourse', () => {
     });
 
     expect(result.current.isAuthzEnabled).toBe(true);
-    expect(result.current.permissions.canViewFiles).toBe(true);
-    expect(result.current.permissions.canManageFiles).toBe(false);
+    expect(result.current.canViewFiles).toBe(true);
+    expect(result.current.canManageFiles).toBe(false);
   });
 });

--- a/src/authz/hooks.ts
+++ b/src/authz/hooks.ts
@@ -8,18 +8,6 @@ type UseCourseUserPermissionsReturn<Query extends PermissionValidationQuery> = {
 } & PermissionValidationAnswer<Query>;
 
 /**
- * Return type for the useUserCoursePermissionsWithAuthz hook
- */
-interface UseUserPermissionsWithAuthzCourseReturn {
-  /** Whether permissions are currently loading */
-  isLoading: boolean;
-  /** Object containing permission results with boolean values */
-  permissions: PermissionValidationAnswer;
-  /** Whether authorization is enabled for the course */
-  isAuthzEnabled: boolean;
-}
-
-/**
  * Custom hook to retrieve and evaluate user permissions for the current course using the openedx-authz service.
  *
  * The hook:
@@ -54,12 +42,15 @@ export const useCourseUserPermissions = <Query extends PermissionValidationQuery
   permissions: Query,
 ): UseCourseUserPermissionsReturn<Query> => {
   const waffleFlags = useWaffleFlags(courseId);
+  const isWaffleFlagsLoading: boolean = waffleFlags?.isLoading ?? true;
   const isAuthzEnabled: boolean = waffleFlags?.enableAuthzCourseAuthoring ?? false;
 
   const {
     isLoading: isLoadingUserPermissions,
     data: userPermissions,
   } = useUserPermissions(permissions, isAuthzEnabled);
+
+  const isLoading = isWaffleFlagsLoading || (isAuthzEnabled && isLoadingUserPermissions);
 
   const resolvePermission = (key: string): boolean => {
     if (!isAuthzEnabled) {
@@ -68,82 +59,19 @@ export const useCourseUserPermissions = <Query extends PermissionValidationQuery
     return userPermissions?.[key] ?? false;
   };
 
-  const permissionResults: Record<string, boolean> = isLoadingUserPermissions
-    ? {}
+  const permissionResults: Record<string, boolean> = isLoading
+    ? Object.keys(permissions).reduce<Record<string, boolean>>((acc, key) => {
+      acc[key] = false;
+      return acc;
+    }, {})
     : Object.keys(permissions).reduce<Record<string, boolean>>((acc, key) => {
       acc[key] = resolvePermission(key);
       return acc;
     }, {});
 
   return {
-    isLoading: isAuthzEnabled ? isLoadingUserPermissions : false,
+    isLoading,
     isAuthzEnabled,
     ...permissionResults as PermissionValidationAnswer<Query>,
-  };
-};
-
-/**
- * Custom hook to handle user permissions with course authorization waffle flag
- *
- * This hook abstracts the common pattern of:
- * 1. Checking if authz is enabled via waffle flag
- * 2. Fetching user permissions when authz is enabled
- * 3. Defaulting all permissions to true when authz is disabled
- * 4. Providing fallback values for undefined permissions
- *
- * @param courseId - The course ID to check permissions for
- * @param permissions - Object mapping permission names to their action/scope definitions
- * @returns Object containing loading state, permissions results, and authz status
- *
- * @example
- * ```tsx
- * const { isLoading, permissions, isAuthzEnabled } = useUserPermissionsWithAuthzCourse(
- *   courseId,
- *   {
- *     canViewFiles: {
- *       action: COURSE_PERMISSIONS.VIEW_FILES,
- *       scope: courseId,
- *     },
- *     canManageFiles: {
- *       action: COURSE_PERMISSIONS.MANAGE_FILES,
- *       scope: courseId,
- *     },
- *   }
- * );
- *
- * const { canViewFiles, canManageFiles } = permissions;
- * ```
- */
-export const useUserPermissionsWithAuthzCourse = (
-  courseId: string,
-  permissions: PermissionValidationQuery,
-): UseUserPermissionsWithAuthzCourseReturn => {
-  const waffleFlags = useWaffleFlags(courseId);
-  const isAuthzEnabled: boolean = waffleFlags?.enableAuthzCourseAuthoring ?? false;
-
-  const {
-    isLoading: isLoadingUserPermissions,
-    data: userPermissions,
-  } = useUserPermissions(permissions, isAuthzEnabled);
-
-  // Build permission results object
-  const permissionResults: PermissionValidationAnswer = {};
-
-  if (!isAuthzEnabled) {
-    // Authz is disabled, default all permissions to true immediately
-    Object.keys(permissions).forEach((permissionKey: string) => {
-      permissionResults[permissionKey] = true;
-    });
-  } else if (!isLoadingUserPermissions) {
-    // Authz is enabled and permissions loaded, use actual permission values with fallback to false
-    Object.keys(permissions).forEach((permissionKey: string) => {
-      permissionResults[permissionKey] = userPermissions?.[permissionKey] ?? false;
-    });
-  }
-
-  return {
-    isLoading: isAuthzEnabled ? isLoadingUserPermissions : false,
-    permissions: permissionResults,
-    isAuthzEnabled,
   };
 };

--- a/src/authz/hooks.ts
+++ b/src/authz/hooks.ts
@@ -8,6 +8,18 @@ type UseCourseUserPermissionsReturn<Query extends PermissionValidationQuery> = {
 } & PermissionValidationAnswer<Query>;
 
 /**
+ * Return type for the useUserCoursePermissionsWithAuthz hook
+ */
+interface UseUserPermissionsWithAuthzCourseReturn {
+  /** Whether permissions are currently loading */
+  isLoading: boolean;
+  /** Object containing permission results with boolean values */
+  permissions: PermissionValidationAnswer;
+  /** Whether authorization is enabled for the course */
+  isAuthzEnabled: boolean;
+}
+
+/**
  * Custom hook to retrieve and evaluate user permissions for the current course using the openedx-authz service.
  *
  * The hook:
@@ -67,5 +79,71 @@ export const useCourseUserPermissions = <Query extends PermissionValidationQuery
     isLoading: isAuthzEnabled ? isLoadingUserPermissions : false,
     isAuthzEnabled,
     ...permissionResults as PermissionValidationAnswer<Query>,
+  };
+};
+
+/**
+ * Custom hook to handle user permissions with course authorization waffle flag
+ *
+ * This hook abstracts the common pattern of:
+ * 1. Checking if authz is enabled via waffle flag
+ * 2. Fetching user permissions when authz is enabled
+ * 3. Defaulting all permissions to true when authz is disabled
+ * 4. Providing fallback values for undefined permissions
+ *
+ * @param courseId - The course ID to check permissions for
+ * @param permissions - Object mapping permission names to their action/scope definitions
+ * @returns Object containing loading state, permissions results, and authz status
+ *
+ * @example
+ * ```tsx
+ * const { isLoading, permissions, isAuthzEnabled } = useUserPermissionsWithAuthzCourse(
+ *   courseId,
+ *   {
+ *     canViewFiles: {
+ *       action: COURSE_PERMISSIONS.VIEW_FILES,
+ *       scope: courseId,
+ *     },
+ *     canManageFiles: {
+ *       action: COURSE_PERMISSIONS.MANAGE_FILES,
+ *       scope: courseId,
+ *     },
+ *   }
+ * );
+ *
+ * const { canViewFiles, canManageFiles } = permissions;
+ * ```
+ */
+export const useUserPermissionsWithAuthzCourse = (
+  courseId: string,
+  permissions: PermissionValidationQuery,
+): UseUserPermissionsWithAuthzCourseReturn => {
+  const waffleFlags = useWaffleFlags(courseId);
+  const isAuthzEnabled: boolean = waffleFlags?.enableAuthzCourseAuthoring ?? false;
+
+  const {
+    isLoading: isLoadingUserPermissions,
+    data: userPermissions,
+  } = useUserPermissions(permissions, isAuthzEnabled);
+
+  // Build permission results object
+  const permissionResults: PermissionValidationAnswer = {};
+
+  if (!isAuthzEnabled) {
+    // Authz is disabled, default all permissions to true immediately
+    Object.keys(permissions).forEach((permissionKey: string) => {
+      permissionResults[permissionKey] = true;
+    });
+  } else if (!isLoadingUserPermissions) {
+    // Authz is enabled and permissions loaded, use actual permission values with fallback to false
+    Object.keys(permissions).forEach((permissionKey: string) => {
+      permissionResults[permissionKey] = userPermissions?.[permissionKey] ?? false;
+    });
+  }
+
+  return {
+    isLoading: isAuthzEnabled ? isLoadingUserPermissions : false,
+    permissions: permissionResults,
+    isAuthzEnabled,
   };
 };

--- a/src/authz/permissionHelpers.test.ts
+++ b/src/authz/permissionHelpers.test.ts
@@ -1,0 +1,32 @@
+import { getCourseUpdatesPermissions } from './permissionHelpers';
+import { COURSE_PERMISSIONS } from './constants';
+
+describe('permissionHelpers', () => {
+  describe('getCourseUpdatesPermissions', () => {
+    const mockCourseId = 'course-v1:edX+DemoX+Demo_Course';
+
+    it('should return correct permission structure for course updates operations', () => {
+      const result = getCourseUpdatesPermissions(mockCourseId);
+
+      expect(result).toEqual({
+        canViewCourseUpdates: {
+          action: COURSE_PERMISSIONS.VIEW_COURSE_UPDATES,
+          scope: mockCourseId,
+        },
+        canManageCourseUpdates: {
+          action: COURSE_PERMISSIONS.MANAGE_COURSE_UPDATES,
+          scope: mockCourseId,
+        },
+      });
+    });
+
+    it('should use the provided courseId as scope for all permissions', () => {
+      const customCourseId = 'course-v1:TestOrg+TestCourse+2024';
+      const result = getCourseUpdatesPermissions(customCourseId);
+
+      Object.values(result).forEach(permission => {
+        expect(permission.scope).toBe(customCourseId);
+      });
+    });
+  });
+});

--- a/src/authz/permissionHelpers.ts
+++ b/src/authz/permissionHelpers.ts
@@ -25,3 +25,14 @@ export const getGradingPermissions = (courseId: string) => ({
     scope: courseId,
   },
 });
+
+export const getCourseUpdatesPermissions = (courseId: string) => ({
+  canViewCourseUpdates: {
+    action: COURSE_PERMISSIONS.VIEW_COURSE_UPDATES,
+    scope: courseId,
+  },
+  canManageCourseUpdates: {
+    action: COURSE_PERMISSIONS.MANAGE_COURSE_UPDATES,
+    scope: courseId,
+  },
+});

--- a/src/course-updates/CourseUpdates.test.tsx
+++ b/src/course-updates/CourseUpdates.test.tsx
@@ -9,6 +9,9 @@ import {
   screen,
 } from '@src/testUtils';
 
+import { useUserPermissions } from '@src/authz/data/apiHooks';
+
+import * as apiHooks from '@src/data/apiHooks';
 import {
   getCourseUpdatesApiUrl,
   getCourseHandoutApiUrl,
@@ -28,6 +31,19 @@ let axiosMock;
 let store;
 const mockPathname = '/foo-bar';
 const courseId = '123';
+
+jest.mock('@src/authz/data/apiHooks', () => ({
+  ...jest.requireActual('@src/authz/data/apiHooks'),
+  useUserPermissions: jest.fn(() => ({
+    isLoading: false,
+    data: { canManageCourseUpdates: false, canViewCourseUpdates: true },
+  })),
+}));
+
+jest.mock('@src/data/apiHooks', () => ({
+  ...jest.requireActual('@src/data/apiHooks'),
+  useWaffleFlags: jest.fn(() => ({ enableAuthzCourseAuthoring: false })),
+}));
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -344,6 +360,155 @@ describe('<CourseUpdates />', () => {
       expect(screen.queryByText('Some handouts 1')).toBeNull();
       expect(screen.getByText(courseHandoutsMock.data)).toBeVisible();
       expect(await screen.findByText(messages.savingHandoutsErrorDescription.defaultMessage));
+    });
+  });
+
+  describe('Authorization and permissions', () => {
+    describe('when user has permission to manage course updates', () => {
+      beforeEach(() => {
+        const mocks = initializeMocks();
+        store = mocks.reduxStore;
+        axiosMock = mocks.axiosMock;
+
+        (apiHooks.useWaffleFlags as jest.Mock).mockReturnValue({ enableAuthzCourseAuthoring: true });
+        (useUserPermissions as jest.Mock).mockReturnValue({
+          isLoading: false,
+          data: { canManageCourseUpdates: true, canViewCourseUpdates: true },
+        });
+
+        axiosMock
+          .onGet(getCourseUpdatesApiUrl(courseId))
+          .reply(200, courseUpdatesMock);
+        axiosMock
+          .onGet(getCourseHandoutApiUrl(courseId))
+          .reply(200, courseHandoutsMock);
+      });
+
+      it('should render the "New update" button', async () => {
+        render(<RootWrapper />);
+
+        expect(
+          await screen.findByRole('button', {
+            name: messages.newUpdateButton.defaultMessage,
+          }),
+        ).toBeInTheDocument();
+      });
+
+      it('should render edit and delete buttons for course updates', async () => {
+        const { container } = render(<RootWrapper />);
+        await waitFor(() => {
+          expect(container.querySelectorAll('.course-update')).toHaveLength(3);
+        });
+
+        expect(await screen.findAllByRole('button', { name: /edit/i })).toHaveLength(4); // 3 for course updates and 1 for handouts
+        expect(await screen.findAllByRole('button', { name: /delete/i })).toHaveLength(3);
+      });
+    });
+
+    describe('when user does NOT have permission to manage course updates and enableAuthzCourseAuthoring is enabled', () => {
+      beforeEach(() => {
+        const mocks = initializeMocks();
+        store = mocks.reduxStore;
+        axiosMock = mocks.axiosMock;
+
+        (apiHooks.useWaffleFlags as jest.Mock).mockReturnValue({ enableAuthzCourseAuthoring: true });
+        (useUserPermissions as jest.Mock).mockReturnValue({
+          isLoading: false,
+          data: { canManageCourseUpdates: false, canViewCourseUpdates: true },
+        });
+
+        axiosMock
+          .onGet(getCourseUpdatesApiUrl(courseId))
+          .reply(200, courseUpdatesMock);
+        axiosMock
+          .onGet(getCourseHandoutApiUrl(courseId))
+          .reply(200, courseHandoutsMock);
+      });
+
+      it('should NOT render the "New update" button', async () => {
+        render(<RootWrapper />);
+
+        await waitFor(() => {
+          expect(screen.getByText(messages.headingTitle.defaultMessage)).toBeInTheDocument();
+        });
+
+        const newUpdateButton = screen.queryByRole('button', { name: /New update/ });
+
+        expect(newUpdateButton).not.toBeInTheDocument();
+      });
+
+      it('should NOT render edit and delete buttons for course updates', async () => {
+        const { container } = render(<RootWrapper />);
+
+        await waitFor(() => {
+          expect(container.querySelectorAll('.course-update')).toHaveLength(3);
+          expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+          expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+        });
+      });
+    });
+
+    describe('when enableAuthzCourseAuthoring is disabled', () => {
+      beforeEach(() => {
+        const mocks = initializeMocks();
+        store = mocks.reduxStore;
+        axiosMock = mocks.axiosMock;
+
+        (apiHooks.useWaffleFlags as jest.Mock).mockReturnValue({ enableAuthzCourseAuthoring: false });
+        (useUserPermissions as jest.Mock).mockReturnValue({
+          isLoading: false,
+          data: { canManageCourseUpdates: false },
+        });
+
+        axiosMock
+          .onGet(getCourseUpdatesApiUrl(courseId))
+          .reply(200, courseUpdatesMock);
+        axiosMock
+          .onGet(getCourseHandoutApiUrl(courseId))
+          .reply(200, courseHandoutsMock);
+      });
+
+      it('should render the "New update" button (defaults to true when authz disabled)', async () => {
+        render(<RootWrapper />);
+
+        expect(
+          await screen.findByRole('button', {
+            name: messages.newUpdateButton.defaultMessage,
+          }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    describe('when user does NOT have permission to view course updates', () => {
+      beforeEach(() => {
+        const mocks = initializeMocks();
+        store = mocks.reduxStore;
+        axiosMock = mocks.axiosMock;
+
+        (apiHooks.useWaffleFlags as jest.Mock).mockReturnValue({ enableAuthzCourseAuthoring: true });
+        (useUserPermissions as jest.Mock).mockReturnValue({
+          isLoading: false,
+          data: { canManageCourseUpdates: false, canViewCourseUpdates: false },
+        });
+
+        axiosMock
+          .onGet(getCourseUpdatesApiUrl(courseId))
+          .reply(200, courseUpdatesMock);
+        axiosMock
+          .onGet(getCourseHandoutApiUrl(courseId))
+          .reply(200, courseHandoutsMock);
+      });
+
+      it('should render PermissionDeniedAlert instead of course updates content', async () => {
+        render(<RootWrapper />);
+
+        expect(await screen.findByText(/You are not authorized to view this page/)).toBeInTheDocument();
+        expect(screen.queryByText(messages.headingTitle.defaultMessage)).not.toBeInTheDocument();
+        expect(screen.queryByText(messages.headingSubtitle.defaultMessage)).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', {
+          name: messages.newUpdateButton.defaultMessage,
+        })).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/src/course-updates/CourseUpdates.test.tsx
+++ b/src/course-updates/CourseUpdates.test.tsx
@@ -8,6 +8,7 @@ import {
   fireEvent,
   screen,
 } from '@src/testUtils';
+import userEvent from '@testing-library/user-event';
 
 import { useUserPermissions } from '@src/authz/data/apiHooks';
 
@@ -42,7 +43,7 @@ jest.mock('@src/authz/data/apiHooks', () => ({
 
 jest.mock('@src/data/apiHooks', () => ({
   ...jest.requireActual('@src/data/apiHooks'),
-  useWaffleFlags: jest.fn(() => ({ enableAuthzCourseAuthoring: false })),
+  useWaffleFlags: jest.fn(() => ({ enableAuthzCourseAuthoring: false, isLoading: false })),
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -370,7 +371,7 @@ describe('<CourseUpdates />', () => {
         store = mocks.reduxStore;
         axiosMock = mocks.axiosMock;
 
-        (apiHooks.useWaffleFlags as jest.Mock).mockReturnValue({ enableAuthzCourseAuthoring: true });
+        (apiHooks.useWaffleFlags as jest.Mock).mockReturnValue({ enableAuthzCourseAuthoring: true, isLoading: false });
         (useUserPermissions as jest.Mock).mockReturnValue({
           isLoading: false,
           data: { canManageCourseUpdates: true, canViewCourseUpdates: true },
@@ -403,6 +404,15 @@ describe('<CourseUpdates />', () => {
         expect(await screen.findAllByRole('button', { name: /edit/i })).toHaveLength(4); // 3 for course updates and 1 for handouts
         expect(await screen.findAllByRole('button', { name: /delete/i })).toHaveLength(3);
       });
+
+      it('should open delete modal when clicking delete button on a course update', async () => {
+        render(<RootWrapper />);
+
+        const deleteButtons = await screen.findAllByTestId('course-update-delete-button');
+        await userEvent.click(deleteButtons[0]);
+
+        expect(screen.getByText('Are you sure you want to delete this update?')).toBeInTheDocument();
+      });
     });
 
     describe('when user does NOT have permission to manage course updates and enableAuthzCourseAuthoring is enabled', () => {
@@ -411,7 +421,7 @@ describe('<CourseUpdates />', () => {
         store = mocks.reduxStore;
         axiosMock = mocks.axiosMock;
 
-        (apiHooks.useWaffleFlags as jest.Mock).mockReturnValue({ enableAuthzCourseAuthoring: true });
+        (apiHooks.useWaffleFlags as jest.Mock).mockReturnValue({ enableAuthzCourseAuthoring: true, isLoading: false });
         (useUserPermissions as jest.Mock).mockReturnValue({
           isLoading: false,
           data: { canManageCourseUpdates: false, canViewCourseUpdates: true },
@@ -454,7 +464,7 @@ describe('<CourseUpdates />', () => {
         store = mocks.reduxStore;
         axiosMock = mocks.axiosMock;
 
-        (apiHooks.useWaffleFlags as jest.Mock).mockReturnValue({ enableAuthzCourseAuthoring: false });
+        (apiHooks.useWaffleFlags as jest.Mock).mockReturnValue({ enableAuthzCourseAuthoring: false, isLoading: false });
         (useUserPermissions as jest.Mock).mockReturnValue({
           isLoading: false,
           data: { canManageCourseUpdates: false },
@@ -479,13 +489,42 @@ describe('<CourseUpdates />', () => {
       });
     });
 
+    describe('when permissions are still loading', () => {
+      beforeEach(() => {
+        const mocks = initializeMocks();
+        store = mocks.reduxStore;
+        axiosMock = mocks.axiosMock;
+
+        (apiHooks.useWaffleFlags as jest.Mock).mockReturnValue({ enableAuthzCourseAuthoring: true, isLoading: false });
+        (useUserPermissions as jest.Mock).mockReturnValue({
+          isLoading: true,
+          data: undefined,
+        });
+
+        axiosMock
+          .onGet(getCourseUpdatesApiUrl(courseId))
+          .reply(200, courseUpdatesMock);
+        axiosMock
+          .onGet(getCourseHandoutApiUrl(courseId))
+          .reply(200, courseHandoutsMock);
+      });
+
+      it('should render loading spinner while permissions are loading', () => {
+        render(<RootWrapper />);
+
+        expect(screen.getByRole('status')).toBeInTheDocument();
+        expect(screen.queryByText(messages.headingTitle.defaultMessage)).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: messages.newUpdateButton.defaultMessage })).not.toBeInTheDocument();
+      });
+    });
+
     describe('when user does NOT have permission to view course updates', () => {
       beforeEach(() => {
         const mocks = initializeMocks();
         store = mocks.reduxStore;
         axiosMock = mocks.axiosMock;
 
-        (apiHooks.useWaffleFlags as jest.Mock).mockReturnValue({ enableAuthzCourseAuthoring: true });
+        (apiHooks.useWaffleFlags as jest.Mock).mockReturnValue({ enableAuthzCourseAuthoring: true, isLoading: false });
         (useUserPermissions as jest.Mock).mockReturnValue({
           isLoading: false,
           data: { canManageCourseUpdates: false, canViewCourseUpdates: false },

--- a/src/course-updates/CourseUpdates.tsx
+++ b/src/course-updates/CourseUpdates.tsx
@@ -14,6 +14,7 @@ import InternetConnectionAlert from '@src/generic/internet-connection-alert';
 import ConnectionErrorAlert from '@src/generic/ConnectionErrorAlert';
 import { RequestStatus } from '@src/data/constants';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
+import PermissionDeniedAlert from '@src/generic/PermissionDeniedAlert';
 import CourseHandouts from './course-handouts/CourseHandouts';
 import CourseUpdate from './course-update/CourseUpdate';
 import DeleteModal from './delete-modal/DeleteModal';
@@ -29,6 +30,8 @@ import {
 import { matchesAnyStatus } from './utils';
 import getPageHeadTitle from '../generic/utils';
 import AlertMessage from '../generic/alert-message';
+import { getCourseUpdatesPermissions } from '@src/authz/permissionHelpers';
+import { useUserPermissionsWithAuthzCourse } from '@src/authz/hooks';
 
 const CourseUpdates = () => {
   const intl = useIntl();
@@ -51,6 +54,13 @@ const CourseUpdates = () => {
     handleDeleteUpdateSubmit,
   } = useCourseUpdates({ courseId });
 
+  const {
+    isLoading: isLoadingPermissions,
+    permissions,
+  } = useUserPermissionsWithAuthzCourse(courseId, getCourseUpdatesPermissions(courseId));
+
+  const { canViewCourseUpdates, canManageCourseUpdates } = permissions;
+
   const loadingStatuses = useSelector(getLoadingStatuses);
   const savingStatuses = useSelector(getSavingStatuses);
   const errors = useSelector(getErrors);
@@ -60,12 +70,18 @@ const CourseUpdates = () => {
   const anyStatusInProgress = matchesAnyStatus({ ...loadingStatuses, ...savingStatuses }, RequestStatus.IN_PROGRESS);
   const anyStatusPending = matchesAnyStatus({ ...loadingStatuses, ...savingStatuses }, RequestStatus.PENDING);
 
+  if (!isLoadingPermissions && !canManageCourseUpdates && !canViewCourseUpdates) {
+    return <PermissionDeniedAlert />;
+  }
   if (anyStatusDenied) {
     return (
       <Container size="xl" className="course-unit px-4 mt-4">
         <ConnectionErrorAlert />
       </Container>
     );
+  }
+  if (isLoadingPermissions) {
+    return null;
   }
 
   return (
@@ -139,17 +155,19 @@ const CourseUpdates = () => {
                     title={intl.formatMessage(messages.headingTitle)}
                     subtitle={intl.formatMessage(messages.headingSubtitle)}
                     instruction={intl.formatMessage(messages.sectionInfo)}
-                    headerActions={
-                      <Button
-                        variant="primary"
-                        iconBefore={AddIcon}
-                        size="sm"
-                        onClick={() => handleOpenUpdateForm(REQUEST_TYPES.add_new_update)}
-                        disabled={isUpdateFormOpen || errors.loadingUpdates}
-                      >
-                        {intl.formatMessage(messages.newUpdateButton)}
-                      </Button>
-                    }
+                    headerActions={canManageCourseUpdates ?
+                      (
+                        <Button
+                          variant="primary"
+                          iconBefore={AddIcon}
+                          size="sm"
+                          onClick={() => handleOpenUpdateForm(REQUEST_TYPES.add_new_update)}
+                          disabled={isUpdateFormOpen || errors.loadingUpdates}
+                        >
+                          {intl.formatMessage(messages.newUpdateButton)}
+                        </Button>
+                      ) :
+                      null}
                   />
                   <section className="updates-section">
                     {isMainFormOpen && (
@@ -184,6 +202,8 @@ const CourseUpdates = () => {
                                   onEdit={() => handleOpenUpdateForm(REQUEST_TYPES.edit_update, courseUpdate)}
                                   onDelete={() => handleOpenDeleteForm(courseUpdate)}
                                   isDisabledButtons={isUpdateFormOpen}
+                                  canEdit={canManageCourseUpdates}
+                                  canDelete={canManageCourseUpdates}
                                 />
                               )
                           ))}
@@ -212,6 +232,7 @@ const CourseUpdates = () => {
                           contentForHandouts={courseHandouts?.data || ''}
                           onEdit={() => handleOpenUpdateForm(REQUEST_TYPES.edit_handouts)}
                           isDisabledButtons={isUpdateFormOpen || errors.loadingHandouts}
+                          canEdit={canManageCourseUpdates}
                         />
                       </div>
                       <DeleteModal

--- a/src/course-updates/CourseUpdates.tsx
+++ b/src/course-updates/CourseUpdates.tsx
@@ -31,7 +31,8 @@ import { matchesAnyStatus } from './utils';
 import getPageHeadTitle from '../generic/utils';
 import AlertMessage from '../generic/alert-message';
 import { getCourseUpdatesPermissions } from '@src/authz/permissionHelpers';
-import { useUserPermissionsWithAuthzCourse } from '@src/authz/hooks';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import Loading from '@src/generic/Loading';
 
 const CourseUpdates = () => {
   const intl = useIntl();
@@ -56,10 +57,9 @@ const CourseUpdates = () => {
 
   const {
     isLoading: isLoadingPermissions,
-    permissions,
-  } = useUserPermissionsWithAuthzCourse(courseId, getCourseUpdatesPermissions(courseId));
-
-  const { canViewCourseUpdates, canManageCourseUpdates } = permissions;
+    canViewCourseUpdates,
+    canManageCourseUpdates,
+  } = useCourseUserPermissions(courseId, getCourseUpdatesPermissions(courseId));
 
   const loadingStatuses = useSelector(getLoadingStatuses);
   const savingStatuses = useSelector(getSavingStatuses);
@@ -81,7 +81,7 @@ const CourseUpdates = () => {
     );
   }
   if (isLoadingPermissions) {
-    return null;
+    return <Loading />;
   }
 
   return (

--- a/src/course-updates/course-handouts/CourseHandouts.jsx
+++ b/src/course-updates/course-handouts/CourseHandouts.jsx
@@ -10,7 +10,7 @@ const CourseHandouts = ({
   contentForHandouts,
   onEdit,
   isDisabledButtons,
-  canEdit,
+  canEdit = true,
 }) => {
   const intl = useIntl();
 
@@ -44,10 +44,6 @@ CourseHandouts.propTypes = {
   onEdit: PropTypes.func.isRequired,
   isDisabledButtons: PropTypes.bool.isRequired,
   canEdit: PropTypes.bool,
-};
-
-CourseHandouts.defaultProps = {
-  canEdit: true,
 };
 
 export default CourseHandouts;

--- a/src/course-updates/course-handouts/CourseHandouts.jsx
+++ b/src/course-updates/course-handouts/CourseHandouts.jsx
@@ -6,21 +6,29 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 
 import messages from './messages';
 
-const CourseHandouts = ({ contentForHandouts, onEdit, isDisabledButtons }) => {
+const CourseHandouts = ({
+  contentForHandouts,
+  onEdit,
+  isDisabledButtons,
+  canEdit,
+}) => {
   const intl = useIntl();
 
   return (
     <div className="course-handouts" data-testid="course-handouts">
       <div className="course-handouts-header">
         <h2 className="course-handouts-header__title lead">{intl.formatMessage(messages.handoutsTitle)}</h2>
-        <IconButtonWithTooltip
-          tooltipContent={intl.formatMessage(messages.editButton)}
-          src={EditOutline}
-          iconAs={Icon}
-          disabled={isDisabledButtons}
-          data-testid="course-handouts-edit-button"
-          onClick={onEdit}
-        />
+        {canEdit && (
+          <IconButtonWithTooltip
+            aria-label={intl.formatMessage(messages.editButton)}
+            tooltipContent={intl.formatMessage(messages.editButton)}
+            src={EditOutline}
+            iconAs={Icon}
+            disabled={isDisabledButtons}
+            data-testid="course-handouts-edit-button"
+            onClick={onEdit}
+          />
+        )}
       </div>
       <div
         className="small"
@@ -35,6 +43,11 @@ CourseHandouts.propTypes = {
   contentForHandouts: PropTypes.string.isRequired,
   onEdit: PropTypes.func.isRequired,
   isDisabledButtons: PropTypes.bool.isRequired,
+  canEdit: PropTypes.bool,
+};
+
+CourseHandouts.defaultProps = {
+  canEdit: true,
 };
 
 export default CourseHandouts;

--- a/src/course-updates/course-handouts/CourseHandouts.test.jsx
+++ b/src/course-updates/course-handouts/CourseHandouts.test.jsx
@@ -43,4 +43,19 @@ describe('<CourseHandouts />', () => {
     const editButton = getByTestId('course-handouts-edit-button');
     expect(editButton).toBeDisabled();
   });
+
+  it('"Edit" button is not rendered when canEdit is false', () => {
+    const { queryByRole } = renderComponent({ canEdit: false });
+
+    const editButton = queryByRole('button', { name: /edit/i });
+    expect(editButton).toBeNull();
+  });
+
+  it('"Edit" button is rendered when canEdit is true', () => {
+    const { getByRole } = renderComponent({ canEdit: true });
+
+    const editButton = getByRole('button', { name: /edit/i });
+    expect(editButton).not.toBeNull();
+    expect(editButton).toBeInTheDocument();
+  });
 });

--- a/src/course-updates/course-update/CourseUpdate.jsx
+++ b/src/course-updates/course-update/CourseUpdate.jsx
@@ -13,6 +13,8 @@ const CourseUpdate = ({
   onEdit,
   onDelete,
   isDisabledButtons,
+  canEdit,
+  canDelete,
 }) => {
   const intl = useIntl();
 
@@ -27,22 +29,28 @@ const CourseUpdate = ({
           </div>
         )}
         <div className="course-update-header__action">
-          <IconButtonWithTooltip
-            tooltipContent={intl.formatMessage(messages.editButton)}
-            src={EditOutline}
-            iconAs={Icon}
-            disabled={isDisabledButtons}
-            data-testid="course-update-edit-button"
-            onClick={onEdit}
-          />
-          <IconButtonWithTooltip
-            tooltipContent={intl.formatMessage(messages.deleteButton)}
-            src={DeleteOutline}
-            iconAs={Icon}
-            disabled={isDisabledButtons}
-            data-testid="course-update-delete-button"
-            onClick={onDelete}
-          />
+          {canEdit && (
+            <IconButtonWithTooltip
+              aria-label={intl.formatMessage(messages.editButton)}
+              tooltipContent={intl.formatMessage(messages.editButton)}
+              src={EditOutline}
+              iconAs={Icon}
+              disabled={isDisabledButtons}
+              data-testid="course-update-edit-button"
+              onClick={onEdit}
+            />
+          )}
+          {canDelete && (
+            <IconButtonWithTooltip
+              aria-label={intl.formatMessage(messages.deleteButton)}
+              tooltipContent={intl.formatMessage(messages.deleteButton)}
+              src={DeleteOutline}
+              iconAs={Icon}
+              disabled={isDisabledButtons}
+              data-testid="course-update-delete-button"
+              onClick={onDelete}
+            />
+          )}
         </div>
       </div>
       {Boolean(contentForUpdate) && (
@@ -63,6 +71,13 @@ CourseUpdate.propTypes = {
   onEdit: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
   isDisabledButtons: PropTypes.bool.isRequired,
+  canEdit: PropTypes.bool,
+  canDelete: PropTypes.bool,
+};
+
+CourseUpdate.defaultProps = {
+  canEdit: true,
+  canDelete: true,
 };
 
 export default CourseUpdate;

--- a/src/course-updates/course-update/CourseUpdate.jsx
+++ b/src/course-updates/course-update/CourseUpdate.jsx
@@ -13,8 +13,8 @@ const CourseUpdate = ({
   onEdit,
   onDelete,
   isDisabledButtons,
-  canEdit,
-  canDelete,
+  canEdit = true,
+  canDelete = true,
 }) => {
   const intl = useIntl();
 
@@ -73,11 +73,6 @@ CourseUpdate.propTypes = {
   isDisabledButtons: PropTypes.bool.isRequired,
   canEdit: PropTypes.bool,
   canDelete: PropTypes.bool,
-};
-
-CourseUpdate.defaultProps = {
-  canEdit: true,
-  canDelete: true,
 };
 
 export default CourseUpdate;

--- a/src/course-updates/course-update/CourseUpdate.test.jsx
+++ b/src/course-updates/course-update/CourseUpdate.test.jsx
@@ -70,4 +70,22 @@ describe('<CourseUpdate />', () => {
     expect(getByTestId('course-update-edit-button')).toBeDisabled();
     expect(getByTestId('course-update-delete-button')).toBeDisabled();
   });
+
+  it('"Edit" and "Delete" buttons are not rendered when canEdit and canDelete are false', () => {
+    const { queryByRole } = renderComponent({ canEdit: false, canDelete: false });
+
+    expect(queryByRole('button', { name: /edit/i })).toBeNull();
+    expect(queryByRole('button', { name: /delete/i })).toBeNull();
+  });
+
+  it('"Edit" and "Delete" buttons are rendered when canEdit and canDelete are true', () => {
+    const { getByRole } = renderComponent({ canEdit: true, canDelete: true });
+
+    const editButton = getByRole('button', { name: /edit/i });
+    const deleteButton = getByRole('button', { name: /delete/i });
+    expect(editButton).not.toBeNull();
+    expect(deleteButton).not.toBeNull();
+    expect(editButton).toBeInTheDocument();
+    expect(deleteButton).toBeInTheDocument();
+  });
 });

--- a/src/header/hooks.test.tsx
+++ b/src/header/hooks.test.tsx
@@ -57,6 +57,11 @@ const createWrapper = () => {
 describe('header utils', () => {
   describe('getContentMenuItems', () => {
     it('when video upload page enabled should include Video Uploads option', () => {
+      mockWaffleFlags({ enableAuthzCourseAuthoring: false });
+      jest.mocked(useUserPermissions).mockReturnValue({
+        isLoading: false,
+        data: { canViewCourseUpdates: false },
+      } as any);
       jest.mocked(useSelector).mockReturnValue({
         librariesV2Enabled: false,
       });
@@ -69,6 +74,15 @@ describe('header utils', () => {
       expect(actualItems).toHaveLength(5);
     });
     it('when video upload page disabled should not include Video Uploads option', () => {
+      mockWaffleFlags({
+        enableAuthzCourseAuthoring: false,
+        useNewVideoUploadsPage: false,
+        useNewCertificatesPage: false,
+      });
+      jest.mocked(useUserPermissions).mockReturnValue({
+        isLoading: false,
+        data: { canViewCourseUpdates: false },
+      } as any);
       jest.mocked(useSelector).mockReturnValue({
         librariesV2Enabled: false,
       });
@@ -81,6 +95,11 @@ describe('header utils', () => {
       expect(actualItems).toHaveLength(4);
     });
     it('adds course libraries link to content menu when libraries v2 is enabled', () => {
+      mockWaffleFlags({ enableAuthzCourseAuthoring: false });
+      jest.mocked(useUserPermissions).mockReturnValue({
+        isLoading: false,
+        data: { canViewCourseUpdates: false },
+      } as any);
       jest.mocked(useSelector).mockReturnValue({
         librariesV2Enabled: true,
       });
@@ -88,9 +107,44 @@ describe('header utils', () => {
         renderHook(() => useContentMenuItems('course-123'), { wrapper: createWrapper() }).result.current;
       expect(actualItems[1]).toEqual({ href: '/course/course-123/libraries', title: 'Library Updates' });
     });
+    it('when authz enabled and user has no permission to view course updates should not include course updates option', () => {
+      mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+      jest.mocked(useUserPermissions).mockReturnValue({
+        isLoading: false,
+        data: { canViewCourseUpdates: false },
+      } as any);
+      jest.mocked(useSelector).mockReturnValue({
+        librariesV2Enabled: false,
+      });
+      const actualItems =
+        renderHook(() => useContentMenuItems('course-123'), { wrapper: createWrapper() }).result.current;
+      const actualItemsTitle = actualItems.map((item) => item.title);
+      expect(actualItemsTitle).not.toContain(messages['header.links.updates'].defaultMessage);
+    });
+    it('when authz enabled and user has permission to view course updates should include course updates option', () => {
+      mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+      jest.mocked(useUserPermissions).mockReturnValue({
+        isLoading: false,
+        data: { canViewCourseUpdates: true },
+      } as any);
+      jest.mocked(useSelector).mockReturnValue({
+        librariesV2Enabled: false,
+      });
+      const actualItems =
+        renderHook(() => useContentMenuItems('course-123'), { wrapper: createWrapper() }).result.current;
+      const actualItemsTitle = actualItems.map((item) => item.title);
+      expect(actualItemsTitle).toContain(messages['header.links.updates'].defaultMessage);
+    });
   });
 
   describe('getSettingsMenuitems', () => {
+    beforeAll(() => {
+      mockWaffleFlags({
+        enableAuthzCourseAuthoring: false,
+        useNewVideoUploadsPage: false,
+        useNewCertificatesPage: false,
+      });
+    });
     beforeEach(() => {
       jest.mocked(useSelector).mockReturnValue({
         canAccessAdvancedSettings: true,

--- a/src/header/hooks.test.tsx
+++ b/src/header/hooks.test.tsx
@@ -135,6 +135,20 @@ describe('header utils', () => {
       const actualItemsTitle = actualItems.map((item) => item.title);
       expect(actualItemsTitle).toContain(messages['header.links.updates'].defaultMessage);
     });
+    it('when useNewUpdatesPage is false should use legacy studio URL for updates', () => {
+      mockWaffleFlags({ enableAuthzCourseAuthoring: false, useNewUpdatesPage: false });
+      jest.mocked(useUserPermissions).mockReturnValue({
+        isLoading: false,
+        data: { canViewCourseUpdates: true },
+      } as any);
+      jest.mocked(useSelector).mockReturnValue({
+        librariesV2Enabled: false,
+      });
+      const actualItems =
+        renderHook(() => useContentMenuItems('course-123'), { wrapper: createWrapper() }).result.current;
+      const updatesItem = actualItems.find((item) => item.title === messages['header.links.updates'].defaultMessage);
+      expect(updatesItem?.href).toContain('/course_info/course-123');
+    });
   });
 
   describe('getSettingsMenuitems', () => {

--- a/src/header/hooks.tsx
+++ b/src/header/hooks.tsx
@@ -14,7 +14,7 @@ import { useUserPermissions } from '@src/authz/data/apiHooks';
 import { COURSE_PERMISSIONS } from '@src/authz/constants';
 import messages from './messages';
 import { getCourseUpdatesPermissions } from '@src/authz/permissionHelpers';
-import { useUserPermissionsWithAuthzCourse } from '@src/authz/hooks';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 
 export const useContentMenuItems = (courseId: string) => {
   const intl = useIntl();
@@ -23,8 +23,8 @@ export const useContentMenuItems = (courseId: string) => {
   const { librariesV2Enabled } = useSelector(getStudioHomeData);
 
   const {
-    permissions: { canViewCourseUpdates },
-  } = useUserPermissionsWithAuthzCourse(courseId, getCourseUpdatesPermissions(courseId));
+    canViewCourseUpdates,
+  } = useCourseUserPermissions(courseId, getCourseUpdatesPermissions(courseId));
 
   const items = [
     {

--- a/src/header/hooks.tsx
+++ b/src/header/hooks.tsx
@@ -13,24 +13,32 @@ import { LibQueryParamKeys } from '@src/library-authoring/routes';
 import { useUserPermissions } from '@src/authz/data/apiHooks';
 import { COURSE_PERMISSIONS } from '@src/authz/constants';
 import messages from './messages';
+import { getCourseUpdatesPermissions } from '@src/authz/permissionHelpers';
+import { useUserPermissionsWithAuthzCourse } from '@src/authz/hooks';
 
 export const useContentMenuItems = (courseId: string) => {
   const intl = useIntl();
   const studioBaseUrl = getConfig().STUDIO_BASE_URL;
-  const waffleFlags = useWaffleFlags();
+  const waffleFlags = useWaffleFlags(courseId);
   const { librariesV2Enabled } = useSelector(getStudioHomeData);
+
+  const {
+    permissions: { canViewCourseUpdates },
+  } = useUserPermissionsWithAuthzCourse(courseId, getCourseUpdatesPermissions(courseId));
 
   const items = [
     {
       href: waffleFlags.useNewCourseOutlinePage ? `/course/${courseId}` : `${studioBaseUrl}/course/${courseId}`,
       title: intl.formatMessage(messages['header.links.outline']),
     },
-    {
-      href: waffleFlags.useNewUpdatesPage
-        ? `/course/${courseId}/course_info`
-        : `${studioBaseUrl}/course_info/${courseId}`,
-      title: intl.formatMessage(messages['header.links.updates']),
-    },
+    ...(canViewCourseUpdates ?
+      [{
+        href: waffleFlags.useNewUpdatesPage
+          ? `/course/${courseId}/course_info`
+          : `${studioBaseUrl}/course_info/${courseId}`,
+        title: intl.formatMessage(messages['header.links.updates']),
+      }] :
+      []),
     {
       href: getPagePath(courseId, 'true', 'tabs'),
       title: intl.formatMessage(messages['header.links.pages']),


### PR DESCRIPTION
## Description
This pr add the permission validations for the Course Updates section on the Content menu from the header.
First this validates the `enableAuthzCourseAuthoring` waffle flag and if it is enabled it checks the permissions from authz over the course updates section.
These are the checks included:
- Checks for the `courses.view_course_updates` permission to display or hide the Course Updates option on the header menu.
- Checks for `courses.manage_course_updates` to display or hide the "+ New update" button and the edit and remove icon buttons for the available course updates and course handouts.

Resolves https://github.com/openedx/frontend-app-authoring/issues/2932

## Supporting information
Depends on backend ticket https://github.com/openedx/openedx-authz/issues/191

## Testing instructions
### Prerequisites
- Access to a course in Studio
- Ability to toggle the `enableAuthzCourseAuthoring` waffle flag
- Access to the authz service to configure user permissions

### Test Scenarios

#### 1. Authz Disabled (Legacy Behavior)
**Setup:** Ensure `enableAuthzCourseAuthoring` waffle flag is **disabled**

| Step | Expected Result |
|------|-----------------|
| Navigate to Course Updates page | Page loads normally |
| Verify "New update" button | Button is visible and enabled |
| Verify edit/delete buttons on existing updates | All edit and delete buttons are visible |
| Verify handouts edit button | Edit button is visible |

#### 2. Authz Enabled — User Has Full Permissions
**Setup:** 
- Enable `enableAuthzCourseAuthoring` waffle flag
- Grant user both `courses.view_course_updates` and `courses.manage_course_updates` permissions

| Step | Expected Result |
|------|-----------------|
| Navigate to Course Updates page | Page loads normally |
| Verify "New update" button | Button is visible and enabled |
| Verify edit/delete buttons on existing updates | All edit and delete buttons are visible |
| Create a new update | Update is created successfully |
| Edit an existing update | Update is saved successfully |
| Delete an update | Update is deleted successfully |
| Edit handouts | Handouts are saved successfully |

#### 3. Authz Enabled — User Has View-Only Permissions
**Setup:**
- Enable `enableAuthzCourseAuthoring` waffle flag
- Grant user only `courses.view_course_updates` permission (no `manage` permission)

| Step | Expected Result |
|------|-----------------|
| Navigate to Course Updates page | Page loads normally, content is visible |
| Verify "New update" button | Button is **NOT** visible |
| Verify edit buttons on existing updates | Edit buttons are **NOT** visible |
| Verify delete buttons on existing updates | Delete buttons are **NOT** visible |
| Verify handouts edit button | Edit button is **NOT** visible |
| Verify updates content | All existing updates and handouts content is readable |

#### 4. Authz Enabled — User Has No Permissions
**Setup:**
- Enable `enableAuthzCourseAuthoring` waffle flag
- Remove both `courses.view_course_updates` and `courses.manage_course_updates` permissions

| Step | Expected Result |
|------|-----------------|
| Navigate to Course Updates page | "Permission Denied" alert is displayed |
| Verify page content | Course updates content is **NOT** visible |
| Verify "New update" button | Button is **NOT** visible |

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
