### PR TITLE
feat: History log in content library components and containers [FC-0123]

### DIFF
--- a/src/library-authoring/common/context/SidebarContext.tsx
+++ b/src/library-authoring/common/context/SidebarContext.tsx
@@ -45,6 +45,7 @@ export const CONTAINER_INFO_TABS = {
   Manage: 'manage',
   Usage: 'usage',
   Settings: 'settings',
+  Details: 'details',
 } as const;
 export type ContainerInfoTab = typeof CONTAINER_INFO_TABS[keyof typeof CONTAINER_INFO_TABS];
 export const isContainerInfoTab = (tab: string): tab is ContainerInfoTab => (

--- a/src/library-authoring/component-info/ComponentDetails.test.tsx
+++ b/src/library-authoring/component-info/ComponentDetails.test.tsx
@@ -4,12 +4,14 @@ import {
   render as baseRender,
   screen,
   fireEvent,
+  findByDeepTextContent,
 } from '@src/testUtils';
 import { mockFetchIndexDocuments, mockContentSearchConfig } from '@src/search-manager/data/api.mock';
 
 import {
   mockContentLibrary,
   mockGetEntityLinks,
+  mockLibraryBlockCreationEntry,
   mockLibraryBlockDraftHistory,
   mockLibraryBlockMetadata,
   mockLibraryBlockPublishHistory,
@@ -24,6 +26,7 @@ import ComponentDetails from './ComponentDetails';
 mockContentSearchConfig.applyMock();
 mockContentLibrary.applyMock();
 mockLibraryBlockMetadata.applyMock();
+mockLibraryBlockCreationEntry.applyMock();
 mockLibraryBlockDraftHistory.applyMock();
 mockLibraryBlockPublishHistory.applyMock();
 mockLibraryBlockPublishHistoryEntries.applyMock();
@@ -66,7 +69,9 @@ describe('<ComponentDetails />', () => {
 
   it('should render the component details error', async () => {
     render(mockLibraryBlockMetadata.usageKeyError404);
-    expect(await screen.findByText(/Mocked request failed with status code 404/)).toBeInTheDocument();
+    // Metadata and history queries fail silently; the section renders empty without crashing
+    expect(await screen.findByText('Component History')).toBeInTheDocument();
+    expect(screen.queryByText(/Mocked request failed/)).not.toBeInTheDocument();
   });
 
   it('should render the component usage', async () => {
@@ -102,7 +107,7 @@ describe('<ComponentDetails />', () => {
 
   it('should render the component history', async () => {
     render(mockLibraryBlockMetadata.usageKeyPublished);
-    // Show created group (no draft or publish history for this usage key)
-    expect(await screen.findByText(/Author created this component/i)).toBeInTheDocument();
+    // usageKeyPublished matches usageKeyEmpty in mockLibraryBlockCreationEntry (TEST2 key)
+    expect(await findByDeepTextContent(/Author created.*Introduction to Testing 2/i)).toBeInTheDocument();
   });
 });

--- a/src/library-authoring/component-info/ComponentDetails.test.tsx
+++ b/src/library-authoring/component-info/ComponentDetails.test.tsx
@@ -10,7 +10,10 @@ import { mockFetchIndexDocuments, mockContentSearchConfig } from '@src/search-ma
 import {
   mockContentLibrary,
   mockGetEntityLinks,
+  mockLibraryBlockDraftHistory,
   mockLibraryBlockMetadata,
+  mockLibraryBlockPublishHistory,
+  mockLibraryBlockPublishHistoryEntries,
   mockXBlockAssets,
   mockXBlockOLX,
 } from '../data/api.mocks';
@@ -21,6 +24,9 @@ import ComponentDetails from './ComponentDetails';
 mockContentSearchConfig.applyMock();
 mockContentLibrary.applyMock();
 mockLibraryBlockMetadata.applyMock();
+mockLibraryBlockDraftHistory.applyMock();
+mockLibraryBlockPublishHistory.applyMock();
+mockLibraryBlockPublishHistoryEntries.applyMock();
 mockXBlockAssets.applyMock();
 mockXBlockOLX.applyMock();
 mockGetEntityLinks.applyMock();
@@ -96,11 +102,7 @@ describe('<ComponentDetails />', () => {
 
   it('should render the component history', async () => {
     render(mockLibraryBlockMetadata.usageKeyPublished);
-    // Show created date
-    expect(await screen.findByText('June 20, 2024')).toBeInTheDocument();
-    // Show modified date
-    expect(await screen.findByText('June 21, 2024')).toBeInTheDocument();
-    // Show last published date
-    expect(await screen.findByText('June 22, 2024')).toBeInTheDocument();
+    // Show created group (no draft or publish history for this usage key)
+    expect(await screen.findByText(/Author created this component/i)).toBeInTheDocument();
   });
 });

--- a/src/library-authoring/component-info/ComponentDetails.tsx
+++ b/src/library-authoring/component-info/ComponentDetails.tsx
@@ -1,10 +1,7 @@
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { Stack } from '@openedx/paragon';
 
-import AlertError from '@src/generic/alert-error';
-import Loading from '@src/generic/Loading';
 import { useSidebarContext } from '../common/context/SidebarContext';
-import { useLibraryBlockMetadata } from '../data/apiHooks';
 import { ComponentAdvancedInfo } from './ComponentAdvancedInfo';
 import { ComponentUsage } from './ComponentUsage';
 import messages from './messages';
@@ -18,21 +15,6 @@ const ComponentDetails = () => {
   // istanbul ignore if: this should never happen
   if (!usageKey) {
     throw new Error('usageKey is required');
-  }
-
-  const {
-    data: componentMetadata,
-    isError,
-    error,
-    isPending,
-  } = useLibraryBlockMetadata(usageKey);
-
-  if (isError) {
-    return <AlertError error={error} />;
-  }
-
-  if (isPending) {
-    return <Loading />;
   }
 
   return (
@@ -50,7 +32,6 @@ const ComponentDetails = () => {
         </h3>
         <HistoryComponentLog
           componentId={usageKey}
-          displayName={componentMetadata.displayName}
         />
       </>
       <ComponentAdvancedInfo />

--- a/src/library-authoring/component-info/ComponentDetails.tsx
+++ b/src/library-authoring/component-info/ComponentDetails.tsx
@@ -1,14 +1,14 @@
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { Stack } from '@openedx/paragon';
 
-import AlertError from '../../generic/alert-error';
-import Loading from '../../generic/Loading';
+import AlertError from '@src/generic/alert-error';
+import Loading from '@src/generic/Loading';
 import { useSidebarContext } from '../common/context/SidebarContext';
 import { useLibraryBlockMetadata } from '../data/apiHooks';
-import HistoryWidget from '../generic/history-widget';
 import { ComponentAdvancedInfo } from './ComponentAdvancedInfo';
 import { ComponentUsage } from './ComponentUsage';
 import messages from './messages';
+import { HistoryComponentLog } from '../generic/history-log/HistoryLog';
 
 const ComponentDetails = () => {
   const { sidebarItemInfo } = useSidebarContext();
@@ -48,7 +48,10 @@ const ComponentDetails = () => {
         <h3 className="h5">
           <FormattedMessage {...messages.detailsTabHistoryTitle} />
         </h3>
-        <HistoryWidget {...componentMetadata} />
+        <HistoryComponentLog
+          componentId={usageKey}
+          displayName={componentMetadata.displayName}
+        />
       </>
       <ComponentAdvancedInfo />
     </Stack>

--- a/src/library-authoring/containers/ContainerDetails.tsx
+++ b/src/library-authoring/containers/ContainerDetails.tsx
@@ -1,18 +1,18 @@
-import { useIntl } from '@edx/frontend-platform/i18n';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import messages from './messages';
 import { HistoryContainerLog } from '../generic/history-log/HistoryLog';
 import { useSidebarContext } from '../common/context/SidebarContext';
 
 export const ContainerDetails = () => {
-  const intl = useIntl();
-
   const { sidebarItemInfo } = useSidebarContext();
 
   const usageKey = sidebarItemInfo?.id;
 
   return (
     <>
-      <h4>{intl.formatMessage(messages.detailsTabHistoryHeading)}</h4>
+      <h4>
+        <FormattedMessage {...messages.detailsTabHistoryHeading} />
+      </h4>
       {usageKey && (
         <HistoryContainerLog
           containerId={usageKey}

--- a/src/library-authoring/containers/ContainerDetails.tsx
+++ b/src/library-authoring/containers/ContainerDetails.tsx
@@ -1,0 +1,23 @@
+import { useIntl } from '@edx/frontend-platform/i18n';
+import messages from './messages';
+import { HistoryContainerLog } from '../generic/history-log/HistoryLog';
+import { useSidebarContext } from '../common/context/SidebarContext';
+
+export const ContainerDetails = () => {
+  const intl = useIntl();
+
+  const { sidebarItemInfo } = useSidebarContext();
+
+  const usageKey = sidebarItemInfo?.id;
+
+  return (
+    <>
+      <h4>{intl.formatMessage(messages.detailsTabHistoryHeading)}</h4>
+      {usageKey && (
+        <HistoryContainerLog
+          containerId={usageKey}
+        />
+      )}
+    </>
+  );
+};

--- a/src/library-authoring/containers/ContainerInfo.tsx
+++ b/src/library-authoring/containers/ContainerInfo.tsx
@@ -34,6 +34,7 @@ import { useContainer } from '../data/apiHooks';
 import ContainerDeleter from './ContainerDeleter';
 import { ContainerPublisher } from './ContainerPublisher';
 import { PublishDraftButton, PublishedChip } from '../generic/publish-status-buttons';
+import { ContainerDetails } from './ContainerDetails';
 
 type ContainerPreviewProps = {
   containerId: string;
@@ -238,6 +239,11 @@ const ContainerInfo = () => {
           CONTAINER_INFO_TABS.Settings,
           intl.formatMessage(messages.settingsTabTitle),
           <ContainerSettings />,
+        )}
+        {renderTab(
+          CONTAINER_INFO_TABS.Details,
+          intl.formatMessage(messages.detailsTabTitle),
+          <ContainerDetails />,
         )}
       </Tabs>
     </Stack>

--- a/src/library-authoring/containers/messages.ts
+++ b/src/library-authoring/containers/messages.ts
@@ -41,6 +41,16 @@ const messages = defineMessages({
     defaultMessage: 'Settings',
     description: 'Title for settings tab',
   },
+  detailsTabTitle: {
+    id: 'course-authoring.library-authoring.container-sidebar.details-tab.title',
+    defaultMessage: 'Details',
+    description: 'Title for details tab',
+  },
+  detailsTabHistoryHeading: {
+    id: 'course-authoring.library-authoring.container-sidebar.details-tab.history-heading',
+    defaultMessage: 'History',
+    description: 'Heading for details tab history section',
+  },
   updateContainerSuccessMsg: {
     id: 'course-authoring.library-authoring.update-container-success-msg',
     defaultMessage: 'Container updated successfully.',

--- a/src/library-authoring/containers/messages.ts
+++ b/src/library-authoring/containers/messages.ts
@@ -41,6 +41,9 @@ const messages = defineMessages({
     defaultMessage: 'Settings',
     description: 'Title for settings tab',
   },
+  // TODO: These messages (detailsTabTitle, detailsTabHistoryHeading, etc.) should be shared
+  // across all sidebar types (components, containers, collections) since the tab names and
+  // headings are identical. Currently they are duplicated in each sidebar's messages file.
   detailsTabTitle: {
     id: 'course-authoring.library-authoring.container-sidebar.details-tab.title',
     defaultMessage: 'Details',

--- a/src/library-authoring/data/api.mocks.ts
+++ b/src/library-authoring/data/api.mocks.ts
@@ -1245,9 +1245,12 @@ mockGetCourseImports.applyMock = () =>
 export async function mockLibraryBlockDraftHistory(usageKey: string): Promise<api.LibraryHistoryEntry[]> {
   const thisMock = mockLibraryBlockDraftHistory;
   switch (usageKey) {
-    case thisMock.usageKey: return thisMock.data;
-    case thisMock.usageKeyEmpty: return [];
-    default: throw new Error(`No mock has been set up for usageKey "${usageKey}"`);
+    case thisMock.usageKey:
+      return thisMock.data;
+    case thisMock.usageKeyEmpty:
+      return [];
+    default:
+      throw new Error(`No mock has been set up for usageKey "${usageKey}"`);
   }
 }
 mockLibraryBlockDraftHistory.usageKey = 'lb:Axim:TEST1:html:571fe018-f3ce-45c9-8f53-5dafcb422fd1';
@@ -1268,17 +1271,18 @@ mockLibraryBlockDraftHistory.data = [
     changedAt: '2026-03-16T11:00:00Z',
     title: 'Electron Arcs',
     action: 'edited',
-    blockType: 'html',
+    itemType: 'html',
   },
   {
     changedBy: mockContributor('test_user_2'),
     changedAt: '2026-03-13T10:00:00Z',
     title: 'More on Quarks',
     action: 'renamed',
-    blockType: 'html',
+    itemType: 'html',
   },
 ] satisfies api.LibraryHistoryEntry[];
-mockLibraryBlockDraftHistory.applyMock = () => jest.spyOn(api, 'getLibraryBlockDraftHistory').mockImplementation(mockLibraryBlockDraftHistory);
+mockLibraryBlockDraftHistory.applyMock = () =>
+  jest.spyOn(api, 'getLibraryBlockDraftHistory').mockImplementation(mockLibraryBlockDraftHistory);
 
 /**
  * Mock for `getLibraryBlockPublishHistory()`
@@ -1288,9 +1292,12 @@ mockLibraryBlockDraftHistory.applyMock = () => jest.spyOn(api, 'getLibraryBlockD
 export async function mockLibraryBlockPublishHistory(usageKey: string): Promise<api.LibraryPublishHistoryGroup[]> {
   const thisMock = mockLibraryBlockPublishHistory;
   switch (usageKey) {
-    case thisMock.usageKeyWithGroups: return thisMock.data;
-    case thisMock.usageKeyEmpty: return [];
-    default: throw new Error(`No mock has been set up for usageKey "${usageKey}"`);
+    case thisMock.usageKeyWithGroups:
+      return thisMock.data;
+    case thisMock.usageKeyEmpty:
+      return [];
+    default:
+      throw new Error(`No mock has been set up for usageKey "${usageKey}"`);
   }
 }
 mockLibraryBlockPublishHistory.usageKeyWithGroups = 'lb:Axim:TEST1:html:571fe018-f3ce-45c9-8f53-5dafcb422fd1';
@@ -1298,24 +1305,26 @@ mockLibraryBlockPublishHistory.usageKeyEmpty = 'lb:Axim:TEST2:html:571fe018-f3ce
 mockLibraryBlockPublishHistory.data = [
   {
     publishLogUuid: 'abc-123',
-    title: 'Protons',
-    blockType: 'html',
+    directPublishedEntities: [
+      { entityKey: 'lb:Axim:TEST1:html:571fe018-f3ce-45c9-8f53-5dafcb422fd1', entityType: 'html', title: 'Protons' },
+    ],
     publishedBy: 'author',
     publishedAt: '2026-03-14T10:00:00Z',
     contributors: ['test_user_1', 'test_user_2', 'test_user_3', 'test_user_4', 'test_user_5'].map(mockContributor),
     contributorsCount: 5,
   },
 ] satisfies api.LibraryPublishHistoryGroup[];
-mockLibraryBlockPublishHistory.applyMock = () => jest.spyOn(api, 'getLibraryBlockPublishHistory').mockImplementation(mockLibraryBlockPublishHistory);
+mockLibraryBlockPublishHistory.applyMock = () =>
+  jest.spyOn(api, 'getLibraryBlockPublishHistory').mockImplementation(mockLibraryBlockPublishHistory);
 
 /**
- * Mock for `getLibraryBlockPublishHistoryEntries()`
+ * Mock for `getLibraryPublishHistoryEntries()`
  *
  * Use `mockLibraryBlockPublishHistoryEntries.applyMock()` to apply it to the whole test suite.
  */
 export async function mockLibraryBlockPublishHistoryEntries(
-  _usageKey: string,
-  _publishGroupId: string,
+  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+  ..._: Parameters<typeof api.getLibraryPublishHistoryEntries>
 ): Promise<api.LibraryHistoryEntry[]> {
   return mockLibraryBlockPublishHistoryEntries.data;
 }
@@ -1325,13 +1334,14 @@ mockLibraryBlockPublishHistoryEntries.data = [
     changedAt: '2026-03-10T09:00:00Z',
     title: 'Protons',
     action: 'edited',
-    blockType: 'html',
+    itemType: 'html',
   },
 ] satisfies api.LibraryHistoryEntry[];
-mockLibraryBlockPublishHistoryEntries.applyMock = () => jest.spyOn(
-  api,
-  'getLibraryBlockPublishHistoryEntries',
-).mockImplementation(mockLibraryBlockPublishHistoryEntries);
+mockLibraryBlockPublishHistoryEntries.applyMock = () =>
+  jest.spyOn(
+    api,
+    'getLibraryPublishHistoryEntries',
+  ).mockImplementation(mockLibraryBlockPublishHistoryEntries);
 
 /**
  * Mock for `getLibraryBlockCreationEntry()`
@@ -1343,9 +1353,12 @@ export async function mockLibraryBlockCreationEntry(usageKey: string): Promise<a
   switch (usageKey) {
     case thisMock.usageKeyThatNeverLoads:
       return new Promise<any>(() => {});
-    case thisMock.usageKey: return thisMock.data;
-    case thisMock.usageKeyEmpty: return thisMock.dataEmpty;
-    default: throw new Error(`No mock has been set up for usageKey "${usageKey}"`);
+    case thisMock.usageKey:
+      return thisMock.data;
+    case thisMock.usageKeyEmpty:
+      return thisMock.dataEmpty;
+    default:
+      throw new Error(`No mock has been set up for usageKey "${usageKey}"`);
   }
 }
 mockLibraryBlockCreationEntry.usageKeyThatNeverLoads = 'lb:Axim:infiniteLoading:html:123';
@@ -1355,17 +1368,138 @@ mockLibraryBlockCreationEntry.data = {
   changedBy: mockContributor('author'),
   changedAt: '2024-01-01T00:00:00Z',
   title: 'Introduction to Testing 1',
-  blockType: 'html',
+  itemType: 'html',
   action: 'created',
 } satisfies api.LibraryHistoryEntry;
 mockLibraryBlockCreationEntry.dataEmpty = {
   changedBy: mockContributor('Author'),
   changedAt: '2024-01-01T00:00:00Z',
   title: 'Introduction to Testing 2',
-  blockType: 'html',
+  itemType: 'html',
   action: 'created',
 } satisfies api.LibraryHistoryEntry;
-mockLibraryBlockCreationEntry.applyMock = () => jest.spyOn(api, 'getLibraryBlockCreationEntry').mockImplementation(mockLibraryBlockCreationEntry);
+mockLibraryBlockCreationEntry.applyMock = () =>
+  jest.spyOn(api, 'getLibraryBlockCreationEntry').mockImplementation(mockLibraryBlockCreationEntry);
+
+/**
+ * Mock for `getLibraryContainerDraftHistory()`
+ *
+ * Use `mockLibraryContainerDraftHistory.applyMock()` to apply it to the whole test suite.
+ */
+export async function mockLibraryContainerDraftHistory(containerKey: string): Promise<api.LibraryHistoryEntry[]> {
+  const thisMock = mockLibraryContainerDraftHistory;
+  switch (containerKey) {
+    case thisMock.containerKeyThatNeverLoads:
+      return new Promise<any>(() => {});
+    case thisMock.containerKey:
+      return thisMock.data;
+    case thisMock.containerKeyEmpty:
+      return [];
+    default:
+      throw new Error(`No mock has been set up for containerKey "${containerKey}"`);
+  }
+}
+mockLibraryContainerDraftHistory.containerKeyThatNeverLoads = 'lct:Axim:TEST1:unit:infiniteLoading';
+mockLibraryContainerDraftHistory.containerKey = 'lct:Axim:TEST1:unit:571fe018-f3ce-45c9-8f53-5dafcb422fd1';
+mockLibraryContainerDraftHistory.containerKeyEmpty = 'lct:Axim:TEST2:unit:571fe018-f3ce-45c9-8f53-5dafcb422fd2';
+mockLibraryContainerDraftHistory.data = [
+  {
+    changedBy: mockContributor('container_user_1'),
+    changedAt: '2026-03-16T11:00:00Z',
+    title: 'Intro Unit',
+    action: 'edited',
+    itemType: 'unit',
+  },
+  {
+    changedBy: mockContributor('container_user_2'),
+    changedAt: '2026-03-13T10:00:00Z',
+    title: 'Unit Renamed',
+    action: 'renamed',
+    itemType: 'unit',
+  },
+] satisfies api.LibraryHistoryEntry[];
+mockLibraryContainerDraftHistory.applyMock = () =>
+  jest.spyOn(api, 'getLibraryContainerDraftHistory').mockImplementation(mockLibraryContainerDraftHistory);
+
+/**
+ * Mock for `getLibraryContainerPublishHistory()`
+ *
+ * Use `mockLibraryContainerPublishHistory.applyMock()` to apply it to the whole test suite.
+ */
+export async function mockLibraryContainerPublishHistory(
+  containerKey: string,
+): Promise<api.LibraryPublishHistoryGroup[]> {
+  const thisMock = mockLibraryContainerPublishHistory;
+  switch (containerKey) {
+    case thisMock.containerKeyThatNeverLoads:
+      return new Promise<any>(() => {});
+    case thisMock.containerKeyWithGroups:
+      return thisMock.data;
+    case thisMock.containerKeyEmpty:
+      return [];
+    default:
+      throw new Error(`No mock has been set up for containerKey "${containerKey}"`);
+  }
+}
+mockLibraryContainerPublishHistory.containerKeyThatNeverLoads = 'lct:Axim:TEST1:unit:infiniteLoading';
+mockLibraryContainerPublishHistory.containerKeyWithGroups = 'lct:Axim:TEST1:unit:571fe018-f3ce-45c9-8f53-5dafcb422fd1';
+mockLibraryContainerPublishHistory.containerKeyEmpty = 'lct:Axim:TEST2:unit:571fe018-f3ce-45c9-8f53-5dafcb422fd2';
+mockLibraryContainerPublishHistory.data = [
+  {
+    publishLogUuid: 'def-456',
+    directPublishedEntities: [
+      {
+        entityKey: 'lct:Axim:TEST1:unit:571fe018-f3ce-45c9-8f53-5dafcb422fd1',
+        entityType: 'unit',
+        title: 'Intro Unit',
+      },
+    ],
+    publishedBy: 'container_author',
+    publishedAt: '2026-03-14T10:00:00Z',
+    contributors: ['container_user_1', 'container_user_2'].map(mockContributor),
+    contributorsCount: 2,
+  },
+] satisfies api.LibraryPublishHistoryGroup[];
+mockLibraryContainerPublishHistory.applyMock = () =>
+  jest.spyOn(api, 'getLibraryContainerPublishHistory').mockImplementation(mockLibraryContainerPublishHistory);
+
+/**
+ * Mock for `getLibraryContainerCreationEntry()`
+ *
+ * Use `mockLibraryContainerCreationEntry.applyMock()` to apply it to the whole test suite.
+ */
+export async function mockLibraryContainerCreationEntry(containerKey: string): Promise<api.LibraryHistoryEntry> {
+  const thisMock = mockLibraryContainerCreationEntry;
+  switch (containerKey) {
+    case thisMock.usageKeyThatNeverLoads:
+      return new Promise<any>(() => {});
+    case thisMock.usageKey:
+      return thisMock.data;
+    case thisMock.usageKeyEmpty:
+      return thisMock.dataEmpty;
+    default:
+      throw new Error(`No mock has been set up for containerKey "${containerKey}"`);
+  }
+}
+mockLibraryContainerCreationEntry.usageKeyThatNeverLoads = 'lct:Axim:TEST1:unit:infiniteLoading';
+mockLibraryContainerCreationEntry.usageKey = 'lct:Axim:TEST1:unit:571fe018-f3ce-45c9-8f53-5dafcb422fd1';
+mockLibraryContainerCreationEntry.usageKeyEmpty = 'lct:Axim:TEST2:unit:571fe018-f3ce-45c9-8f53-5dafcb422fd2';
+mockLibraryContainerCreationEntry.data = {
+  changedBy: mockContributor('author'),
+  changedAt: '2024-01-01T00:00:00Z',
+  title: 'Introduction to Testing Unit 1',
+  itemType: 'unit',
+  action: 'created',
+} satisfies api.LibraryHistoryEntry;
+mockLibraryContainerCreationEntry.dataEmpty = {
+  changedBy: mockContributor('Author'),
+  changedAt: '2024-01-01T00:00:00Z',
+  title: 'Introduction to Testing Unit 2',
+  itemType: 'unit',
+  action: 'created',
+} satisfies api.LibraryHistoryEntry;
+mockLibraryContainerCreationEntry.applyMock = () =>
+  jest.spyOn(api, 'getLibraryContainerCreationEntry').mockImplementation(mockLibraryContainerCreationEntry);
 
 export const mockGetMigrationInfo = {
   applyMock: () =>

--- a/src/library-authoring/data/api.mocks.ts
+++ b/src/library-authoring/data/api.mocks.ts
@@ -1267,14 +1267,14 @@ const mockContributor = (username: string): api.LibraryPublishContributor => ({
 
 mockLibraryBlockDraftHistory.data = [
   {
-    changedBy: mockContributor('test_user_1'),
+    contributor: mockContributor('test_user_1'),
     changedAt: '2026-03-16T11:00:00Z',
     title: 'Electron Arcs',
     action: 'edited',
     itemType: 'html',
   },
   {
-    changedBy: mockContributor('test_user_2'),
+    contributor: mockContributor('test_user_2'),
     changedAt: '2026-03-13T10:00:00Z',
     title: 'More on Quarks',
     action: 'renamed',
@@ -1330,7 +1330,7 @@ export async function mockLibraryBlockPublishHistoryEntries(
 }
 mockLibraryBlockPublishHistoryEntries.data = [
   {
-    changedBy: mockContributor('test_user'),
+    contributor: mockContributor('test_user'),
     changedAt: '2026-03-10T09:00:00Z',
     title: 'Protons',
     action: 'edited',
@@ -1365,14 +1365,14 @@ mockLibraryBlockCreationEntry.usageKeyThatNeverLoads = 'lb:Axim:infiniteLoading:
 mockLibraryBlockCreationEntry.usageKey = 'lb:Axim:TEST1:html:571fe018-f3ce-45c9-8f53-5dafcb422fd1';
 mockLibraryBlockCreationEntry.usageKeyEmpty = 'lb:Axim:TEST2:html:571fe018-f3ce-45c9-8f53-5dafcb422fd2';
 mockLibraryBlockCreationEntry.data = {
-  changedBy: mockContributor('author'),
+  contributor: mockContributor('author'),
   changedAt: '2024-01-01T00:00:00Z',
   title: 'Introduction to Testing 1',
   itemType: 'html',
   action: 'created',
 } satisfies api.LibraryHistoryEntry;
 mockLibraryBlockCreationEntry.dataEmpty = {
-  changedBy: mockContributor('Author'),
+  contributor: mockContributor('Author'),
   changedAt: '2024-01-01T00:00:00Z',
   title: 'Introduction to Testing 2',
   itemType: 'html',
@@ -1404,14 +1404,14 @@ mockLibraryContainerDraftHistory.containerKey = 'lct:Axim:TEST1:unit:571fe018-f3
 mockLibraryContainerDraftHistory.containerKeyEmpty = 'lct:Axim:TEST2:unit:571fe018-f3ce-45c9-8f53-5dafcb422fd2';
 mockLibraryContainerDraftHistory.data = [
   {
-    changedBy: mockContributor('container_user_1'),
+    contributor: mockContributor('container_user_1'),
     changedAt: '2026-03-16T11:00:00Z',
     title: 'Intro Unit',
     action: 'edited',
     itemType: 'unit',
   },
   {
-    changedBy: mockContributor('container_user_2'),
+    contributor: mockContributor('container_user_2'),
     changedAt: '2026-03-13T10:00:00Z',
     title: 'Unit Renamed',
     action: 'renamed',
@@ -1485,14 +1485,14 @@ mockLibraryContainerCreationEntry.usageKeyThatNeverLoads = 'lct:Axim:TEST1:unit:
 mockLibraryContainerCreationEntry.usageKey = 'lct:Axim:TEST1:unit:571fe018-f3ce-45c9-8f53-5dafcb422fd1';
 mockLibraryContainerCreationEntry.usageKeyEmpty = 'lct:Axim:TEST2:unit:571fe018-f3ce-45c9-8f53-5dafcb422fd2';
 mockLibraryContainerCreationEntry.data = {
-  changedBy: mockContributor('author'),
+  contributor: mockContributor('author'),
   changedAt: '2024-01-01T00:00:00Z',
   title: 'Introduction to Testing Unit 1',
   itemType: 'unit',
   action: 'created',
 } satisfies api.LibraryHistoryEntry;
 mockLibraryContainerCreationEntry.dataEmpty = {
-  changedBy: mockContributor('Author'),
+  contributor: mockContributor('Author'),
   changedAt: '2024-01-01T00:00:00Z',
   title: 'Introduction to Testing Unit 2',
   itemType: 'unit',

--- a/src/library-authoring/data/api.mocks.ts
+++ b/src/library-authoring/data/api.mocks.ts
@@ -1313,7 +1313,7 @@ mockLibraryBlockPublishHistory.data = [
     contributors: ['test_user_1', 'test_user_2', 'test_user_3', 'test_user_4', 'test_user_5'].map(mockContributor),
     contributorsCount: 5,
   },
-] satisfies api.LibraryPublishHistoryGroup[];
+] as api.LibraryPublishHistoryGroup[];
 mockLibraryBlockPublishHistory.applyMock = () =>
   jest.spyOn(api, 'getLibraryBlockPublishHistory').mockImplementation(mockLibraryBlockPublishHistory);
 

--- a/src/library-authoring/data/api.mocks.ts
+++ b/src/library-authoring/data/api.mocks.ts
@@ -1311,7 +1311,6 @@ mockLibraryBlockPublishHistory.data = [
     publishedBy: 'author',
     publishedAt: '2026-03-14T10:00:00Z',
     contributors: ['test_user_1', 'test_user_2', 'test_user_3', 'test_user_4', 'test_user_5'].map(mockContributor),
-    contributorsCount: 5,
   },
 ] as api.LibraryPublishHistoryGroup[];
 mockLibraryBlockPublishHistory.applyMock = () =>
@@ -1457,7 +1456,6 @@ mockLibraryContainerPublishHistory.data = [
     publishedBy: 'container_author',
     publishedAt: '2026-03-14T10:00:00Z',
     contributors: ['container_user_1', 'container_user_2'].map(mockContributor),
-    contributorsCount: 2,
   },
 ] satisfies api.LibraryPublishHistoryGroup[];
 mockLibraryContainerPublishHistory.applyMock = () =>

--- a/src/library-authoring/data/api.mocks.ts
+++ b/src/library-authoring/data/api.mocks.ts
@@ -258,6 +258,7 @@ mockCreateLibraryBlock.newHtmlData = {
   publishedBy: null, // or e.g. 'test_author',
   lastDraftCreated: '2024-07-22T21:37:49Z',
   lastDraftCreatedBy: null,
+  createdBy: null,
   created: '2024-07-22T21:37:49Z',
   modified: '2024-07-22T21:37:49Z',
   tagsCount: 0,
@@ -273,6 +274,7 @@ mockCreateLibraryBlock.newProblemData = {
   publishedBy: null, // or e.g. 'test_author',
   lastDraftCreated: '2024-07-22T21:37:49Z',
   lastDraftCreatedBy: null,
+  createdBy: null,
   created: '2024-07-22T21:37:49Z',
   modified: '2024-07-22T21:37:49Z',
   tagsCount: 0,
@@ -288,6 +290,7 @@ mockCreateLibraryBlock.newVideoData = {
   publishedBy: null, // or e.g. 'test_author',
   lastDraftCreated: '2024-07-22T21:37:49Z',
   lastDraftCreatedBy: null,
+  createdBy: null,
   created: '2024-07-22T21:37:49Z',
   modified: '2024-07-22T21:37:49Z',
   tagsCount: 0,
@@ -459,6 +462,7 @@ mockLibraryBlockMetadata.dataNeverPublished = {
   lastDraftCreated: null,
   lastDraftCreatedBy: null,
   hasUnpublishedChanges: true,
+  createdBy: null,
   created: '2024-06-20T13:54:21Z',
   modified: '2024-06-21T13:54:21Z',
   tagsCount: 0,
@@ -478,6 +482,7 @@ mockLibraryBlockMetadata.dataPublished = {
   created: '2024-06-20T13:54:21Z',
   modified: '2024-06-21T13:54:21Z',
   tagsCount: 0,
+  createdBy: null,
   collections: [],
 } satisfies api.LibraryBlockMetadata;
 mockLibraryBlockMetadata.usageKeyPublishDisabled = 'lb:Axim:TEST2-disabled:html:571fe018-f3ce-45c9-8f53-5dafcb422fd2';
@@ -504,6 +509,7 @@ mockLibraryBlockMetadata.dataWithCollections = {
   lastDraftCreated: null,
   lastDraftCreatedBy: '2024-06-20T20:00:00Z',
   hasUnpublishedChanges: false,
+  createdBy: null,
   created: '2024-06-20T13:54:21Z',
   modified: '2024-06-21T13:54:21Z',
   tagsCount: 0,
@@ -521,6 +527,7 @@ mockLibraryBlockMetadata.dataPublishedWithChanges = {
   lastDraftCreated: null,
   lastDraftCreatedBy: '2024-06-20T20:00:00Z',
   hasUnpublishedChanges: true,
+  createdBy: null,
   created: '2024-06-20T13:54:21Z',
   modified: '2024-06-23T13:54:21Z',
   tagsCount: 0,
@@ -741,6 +748,7 @@ mockGetContainerChildren.childTemplate = {
   publishedBy: null,
   lastDraftCreated: null,
   lastDraftCreatedBy: null,
+  createdBy: null,
   hasUnpublishedChanges: false,
   created: null,
   modified: null,
@@ -1228,6 +1236,136 @@ mockGetCourseImports.applyMock = () =>
     api,
     'getCourseImports',
   ).mockImplementation(mockGetCourseImports);
+
+/**
+ * Mock for `getLibraryBlockDraftHistory()`
+ *
+ * Use `mockLibraryBlockDraftHistory.applyMock()` to apply it to the whole test suite.
+ */
+export async function mockLibraryBlockDraftHistory(usageKey: string): Promise<api.LibraryHistoryEntry[]> {
+  const thisMock = mockLibraryBlockDraftHistory;
+  switch (usageKey) {
+    case thisMock.usageKey: return thisMock.data;
+    case thisMock.usageKeyEmpty: return [];
+    default: throw new Error(`No mock has been set up for usageKey "${usageKey}"`);
+  }
+}
+mockLibraryBlockDraftHistory.usageKey = 'lb:Axim:TEST1:html:571fe018-f3ce-45c9-8f53-5dafcb422fd1';
+mockLibraryBlockDraftHistory.usageKeyEmpty = 'lb:Axim:TEST2:html:571fe018-f3ce-45c9-8f53-5dafcb422fd2';
+const mockContributor = (username: string): api.LibraryPublishContributor => ({
+  username,
+  profileImageUrls: {
+    full: 'icon/mock/path',
+    large: 'icon/mock/path',
+    medium: 'icon/mock/path',
+    small: 'icon/mock/path',
+  },
+});
+
+mockLibraryBlockDraftHistory.data = [
+  {
+    changedBy: mockContributor('test_user_1'),
+    changedAt: '2026-03-16T11:00:00Z',
+    title: 'Electron Arcs',
+    action: 'edited',
+    blockType: 'html',
+  },
+  {
+    changedBy: mockContributor('test_user_2'),
+    changedAt: '2026-03-13T10:00:00Z',
+    title: 'More on Quarks',
+    action: 'renamed',
+    blockType: 'html',
+  },
+] satisfies api.LibraryHistoryEntry[];
+mockLibraryBlockDraftHistory.applyMock = () => jest.spyOn(api, 'getLibraryBlockDraftHistory').mockImplementation(mockLibraryBlockDraftHistory);
+
+/**
+ * Mock for `getLibraryBlockPublishHistory()`
+ *
+ * Use `mockLibraryBlockPublishHistory.applyMock()` to apply it to the whole test suite.
+ */
+export async function mockLibraryBlockPublishHistory(usageKey: string): Promise<api.LibraryPublishHistoryGroup[]> {
+  const thisMock = mockLibraryBlockPublishHistory;
+  switch (usageKey) {
+    case thisMock.usageKeyWithGroups: return thisMock.data;
+    case thisMock.usageKeyEmpty: return [];
+    default: throw new Error(`No mock has been set up for usageKey "${usageKey}"`);
+  }
+}
+mockLibraryBlockPublishHistory.usageKeyWithGroups = 'lb:Axim:TEST1:html:571fe018-f3ce-45c9-8f53-5dafcb422fd1';
+mockLibraryBlockPublishHistory.usageKeyEmpty = 'lb:Axim:TEST2:html:571fe018-f3ce-45c9-8f53-5dafcb422fd2';
+mockLibraryBlockPublishHistory.data = [
+  {
+    publishLogUuid: 'abc-123',
+    title: 'Protons',
+    blockType: 'html',
+    publishedBy: 'author',
+    publishedAt: '2026-03-14T10:00:00Z',
+    contributors: ['test_user_1', 'test_user_2', 'test_user_3', 'test_user_4', 'test_user_5'].map(mockContributor),
+    contributorsCount: 5,
+  },
+] satisfies api.LibraryPublishHistoryGroup[];
+mockLibraryBlockPublishHistory.applyMock = () => jest.spyOn(api, 'getLibraryBlockPublishHistory').mockImplementation(mockLibraryBlockPublishHistory);
+
+/**
+ * Mock for `getLibraryBlockPublishHistoryEntries()`
+ *
+ * Use `mockLibraryBlockPublishHistoryEntries.applyMock()` to apply it to the whole test suite.
+ */
+export async function mockLibraryBlockPublishHistoryEntries(
+  _usageKey: string,
+  _publishGroupId: string,
+): Promise<api.LibraryHistoryEntry[]> {
+  return mockLibraryBlockPublishHistoryEntries.data;
+}
+mockLibraryBlockPublishHistoryEntries.data = [
+  {
+    changedBy: mockContributor('test_user'),
+    changedAt: '2026-03-10T09:00:00Z',
+    title: 'Protons',
+    action: 'edited',
+    blockType: 'html',
+  },
+] satisfies api.LibraryHistoryEntry[];
+mockLibraryBlockPublishHistoryEntries.applyMock = () => jest.spyOn(
+  api,
+  'getLibraryBlockPublishHistoryEntries',
+).mockImplementation(mockLibraryBlockPublishHistoryEntries);
+
+/**
+ * Mock for `getLibraryBlockCreationEntry()`
+ *
+ * Use `mockLibraryBlockCreationEntry.applyMock()` to apply it to the whole test suite.
+ */
+export async function mockLibraryBlockCreationEntry(usageKey: string): Promise<api.LibraryHistoryEntry> {
+  const thisMock = mockLibraryBlockCreationEntry;
+  switch (usageKey) {
+    case thisMock.usageKeyThatNeverLoads:
+      return new Promise<any>(() => {});
+    case thisMock.usageKey: return thisMock.data;
+    case thisMock.usageKeyEmpty: return thisMock.dataEmpty;
+    default: throw new Error(`No mock has been set up for usageKey "${usageKey}"`);
+  }
+}
+mockLibraryBlockCreationEntry.usageKeyThatNeverLoads = 'lb:Axim:infiniteLoading:html:123';
+mockLibraryBlockCreationEntry.usageKey = 'lb:Axim:TEST1:html:571fe018-f3ce-45c9-8f53-5dafcb422fd1';
+mockLibraryBlockCreationEntry.usageKeyEmpty = 'lb:Axim:TEST2:html:571fe018-f3ce-45c9-8f53-5dafcb422fd2';
+mockLibraryBlockCreationEntry.data = {
+  changedBy: mockContributor('author'),
+  changedAt: '2024-01-01T00:00:00Z',
+  title: 'Introduction to Testing 1',
+  blockType: 'html',
+  action: 'created',
+} satisfies api.LibraryHistoryEntry;
+mockLibraryBlockCreationEntry.dataEmpty = {
+  changedBy: mockContributor('Author'),
+  changedAt: '2024-01-01T00:00:00Z',
+  title: 'Introduction to Testing 2',
+  blockType: 'html',
+  action: 'created',
+} satisfies api.LibraryHistoryEntry;
+mockLibraryBlockCreationEntry.applyMock = () => jest.spyOn(api, 'getLibraryBlockCreationEntry').mockImplementation(mockLibraryBlockCreationEntry);
 
 export const mockGetMigrationInfo = {
   applyMock: () =>

--- a/src/library-authoring/data/api.test.ts
+++ b/src/library-authoring/data/api.test.ts
@@ -151,4 +151,90 @@ describe('library data API', () => {
     await api.getContentLibraryV2List({ type: 'complex' });
     expect(axiosMock.history.get[0].url).toEqual(url);
   });
+
+  describe('getLibraryBlockDraftHistory', () => {
+    it('should fetch draft history for a library block', async () => {
+      const usageKey = 'lb:org:lib:html:1';
+      const url = api.getLibraryBlockDraftHistoryUrl(usageKey);
+      axiosMock.onGet(url).reply(200, []);
+
+      await api.getLibraryBlockDraftHistory(usageKey);
+
+      expect(axiosMock.history.get[0].url).toEqual(url);
+    });
+  });
+
+  describe('getLibraryBlockPublishHistory', () => {
+    it('should fetch publish history groups for a library block', async () => {
+      const usageKey = 'lb:org:lib:html:1';
+      const url = api.getLibraryBlockPublishHistoryUrl(usageKey);
+      axiosMock.onGet(url).reply(200, []);
+
+      await api.getLibraryBlockPublishHistory(usageKey);
+
+      expect(axiosMock.history.get[0].url).toEqual(url);
+    });
+  });
+
+  describe('getLibraryPublishHistoryEntries', () => {
+    it('should fetch entries for a publish history group', async () => {
+      const libraryId = 'lib:org:lib1';
+      const entityKey = 'lb:org:lib:html:1';
+      const publishGroupId = 'abc-123';
+      const url = api.getLibraryPublishHistoryEntriesUrl(libraryId, entityKey, publishGroupId);
+      axiosMock.onGet(url).reply(200, []);
+
+      await api.getLibraryPublishHistoryEntries(libraryId, entityKey, publishGroupId);
+
+      expect(axiosMock.history.get[0].url).toEqual(url);
+    });
+  });
+
+  describe('getLibraryBlockCreationEntry', () => {
+    it('should fetch the creation entry for a library block', async () => {
+      const usageKey = 'lb:org:lib:html:1';
+      const url = api.getLibraryBlockCreationEntryUrl(usageKey);
+      axiosMock.onGet(url).reply(200, {});
+
+      await api.getLibraryBlockCreationEntry(usageKey);
+
+      expect(axiosMock.history.get[0].url).toEqual(url);
+    });
+  });
+
+  describe('getLibraryContainerDraftHistory', () => {
+    it('should fetch draft history for a library container', async () => {
+      const containerKey = 'lct:org:lib:unit:1';
+      const url = api.getLibraryContainerDraftHistoryUrl(containerKey);
+      axiosMock.onGet(url).reply(200, []);
+
+      await api.getLibraryContainerDraftHistory(containerKey);
+
+      expect(axiosMock.history.get[0].url).toEqual(url);
+    });
+  });
+
+  describe('getLibraryContainerPublishHistory', () => {
+    it('should fetch publish history groups for a library container', async () => {
+      const containerKey = 'lct:org:lib:unit:1';
+      const url = api.getLibraryContainerPublishHistoryUrl(containerKey);
+      axiosMock.onGet(url).reply(200, []);
+
+      await api.getLibraryContainerPublishHistory(containerKey);
+
+      expect(axiosMock.history.get[0].url).toEqual(url);
+    });
+  });
+
+  describe('getLibraryContainerCreationEntry', () => {
+    it('should fetch the creation entry for a library container', async () => {
+      const containerKey = 'lct:org:lib:unit:1';
+      const url = api.getLibraryContainerCreationEntryUrl(containerKey);
+      axiosMock.onGet(url).reply(200, {});
+
+      await api.getLibraryContainerCreationEntry(containerKey);
+
+      expect(axiosMock.history.get[0].url).toEqual(url);
+    });
+  });
 });

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -34,6 +34,16 @@ export const getBlockTypesMetaDataUrl = (libraryId: string) =>
   `${getApiBaseUrl()}/api/libraries/v2/${libraryId}/block_types/`;
 
 /**
+ * Get the URL for the entries of a publish group.
+ */
+export const getLibraryPublishHistoryEntriesUrl = (
+  libraryId: string,
+  entityKey: string,
+  publishGroupId: string,
+) =>
+  `${getApiBaseUrl()}/api/libraries/v2/${libraryId}/publish_history_entries/?scope_entity_key=${entityKey}&publish_log_uuid=${publishGroupId}`;
+
+/**
  * Get the URL for library block metadata.
  */
 export const getLibraryBlockMetadataUrl = (usageKey: string) =>
@@ -58,22 +68,20 @@ export const getLibraryBlockHierarchyUrl = (usageKey: string) => `${getLibraryBl
 /**
  * Get the URL for the component draft history.
  */
-export const getLibraryBlockDraftHistoryUrl = (usageKey: string) => `${getLibraryBlockMetadataUrl(usageKey)}draft_history/`;
+export const getLibraryBlockDraftHistoryUrl = (usageKey: string) =>
+  `${getLibraryBlockMetadataUrl(usageKey)}draft_history/`;
 
 /**
  * Get the URL for the component publish history.
  */
-export const getLibraryBlockPublishHistoryUrl = (usageKey: string) => `${getLibraryBlockMetadataUrl(usageKey)}publish_history/`;
-
-/**
- * Get the URL for the entries of a publish group.
- */
-export const getLibraryBlockPublishHistoryEntriesUrl = (usageKey: string, publishGroupId: string) => `${getLibraryBlockMetadataUrl(usageKey)}publish_history/${publishGroupId}/entries/`
+export const getLibraryBlockPublishHistoryUrl = (usageKey: string) =>
+  `${getLibraryBlockMetadataUrl(usageKey)}publish_history/`;
 
 /**
  * Get the URL for the creation entry of a component.
  */
-export const getLibraryBlockCreationEntryUrl = (usageKey: string) => `${getLibraryBlockMetadataUrl(usageKey)}creation_entry/`;
+export const getLibraryBlockCreationEntryUrl = (usageKey: string) =>
+  `${getLibraryBlockMetadataUrl(usageKey)}creation_entry/`;
 
 /**
  * Get the URL for content library list API.
@@ -180,6 +188,21 @@ export const getLibraryContainerCollectionsUrl = (containerId: string) =>
  */
 export const getLibraryContainerPublishApiUrl = (containerId: string) =>
   `${getLibraryContainerApiUrl(containerId)}publish/`;
+/**
+ * Get the URL for the draft history log of a contaienr.
+ */
+export const getLibraryContainerDraftHistoryUrl = (containerId: string) =>
+  `${getLibraryContainerApiUrl(containerId)}draft_history/`;
+/**
+ * Get the URL for the publish history log of a container.
+ */
+export const getLibraryContainerPublishHistoryUrl = (containerId: string) =>
+  `${getLibraryContainerApiUrl(containerId)}publish_history/`;
+/**
+ * Get the URL for the creation entry of a container.
+ */
+export const getLibraryContainerCreationEntryUrl = (usageKey: string) =>
+  `${getLibraryContainerApiUrl(usageKey)}creation_entry/`;
 /**
  * Get the URL for the API endpoint to create a backup of a v2 library.
  */
@@ -954,14 +977,25 @@ export async function getModulestoreMigrationBlocksInfo(
   return camelCaseObject(data);
 }
 
+export interface DirectPublishedEntity {
+  entityKey: string;
+  entityType: string;
+  title: string;
+}
 export interface LibraryPublishHistoryGroup {
   publishLogUuid: string;
-  title: string;
+  directPublishedEntities: DirectPublishedEntity[];
   publishedBy: string;
   publishedAt: string;
-  blockType: string;
   contributors: LibraryPublishContributor[];
   contributorsCount: number;
+  /**
+   * Key to use as `scope_entity_key` when fetching entries for this group.
+   * Pre-Verawood: the specific entity key for this group (container or usage key).
+   * Post-Verawood container groups: null — use the container currently being viewed.
+   * Component history (all eras): the component's usage key.
+   */
+  scopeEntityKey?: string;
 }
 
 export interface LibraryPublishContributor {
@@ -978,7 +1012,7 @@ export interface LibraryHistoryEntry {
   changedBy: LibraryPublishContributor;
   changedAt: string;
   title: string;
-  blockType: string;
+  itemType: string;
   action: 'edited' | 'renamed' | 'created';
 }
 
@@ -993,8 +1027,14 @@ export async function getLibraryBlockPublishHistory(usageKey: string): Promise<L
 /**
  * Get the entries for a publish history group of a library block.
  */
-export async function getLibraryBlockPublishHistoryEntries(usageKey: string, publishGroupId: string): Promise<LibraryHistoryEntry[]> {
-  const { data } = await getAuthenticatedHttpClient().get(getLibraryBlockPublishHistoryEntriesUrl(usageKey, publishGroupId));
+export async function getLibraryPublishHistoryEntries(
+  libraryId: string,
+  entityKey: string,
+  publishGroupId: string,
+): Promise<LibraryHistoryEntry[]> {
+  const { data } = await getAuthenticatedHttpClient().get(
+    getLibraryPublishHistoryEntriesUrl(libraryId, entityKey, publishGroupId),
+  );
   return camelCaseObject(data);
 }
 
@@ -1011,5 +1051,29 @@ export async function getLibraryBlockDraftHistory(usageKey: string): Promise<Lib
  */
 export async function getLibraryBlockCreationEntry(usageKey: string): Promise<LibraryHistoryEntry> {
   const { data } = await getAuthenticatedHttpClient().get(getLibraryBlockCreationEntryUrl(usageKey));
+  return camelCaseObject(data);
+}
+
+/**
+ * Get the creation entry for a library container.
+ */
+export async function getLibraryContainerCreationEntry(containerKey: string): Promise<LibraryHistoryEntry> {
+  const { data } = await getAuthenticatedHttpClient().get(getLibraryContainerCreationEntryUrl(containerKey));
+  return camelCaseObject(data);
+}
+
+/**
+ * Get the publish history for a library container.
+ */
+export async function getLibraryContainerPublishHistory(containerKey: string): Promise<LibraryPublishHistoryGroup[]> {
+  const { data } = await getAuthenticatedHttpClient().get(getLibraryContainerPublishHistoryUrl(containerKey));
+  return camelCaseObject(data);
+}
+
+/**
+ * Get the draft history for a library container.
+ */
+export async function getLibraryContainerDraftHistory(containerKey: string): Promise<LibraryHistoryEntry[]> {
+  const { data } = await getAuthenticatedHttpClient().get(getLibraryContainerDraftHistoryUrl(containerKey));
   return camelCaseObject(data);
 }

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -988,7 +988,6 @@ export interface LibraryPublishHistoryGroup {
   publishedBy?: string;
   publishedAt: string;
   contributors: LibraryPublishContributor[];
-  contributorsCount: number;
   /**
    * Key to use as `scope_entity_key` when fetching entries for this group.
    * Pre-Verawood: the specific entity key for this group (container or usage key).

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -56,6 +56,26 @@ export const getLibraryBlockCollectionsUrl = (usageKey: string) =>
 export const getLibraryBlockHierarchyUrl = (usageKey: string) => `${getLibraryBlockMetadataUrl(usageKey)}hierarchy/`;
 
 /**
+ * Get the URL for the component draft history.
+ */
+export const getLibraryBlockDraftHistoryUrl = (usageKey: string) => `${getLibraryBlockMetadataUrl(usageKey)}draft_history/`;
+
+/**
+ * Get the URL for the component publish history.
+ */
+export const getLibraryBlockPublishHistoryUrl = (usageKey: string) => `${getLibraryBlockMetadataUrl(usageKey)}publish_history/`;
+
+/**
+ * Get the URL for the entries of a publish group.
+ */
+export const getLibraryBlockPublishHistoryEntriesUrl = (usageKey: string, publishGroupId: string) => `${getLibraryBlockMetadataUrl(usageKey)}publish_history/${publishGroupId}/entries/`
+
+/**
+ * Get the URL for the creation entry of a component.
+ */
+export const getLibraryBlockCreationEntryUrl = (usageKey: string) => `${getLibraryBlockMetadataUrl(usageKey)}creation_entry/`;
+
+/**
  * Get the URL for content library list API.
  */
 export const getContentLibraryV2ListApiUrl = () => `${getApiBaseUrl()}/api/libraries/v2/`;
@@ -332,6 +352,7 @@ export interface LibraryBlockMetadata {
   lastDraftCreatedBy: string | null;
   hasUnpublishedChanges: boolean;
   created: string | null;
+  createdBy: string | null;
   modified: string | null;
   tagsCount: number;
   collections: CollectionMetadata[];
@@ -930,5 +951,65 @@ export async function getModulestoreMigrationBlocksInfo(
   }
 
   const { data } = await client.get(getModulestoreMigratedBlocksInfoUrl(), { params });
+  return camelCaseObject(data);
+}
+
+export interface LibraryPublishHistoryGroup {
+  publishLogUuid: string;
+  title: string;
+  publishedBy: string;
+  publishedAt: string;
+  blockType: string;
+  contributors: LibraryPublishContributor[];
+  contributorsCount: number;
+}
+
+export interface LibraryPublishContributor {
+  profileImageUrls: {
+    full: string;
+    large: string;
+    medium: string;
+    small: string;
+  };
+  username: string;
+}
+
+export interface LibraryHistoryEntry {
+  changedBy: LibraryPublishContributor;
+  changedAt: string;
+  title: string;
+  blockType: string;
+  action: 'edited' | 'renamed' | 'created';
+}
+
+/**
+ * Get the publish history for a library block.
+ */
+export async function getLibraryBlockPublishHistory(usageKey: string): Promise<LibraryPublishHistoryGroup[]> {
+  const { data } = await getAuthenticatedHttpClient().get(getLibraryBlockPublishHistoryUrl(usageKey));
+  return camelCaseObject(data);
+}
+
+/**
+ * Get the entries for a publish history group of a library block.
+ */
+export async function getLibraryBlockPublishHistoryEntries(usageKey: string, publishGroupId: string): Promise<LibraryHistoryEntry[]> {
+  const { data } = await getAuthenticatedHttpClient().get(getLibraryBlockPublishHistoryEntriesUrl(usageKey, publishGroupId));
+  return camelCaseObject(data);
+}
+
+/**
+ * Get the draft history for a library block.
+ */
+export async function getLibraryBlockDraftHistory(usageKey: string): Promise<LibraryHistoryEntry[]> {
+  const { data } = await getAuthenticatedHttpClient().get(getLibraryBlockDraftHistoryUrl(usageKey));
+  return camelCaseObject(data);
+}
+
+/**
+ * Get the creation entry for a library block.
+ */
+export async function getLibraryBlockCreationEntry(usageKey: string): Promise<LibraryHistoryEntry> {
+  const { data } = await getAuthenticatedHttpClient().get(getLibraryBlockCreationEntryUrl(usageKey));
   return camelCaseObject(data);
 }

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -985,7 +985,7 @@ export interface DirectPublishedEntity {
 export interface LibraryPublishHistoryGroup {
   publishLogUuid: string;
   directPublishedEntities: DirectPublishedEntity[];
-  publishedBy: string;
+  publishedBy?: string;
   publishedAt: string;
   contributors: LibraryPublishContributor[];
   contributorsCount: number;
@@ -1005,7 +1005,7 @@ export interface LibraryPublishContributor {
     medium: string;
     small: string;
   };
-  username: string;
+  username?: string;
 }
 
 export interface LibraryHistoryEntry {

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -35,13 +35,14 @@ export const getBlockTypesMetaDataUrl = (libraryId: string) =>
 
 /**
  * Get the URL for the entries of a publish group.
+ * publishGroupUuid: UUID of the PublishLog that groups this set of published entities.
  */
 export const getLibraryPublishHistoryEntriesUrl = (
   libraryId: string,
   entityKey: string,
-  publishGroupId: string,
+  publishGroupUuid: string,
 ) =>
-  `${getApiBaseUrl()}/api/libraries/v2/${libraryId}/publish_history_entries/?scope_entity_key=${entityKey}&publish_log_uuid=${publishGroupId}`;
+  `${getApiBaseUrl()}/api/libraries/v2/${libraryId}/publish_history_entries/?scope_entity_key=${entityKey}&publish_log_uuid=${publishGroupUuid}`;
 
 /**
  * Get the URL for library block metadata.
@@ -79,6 +80,7 @@ export const getLibraryBlockPublishHistoryUrl = (usageKey: string) =>
 
 /**
  * Get the URL for the creation entry of a component.
+ * The creation entry is the draft change record representing when the component was first added to the library.
  */
 export const getLibraryBlockCreationEntryUrl = (usageKey: string) =>
   `${getLibraryBlockMetadataUrl(usageKey)}creation_entry/`;
@@ -200,6 +202,7 @@ export const getLibraryContainerPublishHistoryUrl = (containerId: string) =>
   `${getLibraryContainerApiUrl(containerId)}publish_history/`;
 /**
  * Get the URL for the creation entry of a container.
+ * The creation entry is the draft change record representing when the container was first added to the library.
  */
 export const getLibraryContainerCreationEntryUrl = (usageKey: string) =>
   `${getLibraryContainerApiUrl(usageKey)}creation_entry/`;
@@ -990,7 +993,7 @@ export interface LibraryPublishHistoryGroup {
   contributors: LibraryPublishContributor[];
   /**
    * Key to use as `scope_entity_key` when fetching entries for this group.
-   * Pre-Verawood: the specific entity key for this group (container or usage key).
+   * Pre-Verawood history entries: the specific entity key for this group (container or usage key).
    * Post-Verawood container groups: null — use the container currently being viewed.
    * Component history (all eras): the component's usage key.
    */
@@ -1029,10 +1032,10 @@ export async function getLibraryBlockPublishHistory(usageKey: string): Promise<L
 export async function getLibraryPublishHistoryEntries(
   libraryId: string,
   entityKey: string,
-  publishGroupId: string,
+  publishGroupUuid: string,
 ): Promise<LibraryHistoryEntry[]> {
   const { data } = await getAuthenticatedHttpClient().get(
-    getLibraryPublishHistoryEntriesUrl(libraryId, entityKey, publishGroupId),
+    getLibraryPublishHistoryEntriesUrl(libraryId, entityKey, publishGroupUuid),
   );
   return camelCaseObject(data);
 }

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -1008,7 +1008,7 @@ export interface LibraryPublishContributor {
 }
 
 export interface LibraryHistoryEntry {
-  contributor: LibraryPublishContributor;
+  contributor?: LibraryPublishContributor | null;
   changedAt: string;
   title: string;
   itemType: string;

--- a/src/library-authoring/data/api.ts
+++ b/src/library-authoring/data/api.ts
@@ -1009,7 +1009,7 @@ export interface LibraryPublishContributor {
 }
 
 export interface LibraryHistoryEntry {
-  changedBy: LibraryPublishContributor;
+  contributor: LibraryPublishContributor;
   changedAt: string;
   title: string;
   itemType: string;

--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -91,6 +91,18 @@ export const libraryAuthoringQueryKeys = {
     }
     return ['hierarchy'];
   },
+  containerCreationEntry: (containerId: string) => [
+    ...libraryAuthoringQueryKeys.container(containerId),
+    'creationEntry',
+  ],
+  containerDraftHistory: (containerId: string) => [
+    ...libraryAuthoringQueryKeys.container(containerId),
+    'draftHistory',
+  ],
+  containerPublishHistory: (containerId: string) => [
+    ...libraryAuthoringQueryKeys.container(containerId),
+    'publishHistory',
+  ],
   courseImports: (libraryId: string) => [
     ...libraryAuthoringQueryKeys.contentLibrary(libraryId),
     'courseImports',
@@ -127,7 +139,10 @@ export const xblockQueryKeys = {
   componentDownstreamLinks: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'downstreamLinks'],
   draftHistory: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'draftHistory'],
   publishHistory: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'publishHistory'],
-  publishHistoryEntries: (usageKey: string, publishGroupId: string) => [...xblockQueryKeys.xblock(usageKey), 'publishHistory', publishGroupId, 'entries'],
+  publishHistoryEntries: (
+    usageKey: string,
+    publishGroupId: string,
+  ) => [...xblockQueryKeys.xblock(usageKey), 'publishHistory', publishGroupId, 'entries'],
   creationEntry: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'creationEntry'],
 
   /**
@@ -1056,26 +1071,58 @@ export const useLibraryBlockPublishHistory = (usageKey?: string) => (
 );
 
 /**
- * Returns the entries for a publish history group of a library block.
+ * Returns the entries for a publish history group of a library item.
  */
-export const useLibraryBlockPublishHistoryEntries = (
+export const useLibraryPublishHistoryEntries = (
   usageKey?: string,
   publishGroupId?: string,
   enabled: boolean = true,
 ) => (
   useQuery({
     queryKey: xblockQueryKeys.publishHistoryEntries(usageKey!, publishGroupId!),
-    queryFn: (usageKey && publishGroupId && enabled) ? () => api.getLibraryBlockPublishHistoryEntries(usageKey, publishGroupId) : skipToken,
+    queryFn: (usageKey && publishGroupId && enabled)
+      ? () => api.getLibraryPublishHistoryEntries(getLibraryId(usageKey), usageKey, publishGroupId)
+      : skipToken,
   })
 );
 
 /**
  * Returns the creation entry for a library block.
  */
-export const useLibraryBlockCreationEntry = (usageKey?: string ) => (
+export const useLibraryBlockCreationEntry = (usageKey?: string) => (
   useQuery({
     queryKey: xblockQueryKeys.creationEntry(usageKey!),
     queryFn: usageKey ? () => api.getLibraryBlockCreationEntry(usageKey) : skipToken,
+  })
+);
+
+/**
+ * Hook to fetch the publish history groups for a library container (unit, section, subsection).
+ */
+export const useLibraryContainerPublishHistory = (containerKey?: string) => (
+  useQuery({
+    queryKey: libraryAuthoringQueryKeys.containerPublishHistory(containerKey!),
+    queryFn: containerKey ? () => api.getLibraryContainerPublishHistory(containerKey) : skipToken,
+  })
+);
+
+/**
+ * Hook to fetch the draft history entries for a library container (unit, section, subsection).
+ */
+export const useLibraryContainerDraftHistory = (containerKey?: string) => (
+  useQuery({
+    queryKey: libraryAuthoringQueryKeys.containerDraftHistory(containerKey!),
+    queryFn: containerKey ? () => api.getLibraryContainerDraftHistory(containerKey) : skipToken,
+  })
+);
+
+/**
+ * Hook to fetch the creation entry for a library container (unit, section, subsection).
+ */
+export const useLibraryContainerCreationEntry = (containerKey?: string) => (
+  useQuery({
+    queryKey: libraryAuthoringQueryKeys.containerCreationEntry(containerKey!),
+    queryFn: containerKey ? () => api.getLibraryContainerCreationEntry(containerKey) : skipToken,
   })
 );
 

--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -141,8 +141,8 @@ export const xblockQueryKeys = {
   publishHistory: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'publishHistory'],
   publishHistoryEntries: (
     usageKey: string,
-    publishGroupId: string,
-  ) => [...xblockQueryKeys.xblock(usageKey), 'publishHistory', publishGroupId, 'entries'],
+    publishGroupUuid: string,
+  ) => [...xblockQueryKeys.xblock(usageKey), 'publishHistory', publishGroupUuid, 'entries'],
   creationEntry: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'creationEntry'],
 
   /**
@@ -1075,13 +1075,13 @@ export const useLibraryBlockPublishHistory = (usageKey?: string) => (
  */
 export const useLibraryPublishHistoryEntries = (
   usageKey?: string,
-  publishGroupId?: string,
+  publishGroupUuid?: string,
   enabled: boolean = true,
 ) => (
   useQuery({
-    queryKey: xblockQueryKeys.publishHistoryEntries(usageKey!, publishGroupId!),
-    queryFn: (usageKey && publishGroupId && enabled)
-      ? () => api.getLibraryPublishHistoryEntries(getLibraryId(usageKey), usageKey, publishGroupId)
+    queryKey: xblockQueryKeys.publishHistoryEntries(usageKey!, publishGroupUuid!),
+    queryFn: (usageKey && publishGroupUuid && enabled)
+      ? () => api.getLibraryPublishHistoryEntries(getLibraryId(usageKey), usageKey, publishGroupUuid)
       : skipToken,
   })
 );

--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -125,6 +125,10 @@ export const xblockQueryKeys = {
   xblockAssets: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'assets'],
   componentMetadata: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'componentMetadata'],
   componentDownstreamLinks: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'downstreamLinks'],
+  draftHistory: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'draftHistory'],
+  publishHistory: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'publishHistory'],
+  publishHistoryEntries: (usageKey: string, publishGroupId: string) => [...xblockQueryKeys.xblock(usageKey), 'publishHistory', publishGroupId, 'entries'],
+  creationEntry: (usageKey: string) => [...xblockQueryKeys.xblock(usageKey), 'creationEntry'],
 
   /**
    * Predicate used to invalidate all metadata only (not OLX, fields, assets, etc.).
@@ -132,6 +136,8 @@ export const xblockQueryKeys = {
    * introspecting the usage keys.
    */
   allComponentMetadata: (query: Query) => query.queryKey[0] === 'xblock' && query.queryKey[2] === 'componentMetadata',
+  allDraftHistory: (query: Query) => query.queryKey[0] === 'xblock' && query.queryKey[2] === 'draftHistory',
+  allPublishHistory: (query: Query) => query.queryKey[0] === 'xblock' && query.queryKey[2] === 'publishHistory',
   componentHierarchy: (usageKey?: string) => {
     if (usageKey) {
       return [
@@ -161,6 +167,24 @@ export function invalidateComponentData(queryClient: QueryClient, contentLibrary
   // This might fail in case this helper is called after deleting the block.
   queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibrary(contentLibraryId) });
   queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, contentLibraryId) });
+  queryClient.invalidateQueries({ queryKey: xblockQueryKeys.draftHistory(usageKey) });
+  queryClient.invalidateQueries({ queryKey: xblockQueryKeys.publishHistory(usageKey) });
+}
+
+/**
+ * Tell react-query to refresh its cache of component-related data across all components in all libraries.
+ *
+ * Use this when a bulk operation (e.g. publish all, revert all) affects an unknown set of components
+ * and it's not practical to invalidate them individually.
+ *
+ * @param queryClient The query client - get it via useQueryClient()
+ */
+export function invalidateAllComponentData(queryClient: QueryClient) {
+  // For XBlocks, the only thing we need to invalidate is the metadata which includes "has unpublished changes"
+  queryClient.invalidateQueries({ predicate: xblockQueryKeys.allComponentMetadata });
+  // For XBlocks, to invalidate the history log queries to refresh the history
+  queryClient.invalidateQueries({ predicate: xblockQueryKeys.allDraftHistory });
+  queryClient.invalidateQueries({ predicate: xblockQueryKeys.allPublishHistory });
 }
 
 /**
@@ -275,8 +299,7 @@ export const useCommitLibraryChanges = () => {
       // Invalidate all content-related metadata and search results for the whole library.
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibrary(libraryId) });
       queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, libraryId) });
-      // For XBlocks, the only thing we need to invalidate is the metadata which includes "has unpublished changes"
-      queryClient.invalidateQueries({ predicate: xblockQueryKeys.allComponentMetadata });
+      invalidateAllComponentData(queryClient);
     },
   });
 };
@@ -290,8 +313,7 @@ export const useRevertLibraryChanges = () => {
       // Invalidate all content-related metadata and search results for the whole library.
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibrary(libraryId) });
       queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, libraryId) });
-      // For XBlocks, the only thing we need to invalidate is the metadata which includes "has unpublished changes"
-      queryClient.invalidateQueries({ predicate: xblockQueryKeys.allComponentMetadata });
+      invalidateAllComponentData(queryClient);
     },
   });
 };
@@ -961,8 +983,7 @@ export const usePublishContainer = (containerId: string) => {
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibraryContent(libraryId) });
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.containerHierarchy(containerId) });
       queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, libraryId) });
-      // For XBlocks, the only thing we need to invalidate is the metadata which includes "has unpublished changes"
-      queryClient.invalidateQueries({ predicate: xblockQueryKeys.allComponentMetadata });
+      invalidateAllComponentData(queryClient);
     },
   });
 };
@@ -1011,6 +1032,50 @@ export const useMigrationInfo = (sourcesKeys: string[], enabled: boolean = true)
   useQuery({
     queryKey: libraryAuthoringQueryKeys.migrationInfo(sourcesKeys),
     queryFn: enabled ? () => api.getMigrationInfo(sourcesKeys) : skipToken,
+  })
+);
+
+/**
+ * Returns the draft history of a library block.
+ */
+export const useLibraryBlockDraftHistory = (usageKey?: string) => (
+  useQuery({
+    queryKey: xblockQueryKeys.draftHistory(usageKey!),
+    queryFn: usageKey ? () => api.getLibraryBlockDraftHistory(usageKey) : skipToken,
+  })
+);
+
+/**
+ * Returns the publish history of a library block.
+ */
+export const useLibraryBlockPublishHistory = (usageKey?: string) => (
+  useQuery({
+    queryKey: xblockQueryKeys.publishHistory(usageKey!),
+    queryFn: usageKey ? () => api.getLibraryBlockPublishHistory(usageKey) : skipToken,
+  })
+);
+
+/**
+ * Returns the entries for a publish history group of a library block.
+ */
+export const useLibraryBlockPublishHistoryEntries = (
+  usageKey?: string,
+  publishGroupId?: string,
+  enabled: boolean = true,
+) => (
+  useQuery({
+    queryKey: xblockQueryKeys.publishHistoryEntries(usageKey!, publishGroupId!),
+    queryFn: (usageKey && publishGroupId && enabled) ? () => api.getLibraryBlockPublishHistoryEntries(usageKey, publishGroupId) : skipToken,
+  })
+);
+
+/**
+ * Returns the creation entry for a library block.
+ */
+export const useLibraryBlockCreationEntry = (usageKey?: string ) => (
+  useQuery({
+    queryKey: xblockQueryKeys.creationEntry(usageKey!),
+    queryFn: usageKey ? () => api.getLibraryBlockCreationEntry(usageKey) : skipToken,
   })
 );
 

--- a/src/library-authoring/generic/history-log/ContributorAvatars.tsx
+++ b/src/library-authoring/generic/history-log/ContributorAvatars.tsx
@@ -1,0 +1,62 @@
+import { ComponentProps, useState } from 'react';
+import { Avatar, Stack } from '@openedx/paragon';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
+import { LibraryPublishContributor } from '@src/library-authoring/data/api';
+import messages from './messages';
+
+const MAX_VISIBLE_CONTRIBUTORS = 5;
+
+interface ContributorAvatarProps {
+  username?: string;
+  src?: string;
+  className: string;
+  size: ComponentProps<typeof Avatar>['size'];
+}
+
+interface ContributorsAvatarsProps {
+  contributors: LibraryPublishContributor[];
+}
+
+export const ContributorAvatar = ({
+  username,
+  src,
+  className,
+  size,
+}: ContributorAvatarProps) => {
+  const intl = useIntl();
+  const [imgError, setImgError] = useState(false);
+  return (
+    <Avatar
+      className={className}
+      size={size}
+      src={imgError ? undefined : src}
+      alt={username || intl.formatMessage(messages.historyEntryDefaultUser)}
+      onError={() => setImgError(true)}
+    />
+  );
+};
+
+export const ContributorsAvatars = ({ contributors }: ContributorsAvatarsProps) => {
+  const visible = contributors.slice(0, MAX_VISIBLE_CONTRIBUTORS);
+  return (
+    <Stack direction="horizontal" gap={2} className="ml-4.5">
+      <div className="contributors-avatars">
+        {visible.map(({ username, profileImageUrls }) => (
+          <ContributorAvatar
+            key={username}
+            size="xs"
+            className="contributors-avatar"
+            username={username}
+            src={profileImageUrls.small}
+          />
+        ))}
+      </div>
+      <span className="small">
+        <FormattedMessage
+          {...messages.historyContributors}
+          values={{ count: contributors.length }}
+        />
+      </span>
+    </Stack>
+  );
+};

--- a/src/library-authoring/generic/history-log/HistoryLog.scss
+++ b/src/library-authoring/generic/history-log/HistoryLog.scss
@@ -1,0 +1,56 @@
+.history-log {
+  .history-log-group {
+    .history-log-group-avatar {
+      &.big-avatar {
+        border: 3px solid;
+      }
+
+      &.small-avatar {
+        border: 2px solid;
+      }      
+    }
+
+    .history-log-title {
+      max-width: 250px;
+    }
+
+    .history-log-vert {
+      width: 8px;
+      height: 2rem;
+      margin: -10px 0 -10px 20px;
+
+      &.history-log-vert-long {
+        height: 3.3rem;
+      }
+    }
+
+    &.draft-group {
+      .history-log-group-avatar {
+        border-color: #B4610E;
+      }
+
+      .history-log-vert {
+        background-color: #B4610E;
+      }
+    }
+
+    .contributors-avatars {
+      display: flex;
+      align-items: center;
+
+      .contributors-avatar {
+        margin-left: -.5rem;
+      }
+    }
+
+    &.publish-group {
+      .history-log-group-avatar {
+        border-color: var(--pgn-color-info-400);
+      }
+
+      .history-log-vert {
+        background-color: var(--pgn-color-info-400);
+      }
+    }
+  }
+}

--- a/src/library-authoring/generic/history-log/HistoryLog.test.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.test.tsx
@@ -7,6 +7,7 @@ import {
   findByDeepTextContent,
 } from '@src/testUtils';
 
+import type { LibraryPublishContributor } from '@src/library-authoring/data/api';
 import {
   mockLibraryBlockDraftHistory,
   mockLibraryBlockPublishHistory,
@@ -39,6 +40,15 @@ const renderContainerComponent = (containerId: string) =>
   render(
     <HistoryContainerLog containerId={containerId} />,
   );
+
+const mockContributorNoUsername = (): LibraryPublishContributor => ({
+  profileImageUrls: {
+    full: 'http://example.com/full.png',
+    large: 'http://example.com/large.png',
+    medium: 'http://example.com/medium.png',
+    small: 'http://example.com/small.png',
+  },
+});
 
 describe('<HistoryComponentLog />', () => {
   beforeEach(() => {
@@ -92,6 +102,38 @@ describe('<HistoryComponentLog />', () => {
   it('always renders the created group with fallback user when createdBy is null', async () => {
     renderComponent(mockLibraryBlockCreationEntry.usageKey);
     expect(await findByDeepTextContent(/Author created.*Introduction to Testing 1/i)).toBeInTheDocument();
+  });
+
+  it('shows fallback "Author" for draft entry when changedBy has no username', async () => {
+    const user = userEvent.setup();
+    const originalData = mockLibraryBlockDraftHistory.data;
+    mockLibraryBlockDraftHistory.data = [
+      {
+        changedBy: mockContributorNoUsername(),
+        changedAt: '2026-03-16T11:00:00Z',
+        title: 'Anonymous Component',
+        itemType: 'html',
+        action: 'edited',
+      },
+    ];
+    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    const trigger = await findByDeepTextContent(/Introduction to Testing 1 is a draft/i);
+    await user.click(trigger);
+    expect(await findByDeepTextContent(/Author edited.*Anonymous Component/i)).toBeInTheDocument();
+    mockLibraryBlockDraftHistory.data = originalData;
+  });
+
+  it('shows fallback "Author" in publish group header when publishedBy is undefined', async () => {
+    const originalData = mockLibraryBlockPublishHistory.data;
+    mockLibraryBlockPublishHistory.data = [
+      {
+        ...originalData[0],
+        publishedBy: undefined,
+      },
+    ];
+    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    expect(await findByDeepTextContent(/Author published.*Protons/i)).toBeInTheDocument();
+    mockLibraryBlockPublishHistory.data = originalData;
   });
 });
 

--- a/src/library-authoring/generic/history-log/HistoryLog.test.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.test.tsx
@@ -249,4 +249,62 @@ describe('<HistoryContainerLog />', () => {
     renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
     expect(await findByDeepTextContent(/author created.*Introduction to Testing Unit 1/i)).toBeInTheDocument();
   });
+
+  it('renders publish groups after container creation before the created entry', async () => {
+    // Default mock: publishedAt '2026-03-14' is after createdAt '2024-01-01'
+    renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
+    const publishGroup = await findByDeepTextContent(/container_author published.*Intro Unit/i);
+    const createdEntry = await findByDeepTextContent(/author created.*Introduction to Testing Unit 1/i);
+    expect(publishGroup.compareDocumentPosition(createdEntry)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it('renders publish groups before container creation after the created entry', async () => {
+    const originalData = mockLibraryContainerPublishHistory.data;
+    mockLibraryContainerPublishHistory.data = [
+      {
+        ...originalData[0],
+        publishedAt: '2023-01-01T00:00:00Z', // before createdAt '2024-01-01'
+      },
+    ];
+    renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
+    const createdEntry = await findByDeepTextContent(/author created.*Introduction to Testing Unit 1/i);
+    expect(await screen.findByText(/2 authors contributed/i)).toBeInTheDocument();
+    // The publish group contributors should still appear
+    const contributorsText = screen.getByText(/2 authors contributed/i);
+    expect(createdEntry.compareDocumentPosition(contributorsText)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    mockLibraryContainerPublishHistory.data = originalData;
+  });
+
+  it('renders both pre-creation and post-creation publish groups in correct order', async () => {
+    const originalData = mockLibraryContainerPublishHistory.data;
+    mockLibraryContainerPublishHistory.data = [
+      {
+        ...originalData[0],
+        publishLogUuid: 'after-uuid',
+        publishedAt: '2026-01-01T00:00:00Z', // after createdAt '2024-01-01'
+        directPublishedEntities: [
+          { ...originalData[0].directPublishedEntities[0], entityKey: 'key-after', title: 'After Unit' },
+        ],
+        contributors: [],
+      },
+      {
+        ...originalData[0],
+        publishLogUuid: 'before-uuid',
+        publishedAt: '2023-01-01T00:00:00Z', // before createdAt '2024-01-01'
+        directPublishedEntities: [
+          { ...originalData[0].directPublishedEntities[0], entityKey: 'key-before', title: 'Before Unit' },
+        ],
+        contributors: [],
+      },
+    ];
+    renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
+    const afterGroup = await findByDeepTextContent(/container_author published.*After Unit/i);
+    const createdEntry = await findByDeepTextContent(/author created.*Introduction to Testing Unit 1/i);
+    // After-creation group comes before the created entry
+    expect(afterGroup.compareDocumentPosition(createdEntry)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    // Before-creation group title is hidden (hideLogVert=true, no contributors), so only the vert line renders
+    // Verify the after-group is visible but before-group title is not
+    expect(screen.queryByText(/container_author published.*Before Unit/i)).not.toBeInTheDocument();
+    mockLibraryContainerPublishHistory.data = originalData;
+  });
 });

--- a/src/library-authoring/generic/history-log/HistoryLog.test.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.test.tsx
@@ -136,6 +136,33 @@ describe('<HistoryComponentLog />', () => {
     mockLibraryBlockPublishHistory.data = originalData;
   });
 
+  it('renders draft entry with "created" action', async () => {
+    const user = userEvent.setup();
+    const originalData = mockLibraryBlockDraftHistory.data;
+    mockLibraryBlockDraftHistory.data = [
+      {
+        changedBy: {
+          username: 'creator_user',
+          profileImageUrls: {
+            full: 'icon/mock/path',
+            large: 'icon/mock/path',
+            medium: 'icon/mock/path',
+            small: 'icon/mock/path',
+          },
+        },
+        changedAt: '2026-03-16T11:00:00Z',
+        title: 'New Component',
+        itemType: 'html',
+        action: 'created',
+      },
+    ] as any;
+    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    const trigger = await findByDeepTextContent(/Introduction to Testing 1 is a draft/i);
+    await user.click(trigger);
+    expect(await findByDeepTextContent(/creator_user created.*New Component/i)).toBeInTheDocument();
+    mockLibraryBlockDraftHistory.data = originalData;
+  });
+
   it('renders publish group without collapsible and without contributor count when contributors is empty', async () => {
     const originalData = mockLibraryBlockPublishHistory.data;
     mockLibraryBlockPublishHistory.data = [
@@ -190,6 +217,33 @@ describe('<HistoryContainerLog />', () => {
     renderContainerComponent(mockLibraryContainerDraftHistory.containerKeyEmpty);
     await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
     expect(screen.queryByText(/published/i)).not.toBeInTheDocument();
+  });
+
+  it('renders draft entry with "created" action', async () => {
+    const user = userEvent.setup();
+    const originalData = mockLibraryContainerDraftHistory.data;
+    mockLibraryContainerDraftHistory.data = [
+      {
+        changedBy: {
+          username: 'creator_user',
+          profileImageUrls: {
+            full: 'icon/mock/path',
+            large: 'icon/mock/path',
+            medium: 'icon/mock/path',
+            small: 'icon/mock/path',
+          },
+        },
+        changedAt: '2026-03-16T11:00:00Z',
+        title: 'New Unit',
+        itemType: 'unit',
+        action: 'created',
+      },
+    ] as any;
+    renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
+    const trigger = await findByDeepTextContent(/Test Unit is a draft/i);
+    await user.click(trigger);
+    expect(await findByDeepTextContent(/creator_user created.*New Unit/i)).toBeInTheDocument();
+    mockLibraryContainerDraftHistory.data = originalData;
   });
 
   it('always renders the created group', async () => {

--- a/src/library-authoring/generic/history-log/HistoryLog.test.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.test.tsx
@@ -135,6 +135,23 @@ describe('<HistoryComponentLog />', () => {
     expect(await findByDeepTextContent(/Author published.*Protons/i)).toBeInTheDocument();
     mockLibraryBlockPublishHistory.data = originalData;
   });
+
+  it('renders publish group without collapsible and without contributor count when contributors is empty', async () => {
+    const originalData = mockLibraryBlockPublishHistory.data;
+    mockLibraryBlockPublishHistory.data = [
+      {
+        ...originalData[0],
+        contributors: [],
+        contributorsCount: 0,
+      },
+    ];
+    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    const publishTitle = await findByDeepTextContent(/author published.*Protons/i);
+    expect(publishTitle).toBeInTheDocument();
+    expect(screen.queryByText(/authors? contributed/i)).not.toBeInTheDocument();
+    expect(publishTitle.closest('[role="button"]')).toBeNull();
+    mockLibraryBlockPublishHistory.data = originalData;
+  });
 });
 
 describe('<HistoryContainerLog />', () => {

--- a/src/library-authoring/generic/history-log/HistoryLog.test.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.test.tsx
@@ -8,28 +8,18 @@ import {
 } from '@src/testUtils';
 
 import type { LibraryPublishContributor } from '@src/library-authoring/data/api';
-import {
-  mockLibraryBlockDraftHistory,
-  mockLibraryBlockPublishHistory,
-  mockLibraryBlockPublishHistoryEntries,
-  mockLibraryBlockCreationEntry,
-  mockLibraryBlockMetadata,
-  mockLibraryContainerDraftHistory,
-  mockLibraryContainerPublishHistory,
-  mockLibraryContainerCreationEntry,
-  mockGetContainerMetadata,
-} from '@src/library-authoring/data/api.mocks';
+import * as apiMocks from '@src/library-authoring/data/api.mocks';
 import { HistoryComponentLog, HistoryContainerLog } from './HistoryLog';
 
-mockLibraryBlockDraftHistory.applyMock();
-mockLibraryBlockPublishHistory.applyMock();
-mockLibraryBlockPublishHistoryEntries.applyMock();
-mockLibraryBlockCreationEntry.applyMock();
-mockLibraryBlockMetadata.applyMock();
-mockLibraryContainerDraftHistory.applyMock();
-mockLibraryContainerPublishHistory.applyMock();
-mockLibraryContainerCreationEntry.applyMock();
-mockGetContainerMetadata.applyMock();
+apiMocks.mockLibraryBlockDraftHistory.applyMock();
+apiMocks.mockLibraryBlockPublishHistory.applyMock();
+apiMocks.mockLibraryBlockPublishHistoryEntries.applyMock();
+apiMocks.mockLibraryBlockCreationEntry.applyMock();
+apiMocks.mockLibraryBlockMetadata.applyMock();
+apiMocks.mockLibraryContainerDraftHistory.applyMock();
+apiMocks.mockLibraryContainerPublishHistory.applyMock();
+apiMocks.mockLibraryContainerCreationEntry.applyMock();
+apiMocks.mockGetContainerMetadata.applyMock();
 
 const renderComponent = (componentId: string) =>
   render(
@@ -56,13 +46,13 @@ describe('<HistoryComponentLog />', () => {
   });
 
   it('shows loading spinner while fetching', () => {
-    renderComponent(mockLibraryBlockCreationEntry.usageKeyThatNeverLoads);
+    renderComponent(apiMocks.mockLibraryBlockCreationEntry.usageKeyThatNeverLoads);
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
   it('renders draft history group with entries when they exist', async () => {
     const user = userEvent.setup();
-    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    renderComponent(apiMocks.mockLibraryBlockCreationEntry.usageKey);
     const trigger = await findByDeepTextContent(/Introduction to Testing 1 is a draft/i);
     expect(trigger).toBeInTheDocument();
     await user.click(trigger);
@@ -71,20 +61,20 @@ describe('<HistoryComponentLog />', () => {
   });
 
   it('does not render draft history group when there are no draft entries', async () => {
-    renderComponent(mockLibraryBlockCreationEntry.usageKeyEmpty);
+    renderComponent(apiMocks.mockLibraryBlockCreationEntry.usageKeyEmpty);
     await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
     expect(screen.queryByText(/is a draft/i)).not.toBeInTheDocument();
   });
 
   it('renders publish history group when one exists', async () => {
-    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    renderComponent(apiMocks.mockLibraryBlockCreationEntry.usageKey);
     expect(await findByDeepTextContent(/author published.*Protons/i)).toBeInTheDocument();
     expect(await screen.findByText(/5 authors contributed/i)).toBeInTheDocument();
   });
 
   it('loads and shows publish history entries after expanding the publish group', async () => {
     const user = userEvent.setup();
-    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    renderComponent(apiMocks.mockLibraryBlockCreationEntry.usageKey);
     expect(await screen.findByText(/5 authors contributed/i)).toBeInTheDocument();
     const publishTrigger = await findByDeepTextContent(/author published.*Protons/i);
 
@@ -94,20 +84,20 @@ describe('<HistoryComponentLog />', () => {
   });
 
   it('does not render publish history group when list is empty', async () => {
-    renderComponent(mockLibraryBlockCreationEntry.usageKeyEmpty);
+    renderComponent(apiMocks.mockLibraryBlockCreationEntry.usageKeyEmpty);
     await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
     expect(screen.queryByText(/published/i)).not.toBeInTheDocument();
   });
 
   it('always renders the created group with fallback user when createdBy is null', async () => {
-    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    renderComponent(apiMocks.mockLibraryBlockCreationEntry.usageKey);
     expect(await findByDeepTextContent(/Author created.*Introduction to Testing 1/i)).toBeInTheDocument();
   });
 
   it('shows fallback "Author" for draft entry when contributor has no username', async () => {
     const user = userEvent.setup();
-    const originalData = mockLibraryBlockDraftHistory.data;
-    mockLibraryBlockDraftHistory.data = [
+    const originalData = apiMocks.mockLibraryBlockDraftHistory.data;
+    apiMocks.mockLibraryBlockDraftHistory.data = [
       {
         contributor: mockContributorNoUsername(),
         changedAt: '2026-03-16T11:00:00Z',
@@ -116,30 +106,30 @@ describe('<HistoryComponentLog />', () => {
         action: 'edited',
       },
     ];
-    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    renderComponent(apiMocks.mockLibraryBlockCreationEntry.usageKey);
     const trigger = await findByDeepTextContent(/Introduction to Testing 1 is a draft/i);
     await user.click(trigger);
     expect(await findByDeepTextContent(/Author edited.*Anonymous Component/i)).toBeInTheDocument();
-    mockLibraryBlockDraftHistory.data = originalData;
+    apiMocks.mockLibraryBlockDraftHistory.data = originalData;
   });
 
   it('shows fallback "Author" in publish group header when publishedBy is undefined', async () => {
-    const originalData = mockLibraryBlockPublishHistory.data;
-    mockLibraryBlockPublishHistory.data = [
+    const originalData = apiMocks.mockLibraryBlockPublishHistory.data;
+    apiMocks.mockLibraryBlockPublishHistory.data = [
       {
         ...originalData[0],
         publishedBy: undefined,
       },
     ];
-    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    renderComponent(apiMocks.mockLibraryBlockCreationEntry.usageKey);
     expect(await findByDeepTextContent(/Author published.*Protons/i)).toBeInTheDocument();
-    mockLibraryBlockPublishHistory.data = originalData;
+    apiMocks.mockLibraryBlockPublishHistory.data = originalData;
   });
 
   it('renders draft entry with "created" action', async () => {
     const user = userEvent.setup();
-    const originalData = mockLibraryBlockDraftHistory.data;
-    mockLibraryBlockDraftHistory.data = [
+    const originalData = apiMocks.mockLibraryBlockDraftHistory.data;
+    apiMocks.mockLibraryBlockDraftHistory.data = [
       {
         contributor: {
           username: 'creator_user',
@@ -156,27 +146,27 @@ describe('<HistoryComponentLog />', () => {
         action: 'created',
       },
     ] as any;
-    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    renderComponent(apiMocks.mockLibraryBlockCreationEntry.usageKey);
     const trigger = await findByDeepTextContent(/Introduction to Testing 1 is a draft/i);
     await user.click(trigger);
     expect(await findByDeepTextContent(/creator_user created.*New Component/i)).toBeInTheDocument();
-    mockLibraryBlockDraftHistory.data = originalData;
+    apiMocks.mockLibraryBlockDraftHistory.data = originalData;
   });
 
   it('renders publish group without collapsible and without contributor count when contributors is empty', async () => {
-    const originalData = mockLibraryBlockPublishHistory.data;
-    mockLibraryBlockPublishHistory.data = [
+    const originalData = apiMocks.mockLibraryBlockPublishHistory.data;
+    apiMocks.mockLibraryBlockPublishHistory.data = [
       {
         ...originalData[0],
         contributors: [],
       },
     ];
-    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    renderComponent(apiMocks.mockLibraryBlockCreationEntry.usageKey);
     const publishTitle = await findByDeepTextContent(/author published.*Protons/i);
     expect(publishTitle).toBeInTheDocument();
     expect(screen.queryByText(/authors? contributed/i)).not.toBeInTheDocument();
     expect(publishTitle.closest('[role="button"]')).toBeNull();
-    mockLibraryBlockPublishHistory.data = originalData;
+    apiMocks.mockLibraryBlockPublishHistory.data = originalData;
   });
 });
 
@@ -186,13 +176,13 @@ describe('<HistoryContainerLog />', () => {
   });
 
   it('shows loading spinner while fetching', () => {
-    renderContainerComponent(mockLibraryContainerDraftHistory.containerKeyThatNeverLoads);
+    renderContainerComponent(apiMocks.mockLibraryContainerDraftHistory.containerKeyThatNeverLoads);
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
   it('renders draft history group with entries when they exist', async () => {
     const user = userEvent.setup();
-    renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
+    renderContainerComponent(apiMocks.mockLibraryContainerDraftHistory.containerKey);
     const trigger = await findByDeepTextContent(/Test Unit is a draft/i);
     expect(trigger).toBeInTheDocument();
     await user.click(trigger);
@@ -201,27 +191,27 @@ describe('<HistoryContainerLog />', () => {
   });
 
   it('does not render draft history group when there are no draft entries', async () => {
-    renderContainerComponent(mockLibraryContainerDraftHistory.containerKeyEmpty);
+    renderContainerComponent(apiMocks.mockLibraryContainerDraftHistory.containerKeyEmpty);
     await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
     expect(screen.queryByText(/is a draft/i)).not.toBeInTheDocument();
   });
 
   it('renders publish history group when one exists', async () => {
-    renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
+    renderContainerComponent(apiMocks.mockLibraryContainerDraftHistory.containerKey);
     expect(await findByDeepTextContent(/container_author published.*Intro Unit/i)).toBeInTheDocument();
     expect(await screen.findByText(/2 authors contributed/i)).toBeInTheDocument();
   });
 
   it('does not render publish history group when list is empty', async () => {
-    renderContainerComponent(mockLibraryContainerDraftHistory.containerKeyEmpty);
+    renderContainerComponent(apiMocks.mockLibraryContainerDraftHistory.containerKeyEmpty);
     await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
     expect(screen.queryByText(/published/i)).not.toBeInTheDocument();
   });
 
   it('renders draft entry with "created" action', async () => {
     const user = userEvent.setup();
-    const originalData = mockLibraryContainerDraftHistory.data;
-    mockLibraryContainerDraftHistory.data = [
+    const originalData = apiMocks.mockLibraryContainerDraftHistory.data;
+    apiMocks.mockLibraryContainerDraftHistory.data = [
       {
         contributor: {
           username: 'creator_user',
@@ -238,46 +228,46 @@ describe('<HistoryContainerLog />', () => {
         action: 'created',
       },
     ] as any;
-    renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
+    renderContainerComponent(apiMocks.mockLibraryContainerDraftHistory.containerKey);
     const trigger = await findByDeepTextContent(/Test Unit is a draft/i);
     await user.click(trigger);
     expect(await findByDeepTextContent(/creator_user created.*New Unit/i)).toBeInTheDocument();
-    mockLibraryContainerDraftHistory.data = originalData;
+    apiMocks.mockLibraryContainerDraftHistory.data = originalData;
   });
 
   it('always renders the created group', async () => {
-    renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
+    renderContainerComponent(apiMocks.mockLibraryContainerDraftHistory.containerKey);
     expect(await findByDeepTextContent(/author created.*Introduction to Testing Unit 1/i)).toBeInTheDocument();
   });
 
   it('renders publish groups after container creation before the created entry', async () => {
     // Default mock: publishedAt '2026-03-14' is after createdAt '2024-01-01'
-    renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
+    renderContainerComponent(apiMocks.mockLibraryContainerDraftHistory.containerKey);
     const publishGroup = await findByDeepTextContent(/container_author published.*Intro Unit/i);
     const createdEntry = await findByDeepTextContent(/author created.*Introduction to Testing Unit 1/i);
     expect(publishGroup.compareDocumentPosition(createdEntry)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
   it('renders publish groups before container creation after the created entry', async () => {
-    const originalData = mockLibraryContainerPublishHistory.data;
-    mockLibraryContainerPublishHistory.data = [
+    const originalData = apiMocks.mockLibraryContainerPublishHistory.data;
+    apiMocks.mockLibraryContainerPublishHistory.data = [
       {
         ...originalData[0],
         publishedAt: '2023-01-01T00:00:00Z', // before createdAt '2024-01-01'
       },
     ];
-    renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
+    renderContainerComponent(apiMocks.mockLibraryContainerDraftHistory.containerKey);
     const createdEntry = await findByDeepTextContent(/author created.*Introduction to Testing Unit 1/i);
     expect(await screen.findByText(/2 authors contributed/i)).toBeInTheDocument();
     // The publish group contributors should still appear
     const contributorsText = screen.getByText(/2 authors contributed/i);
     expect(createdEntry.compareDocumentPosition(contributorsText)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
-    mockLibraryContainerPublishHistory.data = originalData;
+    apiMocks.mockLibraryContainerPublishHistory.data = originalData;
   });
 
   it('renders both pre-creation and post-creation publish groups in correct order', async () => {
-    const originalData = mockLibraryContainerPublishHistory.data;
-    mockLibraryContainerPublishHistory.data = [
+    const originalData = apiMocks.mockLibraryContainerPublishHistory.data;
+    apiMocks.mockLibraryContainerPublishHistory.data = [
       {
         ...originalData[0],
         publishLogUuid: 'after-uuid',
@@ -297,7 +287,7 @@ describe('<HistoryContainerLog />', () => {
         contributors: [],
       },
     ];
-    renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
+    renderContainerComponent(apiMocks.mockLibraryContainerDraftHistory.containerKey);
     const afterGroup = await findByDeepTextContent(/container_author published.*After Unit/i);
     const createdEntry = await findByDeepTextContent(/author created.*Introduction to Testing Unit 1/i);
     // After-creation group comes before the created entry
@@ -305,6 +295,6 @@ describe('<HistoryContainerLog />', () => {
     // Before-creation group title is hidden (hideLogVert=true, no contributors), so only the vert line renders
     // Verify the after-group is visible but before-group title is not
     expect(screen.queryByText(/container_author published.*Before Unit/i)).not.toBeInTheDocument();
-    mockLibraryContainerPublishHistory.data = originalData;
+    apiMocks.mockLibraryContainerPublishHistory.data = originalData;
   });
 });

--- a/src/library-authoring/generic/history-log/HistoryLog.test.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.test.tsx
@@ -169,7 +169,6 @@ describe('<HistoryComponentLog />', () => {
       {
         ...originalData[0],
         contributors: [],
-        contributorsCount: 0,
       },
     ];
     renderComponent(mockLibraryBlockCreationEntry.usageKey);

--- a/src/library-authoring/generic/history-log/HistoryLog.test.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.test.tsx
@@ -104,12 +104,12 @@ describe('<HistoryComponentLog />', () => {
     expect(await findByDeepTextContent(/Author created.*Introduction to Testing 1/i)).toBeInTheDocument();
   });
 
-  it('shows fallback "Author" for draft entry when changedBy has no username', async () => {
+  it('shows fallback "Author" for draft entry when contributor has no username', async () => {
     const user = userEvent.setup();
     const originalData = mockLibraryBlockDraftHistory.data;
     mockLibraryBlockDraftHistory.data = [
       {
-        changedBy: mockContributorNoUsername(),
+        contributor: mockContributorNoUsername(),
         changedAt: '2026-03-16T11:00:00Z',
         title: 'Anonymous Component',
         itemType: 'html',
@@ -141,7 +141,7 @@ describe('<HistoryComponentLog />', () => {
     const originalData = mockLibraryBlockDraftHistory.data;
     mockLibraryBlockDraftHistory.data = [
       {
-        changedBy: {
+        contributor: {
           username: 'creator_user',
           profileImageUrls: {
             full: 'icon/mock/path',
@@ -224,7 +224,7 @@ describe('<HistoryContainerLog />', () => {
     const originalData = mockLibraryContainerDraftHistory.data;
     mockLibraryContainerDraftHistory.data = [
       {
-        changedBy: {
+        contributor: {
           username: 'creator_user',
           profileImageUrls: {
             full: 'icon/mock/path',

--- a/src/library-authoring/generic/history-log/HistoryLog.test.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.test.tsx
@@ -1,0 +1,81 @@
+import { userEvent } from '@testing-library/user-event';
+import {
+  initializeMocks,
+  render,
+  screen,
+  waitFor,
+  findByDeepTextContent,
+} from '@src/testUtils';
+
+import {
+  mockLibraryBlockDraftHistory,
+  mockLibraryBlockPublishHistory,
+  mockLibraryBlockPublishHistoryEntries,
+  mockLibraryBlockCreationEntry,
+} from '@src/library-authoring/data/api.mocks';
+import { HistoryComponentLog } from './HistoryLog';
+
+mockLibraryBlockDraftHistory.applyMock();
+mockLibraryBlockPublishHistory.applyMock();
+mockLibraryBlockPublishHistoryEntries.applyMock();
+mockLibraryBlockCreationEntry.applyMock();
+
+const renderComponent = (componentId: string) => render(
+  <HistoryComponentLog componentId={componentId} displayName="Test Component" />,
+);
+
+
+describe('<HistoryComponentLog />', () => {
+  beforeEach(() => {
+    initializeMocks();
+  });
+
+  it('shows loading spinner while fetching', () => {
+    renderComponent(mockLibraryBlockCreationEntry.usageKeyThatNeverLoads);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('renders draft history group with entries when they exist', async () => {
+    const user = userEvent.setup();
+    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    const trigger = await findByDeepTextContent(/Test Component is a draft/i);
+    expect(trigger).toBeInTheDocument();
+    await user.click(trigger);
+    expect(await findByDeepTextContent(/test_user_1 edited.*Electron Arcs/i)).toBeInTheDocument();
+    expect(await findByDeepTextContent(/test_user_2 renamed.*More on Quarks/i)).toBeInTheDocument();
+  });
+
+  it('does not render draft history group when there are no draft entries', async () => {
+    renderComponent(mockLibraryBlockCreationEntry.usageKeyEmpty);
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+    expect(screen.queryByText('Test Component is a draft')).not.toBeInTheDocument();
+  });
+
+  it('renders publish history group when one exists', async () => {
+    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    expect(await findByDeepTextContent(/author published.*Protons/i)).toBeInTheDocument();
+    expect(await screen.findByText(/5 authors contributed/i)).toBeInTheDocument();
+  });
+
+  it('loads and shows publish history entries after expanding the publish group', async () => {
+    const user = userEvent.setup();
+    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    expect(await screen.findByText(/5 authors contributed/i)).toBeInTheDocument();
+    const publishTrigger = await findByDeepTextContent(/author published.*Protons/i);
+
+    await user.click(publishTrigger);
+    expect(await findByDeepTextContent(/test_user edited.*Protons/i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText(/5 authors contributed/i)).not.toBeInTheDocument());
+  });
+
+  it('does not render publish history group when list is empty', async () => {
+    renderComponent(mockLibraryBlockCreationEntry.usageKeyEmpty);
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+    expect(screen.queryByText(/published/i)).not.toBeInTheDocument();
+  });
+
+  it('always renders the created group with fallback user when createdBy is null', async () => {
+    renderComponent(mockLibraryBlockCreationEntry.usageKey);
+    expect(await findByDeepTextContent(/Author created.*Introduction to Testing 1/i)).toBeInTheDocument();
+  });
+});

--- a/src/library-authoring/generic/history-log/HistoryLog.test.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.test.tsx
@@ -12,18 +12,33 @@ import {
   mockLibraryBlockPublishHistory,
   mockLibraryBlockPublishHistoryEntries,
   mockLibraryBlockCreationEntry,
+  mockLibraryBlockMetadata,
+  mockLibraryContainerDraftHistory,
+  mockLibraryContainerPublishHistory,
+  mockLibraryContainerCreationEntry,
+  mockGetContainerMetadata,
 } from '@src/library-authoring/data/api.mocks';
-import { HistoryComponentLog } from './HistoryLog';
+import { HistoryComponentLog, HistoryContainerLog } from './HistoryLog';
 
 mockLibraryBlockDraftHistory.applyMock();
 mockLibraryBlockPublishHistory.applyMock();
 mockLibraryBlockPublishHistoryEntries.applyMock();
 mockLibraryBlockCreationEntry.applyMock();
+mockLibraryBlockMetadata.applyMock();
+mockLibraryContainerDraftHistory.applyMock();
+mockLibraryContainerPublishHistory.applyMock();
+mockLibraryContainerCreationEntry.applyMock();
+mockGetContainerMetadata.applyMock();
 
-const renderComponent = (componentId: string) => render(
-  <HistoryComponentLog componentId={componentId} displayName="Test Component" />,
-);
+const renderComponent = (componentId: string) =>
+  render(
+    <HistoryComponentLog componentId={componentId} />,
+  );
 
+const renderContainerComponent = (containerId: string) =>
+  render(
+    <HistoryContainerLog containerId={containerId} />,
+  );
 
 describe('<HistoryComponentLog />', () => {
   beforeEach(() => {
@@ -38,7 +53,7 @@ describe('<HistoryComponentLog />', () => {
   it('renders draft history group with entries when they exist', async () => {
     const user = userEvent.setup();
     renderComponent(mockLibraryBlockCreationEntry.usageKey);
-    const trigger = await findByDeepTextContent(/Test Component is a draft/i);
+    const trigger = await findByDeepTextContent(/Introduction to Testing 1 is a draft/i);
     expect(trigger).toBeInTheDocument();
     await user.click(trigger);
     expect(await findByDeepTextContent(/test_user_1 edited.*Electron Arcs/i)).toBeInTheDocument();
@@ -48,7 +63,7 @@ describe('<HistoryComponentLog />', () => {
   it('does not render draft history group when there are no draft entries', async () => {
     renderComponent(mockLibraryBlockCreationEntry.usageKeyEmpty);
     await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
-    expect(screen.queryByText('Test Component is a draft')).not.toBeInTheDocument();
+    expect(screen.queryByText(/is a draft/i)).not.toBeInTheDocument();
   });
 
   it('renders publish history group when one exists', async () => {
@@ -77,5 +92,49 @@ describe('<HistoryComponentLog />', () => {
   it('always renders the created group with fallback user when createdBy is null', async () => {
     renderComponent(mockLibraryBlockCreationEntry.usageKey);
     expect(await findByDeepTextContent(/Author created.*Introduction to Testing 1/i)).toBeInTheDocument();
+  });
+});
+
+describe('<HistoryContainerLog />', () => {
+  beforeEach(() => {
+    initializeMocks();
+  });
+
+  it('shows loading spinner while fetching', () => {
+    renderContainerComponent(mockLibraryContainerDraftHistory.containerKeyThatNeverLoads);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('renders draft history group with entries when they exist', async () => {
+    const user = userEvent.setup();
+    renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
+    const trigger = await findByDeepTextContent(/Test Unit is a draft/i);
+    expect(trigger).toBeInTheDocument();
+    await user.click(trigger);
+    expect(await findByDeepTextContent(/container_user_1 edited.*Intro Unit/i)).toBeInTheDocument();
+    expect(await findByDeepTextContent(/container_user_2 renamed.*Unit Renamed/i)).toBeInTheDocument();
+  });
+
+  it('does not render draft history group when there are no draft entries', async () => {
+    renderContainerComponent(mockLibraryContainerDraftHistory.containerKeyEmpty);
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+    expect(screen.queryByText(/is a draft/i)).not.toBeInTheDocument();
+  });
+
+  it('renders publish history group when one exists', async () => {
+    renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
+    expect(await findByDeepTextContent(/container_author published.*Intro Unit/i)).toBeInTheDocument();
+    expect(await screen.findByText(/2 authors contributed/i)).toBeInTheDocument();
+  });
+
+  it('does not render publish history group when list is empty', async () => {
+    renderContainerComponent(mockLibraryContainerDraftHistory.containerKeyEmpty);
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+    expect(screen.queryByText(/published/i)).not.toBeInTheDocument();
+  });
+
+  it('always renders the created group', async () => {
+    renderContainerComponent(mockLibraryContainerDraftHistory.containerKey);
+    expect(await findByDeepTextContent(/author created.*Introduction to Testing Unit 1/i)).toBeInTheDocument();
   });
 });

--- a/src/library-authoring/generic/history-log/HistoryLog.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.tsx
@@ -56,7 +56,7 @@ export const HistoryComponentLog = ({ componentId }: { componentId: string; }) =
       )}
       {creationEntry && (
         <HistoryCreatedLogGroup
-          user={creationEntry.changedBy?.username}
+          user={creationEntry.contributor?.username}
           displayName={creationEntry.title}
           itemType={creationEntry.itemType}
           createdAt={creationEntry.changedAt}
@@ -111,7 +111,7 @@ export const HistoryContainerLog = ({ containerId }: { containerId: string; }) =
       )}
       {creationEntry && (
         <HistoryCreatedLogGroup
-          user={creationEntry.changedBy?.username}
+          user={creationEntry.contributor?.username}
           displayName={creationEntry.title}
           itemType={creationEntry.itemType}
           createdAt={creationEntry.changedAt}

--- a/src/library-authoring/generic/history-log/HistoryLog.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.tsx
@@ -1,20 +1,17 @@
-import { LoadingSpinner } from "@src/generic/Loading";
+import { LoadingSpinner } from '@src/generic/Loading';
 import {
+  useContainer,
   useLibraryBlockCreationEntry,
   useLibraryBlockDraftHistory,
+  useLibraryBlockMetadata,
   useLibraryBlockPublishHistory,
-} from "@src/library-authoring/data/apiHooks";
-import { HistoryCreatedLogGroup, HistoryDraftLogGroup, HistoryPublishLogGroup } from "./HistoryLogGroup";
+  useLibraryContainerCreationEntry,
+  useLibraryContainerDraftHistory,
+  useLibraryContainerPublishHistory,
+} from '@src/library-authoring/data/apiHooks';
+import { HistoryCreatedLogGroup, HistoryDraftLogGroup, HistoryPublishLogGroup } from './HistoryLogGroup';
 
-export interface HistoryComponentLogProps {
-  componentId: string;
-  displayName: string;
-}
-
-export const HistoryComponentLog = ({
-  componentId,
-  displayName,
-}: HistoryComponentLogProps) => {
+export const HistoryComponentLog = ({ componentId }: { componentId: string; }) => {
   const {
     data: draftHistory,
     isPending: isPendingDraftHistory,
@@ -28,37 +25,95 @@ export const HistoryComponentLog = ({
   const {
     data: creationEntry,
     isPending: isPendingCreationEntry,
-  } = useLibraryBlockCreationEntry(componentId); 
+  } = useLibraryBlockCreationEntry(componentId);
 
-  if (isPendingDraftHistory || isPendingPublishHistoryGroups || isPendingCreationEntry) {
-    return <LoadingSpinner />
+  const {
+    data: componentMetadata,
+    isPending: isPendingComponentMetadata,
+  } = useLibraryBlockMetadata(componentId);
+
+  if (isPendingDraftHistory || isPendingPublishHistoryGroups || isPendingCreationEntry || isPendingComponentMetadata) {
+    return <LoadingSpinner />;
   }
-  
+
   return (
     <div className="history-log">
       {draftHistory && draftHistory.length !== 0 && (
         <HistoryDraftLogGroup
-          displayName={displayName}
+          displayName={componentMetadata?.displayName || ''}
           entries={draftHistory}
-        /> 
+        />
       )}
       {publishHistoryGroups && publishHistoryGroups.length !== 0 && (
-        publishHistoryGroups.map((publishGroup) => {
-          return (
-            <div key={publishGroup.publishLogUuid}>
-              <HistoryPublishLogGroup
-                {...publishGroup}
-                itemId={componentId}
-              />
-            </div>
-          )
-        })
+        publishHistoryGroups.map((publishGroup) => (
+          <div key={`${publishGroup.publishLogUuid}-${publishGroup.directPublishedEntities[0].entityKey}`}>
+            <HistoryPublishLogGroup
+              {...publishGroup}
+              itemId={publishGroup.scopeEntityKey || componentId}
+            />
+          </div>
+        ))
       )}
       {creationEntry && (
         <HistoryCreatedLogGroup
           user={creationEntry.changedBy.username}
           displayName={creationEntry.title}
-          itemType={creationEntry.blockType}
+          itemType={creationEntry.itemType}
+          createdAt={creationEntry.changedAt}
+        />
+      )}
+    </div>
+  );
+};
+
+export const HistoryContainerLog = ({ containerId }: { containerId: string; }) => {
+  const {
+    data: draftHistory,
+    isPending: isPendingDraftHistory,
+  } = useLibraryContainerDraftHistory(containerId);
+
+  const {
+    data: publishHistoryGroups,
+    isPending: isPendingPublishHistoryGroups,
+  } = useLibraryContainerPublishHistory(containerId);
+
+  const {
+    data: creationEntry,
+    isPending: isPendingCreationEntry,
+  } = useLibraryContainerCreationEntry(containerId);
+
+  const {
+    data: container,
+    isPending: isPendingContainer,
+  } = useContainer(containerId);
+
+  if (isPendingDraftHistory || isPendingContainer || isPendingPublishHistoryGroups || isPendingCreationEntry) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <div className="history-log">
+      {draftHistory && draftHistory.length !== 0 && (
+        <HistoryDraftLogGroup
+          displayName={container?.displayName ?? ''}
+          entries={draftHistory}
+        />
+      )}
+      {publishHistoryGroups && publishHistoryGroups.length !== 0 && (
+        publishHistoryGroups.map((publishGroup) => (
+          <div key={`${publishGroup.publishLogUuid}-${publishGroup.directPublishedEntities[0].entityKey}`}>
+            <HistoryPublishLogGroup
+              {...publishGroup}
+              itemId={publishGroup.scopeEntityKey || containerId}
+            />
+          </div>
+        ))
+      )}
+      {creationEntry && (
+        <HistoryCreatedLogGroup
+          user={creationEntry.changedBy.username}
+          displayName={creationEntry.title}
+          itemType={creationEntry.itemType}
           createdAt={creationEntry.changedAt}
         />
       )}

--- a/src/library-authoring/generic/history-log/HistoryLog.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.tsx
@@ -56,7 +56,7 @@ export const HistoryComponentLog = ({ componentId }: { componentId: string; }) =
       )}
       {creationEntry && (
         <HistoryCreatedLogGroup
-          user={creationEntry.changedBy.username}
+          user={creationEntry.changedBy?.username}
           displayName={creationEntry.title}
           itemType={creationEntry.itemType}
           createdAt={creationEntry.changedAt}
@@ -111,7 +111,7 @@ export const HistoryContainerLog = ({ containerId }: { containerId: string; }) =
       )}
       {creationEntry && (
         <HistoryCreatedLogGroup
-          user={creationEntry.changedBy.username}
+          user={creationEntry.changedBy?.username}
           displayName={creationEntry.title}
           itemType={creationEntry.itemType}
           createdAt={creationEntry.changedAt}

--- a/src/library-authoring/generic/history-log/HistoryLog.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.tsx
@@ -13,6 +13,13 @@ import { HistoryCreatedLogGroup, HistoryDraftLogGroup, HistoryPublishLogGroup } 
 import { useMemo } from 'react';
 import { LibraryPublishHistoryGroup } from '@src/library-authoring/data/api';
 
+/**
+ * History log for a single component (block).
+ *
+ * Renders, top to bottom: pending draft edits, publish groups, and the creation entry.
+ * For the container equivalent see HistoryContainerLog, which adds logic to split publish
+ * groups into those before and after the container's creation time.
+ */
 export const HistoryComponentLog = ({ componentId }: { componentId: string; }) => {
   const {
     data: draftHistory,
@@ -68,6 +75,17 @@ export const HistoryComponentLog = ({ componentId }: { componentId: string; }) =
   );
 };
 
+/**
+ * History log for a container (e.g. a Unit).
+ *
+ * Similar to HistoryComponentLog but uses container-specific API hooks and splits publish groups
+ * into those after and before the container's creation time. The latter can occur when the container
+ * has children that were published before the container itself was created.
+ * These "before creation" groups are rendered below the creation entry.
+ *
+ * These two components are kept separate because the hooks they use are different and the
+ * before/after creation split logic only applies to containers.
+ */
 export const HistoryContainerLog = ({ containerId }: { containerId: string; }) => {
   const {
     data: draftHistory,

--- a/src/library-authoring/generic/history-log/HistoryLog.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.tsx
@@ -10,6 +10,8 @@ import {
   useLibraryContainerPublishHistory,
 } from '@src/library-authoring/data/apiHooks';
 import { HistoryCreatedLogGroup, HistoryDraftLogGroup, HistoryPublishLogGroup } from './HistoryLogGroup';
+import { useMemo } from 'react';
+import { LibraryPublishHistoryGroup } from '@src/library-authoring/data/api';
 
 export const HistoryComponentLog = ({ componentId }: { componentId: string; }) => {
   const {
@@ -87,9 +89,44 @@ export const HistoryContainerLog = ({ containerId }: { containerId: string; }) =
     isPending: isPendingContainer,
   } = useContainer(containerId);
 
+  const creationTime = creationEntry?.changedAt;
+
+  const {
+    groupsAfterCreation,
+    groupsBeforeCreation,
+  } = useMemo(() => {
+    return {
+      groupsAfterCreation: publishHistoryGroups?.filter(
+        (group) => !creationTime || group.publishedAt >= creationTime,
+      ) ?? [],
+      groupsBeforeCreation: publishHistoryGroups?.filter(
+        (group) => creationTime && group.publishedAt < creationTime,
+      ) ?? [],
+    };
+  }, [publishHistoryGroups, creationTime]);
+
   if (isPendingDraftHistory || isPendingContainer || isPendingPublishHistoryGroups || isPendingCreationEntry) {
     return <LoadingSpinner />;
   }
+
+  const hasBeforeCreationGroups = groupsBeforeCreation.length > 0;
+
+  const renderPublishGroups = (
+    groups: LibraryPublishHistoryGroup[],
+    isBeforeGroup: boolean,
+  ) =>
+    groups.map((publishGroup, index, arr) => {
+      const isLast = index === arr.length - 1;
+      return (
+        <div key={`${publishGroup.publishLogUuid}-${publishGroup.directPublishedEntities[0].entityKey}`}>
+          <HistoryPublishLogGroup
+            {...publishGroup}
+            itemId={publishGroup.scopeEntityKey || containerId}
+            hideLogVert={isLast && isBeforeGroup}
+          />
+        </div>
+      );
+    });
 
   return (
     <div className="history-log">
@@ -99,24 +136,17 @@ export const HistoryContainerLog = ({ containerId }: { containerId: string; }) =
           entries={draftHistory}
         />
       )}
-      {publishHistoryGroups && publishHistoryGroups.length !== 0 && (
-        publishHistoryGroups.map((publishGroup) => (
-          <div key={`${publishGroup.publishLogUuid}-${publishGroup.directPublishedEntities[0].entityKey}`}>
-            <HistoryPublishLogGroup
-              {...publishGroup}
-              itemId={publishGroup.scopeEntityKey || containerId}
-            />
-          </div>
-        ))
-      )}
+      {renderPublishGroups(groupsAfterCreation, false)}
       {creationEntry && (
         <HistoryCreatedLogGroup
           user={creationEntry.contributor?.username}
           displayName={creationEntry.title}
           itemType={creationEntry.itemType}
           createdAt={creationEntry.changedAt}
+          showLogVert={hasBeforeCreationGroups}
         />
       )}
+      {hasBeforeCreationGroups && renderPublishGroups(groupsBeforeCreation, true)}
     </div>
   );
 };

--- a/src/library-authoring/generic/history-log/HistoryLog.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLog.tsx
@@ -1,0 +1,67 @@
+import { LoadingSpinner } from "@src/generic/Loading";
+import {
+  useLibraryBlockCreationEntry,
+  useLibraryBlockDraftHistory,
+  useLibraryBlockPublishHistory,
+} from "@src/library-authoring/data/apiHooks";
+import { HistoryCreatedLogGroup, HistoryDraftLogGroup, HistoryPublishLogGroup } from "./HistoryLogGroup";
+
+export interface HistoryComponentLogProps {
+  componentId: string;
+  displayName: string;
+}
+
+export const HistoryComponentLog = ({
+  componentId,
+  displayName,
+}: HistoryComponentLogProps) => {
+  const {
+    data: draftHistory,
+    isPending: isPendingDraftHistory,
+  } = useLibraryBlockDraftHistory(componentId);
+
+  const {
+    data: publishHistoryGroups,
+    isPending: isPendingPublishHistoryGroups,
+  } = useLibraryBlockPublishHistory(componentId);
+
+  const {
+    data: creationEntry,
+    isPending: isPendingCreationEntry,
+  } = useLibraryBlockCreationEntry(componentId); 
+
+  if (isPendingDraftHistory || isPendingPublishHistoryGroups || isPendingCreationEntry) {
+    return <LoadingSpinner />
+  }
+  
+  return (
+    <div className="history-log">
+      {draftHistory && draftHistory.length !== 0 && (
+        <HistoryDraftLogGroup
+          displayName={displayName}
+          entries={draftHistory}
+        /> 
+      )}
+      {publishHistoryGroups && publishHistoryGroups.length !== 0 && (
+        publishHistoryGroups.map((publishGroup) => {
+          return (
+            <div key={publishGroup.publishLogUuid}>
+              <HistoryPublishLogGroup
+                {...publishGroup}
+                itemId={componentId}
+              />
+            </div>
+          )
+        })
+      )}
+      {creationEntry && (
+        <HistoryCreatedLogGroup
+          user={creationEntry.changedBy.username}
+          displayName={creationEntry.title}
+          itemType={creationEntry.blockType}
+          createdAt={creationEntry.changedAt}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
@@ -105,13 +105,24 @@ const HistoryLogGroupEntries = ({
 }: HistoryLogGroupEntriesProps) => {
   const intl = useIntl();
 
+  const getEntryMessage = (entry: LibraryHistoryEntry) => {
+    switch (entry.action) {
+      case 'edited':
+        return messages.historyEditEntry;
+      case 'renamed':
+        return messages.historyRenameEntry;
+      case 'created':
+        return messages.historyCreatedEntry;
+      default:
+        return messages.historyEditEntry;
+    }
+  };
+
   return (
     <Stack gap={0}>
       <div className="history-log-vert" />
       {entries.map((entry) => {
-        const entryMessage = entry.action === 'edited'
-          ? messages.historyEditEntry
-          : messages.historyRenameEntry;
+        const entryMessage = getEntryMessage(entry);
 
         return (
           <div key={entry.changedAt}>

--- a/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
@@ -246,67 +246,64 @@ export const HistoryPublishLogGroup = ({
   } = useLibraryPublishHistoryEntries(itemId, publishLogUuid, isOpenCollapsible);
 
   const dateMessage = moment(publishedAt).fromNow();
+  const hasContributors = contributors.length > 0;
+
+  const titleMessage = directPublishedEntities.length === 1
+    ? intl.formatMessage(messages.publishTitle, {
+      user: publishedBy || intl.formatMessage(messages.historyEntryDefaultUser),
+      displayName: <span className="history-log-title text-truncate">{directPublishedEntities[0].title}</span>,
+      icon: <Icon src={getItemIcon(directPublishedEntities[0].entityType)} />,
+    })
+    : intl.formatMessage(messages.publishTitleMultiple, {
+      user: publishedBy || intl.formatMessage(messages.historyEntryDefaultUser),
+      icon: <Icon src={getItemIcon('default')} />,
+    });
 
   return (
     <div className="history-log-group publish-group">
-      <Collapsible.Advanced
-        open={isOpenCollapsible}
-        onOpen={openCollapsible}
-        onClose={closeCollapsible}
-      >
-        <Collapsible.Trigger>
-          {directPublishedEntities.length === 1 && (
-            <HistoryLogGroupTitle
-              titleMessage={intl.formatMessage(
-                messages.publishTitle,
-                {
-                  user: publishedBy || intl.formatMessage(messages.historyEntryDefaultUser),
-                  displayName: (
-                    <span className="history-log-title text-truncate">{directPublishedEntities[0].title}</span>
-                  ),
-                  icon: <Icon src={getItemIcon(directPublishedEntities[0].entityType)} />,
-                },
-              )}
-              dateMessage={dateMessage}
-            />
-          )}
-          {directPublishedEntities.length > 1 && (
-            <HistoryLogGroupTitle
-              titleMessage={intl.formatMessage(
-                messages.publishTitleMultiple,
-                {
-                  user: publishedBy,
-                  icon: <Icon src={getItemIcon('default')} />,
-                },
-              )}
-              dateMessage={dateMessage}
-            />
-          )}
-        </Collapsible.Trigger>
-        <Collapsible.Body>
-          {isPending ?
-            (
-              <>
-                <div className="history-log-vert" />
-                <div className="ml-2 mt-2 w-100">
-                  <LoadingSpinner />
-                </div>
-              </>
-            ) :
-            <HistoryLogGroupEntries entries={entries ?? []} />}
-        </Collapsible.Body>
-      </Collapsible.Advanced>
-      <Stack direction="horizontal">
-        <div
-          className={classNames(
-            'history-log-vert',
-            {
-              'history-log-vert-long': !isOpenCollapsible,
-            },
-          )}
-        />
-        {!isOpenCollapsible && <ContributorsAvatars contributors={contributors} />}
-      </Stack>
+      {hasContributors ?
+        (
+          <Collapsible.Advanced
+            open={isOpenCollapsible}
+            onOpen={openCollapsible}
+            onClose={closeCollapsible}
+          >
+            <Collapsible.Trigger>
+              <HistoryLogGroupTitle titleMessage={titleMessage} dateMessage={dateMessage} />
+            </Collapsible.Trigger>
+            <Collapsible.Body>
+              {isPending ?
+                (
+                  <>
+                    <div className="history-log-vert" />
+                    <div className="ml-2 mt-2 w-100">
+                      <LoadingSpinner />
+                    </div>
+                  </>
+                ) :
+                <HistoryLogGroupEntries entries={entries ?? []} />}
+            </Collapsible.Body>
+          </Collapsible.Advanced>
+        ) :
+        (
+          <>
+            <HistoryLogGroupTitle titleMessage={titleMessage} dateMessage={dateMessage} disableCollapsible />
+            <div className="history-log-vert" />
+          </>
+        )}
+      {hasContributors && (
+        <Stack direction="horizontal">
+          <div
+            className={classNames(
+              'history-log-vert',
+              {
+                'history-log-vert-long': !isOpenCollapsible,
+              },
+            )}
+          />
+          {!isOpenCollapsible && <ContributorsAvatars contributors={contributors} />}
+        </Stack>
+      )}
     </div>
   );
 };

--- a/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
@@ -128,8 +128,8 @@ const HistoryLogGroupEntries = ({
           <div key={entry.changedAt}>
             <Stack direction="horizontal" gap={2} className="ml-1.5">
               <ContributorAvatar
-                username={entry.changedBy?.username || intl.formatMessage(messages.historyEntryDefaultUser)}
-                src={entry.changedBy.profileImageUrls.medium}
+                username={entry.contributor?.username || intl.formatMessage(messages.historyEntryDefaultUser)}
+                src={entry.contributor.profileImageUrls.medium}
                 className="history-log-group-avatar small-avatar"
                 size="sm"
               />
@@ -138,7 +138,7 @@ const HistoryLogGroupEntries = ({
                   <FormattedMessage
                     {...entryMessage}
                     values={{
-                      user: entry.changedBy.username ?? intl.formatMessage(messages.historyEntryDefaultUser),
+                      user: entry.contributor.username ?? intl.formatMessage(messages.historyEntryDefaultUser),
                       displayName: <span className="history-log-title text-truncate">{entry.title}</span>,
                       icon: <Icon src={getItemIcon(entry.itemType)} />,
                     }}

--- a/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
@@ -25,6 +25,7 @@ export interface HistoryCreatedLogGroupProps {
   displayName: string;
   itemType: string;
   createdAt: string;
+  showLogVert?: boolean;
 }
 
 export interface HistoryDraftLogGroupProps {
@@ -34,10 +35,12 @@ export interface HistoryDraftLogGroupProps {
 
 export interface HistoryLogGroupEntriesProps {
   entries: LibraryHistoryEntry[];
+  hideLastLogVert?: boolean;
 }
 
 export interface HistoryPublishLogGroupProps extends LibraryPublishHistoryGroup {
   itemId: string;
+  hideLogVert?: boolean;
 }
 
 interface ContributorAvatarProps {
@@ -102,6 +105,7 @@ const HistoryLogGroupTitle = ({
 
 const HistoryLogGroupEntries = ({
   entries,
+  hideLastLogVert,
 }: HistoryLogGroupEntriesProps) => {
   const intl = useIntl();
 
@@ -121,7 +125,8 @@ const HistoryLogGroupEntries = ({
   return (
     <Stack gap={0}>
       <div className="history-log-vert" />
-      {entries.map((entry) => {
+      {entries.map((entry, index, arr) => {
+        const isLast = index === arr.length - 1;
         const entryMessage = getEntryMessage(entry);
 
         return (
@@ -149,7 +154,7 @@ const HistoryLogGroupEntries = ({
                 </span>
               </Stack>
             </Stack>
-            <div className="history-log-vert" />
+            {!isLast && !hideLastLogVert && <div className="history-log-vert" />}
           </div>
         );
       })}
@@ -162,6 +167,7 @@ export const HistoryCreatedLogGroup = ({
   displayName,
   itemType,
   createdAt,
+  showLogVert,
 }: HistoryCreatedLogGroupProps) => {
   const intl = useIntl();
 
@@ -176,6 +182,7 @@ export const HistoryCreatedLogGroup = ({
         dateMessage={moment(createdAt).fromNow()}
         disableCollapsible
       />
+      {showLogVert && <div className="history-log-vert" />}
     </div>
   );
 };
@@ -247,6 +254,7 @@ export const HistoryPublishLogGroup = ({
   publishedBy,
   publishedAt,
   contributors,
+  hideLogVert,
 }: HistoryPublishLogGroupProps) => {
   const intl = useIntl();
   const [isOpenCollapsible, openCollapsible, closeCollapsible] = useToggle(false);
@@ -298,21 +306,36 @@ export const HistoryPublishLogGroup = ({
         ) :
         (
           <>
-            <HistoryLogGroupTitle titleMessage={titleMessage} dateMessage={dateMessage} disableCollapsible />
+            {!hideLogVert && (
+              <HistoryLogGroupTitle titleMessage={titleMessage} dateMessage={dateMessage} disableCollapsible />
+            )}
             <div className="history-log-vert" />
           </>
         )}
       {hasContributors && (
         <Stack direction="horizontal">
-          <div
-            className={classNames(
-              'history-log-vert',
-              {
-                'history-log-vert-long': !isOpenCollapsible,
-              },
+          {!hideLogVert && (
+            <div
+              className={classNames(
+                'history-log-vert',
+                {
+                  'history-log-vert-long': !isOpenCollapsible,
+                },
+              )}
+            />
+          )}
+          {!isOpenCollapsible &&
+            (
+              <div
+                className={classNames(
+                  {
+                    'ml-4 pl-1': hideLogVert,
+                  },
+                )}
+              >
+                <ContributorsAvatars contributors={contributors} />
+              </div>
             )}
-          />
-          {!isOpenCollapsible && <ContributorsAvatars contributors={contributors} />}
         </Stack>
       )}
     </div>

--- a/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
@@ -1,0 +1,291 @@
+import { ComponentProps, ReactNode, useState } from "react";
+import moment from "moment";
+import classNames from "classnames";
+import { Avatar, Collapsible, Icon, Stack, useToggle } from "@openedx/paragon";
+import { KeyboardArrowDown, KeyboardArrowUp } from "@openedx/paragon/icons";
+import { FormattedMessage, useIntl } from "@edx/frontend-platform/i18n";
+
+import { useLibraryBlockPublishHistoryEntries } from "@src/library-authoring/data/apiHooks";
+import { LoadingSpinner } from "@src/generic/Loading";
+
+import { LibraryHistoryEntry, LibraryPublishContributor, LibraryPublishHistoryGroup } from "../../data/api";
+import messages from "./messages";
+import { getItemIcon } from "@src/generic/block-type-utils";
+
+const MAX_VISIBLE_CONTRIBUTORS = 5;
+
+export interface HistoryLogGroupTitleProps {
+  titleMessage: string | ReactNode;
+  dateMessage: string;
+  disableCollapsible?: boolean;
+}
+
+export interface HistoryCreatedLogGroupProps {
+  user?: string | null;
+  displayName: string;
+  itemType: string;
+  createdAt: string;
+}
+
+export interface HistoryDraftLogGroupProps {
+  displayName: string;
+  entries: LibraryHistoryEntry[];
+}
+
+export interface HistoryLogGroupEntriesProps {
+  entries: LibraryHistoryEntry[];
+}
+
+export interface HistoryPublishLogGroupProps extends LibraryPublishHistoryGroup {
+  itemId: string;
+}
+
+interface ContributorAvatarProps {
+  username: string;
+  src: string;
+  className: string;
+  size: ComponentProps<typeof Avatar>['size'];
+}
+
+interface ContributorsAvatarsProps {
+  contributors: LibraryPublishContributor[];
+}
+
+const ContributorAvatar = ({
+  username,
+  src,
+  className,
+  size,
+}: ContributorAvatarProps) => {
+  const [imgError, setImgError] = useState(false);
+  return (
+    <Avatar
+      className={className}
+      size={size}
+      src={imgError ? undefined : src}
+      alt={username}
+      onError={() => setImgError(true)}
+    />
+  );
+};
+
+const HistoryLogGroupTitle = ({
+  titleMessage,
+  dateMessage,
+  disableCollapsible = false,
+}: HistoryLogGroupTitleProps) => {
+  return (
+    <Stack direction="horizontal" gap={2} className="mb-1">
+      <Avatar className="history-log-group-avatar big-avatar" size="md"/>
+      <Stack>
+        <Stack direction="horizontal" gap={1}>
+          {titleMessage}
+        </Stack>
+        <span className="small text-gray-500">
+          {dateMessage}
+        </span>
+      </Stack>
+      {!disableCollapsible && (
+        <>
+          <Collapsible.Visible whenClosed>
+            <Icon src={KeyboardArrowDown}/>
+          </Collapsible.Visible>
+          <Collapsible.Visible whenOpen>
+            <Icon src={KeyboardArrowUp}/>
+          </Collapsible.Visible>
+        </>
+      )}
+    </Stack>
+  )
+};
+
+const HistoryLogGroupEntries = ({
+  entries,
+}: HistoryLogGroupEntriesProps) => (
+  <Stack gap={0}>
+    <div className="history-log-vert" />
+    {entries.map((entry) => {
+      const entryMessage = entry.action === 'edited'
+        ? messages.historyEditEntry
+        : messages.historyRenameEntry;
+      
+      return (
+        <div key={entry.changedAt}>
+          <Stack direction="horizontal" gap={2} className="ml-1.5">
+            <ContributorAvatar
+              username={entry.changedBy.username}
+              src={entry.changedBy.profileImageUrls.medium}
+              className="history-log-group-avatar small-avatar"
+              size="sm"
+            />
+            <Stack>
+              <Stack direction="horizontal" gap={1}>
+                <FormattedMessage
+                  {...entryMessage}
+                  values={{
+                    user: entry.changedBy.username,
+                    displayName: <span className="history-log-title text-truncate">{entry.title}</span>,
+                    icon: <Icon src={getItemIcon(entry.blockType)} />
+                  }}
+                />
+              </Stack>
+              <span className="small text-gray-500">
+                {moment(entry.changedAt).fromNow()}
+              </span>
+            </Stack>
+            
+          </Stack>
+          <div className="history-log-vert" />
+        </div>
+      );
+    })}
+  </Stack>
+);
+
+export const HistoryCreatedLogGroup = ({
+  user,
+  displayName,
+  itemType,
+  createdAt,
+}: HistoryCreatedLogGroupProps) => {
+  const intl = useIntl();
+
+  return (
+    <div className="history-log-group publish-group">
+      <HistoryLogGroupTitle
+        titleMessage={intl.formatMessage(messages.createdTitle, {
+          user: user ?? intl.formatMessage(messages.historyEntryDefaultUser),
+          displayName: <span className="history-log-title text-truncate">{displayName}</span>,
+          icon: <Icon src={getItemIcon(itemType)} />,
+        })}
+        dateMessage={moment(createdAt).fromNow()}
+        disableCollapsible
+      />
+    </div>
+  );
+};
+
+export const HistoryDraftLogGroup = ({
+  displayName,
+  entries,
+}: HistoryDraftLogGroupProps) => {
+  const intl = useIntl();
+
+  return (
+    <div className="history-log-group draft-group">
+      <Collapsible.Advanced>
+        <Collapsible.Trigger>
+          <HistoryLogGroupTitle
+            titleMessage={intl.formatMessage(
+              messages.draftTitle,
+              {
+                displayName: <span className="history-log-title text-truncate">{displayName}</span>
+              }
+            )}
+            dateMessage={intl.formatMessage(
+              messages.draftTitleDate,
+              {
+                count: entries.length,
+                date: moment(entries?.at(-1)?.changedAt ?? '').fromNow(),
+              }
+            )}
+          />
+        </Collapsible.Trigger>
+        <Collapsible.Body>
+          <HistoryLogGroupEntries entries={entries} />
+        </Collapsible.Body>
+      </Collapsible.Advanced>
+      <div className="history-log-vert" />
+    </div>
+  );
+};
+
+const ContributorsAvatars = ({ contributors }: ContributorsAvatarsProps) => {
+  const visible = contributors.slice(0, MAX_VISIBLE_CONTRIBUTORS);
+  return (
+    <Stack direction="horizontal" gap={2} className="ml-4.5">
+      <div className="contributors-avatars">
+        {visible.map(({ username, profileImageUrls }) => (
+          <ContributorAvatar
+            key={username}
+            size='xs'
+            className="contributors-avatar"
+            username={username}
+            src={profileImageUrls.small}
+          />
+        ))}
+      </div>
+      <span className="small">
+        <FormattedMessage
+          {...messages.historyContributors}
+          values={{ count: contributors.length }}
+        />
+      </span>
+    </Stack>
+  );
+};
+
+export const HistoryPublishLogGroup = ({
+  itemId,
+  publishLogUuid,
+  title,
+  publishedBy,
+  publishedAt,
+  blockType,
+  contributors,
+}: HistoryPublishLogGroupProps) => {
+  const intl = useIntl();
+  const [isOpenCollapsible, openCollapsible, closeCollapsible] = useToggle(false);
+
+  const {
+    data: entries,
+    isPending,
+  } = useLibraryBlockPublishHistoryEntries(itemId, publishLogUuid, isOpenCollapsible);
+
+  return (
+    <div className="history-log-group publish-group">
+      <Collapsible.Advanced
+        open={isOpenCollapsible}
+        onOpen={openCollapsible}
+        onClose={closeCollapsible}
+      >
+        <Collapsible.Trigger>
+          <HistoryLogGroupTitle
+            titleMessage={intl.formatMessage(
+              messages.publishTitle,
+              {
+                user: publishedBy,
+                displayName: <span className="history-log-title text-truncate">{title}</span>,
+                icon: <Icon src={getItemIcon(blockType)} /> 
+              },
+            )}
+            dateMessage={moment(publishedAt).fromNow()}
+          />
+        </Collapsible.Trigger>
+        <Collapsible.Body>
+          {isPending ? (
+            <>
+              <div className="history-log-vert" />
+              <div className="ml-2 mt-2 w-100">
+                <LoadingSpinner />
+              </div>
+            </>
+          ): (
+            <HistoryLogGroupEntries entries={entries ?? []} />
+          )}
+        </Collapsible.Body>
+      </Collapsible.Advanced>
+      <Stack direction="horizontal">
+        <div className={classNames(
+          "history-log-vert",
+          {
+            "history-log-vert-long": !isOpenCollapsible, 
+          }
+        )} />
+        {!isOpenCollapsible && (
+          <ContributorsAvatars contributors={contributors} />
+        )}
+      </Stack>
+    </div>
+  );
+};

--- a/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
@@ -41,7 +41,7 @@ export interface HistoryPublishLogGroupProps extends LibraryPublishHistoryGroup 
 }
 
 interface ContributorAvatarProps {
-  username: string;
+  username?: string;
   src: string;
   className: string;
   size: ComponentProps<typeof Avatar>['size'];
@@ -57,13 +57,14 @@ const ContributorAvatar = ({
   className,
   size,
 }: ContributorAvatarProps) => {
+  const intl = useIntl();
   const [imgError, setImgError] = useState(false);
   return (
     <Avatar
       className={className}
       size={size}
       src={imgError ? undefined : src}
-      alt={username}
+      alt={username || intl.formatMessage(messages.historyEntryDefaultUser)}
       onError={() => setImgError(true)}
     />
   );
@@ -101,45 +102,49 @@ const HistoryLogGroupTitle = ({
 
 const HistoryLogGroupEntries = ({
   entries,
-}: HistoryLogGroupEntriesProps) => (
-  <Stack gap={0}>
-    <div className="history-log-vert" />
-    {entries.map((entry) => {
-      const entryMessage = entry.action === 'edited'
-        ? messages.historyEditEntry
-        : messages.historyRenameEntry;
+}: HistoryLogGroupEntriesProps) => {
+  const intl = useIntl();
 
-      return (
-        <div key={entry.changedAt}>
-          <Stack direction="horizontal" gap={2} className="ml-1.5">
-            <ContributorAvatar
-              username={entry.changedBy.username}
-              src={entry.changedBy.profileImageUrls.medium}
-              className="history-log-group-avatar small-avatar"
-              size="sm"
-            />
-            <Stack>
-              <Stack direction="horizontal" gap={1}>
-                <FormattedMessage
-                  {...entryMessage}
-                  values={{
-                    user: entry.changedBy.username,
-                    displayName: <span className="history-log-title text-truncate">{entry.title}</span>,
-                    icon: <Icon src={getItemIcon(entry.itemType)} />,
-                  }}
-                />
+  return (
+    <Stack gap={0}>
+      <div className="history-log-vert" />
+      {entries.map((entry) => {
+        const entryMessage = entry.action === 'edited'
+          ? messages.historyEditEntry
+          : messages.historyRenameEntry;
+
+        return (
+          <div key={entry.changedAt}>
+            <Stack direction="horizontal" gap={2} className="ml-1.5">
+              <ContributorAvatar
+                username={entry.changedBy?.username || intl.formatMessage(messages.historyEntryDefaultUser)}
+                src={entry.changedBy.profileImageUrls.medium}
+                className="history-log-group-avatar small-avatar"
+                size="sm"
+              />
+              <Stack>
+                <Stack direction="horizontal" gap={1}>
+                  <FormattedMessage
+                    {...entryMessage}
+                    values={{
+                      user: entry.changedBy.username ?? intl.formatMessage(messages.historyEntryDefaultUser),
+                      displayName: <span className="history-log-title text-truncate">{entry.title}</span>,
+                      icon: <Icon src={getItemIcon(entry.itemType)} />,
+                    }}
+                  />
+                </Stack>
+                <span className="small text-gray-500">
+                  {moment(entry.changedAt).fromNow()}
+                </span>
               </Stack>
-              <span className="small text-gray-500">
-                {moment(entry.changedAt).fromNow()}
-              </span>
             </Stack>
-          </Stack>
-          <div className="history-log-vert" />
-        </div>
-      );
-    })}
-  </Stack>
-);
+            <div className="history-log-vert" />
+          </div>
+        );
+      })}
+    </Stack>
+  );
+};
 
 export const HistoryCreatedLogGroup = ({
   user,
@@ -255,7 +260,7 @@ export const HistoryPublishLogGroup = ({
               titleMessage={intl.formatMessage(
                 messages.publishTitle,
                 {
-                  user: publishedBy,
+                  user: publishedBy || intl.formatMessage(messages.historyEntryDefaultUser),
                   displayName: (
                     <span className="history-log-title text-truncate">{directPublishedEntities[0].title}</span>
                   ),

--- a/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
@@ -45,7 +45,7 @@ export interface HistoryPublishLogGroupProps extends LibraryPublishHistoryGroup 
 
 interface ContributorAvatarProps {
   username?: string;
-  src: string;
+  src?: string;
   className: string;
   size: ComponentProps<typeof Avatar>['size'];
 }
@@ -134,7 +134,7 @@ const HistoryLogGroupEntries = ({
             <Stack direction="horizontal" gap={2} className="ml-1.5">
               <ContributorAvatar
                 username={entry.contributor?.username || intl.formatMessage(messages.historyEntryDefaultUser)}
-                src={entry.contributor.profileImageUrls.medium}
+                src={entry.contributor?.profileImageUrls.medium}
                 className="history-log-group-avatar small-avatar"
                 size="sm"
               />
@@ -143,7 +143,7 @@ const HistoryLogGroupEntries = ({
                   <FormattedMessage
                     {...entryMessage}
                     values={{
-                      user: entry.contributor.username ?? intl.formatMessage(messages.historyEntryDefaultUser),
+                      user: entry.contributor?.username ?? intl.formatMessage(messages.historyEntryDefaultUser),
                       displayName: <span className="history-log-title text-truncate">{entry.title}</span>,
                       icon: <Icon src={getItemIcon(entry.itemType)} />,
                     }}

--- a/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
@@ -25,6 +25,7 @@ export interface HistoryCreatedLogGroupProps {
   displayName: string;
   itemType: string;
   createdAt: string;
+  // When true, renders a vertical connector line below the creation entry to link it to publish groups that predate the container's creation.
   showLogVert?: boolean;
 }
 
@@ -35,11 +36,12 @@ export interface HistoryDraftLogGroupProps {
 
 export interface HistoryLogGroupEntriesProps {
   entries: LibraryHistoryEntry[];
-  hideLastLogVert?: boolean;
 }
 
 export interface HistoryPublishLogGroupProps extends LibraryPublishHistoryGroup {
   itemId: string;
+  // When true, hides the vertical connector line rendered below this group. Used for the last group
+  // in the history log to avoid a dangling connector with nothing below it.
   hideLogVert?: boolean;
 }
 
@@ -105,7 +107,6 @@ const HistoryLogGroupTitle = ({
 
 const HistoryLogGroupEntries = ({
   entries,
-  hideLastLogVert,
 }: HistoryLogGroupEntriesProps) => {
   const intl = useIntl();
 
@@ -154,7 +155,7 @@ const HistoryLogGroupEntries = ({
                 </span>
               </Stack>
             </Stack>
-            {!isLast && !hideLastLogVert && <div className="history-log-vert" />}
+            {!isLast && <div className="history-log-vert" />}
           </div>
         );
       })}

--- a/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
@@ -1,16 +1,16 @@
-import { ComponentProps, ReactNode, useState } from "react";
-import moment from "moment";
-import classNames from "classnames";
-import { Avatar, Collapsible, Icon, Stack, useToggle } from "@openedx/paragon";
-import { KeyboardArrowDown, KeyboardArrowUp } from "@openedx/paragon/icons";
-import { FormattedMessage, useIntl } from "@edx/frontend-platform/i18n";
+import { ComponentProps, ReactNode, useState } from 'react';
+import moment from 'moment';
+import classNames from 'classnames';
+import { Avatar, Collapsible, Icon, Stack, useToggle } from '@openedx/paragon';
+import { KeyboardArrowDown, KeyboardArrowUp } from '@openedx/paragon/icons';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 
-import { useLibraryBlockPublishHistoryEntries } from "@src/library-authoring/data/apiHooks";
-import { LoadingSpinner } from "@src/generic/Loading";
+import { useLibraryPublishHistoryEntries } from '@src/library-authoring/data/apiHooks';
+import { LoadingSpinner } from '@src/generic/Loading';
 
-import { LibraryHistoryEntry, LibraryPublishContributor, LibraryPublishHistoryGroup } from "../../data/api";
-import messages from "./messages";
-import { getItemIcon } from "@src/generic/block-type-utils";
+import { LibraryHistoryEntry, LibraryPublishContributor, LibraryPublishHistoryGroup } from '../../data/api';
+import messages from './messages';
+import { getItemIcon } from '@src/generic/block-type-utils';
 
 const MAX_VISIBLE_CONTRIBUTORS = 5;
 
@@ -76,7 +76,7 @@ const HistoryLogGroupTitle = ({
 }: HistoryLogGroupTitleProps) => {
   return (
     <Stack direction="horizontal" gap={2} className="mb-1">
-      <Avatar className="history-log-group-avatar big-avatar" size="md"/>
+      <Avatar className="history-log-group-avatar big-avatar" size="md" />
       <Stack>
         <Stack direction="horizontal" gap={1}>
           {titleMessage}
@@ -88,15 +88,15 @@ const HistoryLogGroupTitle = ({
       {!disableCollapsible && (
         <>
           <Collapsible.Visible whenClosed>
-            <Icon src={KeyboardArrowDown}/>
+            <Icon src={KeyboardArrowDown} />
           </Collapsible.Visible>
           <Collapsible.Visible whenOpen>
-            <Icon src={KeyboardArrowUp}/>
+            <Icon src={KeyboardArrowUp} />
           </Collapsible.Visible>
         </>
       )}
     </Stack>
-  )
+  );
 };
 
 const HistoryLogGroupEntries = ({
@@ -108,7 +108,7 @@ const HistoryLogGroupEntries = ({
       const entryMessage = entry.action === 'edited'
         ? messages.historyEditEntry
         : messages.historyRenameEntry;
-      
+
       return (
         <div key={entry.changedAt}>
           <Stack direction="horizontal" gap={2} className="ml-1.5">
@@ -125,7 +125,7 @@ const HistoryLogGroupEntries = ({
                   values={{
                     user: entry.changedBy.username,
                     displayName: <span className="history-log-title text-truncate">{entry.title}</span>,
-                    icon: <Icon src={getItemIcon(entry.blockType)} />
+                    icon: <Icon src={getItemIcon(entry.itemType)} />,
                   }}
                 />
               </Stack>
@@ -133,7 +133,6 @@ const HistoryLogGroupEntries = ({
                 {moment(entry.changedAt).fromNow()}
               </span>
             </Stack>
-            
           </Stack>
           <div className="history-log-vert" />
         </div>
@@ -179,15 +178,15 @@ export const HistoryDraftLogGroup = ({
             titleMessage={intl.formatMessage(
               messages.draftTitle,
               {
-                displayName: <span className="history-log-title text-truncate">{displayName}</span>
-              }
+                displayName: <span className="history-log-title text-truncate">{displayName}</span>,
+              },
             )}
             dateMessage={intl.formatMessage(
               messages.draftTitleDate,
               {
                 count: entries.length,
                 date: moment(entries?.at(-1)?.changedAt ?? '').fromNow(),
-              }
+              },
             )}
           />
         </Collapsible.Trigger>
@@ -208,7 +207,7 @@ const ContributorsAvatars = ({ contributors }: ContributorsAvatarsProps) => {
         {visible.map(({ username, profileImageUrls }) => (
           <ContributorAvatar
             key={username}
-            size='xs'
+            size="xs"
             className="contributors-avatar"
             username={username}
             src={profileImageUrls.small}
@@ -228,10 +227,9 @@ const ContributorsAvatars = ({ contributors }: ContributorsAvatarsProps) => {
 export const HistoryPublishLogGroup = ({
   itemId,
   publishLogUuid,
-  title,
+  directPublishedEntities,
   publishedBy,
   publishedAt,
-  blockType,
   contributors,
 }: HistoryPublishLogGroupProps) => {
   const intl = useIntl();
@@ -240,7 +238,9 @@ export const HistoryPublishLogGroup = ({
   const {
     data: entries,
     isPending,
-  } = useLibraryBlockPublishHistoryEntries(itemId, publishLogUuid, isOpenCollapsible);
+  } = useLibraryPublishHistoryEntries(itemId, publishLogUuid, isOpenCollapsible);
+
+  const dateMessage = moment(publishedAt).fromNow();
 
   return (
     <div className="history-log-group publish-group">
@@ -250,41 +250,57 @@ export const HistoryPublishLogGroup = ({
         onClose={closeCollapsible}
       >
         <Collapsible.Trigger>
-          <HistoryLogGroupTitle
-            titleMessage={intl.formatMessage(
-              messages.publishTitle,
-              {
-                user: publishedBy,
-                displayName: <span className="history-log-title text-truncate">{title}</span>,
-                icon: <Icon src={getItemIcon(blockType)} /> 
-              },
-            )}
-            dateMessage={moment(publishedAt).fromNow()}
-          />
+          {directPublishedEntities.length === 1 && (
+            <HistoryLogGroupTitle
+              titleMessage={intl.formatMessage(
+                messages.publishTitle,
+                {
+                  user: publishedBy,
+                  displayName: (
+                    <span className="history-log-title text-truncate">{directPublishedEntities[0].title}</span>
+                  ),
+                  icon: <Icon src={getItemIcon(directPublishedEntities[0].entityType)} />,
+                },
+              )}
+              dateMessage={dateMessage}
+            />
+          )}
+          {directPublishedEntities.length > 1 && (
+            <HistoryLogGroupTitle
+              titleMessage={intl.formatMessage(
+                messages.publishTitleMultiple,
+                {
+                  user: publishedBy,
+                  icon: <Icon src={getItemIcon('default')} />,
+                },
+              )}
+              dateMessage={dateMessage}
+            />
+          )}
         </Collapsible.Trigger>
         <Collapsible.Body>
-          {isPending ? (
-            <>
-              <div className="history-log-vert" />
-              <div className="ml-2 mt-2 w-100">
-                <LoadingSpinner />
-              </div>
-            </>
-          ): (
-            <HistoryLogGroupEntries entries={entries ?? []} />
-          )}
+          {isPending ?
+            (
+              <>
+                <div className="history-log-vert" />
+                <div className="ml-2 mt-2 w-100">
+                  <LoadingSpinner />
+                </div>
+              </>
+            ) :
+            <HistoryLogGroupEntries entries={entries ?? []} />}
         </Collapsible.Body>
       </Collapsible.Advanced>
       <Stack direction="horizontal">
-        <div className={classNames(
-          "history-log-vert",
-          {
-            "history-log-vert-long": !isOpenCollapsible, 
-          }
-        )} />
-        {!isOpenCollapsible && (
-          <ContributorsAvatars contributors={contributors} />
-        )}
+        <div
+          className={classNames(
+            'history-log-vert',
+            {
+              'history-log-vert-long': !isOpenCollapsible,
+            },
+          )}
+        />
+        {!isOpenCollapsible && <ContributorsAvatars contributors={contributors} />}
       </Stack>
     </div>
   );

--- a/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLogGroup.tsx
@@ -1,18 +1,18 @@
-import { ComponentProps, ReactNode, useState } from 'react';
+import { ReactNode } from 'react';
 import moment from 'moment';
 import classNames from 'classnames';
 import { Avatar, Collapsible, Icon, Stack, useToggle } from '@openedx/paragon';
 import { KeyboardArrowDown, KeyboardArrowUp } from '@openedx/paragon/icons';
-import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { useLibraryPublishHistoryEntries } from '@src/library-authoring/data/apiHooks';
 import { LoadingSpinner } from '@src/generic/Loading';
 
-import { LibraryHistoryEntry, LibraryPublishContributor, LibraryPublishHistoryGroup } from '../../data/api';
+import { LibraryHistoryEntry, LibraryPublishHistoryGroup } from '../../data/api';
 import messages from './messages';
 import { getItemIcon } from '@src/generic/block-type-utils';
-
-const MAX_VISIBLE_CONTRIBUTORS = 5;
+import { ContributorsAvatars } from './ContributorAvatars';
+import { HistoryLogGroupEntries } from './HistoryLogGroupEntries';
 
 export interface HistoryLogGroupTitleProps {
   titleMessage: string | ReactNode;
@@ -34,46 +34,12 @@ export interface HistoryDraftLogGroupProps {
   entries: LibraryHistoryEntry[];
 }
 
-export interface HistoryLogGroupEntriesProps {
-  entries: LibraryHistoryEntry[];
-}
-
 export interface HistoryPublishLogGroupProps extends LibraryPublishHistoryGroup {
   itemId: string;
   // When true, hides the vertical connector line rendered below this group. Used for the last group
   // in the history log to avoid a dangling connector with nothing below it.
   hideLogVert?: boolean;
 }
-
-interface ContributorAvatarProps {
-  username?: string;
-  src?: string;
-  className: string;
-  size: ComponentProps<typeof Avatar>['size'];
-}
-
-interface ContributorsAvatarsProps {
-  contributors: LibraryPublishContributor[];
-}
-
-const ContributorAvatar = ({
-  username,
-  src,
-  className,
-  size,
-}: ContributorAvatarProps) => {
-  const intl = useIntl();
-  const [imgError, setImgError] = useState(false);
-  return (
-    <Avatar
-      className={className}
-      size={size}
-      src={imgError ? undefined : src}
-      alt={username || intl.formatMessage(messages.historyEntryDefaultUser)}
-      onError={() => setImgError(true)}
-    />
-  );
-};
 
 const HistoryLogGroupTitle = ({
   titleMessage,
@@ -101,64 +67,6 @@ const HistoryLogGroupTitle = ({
           </Collapsible.Visible>
         </>
       )}
-    </Stack>
-  );
-};
-
-const HistoryLogGroupEntries = ({
-  entries,
-}: HistoryLogGroupEntriesProps) => {
-  const intl = useIntl();
-
-  const getEntryMessage = (entry: LibraryHistoryEntry) => {
-    switch (entry.action) {
-      case 'edited':
-        return messages.historyEditEntry;
-      case 'renamed':
-        return messages.historyRenameEntry;
-      case 'created':
-        return messages.historyCreatedEntry;
-      default:
-        return messages.historyEditEntry;
-    }
-  };
-
-  return (
-    <Stack gap={0}>
-      <div className="history-log-vert" />
-      {entries.map((entry, index, arr) => {
-        const isLast = index === arr.length - 1;
-        const entryMessage = getEntryMessage(entry);
-
-        return (
-          <div key={entry.changedAt}>
-            <Stack direction="horizontal" gap={2} className="ml-1.5">
-              <ContributorAvatar
-                username={entry.contributor?.username || intl.formatMessage(messages.historyEntryDefaultUser)}
-                src={entry.contributor?.profileImageUrls.medium}
-                className="history-log-group-avatar small-avatar"
-                size="sm"
-              />
-              <Stack>
-                <Stack direction="horizontal" gap={1}>
-                  <FormattedMessage
-                    {...entryMessage}
-                    values={{
-                      user: entry.contributor?.username ?? intl.formatMessage(messages.historyEntryDefaultUser),
-                      displayName: <span className="history-log-title text-truncate">{entry.title}</span>,
-                      icon: <Icon src={getItemIcon(entry.itemType)} />,
-                    }}
-                  />
-                </Stack>
-                <span className="small text-gray-500">
-                  {moment(entry.changedAt).fromNow()}
-                </span>
-              </Stack>
-            </Stack>
-            {!isLast && <div className="history-log-vert" />}
-          </div>
-        );
-      })}
     </Stack>
   );
 };
@@ -220,31 +128,6 @@ export const HistoryDraftLogGroup = ({
       </Collapsible.Advanced>
       <div className="history-log-vert" />
     </div>
-  );
-};
-
-const ContributorsAvatars = ({ contributors }: ContributorsAvatarsProps) => {
-  const visible = contributors.slice(0, MAX_VISIBLE_CONTRIBUTORS);
-  return (
-    <Stack direction="horizontal" gap={2} className="ml-4.5">
-      <div className="contributors-avatars">
-        {visible.map(({ username, profileImageUrls }) => (
-          <ContributorAvatar
-            key={username}
-            size="xs"
-            className="contributors-avatar"
-            username={username}
-            src={profileImageUrls.small}
-          />
-        ))}
-      </div>
-      <span className="small">
-        <FormattedMessage
-          {...messages.historyContributors}
-          values={{ count: contributors.length }}
-        />
-      </span>
-    </Stack>
   );
 };
 

--- a/src/library-authoring/generic/history-log/HistoryLogGroupEntries.tsx
+++ b/src/library-authoring/generic/history-log/HistoryLogGroupEntries.tsx
@@ -1,0 +1,69 @@
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
+import { LibraryHistoryEntry } from '@src/library-authoring/data/api';
+import messages from './messages';
+import { Icon, Stack } from '@openedx/paragon';
+import { ContributorAvatar } from './ContributorAvatars';
+import { getItemIcon } from '@src/generic/block-type-utils';
+import moment from 'moment';
+
+export interface HistoryLogGroupEntriesProps {
+  entries: LibraryHistoryEntry[];
+}
+
+export const HistoryLogGroupEntries = ({
+  entries,
+}: HistoryLogGroupEntriesProps) => {
+  const intl = useIntl();
+
+  const getEntryMessage = (entry: LibraryHistoryEntry) => {
+    switch (entry.action) {
+      case 'edited':
+        return messages.historyEditEntry;
+      case 'renamed':
+        return messages.historyRenameEntry;
+      case 'created':
+        return messages.historyCreatedEntry;
+      default:
+        return messages.historyEditEntry;
+    }
+  };
+
+  return (
+    <Stack gap={0}>
+      <div className="history-log-vert" />
+      {entries.map((entry, index, arr) => {
+        const isLast = index === arr.length - 1;
+        const entryMessage = getEntryMessage(entry);
+
+        return (
+          <div key={entry.changedAt}>
+            <Stack direction="horizontal" gap={2} className="ml-1.5">
+              <ContributorAvatar
+                username={entry.contributor?.username || intl.formatMessage(messages.historyEntryDefaultUser)}
+                src={entry.contributor?.profileImageUrls.medium}
+                className="history-log-group-avatar small-avatar"
+                size="sm"
+              />
+              <Stack>
+                <Stack direction="horizontal" gap={1}>
+                  <FormattedMessage
+                    {...entryMessage}
+                    values={{
+                      user: entry.contributor?.username ?? intl.formatMessage(messages.historyEntryDefaultUser),
+                      displayName: <span className="history-log-title text-truncate">{entry.title}</span>,
+                      icon: <Icon src={getItemIcon(entry.itemType)} />,
+                    }}
+                  />
+                </Stack>
+                <span className="small text-gray-500">
+                  {moment(entry.changedAt).fromNow()}
+                </span>
+              </Stack>
+            </Stack>
+            {!isLast && <div className="history-log-vert" />}
+          </div>
+        );
+      })}
+    </Stack>
+  );
+};

--- a/src/library-authoring/generic/history-log/messages.ts
+++ b/src/library-authoring/generic/history-log/messages.ts
@@ -1,0 +1,46 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  draftTitle: {
+    id: 'course-authoring.library-authoring.history.draft.title',
+    defaultMessage: '{displayName} is a draft',
+    description: 'Title for the draft group in the history log section.',
+  },
+  publishTitle: {
+    id: 'course-authoring.library-authoring.history.publish.title',
+    defaultMessage: '{user} published {icon} {displayName}',
+    description: 'Title for the publish group in the history log section.',
+  },
+  draftTitleDate: {
+    id: 'course-authoring.library-authoring.history.draft.date',
+    defaultMessage: '{count, plural, one {{count} change} other {{count} changes}} since {date}',
+    description: 'Title for the draft group in the history log section.',
+  },
+  createdTitle: {
+    id: 'course-authoring.library-authoring.history.created.title',
+    defaultMessage: '{user} created {icon} {displayName}',
+    description: 'Title for the created group in the history log section.',
+  },
+  historyEditEntry: {
+    id: 'course-authoring.library-authoring.history.edit-entry',
+    defaultMessage: '{user} edited {icon} {displayName}',
+    description: 'Edit entry of the history log.',
+  },
+  historyRenameEntry: {
+    id: 'course-authoring.library-authoring.history.rename-entry',
+    defaultMessage: '{user} renamed {icon} {displayName}',
+    description: 'Rename entry of the history log.',
+  },
+  historyEntryDefaultUser: {
+    id: 'course-authoring.library-authoring.history.default-user',
+    defaultMessage: 'Author',
+    description: 'Default user name when the user is not available',
+  },
+  historyContributors: {
+    id: 'course-authoring.library-authoring.history.contributors',
+    defaultMessage: '{count} {count, plural, one {author} other {authors}} contributed',
+    description: 'Contributors count in a publish history group',
+  },
+});
+
+export default messages;

--- a/src/library-authoring/generic/history-log/messages.ts
+++ b/src/library-authoring/generic/history-log/messages.ts
@@ -11,6 +11,11 @@ const messages = defineMessages({
     defaultMessage: '{user} published {icon} {displayName}',
     description: 'Title for the publish group in the history log section.',
   },
+  publishTitleMultiple: {
+    id: 'course-authoring.library-authoring.history.publish.title-multiple',
+    defaultMessage: '{user} published {icon} Multiple Items',
+    description: 'Title for the publish group in the history log section of multiple items.',
+  },
   draftTitleDate: {
     id: 'course-authoring.library-authoring.history.draft.date',
     defaultMessage: '{count, plural, one {{count} change} other {{count} changes}} since {date}',

--- a/src/library-authoring/generic/history-log/messages.ts
+++ b/src/library-authoring/generic/history-log/messages.ts
@@ -36,6 +36,16 @@ const messages = defineMessages({
     defaultMessage: '{user} renamed {icon} {displayName}',
     description: 'Rename entry of the history log.',
   },
+  historyCreatedEntry: {
+    id: 'course-authoring.library-authoring.history.created-entry',
+    defaultMessage: '{user} created {icon} {displayName}',
+    description: 'Created entry of the history log.',
+  },
+  historyDeletedEntry: {
+    id: 'course-authoring.library-authoring.history.deleted-entry',
+    defaultMessage: '{user} deleted {icon} {displayName}',
+    description: 'Deleted entry of the history log.',
+  },
   historyEntryDefaultUser: {
     id: 'course-authoring.library-authoring.history.default-user',
     defaultMessage: 'Author',

--- a/src/library-authoring/generic/index.scss
+++ b/src/library-authoring/generic/index.scss
@@ -2,3 +2,4 @@
 @import "./status-widget/StatusWidget";
 @import "./parent-breadcrumbs";
 @import "./publish-status-buttons";
+@import "./history-log/HistoryLog";

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -255,9 +255,11 @@ const getInnerText = (element: Element | null): string => {
 export const matchInnerText = (
   nodeName: string,
   textToMatch: string,
-) => (_: string, element: Element | null) => !!element
-    && element.nodeName === nodeName
-    && getInnerText(element) === textToMatch;
+) =>
+(_: string, element: Element | null) =>
+  !!element
+  && element.nodeName === nodeName
+  && getInnerText(element) === textToMatch;
 
 /**
  * Finds the innermost element whose full textContent (normalized whitespace) matches a regex.
@@ -269,11 +271,12 @@ export const matchInnerText = (
  *
  * Useful when text is split across child elements (e.g. by an icon or inline tag).
  */
-export const findByDeepTextContent = (pattern: RegExp) => screen.findByText((_, el) => {
-  if (!el) return false;
-  const normalizedText = (el.textContent ?? '').replace(/\s+/g, ' ').trim();
-  if (!pattern.test(normalizedText)) return false;
-  return !Array.from(el.children).some(
-    (child) => pattern.test(((child as Element).textContent ?? '').replace(/\s+/g, ' ').trim()),
-  );
-});
+export const findByDeepTextContent = (pattern: RegExp) =>
+  screen.findByText((_, el) => {
+    if (!el) { return false; }
+    const normalizedText = (el.textContent ?? '').replace(/\s+/g, ' ').trim();
+    if (!pattern.test(normalizedText)) { return false; }
+    return !Array.from(el.children).some(
+      (child) => pattern.test(((child as Element).textContent ?? '').replace(/\s+/g, ' ').trim()),
+    );
+  });

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -13,7 +13,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { AppProvider } from '@edx/frontend-platform/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, type RenderResult } from '@testing-library/react';
+import { render, screen, type RenderResult } from '@testing-library/react';
 import MockAdapter from 'axios-mock-adapter';
 import {
   generatePath,
@@ -244,11 +244,36 @@ const getInnerText = (element: Element | null): string => {
     .join(' ');
 };
 
+/**
+ * Returns a matcher for `getByText`/`findByText` that checks exact text match and element type.
+ * - Requires specifying the element's nodeName (e.g. 'P', 'DIV').
+ * - Uses exact string comparison (no regex).
+ *
+ * For partial/regex matching when text is split across child elements,
+ * use `findByDeepTextContent` instead.
+ */
 export const matchInnerText = (
   nodeName: string,
   textToMatch: string,
-) =>
-(_: string, element: Element | null) =>
-  !!element
-  && element.nodeName === nodeName
-  && getInnerText(element) === textToMatch;
+) => (_: string, element: Element | null) => !!element
+    && element.nodeName === nodeName
+    && getInnerText(element) === textToMatch;
+
+/**
+ * Finds the innermost element whose full textContent (normalized whitespace) matches a regex.
+ * Unlike `matchInnerText`, this:
+ * - Accepts a `RegExp` for partial/pattern matching.
+ * - Does NOT require specifying the element type.
+ * - Normalizes whitespace (collapses multiple spaces/newlines into one).
+ * - Returns the deepest matching element (excludes elements where a direct child also matches).
+ *
+ * Useful when text is split across child elements (e.g. by an icon or inline tag).
+ */
+export const findByDeepTextContent = (pattern: RegExp) => screen.findByText((_, el) => {
+  if (!el) return false;
+  const normalizedText = (el.textContent ?? '').replace(/\s+/g, ' ').trim();
+  if (!pattern.test(normalizedText)) return false;
+  return !Array.from(el.children).some(
+    (child) => pattern.test(((child as Element).textContent ?? '').replace(/\s+/g, ' ').trim()),
+  );
+});


### PR DESCRIPTION
## Description

See https://github.com/openedx/openedx-platform/pull/38178 to understand the Pre-Verawood and Post-Verawood logic.

- Implements the API functions and hooks to fetch:
    - Draft history entries for components and containers.
    - Published history groups for components and containers.
    - Published entries within a history group.
    - Creation entry for components and containers.
- Implements:
    - `HistoryCreatedLogGroup`: Group for the create event.
    - `HistoryDraftLogGroup`: Group and entries for draft changes (collapsible).
    - `HistoryPublishLogGroup`: Group and entries for published changes (lazy-loaded on expand).
    - `HistoryComponentLog`: Renders the full history for a library component.
    - `HistoryContainerLog`: Renders the full history for a library container (unit/section/subsection).
    - `ContainerDetails`: New "Details" tab in the container sidebar that shows the container history log.
- Which user roles will this change impact? **Library Author**.


<img width="511" height="660" alt="image" src="https://github.com/user-attachments/assets/2044a780-4131-4408-b971-83d1f9ee8e04" />
<img width="515" height="516" alt="image" src="https://github.com/user-attachments/assets/25b8744a-6015-4ba3-a1e9-49a6e9dc1216" />
<img width="519" height="781" alt="image" src="https://github.com/user-attachments/assets/8a8da519-fbcf-4f54-9b3f-5a65b7471970" />



## Supporting information

- Github issue (implemented component scope): https://github.com/openedx/frontend-app-authoring/issues/2805
- Depends on:
     - https://github.com/openedx/openedx-platform/pull/38178
     - https://github.com/openedx/openedx-core/pull/501
- Internal ticket: https://tasks.opencraft.com/browse/FAL-4330

## Testing instructions

Follow the instructions in order:

**Pre-Verawood setup**

- Use the `main` branch.
- Go to a content library
- Create a new unit and a new component in the unit
- Make some edits in the component and publish the component.
- Make some edits in the unit and publish the unit.
- Make some edits in the unit and in the component, and publish the unit.

**Test Components: Pre-Verawood**
- Use this branch of edx-platform: https://github.com/openedx/openedx-platform/pull/38178
- Install this branch of openedx-core: https://github.com/openedx/openedx-core/pull/501
- TEMP make a rebase/merge of this PR: https://github.com/openedx/openedx-platform/pull/38402 in edx-platform
- Go to the content library.
- Click in the component to open the component sidebar.
- Go to the `Details` tab of the sidebar.
- Check the history log: 
    - Verify the creation group
    - Verify the first publish group after the creation group. Verify that you can only see the component edits and says: "Author published Component".
    - Verify the second publish group. Verify that you can only see the component edits and says: "Author published Component".

** Test Containers: Pre-Verawood**
- Go to the content library
- Click in the container to open the container sidebar.
- Go to the `Details` tab of the sidebar.
- Check the history log:
    - Verify the creation group
    - Verify the first publish group after the creation group. Verify that you can only see the component edits and says 
    - Verify the second publish group after the creation group. Verify that you can only see the unit edits and says 
    - After, verify that there are two more publish groups, one for the unit changes and the other for the component changes.

**Post-Verawood setup**

- Make some edits in the component and publish the component.
- Make some edits in the unit and publish the unit.
- Make some edits in the unit and in the component, and publish the unit.


**Test Components: Post-Verawood**
- Go to the content library.
- Click in the component to open the component sidebar.
- Go to the `Details` tab of the sidebar.
- Check the history log: 
    - Verify the third publish group. Verify that you can only see the component edits and says: "Author published Component".
    - Verify the fourth publish group. Verify that you can only see the component edits and says: "Author published Unit".
- Make some edits in the component. Verify the Draft group.


**Test Containers: Post-Verawood**
- Go to the content library
- Click in the container to open the container sidebar.
- Go to the `Details` tab of the sidebar.
- Check the history log:
    - Verify the fourth publish group. Verify that you can only see the component changes.
    - Verify the fifth publish group. Verify that you can only see the unit changes.
    - Verify the sixth publish group. Verify that you can see the unit and the component changes.

**To test with more contributors**
- Create 6 users with access to the library (can be superusers)
- Update the profile image of the users: Go to the learner dashboard > Profile and update the image.
- With each user, made updates to the component.
- Verify the draft list group in the history log. Verify the profile images in each entry.
- Publish the changes.
- Verify the contributors in the new publish group. Verify the contributors count. Verify that only five contributor profile images are rendered.


## Other information

**Missing features**

- Delete group for deleted components in containers.
- Import group: When importing a library, the components/containers must have only one import group.
- Show discarded changes edits.
- Paginate publish groups and paginate entries

**Note: The basics have been implemented to meet the Verawood cut on time.**

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [X] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [X] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [X] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [X] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [X] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [X] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [X] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
