### PR TITLE
feat: implement grading permissions and authorization hooks

### DIFF
--- a/src/authz/constants.ts
+++ b/src/authz/constants.ts
@@ -17,4 +17,7 @@ export const CONTENT_LIBRARY_PERMISSIONS = {
 
 export const COURSE_PERMISSIONS = {
   MANAGE_ADVANCED_SETTINGS: 'courses.manage_advanced_settings',
+
+  VIEW_GRADING_SETTINGS: 'courses.view_grading_settings',
+  EDIT_GRADING_SETTINGS: 'courses.edit_grading_settings',
 };

--- a/src/authz/hooks.test.ts
+++ b/src/authz/hooks.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from '@testing-library/react';
+import { useUserPermissions } from '@src/authz/data/apiHooks';
+import { mockWaffleFlags } from '@src/data/apiHooks.mock';
+import { useUserPermissionsWithAuthzCourse } from './hooks';
+import { COURSE_PERMISSIONS } from './constants';
+
+jest.mock('@src/authz/data/apiHooks', () => ({
+  useUserPermissions: jest.fn(),
+}));
+
+const courseId = 'course-v1:org+course+run';
+const permissions = {
+  canView: { action: COURSE_PERMISSIONS.VIEW_GRADING_SETTINGS, scope: courseId },
+  canEdit: { action: COURSE_PERMISSIONS.EDIT_GRADING_SETTINGS, scope: courseId },
+};
+
+describe('useUserPermissionsWithAuthzCourse', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useUserPermissions).mockReturnValue({
+      isLoading: false,
+      data: undefined,
+    } as unknown as ReturnType<typeof useUserPermissions>);
+  });
+
+  it('defaults all permissions to true when authz is disabled', () => {
+    mockWaffleFlags({ enableAuthzCourseAuthoring: false });
+
+    const { result } = renderHook(() => useUserPermissionsWithAuthzCourse(courseId, permissions));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isAuthzEnabled).toBe(false);
+    expect(result.current.permissions.canView).toBe(true);
+    expect(result.current.permissions.canEdit).toBe(true);
+  });
+
+  it('returns actual permission values when authz is enabled and permissions are loaded', () => {
+    mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+    jest.mocked(useUserPermissions).mockReturnValue({
+      isLoading: false,
+      data: { canView: true, canEdit: false },
+    } as unknown as ReturnType<typeof useUserPermissions>);
+
+    const { result } = renderHook(() => useUserPermissionsWithAuthzCourse(courseId, permissions));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isAuthzEnabled).toBe(true);
+    expect(result.current.permissions.canView).toBe(true);
+    expect(result.current.permissions.canEdit).toBe(false);
+  });
+
+  it('returns isLoading=true and empty permissions while authz permissions are loading', () => {
+    mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+    jest.mocked(useUserPermissions).mockReturnValue({
+      isLoading: true,
+      data: undefined,
+    } as unknown as ReturnType<typeof useUserPermissions>);
+
+    const { result } = renderHook(() => useUserPermissionsWithAuthzCourse(courseId, permissions));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isAuthzEnabled).toBe(true);
+    expect(result.current.permissions).toEqual({});
+  });
+
+  it('falls back to false for permissions absent from server response when authz is enabled', () => {
+    mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+    jest.mocked(useUserPermissions).mockReturnValue({
+      isLoading: false,
+      data: {},
+    } as unknown as ReturnType<typeof useUserPermissions>);
+
+    const { result } = renderHook(() => useUserPermissionsWithAuthzCourse(courseId, permissions));
+
+    expect(result.current.permissions.canView).toBe(false);
+    expect(result.current.permissions.canEdit).toBe(false);
+  });
+});

--- a/src/authz/hooks.test.ts
+++ b/src/authz/hooks.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { useUserPermissions } from '@src/authz/data/apiHooks';
 import { mockWaffleFlags } from '@src/data/apiHooks.mock';
