### PR TITLE
fix: clarify "created by" library restore message

### DIFF
--- a/src/library-authoring/create-library/CreateLibrary.test.tsx
+++ b/src/library-authoring/create-library/CreateLibrary.test.tsx
@@ -480,7 +480,7 @@ describe('<CreateLibrary />', () => {
         expect(screen.getByText('TestOrg / test-archive')).toBeInTheDocument();
         // Testing the archive details summary
         expect(screen.getByText(/Contains 8 sections, 12 subsections, 20 units, 15 components/i)).toBeInTheDocument();
-        expect(screen.getByText(/Created on instance test.com/i)).toBeInTheDocument();
+        expect(screen.getByText(/Backup created on instance test.com/i)).toBeInTheDocument();
         expect(screen.getByText(/by user test@example.com/i)).toBeInTheDocument();
       });
     });
@@ -537,7 +537,7 @@ describe('<CreateLibrary />', () => {
       await waitFor(() => {
         // Testing the archive details summary without instance and user email
         expect(screen.getByText(/Contains 8 sections, 12 subsections, 20 units, 15 components/i)).toBeInTheDocument();
-        expect(screen.queryByText(/Created on instance/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Backup created on instance/i)).not.toBeInTheDocument();
         expect(screen.queryByText(/by user/i)).not.toBeInTheDocument();
       });
     });

--- a/src/library-authoring/create-library/messages.ts
+++ b/src/library-authoring/create-library/messages.ts
@@ -48,8 +48,8 @@ const messages = defineMessages({
   },
   slugHelp: {
     id: 'course-authoring.library-authoring.create-library.form.slug.help',
-    defaultMessage: `The unique code that identifies this library. Note: This is 
-    part of your library URL, so no spaces or special characters are allowed. 
+    defaultMessage: `The unique code that identifies this library. Note: This is
+    part of your library URL, so no spaces or special characters are allowed.
     This cannot be changed.`,
     description: 'Help text for the slug field.',
   },
@@ -125,7 +125,7 @@ const messages = defineMessages({
   },
   archiveRestoredCreatedBy: {
     id: 'course-authoring.library-authoring.create-library.form.archive.restored-created-by',
-    defaultMessage: 'Created on instance {server}, by user {createdBy}',
+    defaultMessage: 'Backup created on instance {server}, by user {createdBy}',
     description: 'Text showing who restored the archive.',
   },
   archiveBackupDate: {


### PR DESCRIPTION
## Description

Previously, when you uploaded a backup archive to restore a library
from, it was ambiguous as to whether "created by" referred to the
person who created the original library, or the person who created
the backup archive. This re-wording clarifies that it's the person
who created the backup archive.

This will impact Studio authors creating libraries from backup files.

## Screenshots

Before:

<img width="966" height="204" alt="image" src="https://github.com/user-attachments/assets/d0932571-af52-487e-b208-7447e3f6b9e4" />

After:

<img width="966" height="204" alt="image" src="https://github.com/user-attachments/assets/2f969ff2-04bb-4925-a0a1-a21ade22f0f9" />

