### PR TITLE
fix: Implement sidebar as sticky [FC-0123]

### DIFF
--- a/src/generic/sidebar/index.scss
+++ b/src/generic/sidebar/index.scss
@@ -1,11 +1,15 @@
 .sidebar {
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  max-height: 100vh;
+
   .sidebar-content {
     flex: 0 1 auto;
     min-width: 440px;
     overflow-y: auto;
-    min-height: 100vh;
-    height: 100%;
-    max-height: 300vh;
+    height: 100vh;
+    max-height: 100vh;
 
     /*
      * Change the styles for tabs in all sidebars.


### PR DESCRIPTION
## Description


- Fixes this issue https://github.com/openedx/frontend-app-authoring/issues/2868#issuecomment-4262011699
- Which user roles will this change impact? "Course Author"

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/2868#issuecomment-4262011699
- Internal ticket: https://tasks.opencraft.com/browse/FAL-4331

## Testing instructions

- Go to a course outline.
- Create a lot of sections.
- Scroll down in the course outline page.
- Verify that the sidebar is sticky
- Create a unit, open the unit page.
- Create a lot of components.
- Scroll down in the unit page.
- Verify that the sidebar is sticky

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