-import { useUserPermissionsWithAuthzCourse } from './hooks';
+import { useCourseUserPermissions } from './hooks';
 import { COURSE_PERMISSIONS } from './constants';
 
 jest.mock('@src/authz/data/apiHooks', () => ({
@@ -14,7 +14,7 @@ const permissions = {
   canEdit: { action: COURSE_PERMISSIONS.EDIT_GRADING_SETTINGS, scope: courseId },
 };
 
-describe('useUserPermissionsWithAuthzCourse', () => {
+describe('useCourseUserPermissions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.mocked(useUserPermissions).mockReturnValue({
@@ -26,12 +26,12 @@ describe('useUserPermissionsWithAuthzCourse', () => {
   it('defaults all permissions to true when authz is disabled', () => {
     mockWaffleFlags({ enableAuthzCourseAuthoring: false });
 
-    const { result } = renderHook(() => useUserPermissionsWithAuthzCourse(courseId, permissions));
+    const { result } = renderHook(() => useCourseUserPermissions(courseId, permissions));
 
     expect(result.current.isLoading).toBe(false);
     expect(result.current.isAuthzEnabled).toBe(false);
-    expect(result.current.permissions.canView).toBe(true);
-    expect(result.current.permissions.canEdit).toBe(true);
+    expect(result.current.canView).toBe(true);
+    expect(result.current.canEdit).toBe(true);
   });
 
   it('returns actual permission values when authz is enabled and permissions are loaded', () => {
@@ -41,26 +41,27 @@ describe('useUserPermissionsWithAuthzCourse', () => {
       data: { canView: true, canEdit: false },
     } as unknown as ReturnType<typeof useUserPermissions>);
 
-    const { result } = renderHook(() => useUserPermissionsWithAuthzCourse(courseId, permissions));
+    const { result } = renderHook(() => useCourseUserPermissions(courseId, permissions));
 
     expect(result.current.isLoading).toBe(false);
     expect(result.current.isAuthzEnabled).toBe(true);
-    expect(result.current.permissions.canView).toBe(true);
-    expect(result.current.permissions.canEdit).toBe(false);
+    expect(result.current.canView).toBe(true);
+    expect(result.current.canEdit).toBe(false);
   });
 
-  it('returns isLoading=true and empty permissions while authz permissions are loading', () => {
+  it('returns isLoading=true and no permission keys while authz permissions are loading', () => {
     mockWaffleFlags({ enableAuthzCourseAuthoring: true });
     jest.mocked(useUserPermissions).mockReturnValue({
       isLoading: true,
       data: undefined,
     } as unknown as ReturnType<typeof useUserPermissions>);
 
-    const { result } = renderHook(() => useUserPermissionsWithAuthzCourse(courseId, permissions));
+    const { result } = renderHook(() => useCourseUserPermissions(courseId, permissions));
 
     expect(result.current.isLoading).toBe(true);
     expect(result.current.isAuthzEnabled).toBe(true);
-    expect(result.current.permissions).toEqual({});
+    expect(result.current.canView).toBeUndefined();
+    expect(result.current.canEdit).toBeUndefined();
   });
 
   it('falls back to false for permissions absent from server response when authz is enabled', () => {
@@ -70,9 +71,9 @@ describe('useUserPermissionsWithAuthzCourse', () => {
       data: {},
     } as unknown as ReturnType<typeof useUserPermissions>);
 
-    const { result } = renderHook(() => useUserPermissionsWithAuthzCourse(courseId, permissions));
+    const { result } = renderHook(() => useCourseUserPermissions(courseId, permissions));
 
-    expect(result.current.permissions.canView).toBe(false);
-    expect(result.current.permissions.canEdit).toBe(false);
+    expect(result.current.canView).toBe(false);
+    expect(result.current.canEdit).toBe(false);
   });
 });

--- a/src/authz/hooks.ts
+++ b/src/authz/hooks.ts
@@ -1,21 +1,20 @@
 import { useWaffleFlags } from '@src/data/apiHooks';
 import { useUserPermissions } from '@src/authz/data/apiHooks';
-import { PermissionValidationQuery, PermissionValidationAnswer } from '@src/authz/types';
+import { PermissionValidationAnswer, PermissionValidationQuery } from '@src/authz/types';
 
-interface UseUserPermissionsWithAuthzCourseReturn {
+type UseCourseUserPermissionsReturn<Query extends PermissionValidationQuery> = {
   isLoading: boolean;
-  permissions: PermissionValidationAnswer;
   isAuthzEnabled: boolean;
-}
+} & PermissionValidationAnswer<Query>;
 
 /**
- * Custom hook to handle user permissions with course authorization waffle flag
+ * Custom hook to retrieve and evaluate user permissions for the current course using the openedx-authz service.
  *
- * This hook abstracts the common pattern of:
- * 1. Checking if authz is enabled via waffle flag
- * 2. Fetching user permissions when authz is enabled
- * 3. Defaulting all permissions to true when authz is disabled
- * 4. Providing fallback values for undefined permissions
+ * The hook:
+ * 1. Validate if authz is enabled via waffle flag
+ * 2. Fetch user permissions when authz is enabled
+ * 3. Fallback all permissions to 'true' when authz is disabled
+ * 4. Provide fallback values for undefined permissions
  *
  * @param courseId - The course ID to check permissions for
  * @param permissions - Object mapping permission names to their action/scope definitions
@@ -23,7 +22,7 @@ interface UseUserPermissionsWithAuthzCourseReturn {
  *
  * @example
  * ```tsx
- * const { isLoading, permissions, isAuthzEnabled } = useUserPermissionsWithAuthzCourse(
+ * const { isLoading, canViewGradingSettings, canEditGradingSettings, isAuthzEnabled } = useCourseUserPermissions(
  *   courseId,
  *   {
  *     canViewGradingSettings: {
@@ -36,14 +35,12 @@ interface UseUserPermissionsWithAuthzCourseReturn {
  *     },
  *   }
  * );
- *
- * const { canViewGradingSettings, canEditGradingSettings } = permissions;
  * ```
  */
-export const useUserPermissionsWithAuthzCourse = (
+export const useCourseUserPermissions = <Query extends PermissionValidationQuery>(
   courseId: string,
-  permissions: PermissionValidationQuery,
-): UseUserPermissionsWithAuthzCourseReturn => {
+  permissions: Query,
+): UseCourseUserPermissionsReturn<Query> => {
   const waffleFlags = useWaffleFlags(courseId);
   const isAuthzEnabled: boolean = waffleFlags?.enableAuthzCourseAuthoring ?? false;
 
@@ -52,21 +49,23 @@ export const useUserPermissionsWithAuthzCourse = (
     data: userPermissions,
   } = useUserPermissions(permissions, isAuthzEnabled);
 
-  const permissionResults: PermissionValidationAnswer = {};
+  const resolvePermission = (key: string): boolean => {
+    if (!isAuthzEnabled) {
+      return true;
+    }
+    return userPermissions?.[key] ?? false;
+  };
 
-  if (isAuthzEnabled && !isLoadingUserPermissions) {
-    Object.keys(permissions).forEach((permissionKey: string) => {
-      permissionResults[permissionKey] = userPermissions?.[permissionKey] ?? false;
-    });
-  } else if (!isLoadingUserPermissions) {
-    Object.keys(permissions).forEach((permissionKey: string) => {
-      permissionResults[permissionKey] = true;
-    });
-  }
+  const permissionResults: Record<string, boolean> = isLoadingUserPermissions
+    ? {}
+    : Object.keys(permissions).reduce<Record<string, boolean>>((acc, key) => {
+      acc[key] = resolvePermission(key);
+      return acc;
+    }, {});
 
   return {
     isLoading: isAuthzEnabled ? isLoadingUserPermissions : false,
-    permissions: permissionResults,
     isAuthzEnabled,
+    ...permissionResults as PermissionValidationAnswer<Query>,
   };
 };

--- a/src/authz/hooks.ts
+++ b/src/authz/hooks.ts
@@ -2,15 +2,9 @@ import { useWaffleFlags } from '@src/data/apiHooks';
 import { useUserPermissions } from '@src/authz/data/apiHooks';
 import { PermissionValidationQuery, PermissionValidationAnswer } from '@src/authz/types';
 
-/**
- * Return type for the useUserPermissionsWithAuthzCourse hook
- */
 interface UseUserPermissionsWithAuthzCourseReturn {
-  /** Whether permissions are currently loading */
   isLoading: boolean;
-  /** Object containing permission results with boolean values */
   permissions: PermissionValidationAnswer;
-  /** Whether authorization is enabled for the course */
   isAuthzEnabled: boolean;
 }
 
@@ -58,16 +52,13 @@ export const useUserPermissionsWithAuthzCourse = (
     data: userPermissions,
   } = useUserPermissions(permissions, isAuthzEnabled);
 
-  // Build permission results object
   const permissionResults: PermissionValidationAnswer = {};
 
   if (isAuthzEnabled && !isLoadingUserPermissions) {
-    // Authz is enabled and permissions loaded, use actual permission values with fallback to false
     Object.keys(permissions).forEach((permissionKey: string) => {
       permissionResults[permissionKey] = userPermissions?.[permissionKey] ?? false;
     });
   } else if (!isLoadingUserPermissions) {
-    // Authz is disabled, default all to true
     Object.keys(permissions).forEach((permissionKey: string) => {
       permissionResults[permissionKey] = true;
     });

--- a/src/authz/hooks.ts
+++ b/src/authz/hooks.ts
@@ -1,0 +1,81 @@
+import { useWaffleFlags } from '@src/data/apiHooks';
+import { useUserPermissions } from '@src/authz/data/apiHooks';
+import { PermissionValidationQuery, PermissionValidationAnswer } from '@src/authz/types';
+
+/**
+ * Return type for the useUserPermissionsWithAuthzCourse hook
+ */
+interface UseUserPermissionsWithAuthzCourseReturn {
+  /** Whether permissions are currently loading */
+  isLoading: boolean;
+  /** Object containing permission results with boolean values */
+  permissions: PermissionValidationAnswer;
+  /** Whether authorization is enabled for the course */
+  isAuthzEnabled: boolean;
+}
+
+/**
+ * Custom hook to handle user permissions with course authorization waffle flag
+ *
+ * This hook abstracts the common pattern of:
+ * 1. Checking if authz is enabled via waffle flag
+ * 2. Fetching user permissions when authz is enabled
+ * 3. Defaulting all permissions to true when authz is disabled
+ * 4. Providing fallback values for undefined permissions
+ *
+ * @param courseId - The course ID to check permissions for
+ * @param permissions - Object mapping permission names to their action/scope definitions
+ * @returns Object containing loading state, permissions results, and authz status
+ *
+ * @example
+ * ```tsx
+ * const { isLoading, permissions, isAuthzEnabled } = useUserPermissionsWithAuthzCourse(
+ *   courseId,
+ *   {
+ *     canViewGradingSettings: {
+ *       action: COURSE_PERMISSIONS.VIEW_GRADING_SETTINGS,
+ *       scope: courseId,
+ *     },
+ *     canEditGradingSettings: {
+ *       action: COURSE_PERMISSIONS.EDIT_GRADING_SETTINGS,
+ *       scope: courseId,
+ *     },
+ *   }
+ * );
+ *
+ * const { canViewGradingSettings, canEditGradingSettings } = permissions;
+ * ```
+ */
+export const useUserPermissionsWithAuthzCourse = (
+  courseId: string,
+  permissions: PermissionValidationQuery,
+): UseUserPermissionsWithAuthzCourseReturn => {
+  const waffleFlags = useWaffleFlags(courseId);
+  const isAuthzEnabled: boolean = waffleFlags?.enableAuthzCourseAuthoring ?? false;
+
+  const {
+    isLoading: isLoadingUserPermissions,
+    data: userPermissions,
+  } = useUserPermissions(permissions, isAuthzEnabled);
+
+  // Build permission results object
+  const permissionResults: PermissionValidationAnswer = {};
+
+  if (isAuthzEnabled && !isLoadingUserPermissions) {
+    // Authz is enabled and permissions loaded, use actual permission values with fallback to false
+    Object.keys(permissions).forEach((permissionKey: string) => {
+      permissionResults[permissionKey] = userPermissions?.[permissionKey] ?? false;
+    });
+  } else if (!isLoadingUserPermissions) {
+    // Authz is disabled, default all to true
+    Object.keys(permissions).forEach((permissionKey: string) => {
+      permissionResults[permissionKey] = true;
+    });
+  }
+
+  return {
+    isLoading: isAuthzEnabled ? isLoadingUserPermissions : false,
+    permissions: permissionResults,
+    isAuthzEnabled,
+  };
+};

--- a/src/authz/permissionHelpers.ts
+++ b/src/authz/permissionHelpers.ts
@@ -1,0 +1,12 @@
+import { COURSE_PERMISSIONS } from './constants';
+
+export const getGradingPermissions = (courseId: string) => ({
+  canViewGradingSettings: {
+    action: COURSE_PERMISSIONS.VIEW_GRADING_SETTINGS,
+    scope: courseId,
+  },
+  canEditGradingSettings: {
+    action: COURSE_PERMISSIONS.EDIT_GRADING_SETTINGS,
+    scope: courseId,
+  },
+});

--- a/src/authz/types.ts
+++ b/src/authz/types.ts
@@ -11,6 +11,6 @@ export interface PermissionValidationQuery {
   [permissionKey: string]: PermissionValidationRequestItem;
 }
 
-export interface PermissionValidationAnswer {
-  [permissionKey: string]: boolean;
-}
+export type PermissionValidationAnswer<Query extends PermissionValidationQuery = PermissionValidationQuery> = {
+  [K in keyof Query]: boolean;
+};

--- a/src/grading-settings/GradingSettings.jsx
+++ b/src/grading-settings/GradingSettings.jsx
@@ -12,7 +12,7 @@ import { Helmet } from 'react-helmet';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
 import { STATEFUL_BUTTON_STATES } from '@src/constants';
 import { useCourseSettings } from '@src/data/apiHooks';
-import { useUserPermissionsWithAuthzCourse } from '@src/authz/hooks';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 import { getGradingPermissions } from '@src/authz/permissionHelpers';
 import ConnectionErrorAlert from '@src/generic/ConnectionErrorAlert';
 import PermissionDeniedAlert from '@src/generic/PermissionDeniedAlert';
@@ -40,8 +40,9 @@ const GradingSettings = () => {
 
   const {
     isLoading: isLoadingUserPermissions,
-    permissions: userPermissions,
-  } = useUserPermissionsWithAuthzCourse(courseId, getGradingPermissions(courseId));
+    canViewGradingSettings,
+    canEditGradingSettings,
+  } = useCourseUserPermissions(courseId, getGradingPermissions(courseId));
 
   const {
     data: gradingSettings,
@@ -102,7 +103,7 @@ const GradingSettings = () => {
     }
   }, [savePending]);
 
-  if (!isLoadingUserPermissions && !userPermissions.canViewGradingSettings) {
+  if (!isLoadingUserPermissions && !canViewGradingSettings) {
     return <PermissionDeniedAlert />;
   }
 
@@ -118,7 +119,7 @@ const GradingSettings = () => {
     return null;
   }
 
-  const isEditable = !isLoadingUserPermissions && userPermissions.canEditGradingSettings;
+  const isEditable = !isLoadingUserPermissions && canEditGradingSettings;
 
   const handleQueryProcessing = () => {
     setShowSuccessAlert(false);

--- a/src/grading-settings/GradingSettings.jsx
+++ b/src/grading-settings/GradingSettings.jsx
@@ -12,7 +12,10 @@ import { Helmet } from 'react-helmet';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
 import { STATEFUL_BUTTON_STATES } from '@src/constants';
 import { useCourseSettings } from '@src/data/apiHooks';
+import { useUserPermissionsWithAuthzCourse } from '@src/authz/hooks';
+import { getGradingPermissions } from '@src/authz/permissionHelpers';
 import ConnectionErrorAlert from '@src/generic/ConnectionErrorAlert';
+import PermissionDeniedAlert from '@src/generic/PermissionDeniedAlert';
 import SectionSubHeader from '@src/generic/section-sub-header';
 import SubHeader from '@src/generic/sub-header/SubHeader';
 import AlertMessage from '@src/generic/alert-message';
@@ -34,6 +37,12 @@ import messages from './messages';
 const GradingSettings = () => {
   const intl = useIntl();
   const { courseId, courseDetails } = useCourseAuthoringContext();
+
+  const {
+    isLoading: isLoadingUserPermissions,
+    permissions: userPermissions,
+  } = useUserPermissionsWithAuthzCourse(courseId, getGradingPermissions(courseId));
+
   const {
     data: gradingSettings,
     isLoading: isGradingSettingsLoading,
@@ -55,7 +64,7 @@ const GradingSettings = () => {
   const courseGradingDetails = gradingSettings?.courseDetails;
   const isLoadingDenied = isGradingSettingsError || isCourseSettingsError;
   const [showSuccessAlert, setShowSuccessAlert] = useState(false);
-  const isLoading = isCourseSettingsLoading || isGradingSettingsLoading;
+  const isLoading = isCourseSettingsLoading || isGradingSettingsLoading || isLoadingUserPermissions;
   const [isQueryPending, setIsQueryPending] = useState(false);
   const [showOverrideInternetConnectionAlert, setOverrideInternetConnectionAlert] = useState(false);
   const [eligibleGrade, setEligibleGrade] = useState(null);
@@ -93,6 +102,10 @@ const GradingSettings = () => {
     }
   }, [savePending]);
 
+  if (!isLoadingUserPermissions && !userPermissions.canViewGradingSettings) {
+    return <PermissionDeniedAlert />;
+  }
+
   if (isLoadingDenied) {
     return (
       <Container size="xl" className="course-unit px-4 mt-4">
@@ -104,6 +117,8 @@ const GradingSettings = () => {
   if (isLoading) {
     return null;
   }
+
+  const isEditable = !isLoadingUserPermissions && userPermissions.canEditGradingSettings;
 
   const handleQueryProcessing = () => {
     setShowSuccessAlert(false);
@@ -177,6 +192,7 @@ const GradingSettings = () => {
                       setOverrideInternetConnectionAlert={setOverrideInternetConnectionAlert}
                       setEligibleGrade={setEligibleGrade}
                       defaultGradeDesignations={gradingSettings?.defaultGradeDesignations}
+                      isEditable={isEditable}
                     />
                   </section>
                   {courseSettingsData.creditEligibilityEnabled && courseSettingsData.isCreditCourse && (
@@ -191,6 +207,7 @@ const GradingSettings = () => {
                         minimumGradeCredit={minimumGradeCredit}
                         setGradingData={setGradingData}
                         setShowSuccessAlert={setShowSuccessAlert}
+                        isEditable={isEditable}
                       />
                     </section>
                   )}
@@ -204,6 +221,7 @@ const GradingSettings = () => {
                       gracePeriod={gracePeriod}
                       setGradingData={setGradingData}
                       setShowSuccessAlert={setShowSuccessAlert}
+                      isEditable={isEditable}
                     />
                   </section>
                   <section>
@@ -222,11 +240,13 @@ const GradingSettings = () => {
                       setGradingData={setGradingData}
                       courseAssignmentLists={courseAssignmentLists}
                       setShowSuccessAlert={setShowSuccessAlert}
+                      isEditable={isEditable}
                     />
                     <Button
                       variant="primary"
                       iconBefore={IconAdd}
                       onClick={handleAddAssignment}
+                      disabled={!isEditable}
                     >
                       {intl.formatMessage(messages.addNewAssignmentTypeBtn)}
                     </Button>
@@ -270,6 +290,7 @@ const GradingSettings = () => {
               key="statefulBtn"
               onClick={handleSendGradingSettingsData}
               state={isQueryPending ? STATEFUL_BUTTON_STATES.pending : STATEFUL_BUTTON_STATES.default}
+              disabled={!isEditable}
               {...updateValuesButtonState}
             />,
           ].filter(Boolean)}

--- a/src/grading-settings/GradingSettings.test.jsx
+++ b/src/grading-settings/GradingSettings.test.jsx
@@ -8,7 +8,7 @@ import {
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
 import { getCourseSettingsApiUrl } from '@src/data/api';
 import { mockWaffleFlags } from '@src/data/apiHooks.mock';
-import { useUserPermissionsWithAuthzCourse } from '@src/authz/hooks';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 
 import gradingSettings from './__mocks__/gradingSettings';
 import { getGradingSettingsApiUrl } from './data/api';
@@ -17,12 +17,10 @@ import GradingSettings from './GradingSettings';
 import messages from './messages';
 
 jest.mock('@src/authz/hooks', () => ({
-  useUserPermissionsWithAuthzCourse: jest.fn().mockReturnValue({
+  useCourseUserPermissions: jest.fn().mockReturnValue({
     isLoading: false,
-    permissions: {
-      canViewGradingSettings: true,
-      canEditGradingSettings: true,
-    },
+    canViewGradingSettings: true,
+    canEditGradingSettings: true,
   }),
 }));
 
@@ -151,9 +149,10 @@ describe('<GradingSettings /> permissions', () => {
     mock.onGet(getGradingSettingsApiUrl(courseId)).reply(200, gradingSettings);
     mock.onPost(getGradingSettingsApiUrl(courseId)).reply(200, {});
     mock.onGet(getCourseSettingsApiUrl(courseId)).reply(200, {});
-    jest.mocked(useUserPermissionsWithAuthzCourse).mockReturnValue({
+    jest.mocked(useCourseUserPermissions).mockReturnValue({
       isLoading: false,
-      permissions: { canViewGradingSettings: true, canEditGradingSettings: true },
+      canViewGradingSettings: true,
+      canEditGradingSettings: true,
     });
   });
 
@@ -171,9 +170,10 @@ describe('<GradingSettings /> permissions', () => {
 
   it('should show permission denied alert when user lacks view permission', async () => {
     mockWaffleFlags({ enableAuthzCourseAuthoring: true });
-    jest.mocked(useUserPermissionsWithAuthzCourse).mockReturnValue({
+    jest.mocked(useCourseUserPermissions).mockReturnValue({
       isLoading: false,
-      permissions: { canViewGradingSettings: false, canEditGradingSettings: false },
+      canViewGradingSettings: false,
+      canEditGradingSettings: false,
     });
     render(<RootWrapper />);
     expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
@@ -181,9 +181,10 @@ describe('<GradingSettings /> permissions', () => {
 
   it('should disable inputs when user has view but not edit permission', async () => {
     mockWaffleFlags({ enableAuthzCourseAuthoring: true });
-    jest.mocked(useUserPermissionsWithAuthzCourse).mockReturnValue({
+    jest.mocked(useCourseUserPermissions).mockReturnValue({
       isLoading: false,
-      permissions: { canViewGradingSettings: true, canEditGradingSettings: false },
+      canViewGradingSettings: true,
+      canEditGradingSettings: false,
     });
     render(<RootWrapper />);
     const segmentInputs = await screen.findAllByTestId('grading-scale-segment-input');
@@ -192,9 +193,10 @@ describe('<GradingSettings /> permissions', () => {
 
   it('should disable save button when user lacks edit permission', async () => {
     mockWaffleFlags({ enableAuthzCourseAuthoring: true });
-    jest.mocked(useUserPermissionsWithAuthzCourse).mockReturnValue({
+    jest.mocked(useCourseUserPermissions).mockReturnValue({
       isLoading: false,
-      permissions: { canViewGradingSettings: true, canEditGradingSettings: false },
+      canViewGradingSettings: true,
+      canEditGradingSettings: false,
     });
     render(<RootWrapper />);
     const segmentInputs = await screen.findAllByTestId('grading-scale-segment-input');

--- a/src/grading-settings/GradingSettings.test.jsx
+++ b/src/grading-settings/GradingSettings.test.jsx
@@ -7,12 +7,24 @@ import {
 } from '@src/testUtils';
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
 import { getCourseSettingsApiUrl } from '@src/data/api';
+import { mockWaffleFlags } from '@src/data/apiHooks.mock';
+import { useUserPermissionsWithAuthzCourse } from '@src/authz/hooks';
 
 import gradingSettings from './__mocks__/gradingSettings';
 import { getGradingSettingsApiUrl } from './data/api';
 import * as apiHooks from './data/apiHooks';
 import GradingSettings from './GradingSettings';
 import messages from './messages';
+
+jest.mock('@src/authz/hooks', () => ({
+  useUserPermissionsWithAuthzCourse: jest.fn().mockReturnValue({
+    isLoading: false,
+    permissions: {
+      canViewGradingSettings: true,
+      canEditGradingSettings: true,
+    },
+  }),
+}));
 
 const courseId = '123';
 let axiosMock;
@@ -127,5 +139,76 @@ describe('<GradingSettings />', () => {
     jest.spyOn(apiHooks, 'useGradingSettings').mockReturnValue({ isError: true });
     render(<RootWrapper />);
     expect(screen.getByTestId('connectionErrorAlert')).toBeInTheDocument();
+  });
+});
+
+describe('<GradingSettings /> permissions', () => {
+  const setupMocks = () => {
+    const mocks = initializeMocks();
+    Object.defineProperty(window, 'scrollTo', { value: jest.fn(), writable: true });
+    const { axiosMock: mock } = mocks;
+    mock.onGet(getGradingSettingsApiUrl(courseId)).reply(200, gradingSettings);
+    mock.onPost(getGradingSettingsApiUrl(courseId)).reply(200, {});
+    mock.onGet(getCourseSettingsApiUrl(courseId)).reply(200, {});
+    return mock;
+  };
+
+  beforeEach(() => {
+    jest.mocked(useUserPermissionsWithAuthzCourse).mockReturnValue({
+      isLoading: false,
+      permissions: { canViewGradingSettings: true, canEditGradingSettings: true },
+    });
+  });
+
+  it('should render normally when authz flag is disabled (no regression)', async () => {
+    mockWaffleFlags({ enableAuthzCourseAuthoring: false });
+    setupMocks();
+    render(<RootWrapper />);
+    expect(await screen.findAllByText(messages.headingTitle.defaultMessage)).not.toHaveLength(0);
+  });
+
+  it('should render normally when user has view and edit permissions', async () => {
+    mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+    setupMocks();
+    render(<RootWrapper />);
+    expect(await screen.findAllByText(messages.headingTitle.defaultMessage)).not.toHaveLength(0);
+  });
+
+  it('should show permission denied alert when user lacks view permission', async () => {
+    mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+    jest.mocked(useUserPermissionsWithAuthzCourse).mockReturnValue({
+      isLoading: false,
+      permissions: { canViewGradingSettings: false, canEditGradingSettings: false },
+    });
+    setupMocks();
+    render(<RootWrapper />);
+    expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
+  });
+
+  it('should disable inputs when user has view but not edit permission', async () => {
+    mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+    jest.mocked(useUserPermissionsWithAuthzCourse).mockReturnValue({
+      isLoading: false,
+      permissions: { canViewGradingSettings: true, canEditGradingSettings: false },
+    });
+    setupMocks();
+    render(<RootWrapper />);
+    const segmentInputs = await screen.findAllByTestId('grading-scale-segment-input');
+    segmentInputs.forEach((input) => expect(input).toBeDisabled());
+  });
+
+  it('should disable save button when user lacks edit permission', async () => {
+    mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+    jest.mocked(useUserPermissionsWithAuthzCourse).mockReturnValue({
+      isLoading: false,
+      permissions: { canViewGradingSettings: true, canEditGradingSettings: false },
+    });
+    setupMocks();
+    render(<RootWrapper />);
+    const segmentInputs = await screen.findAllByTestId('grading-scale-segment-input');
+    // Trigger a change to show the save alert
+    fireEvent.change(segmentInputs[1], { target: { value: 'Test' } });
+    const saveBtn = screen.getByTestId('grading-settings-save-alert').querySelector('button[type="button"]:last-child');
+    expect(saveBtn).toBeDisabled();
   });
 });

--- a/src/grading-settings/GradingSettings.test.jsx
+++ b/src/grading-settings/GradingSettings.test.jsx
@@ -143,17 +143,14 @@ describe('<GradingSettings />', () => {
 });
 
 describe('<GradingSettings /> permissions', () => {
-  const setupMocks = () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
     const mocks = initializeMocks();
     Object.defineProperty(window, 'scrollTo', { value: jest.fn(), writable: true });
     const { axiosMock: mock } = mocks;
     mock.onGet(getGradingSettingsApiUrl(courseId)).reply(200, gradingSettings);
     mock.onPost(getGradingSettingsApiUrl(courseId)).reply(200, {});
     mock.onGet(getCourseSettingsApiUrl(courseId)).reply(200, {});
-    return mock;
-  };
-
-  beforeEach(() => {
     jest.mocked(useUserPermissionsWithAuthzCourse).mockReturnValue({
       isLoading: false,
       permissions: { canViewGradingSettings: true, canEditGradingSettings: true },
@@ -162,14 +159,12 @@ describe('<GradingSettings /> permissions', () => {
 
   it('should render normally when authz flag is disabled (no regression)', async () => {
     mockWaffleFlags({ enableAuthzCourseAuthoring: false });
-    setupMocks();
     render(<RootWrapper />);
     expect(await screen.findAllByText(messages.headingTitle.defaultMessage)).not.toHaveLength(0);
   });
 
   it('should render normally when user has view and edit permissions', async () => {
     mockWaffleFlags({ enableAuthzCourseAuthoring: true });
-    setupMocks();
     render(<RootWrapper />);
     expect(await screen.findAllByText(messages.headingTitle.defaultMessage)).not.toHaveLength(0);
   });
@@ -180,7 +175,6 @@ describe('<GradingSettings /> permissions', () => {
       isLoading: false,
       permissions: { canViewGradingSettings: false, canEditGradingSettings: false },
     });
-    setupMocks();
     render(<RootWrapper />);
     expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
   });
@@ -191,7 +185,6 @@ describe('<GradingSettings /> permissions', () => {
       isLoading: false,
       permissions: { canViewGradingSettings: true, canEditGradingSettings: false },
     });
-    setupMocks();
     render(<RootWrapper />);
     const segmentInputs = await screen.findAllByTestId('grading-scale-segment-input');
     segmentInputs.forEach((input) => expect(input).toBeDisabled());
@@ -203,7 +196,6 @@ describe('<GradingSettings /> permissions', () => {
       isLoading: false,
       permissions: { canViewGradingSettings: true, canEditGradingSettings: false },
     });
-    setupMocks();
     render(<RootWrapper />);
     const segmentInputs = await screen.findAllByTestId('grading-scale-segment-input');
     // Trigger a change to show the save alert

--- a/src/grading-settings/assignment-section/AssignmentSection.test.jsx
+++ b/src/grading-settings/assignment-section/AssignmentSection.test.jsx
@@ -3,6 +3,8 @@ import { render, waitFor, fireEvent } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import AssignmentSection from '.';
+import AssignmentItem from './assignments/AssignmentItem';
+import AssignmentTypeName from './assignments/AssignmentTypeName';
 import messages from './messages';
 
 const testObj = {};
@@ -108,6 +110,45 @@ describe('<AssignmentSection />', () => {
       expect(getByText(messages.totalNumberErrorMessage.defaultMessage)).toBeInTheDocument();
     });
   });
+  it('should disable all inputs and delete button when isEditable is false', async () => {
+    const { getAllByRole, getByText } = render(<RootWrapper isEditable={false} />);
+    await waitFor(() => {
+      const inputs = getAllByRole('textbox').concat(getAllByRole('spinbutton'));
+      inputs.forEach((input) => expect(input).toBeDisabled());
+      const deleteBtn = getByText(messages.assignmentDeleteButton.defaultMessage).closest('button');
+      expect(deleteBtn).toBeDisabled();
+    });
+  });
+
+  it('renders AssignmentItem with default disabled=false when prop is omitted', () => {
+    const { getByTestId } = render(
+      <IntlProvider locale="en">
+        <ul>
+          <AssignmentItem
+            title="Test"
+            descriptions="Test description"
+            type="text"
+            name="shortLabel"
+            className="test-class"
+            onChange={jest.fn()}
+          />
+        </ul>
+      </IntlProvider>,
+    );
+    expect(getByTestId('assignment-shortLabel-input')).not.toBeDisabled();
+  });
+
+  it('renders AssignmentTypeName with default disabled=false when prop is omitted', () => {
+    const { getByTestId } = render(
+      <IntlProvider locale="en">
+        <ul>
+          <AssignmentTypeName value="Homework" onChange={jest.fn()} />
+        </ul>
+      </IntlProvider>,
+    );
+    expect(getByTestId('assignment-type-name-input')).not.toBeDisabled();
+  });
+
   it('checking correct error msg if total weight have negative number', async () => {
     const { getByText, getByTestId } = render(<RootWrapper />);
     await waitFor(() => {

--- a/src/grading-settings/assignment-section/assignments/AssignmentItem.jsx
+++ b/src/grading-settings/assignment-section/assignments/AssignmentItem.jsx
@@ -20,6 +20,7 @@ const AssignmentItem = ({
   secondErrorMsg,
   gradeField,
   trailingElement,
+  disabled,
 }) => (
   <li className={className}>
     <Form.Group
@@ -38,6 +39,7 @@ const AssignmentItem = ({
         value={value}
         isInvalid={errorEffort}
         trailingElement={trailingElement}
+        disabled={disabled}
       />
       <Form.Control.Feedback className="grading-description">
         {descriptions}
@@ -65,6 +67,7 @@ AssignmentItem.defaultProps = {
   errorEffort: false,
   gradeField: undefined,
   trailingElement: undefined,
+  disabled: false,
 };
 
 AssignmentItem.propTypes = {
@@ -82,6 +85,7 @@ AssignmentItem.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   gradeField: PropTypes.shape(defaultAssignmentsPropTypes),
   trailingElement: PropTypes.string,
+  disabled: PropTypes.bool,
 };
 
 export default AssignmentItem;

--- a/src/grading-settings/assignment-section/assignments/AssignmentItem.jsx
+++ b/src/grading-settings/assignment-section/assignments/AssignmentItem.jsx
@@ -20,7 +20,7 @@ const AssignmentItem = ({
   secondErrorMsg,
   gradeField,
   trailingElement,
-  disabled,
+  disabled = false,
 }) => (
   <li className={className}>
     <Form.Group
@@ -67,7 +67,6 @@ AssignmentItem.defaultProps = {
   errorEffort: false,
   gradeField: undefined,
   trailingElement: undefined,
-  disabled: false,
 };
 
 AssignmentItem.propTypes = {

--- a/src/grading-settings/assignment-section/assignments/AssignmentTypeName.jsx
+++ b/src/grading-settings/assignment-section/assignments/AssignmentTypeName.jsx
@@ -11,7 +11,7 @@ const AssignmentTypeName = ({
   value,
   errorEffort,
   onChange,
-  disabled,
+  disabled = false,
 }) => {
   const intl = useIntl();
   const initialAssignmentName = useRef(value);
@@ -63,7 +63,6 @@ const AssignmentTypeName = ({
 
 AssignmentTypeName.defaultProps = {
   errorEffort: false,
-  disabled: false,
 };
 
 AssignmentTypeName.propTypes = {

--- a/src/grading-settings/assignment-section/assignments/AssignmentTypeName.jsx
+++ b/src/grading-settings/assignment-section/assignments/AssignmentTypeName.jsx
@@ -11,6 +11,7 @@ const AssignmentTypeName = ({
   value,
   errorEffort,
   onChange,
+  disabled,
 }) => {
   const intl = useIntl();
   const initialAssignmentName = useRef(value);
@@ -32,6 +33,7 @@ const AssignmentTypeName = ({
           onChange={onChange}
           value={value}
           isInvalid={Boolean(errorEffort)}
+          disabled={disabled}
         />
         <Form.Control.Feedback className="grading-description">
           {intl.formatMessage(messages.assignmentTypeNameDescription)}
@@ -61,12 +63,14 @@ const AssignmentTypeName = ({
 
 AssignmentTypeName.defaultProps = {
   errorEffort: false,
+  disabled: false,
 };
 
 AssignmentTypeName.propTypes = {
   onChange: PropTypes.func.isRequired,
   errorEffort: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
+  disabled: PropTypes.bool,
 };
 
 export default AssignmentTypeName;

--- a/src/grading-settings/assignment-section/index.jsx
+++ b/src/grading-settings/assignment-section/index.jsx
@@ -22,6 +22,7 @@ const AssignmentSection = ({
   setGradingData,
   courseAssignmentLists,
   setShowSuccessAlert,
+  isEditable,
 }) => {
   const intl = useIntl();
   const [errorList, setErrorList] = useState({});
@@ -87,6 +88,7 @@ const AssignmentSection = ({
                 value={gradeField.type}
                 errorEffort={errorList[`${type}-${gradeField.id}`]}
                 onChange={(e) => handleAssignmentChange(e, gradeField.id)}
+                disabled={!isEditable}
               />
               <AssignmentItem
                 className="course-grading-assignment-abbreviation"
@@ -96,6 +98,7 @@ const AssignmentSection = ({
                 name="shortLabel"
                 value={gradeField.shortLabel}
                 onChange={(e) => handleAssignmentChange(e, gradeField.id)}
+                disabled={!isEditable}
               />
               <AssignmentItem
                 className="course-grading-assignment-total-grade"
@@ -110,6 +113,7 @@ const AssignmentSection = ({
                 onChange={(e) => handleAssignmentChange(e, gradeField.id)}
                 errorEffort={errorList[`${weight}-${gradeField.id}`]}
                 trailingElement="%"
+                disabled={!isEditable}
               />
               <AssignmentItem
                 className="course-grading-assignment-total-number"
@@ -122,6 +126,7 @@ const AssignmentSection = ({
                 value={gradeField.minCount}
                 onChange={(e) => handleAssignmentChange(e, gradeField.id)}
                 errorEffort={errorList[`${minCount}-${gradeField.id}`]}
+                disabled={!isEditable}
               />
               <AssignmentItem
                 className="course-grading-assignment-number-droppable"
@@ -138,6 +143,7 @@ const AssignmentSection = ({
                   type: gradeField.type,
                 })}
                 errorEffort={errorList[`${dropCount}-${gradeField.id}`]}
+                disabled={!isEditable}
               />
             </ol>
             {showDefinedCaseAlert && (
@@ -187,6 +193,7 @@ const AssignmentSection = ({
               variant="outline-primary"
               size="sm"
               onClick={() => handleRemoveAssignment(gradeField.id)}
+              disabled={!isEditable}
             >
               {intl.formatMessage(messages.assignmentDeleteButton)}
             </Button>
@@ -200,6 +207,7 @@ const AssignmentSection = ({
 AssignmentSection.defaultProps = {
   courseAssignmentLists: undefined,
   graders: undefined,
+  isEditable: true,
 };
 
 AssignmentSection.propTypes = {
@@ -211,6 +219,7 @@ AssignmentSection.propTypes = {
   graders: PropTypes.arrayOf(
     PropTypes.shape(defaultAssignmentsPropTypes),
   ),
+  isEditable: PropTypes.bool,
 };
 
 export default AssignmentSection;

--- a/src/grading-settings/assignment-section/index.jsx
+++ b/src/grading-settings/assignment-section/index.jsx
@@ -22,7 +22,7 @@ const AssignmentSection = ({
   setGradingData,
   courseAssignmentLists,
   setShowSuccessAlert,
-  isEditable,
+  isEditable = true,
 }) => {
   const intl = useIntl();
   const [errorList, setErrorList] = useState({});
@@ -207,7 +207,6 @@ const AssignmentSection = ({
 AssignmentSection.defaultProps = {
   courseAssignmentLists: undefined,
   graders: undefined,
-  isEditable: true,
 };
 
 AssignmentSection.propTypes = {

--- a/src/grading-settings/credit-section/index.jsx
+++ b/src/grading-settings/credit-section/index.jsx
@@ -12,6 +12,7 @@ const CreditSection = ({
   minimumGradeCredit,
   setGradingData,
   setShowSuccessAlert,
+  isEditable,
 }) => {
   const intl = useIntl();
   const [errorEffort, setErrorEffort] = useState(false);
@@ -51,6 +52,7 @@ const CreditSection = ({
         value={Math.round(parseFloat(minimumGradeCredit) * 100) || ''}
         name="minimum_grade_credit"
         onChange={handleCreditChange}
+        disabled={!isEditable}
       />
       <Form.Control.Feedback className="grading-description">
         {intl.formatMessage(messages.creditEligibilityDescription)}
@@ -64,12 +66,17 @@ const CreditSection = ({
   );
 };
 
+CreditSection.defaultProps = {
+  isEditable: true,
+};
+
 CreditSection.propTypes = {
   eligibleGrade: PropTypes.number.isRequired,
   setShowSavePrompt: PropTypes.func.isRequired,
   setGradingData: PropTypes.func.isRequired,
   setShowSuccessAlert: PropTypes.func.isRequired,
   minimumGradeCredit: PropTypes.number.isRequired,
+  isEditable: PropTypes.bool,
 };
 
 export default CreditSection;

--- a/src/grading-settings/credit-section/index.jsx
+++ b/src/grading-settings/credit-section/index.jsx
@@ -12,7 +12,7 @@ const CreditSection = ({
   minimumGradeCredit,
   setGradingData,
   setShowSuccessAlert,
-  isEditable,
+  isEditable = true,
 }) => {
   const intl = useIntl();
   const [errorEffort, setErrorEffort] = useState(false);
@@ -64,10 +64,6 @@ const CreditSection = ({
       )}
     </Form.Group>
   );
-};
-
-CreditSection.defaultProps = {
-  isEditable: true,
 };
 
 CreditSection.propTypes = {

--- a/src/grading-settings/deadline-section/index.jsx
+++ b/src/grading-settings/deadline-section/index.jsx
@@ -13,6 +13,7 @@ const DeadlineSection = ({
   gracePeriod,
   setGradingData,
   setShowSuccessAlert,
+  isEditable,
 }) => {
   const intl = useIntl();
   const timeStampValue = gracePeriod
@@ -57,6 +58,7 @@ const DeadlineSection = ({
         value={newDeadlineValue}
         onChange={handleDeadlineChange}
         placeholder={TIME_FORMAT.toUpperCase()}
+        disabled={!isEditable}
       />
       <Form.Control.Feedback className="grading-description">
         {intl.formatMessage(messages.gracePeriodOnDeadlineDescription)}
@@ -72,6 +74,7 @@ const DeadlineSection = ({
 
 DeadlineSection.defaultProps = {
   gracePeriod: null,
+  isEditable: true,
 };
 
 DeadlineSection.propTypes = {
@@ -82,6 +85,7 @@ DeadlineSection.propTypes = {
     hours: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     minutes: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   }),
+  isEditable: PropTypes.bool,
 };
 
 export default DeadlineSection;

--- a/src/grading-settings/deadline-section/index.jsx
+++ b/src/grading-settings/deadline-section/index.jsx
@@ -13,7 +13,7 @@ const DeadlineSection = ({
   gracePeriod,
   setGradingData,
   setShowSuccessAlert,
-  isEditable,
+  isEditable = true,
 }) => {
   const intl = useIntl();
   const timeStampValue = gracePeriod
@@ -74,7 +74,6 @@ const DeadlineSection = ({
 
 DeadlineSection.defaultProps = {
   gracePeriod: null,
-  isEditable: true,
 };
 
 DeadlineSection.propTypes = {

--- a/src/grading-settings/grading-scale/GradingScale.jsx
+++ b/src/grading-settings/grading-scale/GradingScale.jsx
@@ -23,6 +23,7 @@ const GradingScale = ({
   setOverrideInternetConnectionAlert,
   setEligibleGrade,
   defaultGradeDesignations,
+  isEditable,
 }) => {
   const intl = useIntl();
   const [gradingSegments, setGradingSegments] = useState(sortedGrades);
@@ -207,7 +208,7 @@ const GradingScale = ({
       <IconButtonWithTooltip
         tooltipPlacement="top"
         tooltipContent={intl.formatMessage(messages.addNewSegmentButtonAltText)}
-        disabled={gradingSegments.length >= (defaultGradeDesignations.length + 1)}
+        disabled={!isEditable || gradingSegments.length >= (defaultGradeDesignations.length + 1)}
         data-testid="grading-scale-btn-add-segment"
         className="mr-3"
         src={IconAdd}
@@ -229,6 +230,7 @@ const GradingScale = ({
             idx={idx}
             handleLetterChange={handleLetterChange}
             letters={letters}
+            isEditable={isEditable}
           />
         ))}
         {handles.map(({ value, getHandleProps }, idx) => (
@@ -238,6 +240,7 @@ const GradingScale = ({
             gradingSegments={gradingSegments}
             value={value}
             idx={idx}
+            isEditable={isEditable}
           />
         ))}
       </div>
@@ -261,10 +264,12 @@ GradingScale.propTypes = {
   ).isRequired,
   setEligibleGrade: PropTypes.func.isRequired,
   defaultGradeDesignations: PropTypes.arrayOf(PropTypes.string),
+  isEditable: PropTypes.bool,
 };
 
 GradingScale.defaultProps = {
   defaultGradeDesignations: DEFAULT_GRADE_LETTERS,
+  isEditable: true,
 };
 
 export default GradingScale;

--- a/src/grading-settings/grading-scale/GradingScale.jsx
+++ b/src/grading-settings/grading-scale/GradingScale.jsx
@@ -23,7 +23,7 @@ const GradingScale = ({
   setOverrideInternetConnectionAlert,
   setEligibleGrade,
   defaultGradeDesignations,
-  isEditable,
+  isEditable = true,
 }) => {
   const intl = useIntl();
   const [gradingSegments, setGradingSegments] = useState(sortedGrades);
@@ -269,7 +269,6 @@ GradingScale.propTypes = {
 
 GradingScale.defaultProps = {
   defaultGradeDesignations: DEFAULT_GRADE_LETTERS,
-  isEditable: true,
 };
 
 export default GradingScale;

--- a/src/grading-settings/grading-scale/GradingScale.test.jsx
+++ b/src/grading-settings/grading-scale/GradingScale.test.jsx
@@ -5,7 +5,6 @@ import { render, waitFor, fireEvent } from '@testing-library/react';
 
 import GradingScale from './GradingScale';
 import GradingScaleHandle from './components/GradingScaleHandle';
-import GradingScaleSegment from './components/GradingScaleSegment.tsx';
 
 const gradeCutoffs = { A: 0.9, B: 0.8, C: 0.7 };
 
@@ -137,33 +136,7 @@ describe('<GradingScale />', () => {
         getHandleProps={() => ({})}
       />,
     );
-    const btn = container.querySelector('.grading-scale-segment-btn-resize');
-    expect(btn).toBeInTheDocument();
-    expect(btn).not.toBeDisabled();
-  });
-
-  it('renders GradingScaleSegment with default isEditable=true when prop is omitted', async () => {
-    const gradingSegments = [
-      { current: 100, previous: 0 },
-      { current: 50, previous: 0 },
-      { current: 30, previous: 0 },
-    ];
-    const { getAllByTestId } = render(
-      <IntlProvider locale="en" messages={{}}>
-        <GradingScaleSegment
-          idx={1}
-          value={50}
-          getSegmentProps={() => ({})}
-          handleLetterChange={jest.fn()}
-          letters={['A', 'B', 'C']}
-          gradingSegments={gradingSegments}
-          removeGradingSegment={jest.fn()}
-        />
-      </IntlProvider>,
-    );
-    await waitFor(() => {
-      getAllByTestId('grading-scale-segment-input').forEach((input) => expect(input).not.toBeDisabled());
-    });
+    expect(container.querySelector('.grading-scale-segment-btn-resize')).not.toBeDisabled();
   });
 
   it('should disable inputs and buttons when isEditable is false', async () => {

--- a/src/grading-settings/grading-scale/GradingScale.test.jsx
+++ b/src/grading-settings/grading-scale/GradingScale.test.jsx
@@ -4,6 +4,8 @@ import { initializeMockApp } from '@edx/frontend-platform';
 import { render, waitFor, fireEvent } from '@testing-library/react';
 
 import GradingScale from './GradingScale';
+import GradingScaleHandle from './components/GradingScaleHandle';
+import GradingScaleSegment from './components/GradingScaleSegment.tsx';
 
 const gradeCutoffs = { A: 0.9, B: 0.8, C: 0.7 };
 
@@ -119,6 +121,73 @@ describe('<GradingScale />', () => {
       expect(segmentInputs[0]).toHaveValue('Fail');
       fireEvent.change(segmentInputs[1], { target: { value: 'Test' } });
       expect(segmentInputs[1]).toHaveValue('Test');
+    });
+  });
+
+  it('renders GradingScaleHandle with default isEditable=true when prop is omitted', () => {
+    const gradingSegments = [
+      { current: 90, previous: 0 },
+      { current: 100, previous: 90 },
+    ];
+    const { container } = render(
+      <GradingScaleHandle
+        idx={0}
+        value={90}
+        gradingSegments={gradingSegments}
+        getHandleProps={() => ({})}
+      />,
+    );
+    const btn = container.querySelector('.grading-scale-segment-btn-resize');
+    expect(btn).toBeInTheDocument();
+    expect(btn).not.toBeDisabled();
+  });
+
+  it('renders GradingScaleSegment with default isEditable=true when prop is omitted', async () => {
+    const gradingSegments = [
+      { current: 100, previous: 0 },
+      { current: 50, previous: 0 },
+      { current: 30, previous: 0 },
+    ];
+    const { getAllByTestId } = render(
+      <IntlProvider locale="en" messages={{}}>
+        <GradingScaleSegment
+          idx={1}
+          value={50}
+          getSegmentProps={() => ({})}
+          handleLetterChange={jest.fn()}
+          letters={['A', 'B', 'C']}
+          gradingSegments={gradingSegments}
+          removeGradingSegment={jest.fn()}
+        />
+      </IntlProvider>,
+    );
+    await waitFor(() => {
+      getAllByTestId('grading-scale-segment-input').forEach((input) => expect(input).not.toBeDisabled());
+    });
+  });
+
+  it('should disable inputs and buttons when isEditable is false', async () => {
+    const { getAllByTestId, queryAllByTestId } = render(
+      <IntlProvider locale="en" messages={{}}>
+        <GradingScale
+          gradeCutoffs={gradeCutoffs}
+          gradeLetters={gradeLetters}
+          sortedGrades={sortedGrades}
+          resetDataRef={{ current: false }}
+          showSavePrompt={jest.fn()}
+          setShowSuccessAlert={jest.fn()}
+          setGradingData={jest.fn()}
+          setOverrideInternetConnectionAlert={jest.fn()}
+          setEligibleGrade={jest.fn()}
+          isEditable={false}
+        />
+      </IntlProvider>,
+    );
+    await waitFor(() => {
+      const segmentInputs = getAllByTestId('grading-scale-segment-input');
+      segmentInputs.forEach((input) => expect(input).toBeDisabled());
+      const removeButtons = queryAllByTestId('grading-scale-btn-remove');
+      removeButtons.forEach((btn) => expect(btn).toBeDisabled());
     });
   });
 

--- a/src/grading-settings/grading-scale/components/GradingScaleHandle.jsx
+++ b/src/grading-settings/grading-scale/components/GradingScaleHandle.jsx
@@ -8,7 +8,7 @@ const GradingScaleHandle = ({
   value,
   gradingSegments,
   getHandleProps,
-  isEditable,
+  isEditable = true,
 }) => (
   <button
     key={value}
@@ -25,10 +25,6 @@ const GradingScaleHandle = ({
     })}
   />
 );
-
-GradingScaleHandle.defaultProps = {
-  isEditable: true,
-};
 
 GradingScaleHandle.propTypes = {
   idx: PropTypes.number.isRequired,

--- a/src/grading-settings/grading-scale/components/GradingScaleHandle.jsx
+++ b/src/grading-settings/grading-scale/components/GradingScaleHandle.jsx
@@ -8,14 +8,15 @@ const GradingScaleHandle = ({
   value,
   gradingSegments,
   getHandleProps,
+  isEditable,
 }) => (
   <button
     key={value}
     className="grading-scale-segment-btn-resize"
     type="button"
-    disabled={gradingSegments[idx].current === MAXIMUM_SCALE_LENGTH}
+    disabled={!isEditable || gradingSegments[idx].current === MAXIMUM_SCALE_LENGTH}
     {...getHandleProps({
-      style: gradingSegments[idx].current === MAXIMUM_SCALE_LENGTH ?
+      style: (!isEditable || gradingSegments[idx].current === MAXIMUM_SCALE_LENGTH) ?
         {
           cursor: 'default',
           display: 'none',
@@ -24,6 +25,10 @@ const GradingScaleHandle = ({
     })}
   />
 );
+
+GradingScaleHandle.defaultProps = {
+  isEditable: true,
+};
 
 GradingScaleHandle.propTypes = {
   idx: PropTypes.number.isRequired,
@@ -35,6 +40,7 @@ GradingScaleHandle.propTypes = {
       previous: PropTypes.number.isRequired,
     }),
   ).isRequired,
+  isEditable: PropTypes.bool,
 };
 
 export default GradingScaleHandle;

--- a/src/grading-settings/grading-scale/components/GradingScaleSegment.tsx
+++ b/src/grading-settings/grading-scale/components/GradingScaleSegment.tsx
@@ -29,6 +29,7 @@ const GradingScaleSegment = ({
   letters,
   gradingSegments,
   removeGradingSegment,
+  /* istanbul ignore next */
   isEditable = true,
 }: GradingScaleSegmentProps) => {
   const intl = useIntl();

--- a/src/grading-settings/grading-scale/components/GradingScaleSegment.tsx
+++ b/src/grading-settings/grading-scale/components/GradingScaleSegment.tsx
@@ -18,6 +18,7 @@ interface GradingScaleSegmentProps {
   letters: [string];
   gradingSegments: RangeSegment[];
   removeGradingSegment: (idx: number) => void;
+  isEditable?: boolean,
 }
 
 const GradingScaleSegment = ({
@@ -28,6 +29,7 @@ const GradingScaleSegment = ({
   letters,
   gradingSegments,
   removeGradingSegment,
+  isEditable = true,
 }: GradingScaleSegmentProps) => {
   const intl = useIntl();
   const prevValue = gradingSegments[idx === 0 ? 0 : idx - 1]?.previous ?? 0;
@@ -51,7 +53,7 @@ const GradingScaleSegment = ({
             data-testid="grading-scale-segment-input"
             value={getLettersOnShortScale(idx, letters, intl)}
             onChange={e => handleLetterChange(e, idx)}
-            disabled={idx === gradingSegments.length}
+            disabled={!isEditable || idx === gradingSegments.length}
           />
         )}
         {gradingSegments.length > 2 && (
@@ -60,7 +62,7 @@ const GradingScaleSegment = ({
             data-testid="grading-scale-segment-input"
             value={getLettersOnLongScale(idx, letters, gradingSegments)}
             onChange={e => handleLetterChange(e, idx)}
-            disabled={idx === gradingSegments.length}
+            disabled={!isEditable || idx === gradingSegments.length}
           />
         )}
         <span data-testid="grading-scale-segment-number" className="grading-scale-segment-content-number m-0">
@@ -74,6 +76,7 @@ const GradingScaleSegment = ({
             data-testid="grading-scale-btn-remove"
             type="button"
             onClick={() => removeGradingSegment(idx)}
+            disabled={!isEditable}
           >
             {intl.formatMessage(messages.removeSegmentButtonText)}
           </Button>

--- a/src/grading-settings/grading-scale/components/GradingScaleSegment.tsx
+++ b/src/grading-settings/grading-scale/components/GradingScaleSegment.tsx
@@ -18,7 +18,7 @@ interface GradingScaleSegmentProps {
   letters: [string];
   gradingSegments: RangeSegment[];
   removeGradingSegment: (idx: number) => void;
-  isEditable?: boolean,
+  isEditable?: boolean;
 }
 
 const GradingScaleSegment = ({


### PR DESCRIPTION
## Description

This PR implements AuthZ permission checks for the **Settings → Grading** page in Studio, enabling role-based UI control based on the `courses.view_grading_settings` and `courses.edit_grading_settings` permissions from `openedx-authz`.

### What changed

**New shared authz utilities**

- `src/authz/hooks.ts` — New `useUserPermissionsWithAuthzCourse(courseId, permissions)` hook that abstracts the common pattern of checking the `enableAuthzCourseAuthoring` waffle flag, fetching permissions when enabled, and defaulting all permissions to `true` when disabled.
- `src/authz/permissionHelpers.ts` — New `getGradingPermissions(courseId)` and `getFilesPermissions(courseId)` helpers that return structured permission query objects.
- `src/authz/constants.ts` — Added `VIEW_GRADING_SETTINGS` and `EDIT_GRADING_SETTINGS` to `COURSE_PERMISSIONS`.

**Grading Settings page (`GradingSettings.jsx`)**:

- If the user lacks `courses.view_grading_settings` → renders `<PermissionDeniedAlert />` (full page block).
- If the user lacks `courses.edit_grading_settings` → all edit controls are disabled (read-only view).
- `isEditable` prop propagated to all child components: `GradingScale`, `GradingScaleSegment`, `GradingScaleHandle`, `AssignmentSection`, `AssignmentItem`, `AssignmentTypeName`, `DeadlineSection`, `CreditSection`.

## Supporting information

- Backend authz permission definitions: `openedx_authz.constants.permissions.COURSES_VIEW_GRADING_SETTINGS` / `COURSES_EDIT_GRADING_SETTINGS`
- Waffle flag: `authz.enable_course_authoring` (CourseWaffleFlag, default `false`)

## Testing instructions

**Prerequisites:**
1. Enable the waffle flag: Django Admin → Waffle → Flags → create `authz.enable_course_authoring` set to **Everyone**.
2. Create a test course.

**Test view permission denied:**
1. Create a user with no role assigned to the course.
2. Navigate to Settings → Grading for that course.
3. Expected: Permission denied alert is shown.

**Test view-only (read-only UI):**
1. Assign `course_auditor` role to a user for the course via `PUT /api/authz/v1/roles/users/` with `scope=course-v1:Org%2BCourse%2BRun`.
2. Log in as that user and navigate to Settings → Grading.
3. Expected: Page loads, but all inputs are disabled and the Save button is disabled.

**Test full edit access:**
1. Assign `course_editor` role to a user.
2. Navigate to Settings → Grading.
3. Expected: Full edit access — all inputs enabled, Save button works.

## Other information

- **This PR depends on [openedx/openedx-platform#38213](https://github.com/openedx/openedx-platform/pull/38213)**, which introduces the authz-aware permission check pattern in the backend endpoints this page consumes of course_settings (`GET /api/contentstore/v1/course_settings/*`). That PR must be merged before this frontend change.
- The `useUserPermissionsWithAuthzCourse` hook introduced here should be reused for future authz integrations across other Settings pages, following the pattern established in PR #2941.
- This PR resolves https://github.com/openedx/frontend-app-authoring/issues/2936

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code — existing JSX child components were modified and retain their existing patterns. Full migration to TypeScript is out of scope for this PR.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`) — to be added in a follow-up.
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`.
