### PR TITLE
fix: Show tag button adding containers with tags from library [FC-0123]

### DIFF
--- a/src/course-outline/data/apiHooks.ts
+++ b/src/course-outline/data/apiHooks.ts
@@ -129,6 +129,8 @@ export const useCreateCourseBlock = (
       });
       await invalidateParentQueries(queryClient, variables);
       // Invalidate tags count for the newly created block
+      // Strips "+type@<blockType>+block@<id>" to produce a course-run wildcard, e.g.
+      // "block-v1:org+course+run+type@vertical+block@abc" → "block-v1:org+course+run*"
       const contentPattern = data.locator.replace(/\+type@.*$/, '*');
       queryClient.invalidateQueries({ queryKey: ['contentTagsCount', contentPattern] });
       // scroll to newly added block

--- a/src/course-outline/data/apiHooks.ts
+++ b/src/course-outline/data/apiHooks.ts
@@ -128,6 +128,9 @@ export const useCreateCourseBlock = (
         queryKey: courseOutlineQueryKeys.courseDetails(getCourseKey(data.locator)),
       });
       await invalidateParentQueries(queryClient, variables);
+      // Invalidate tags count for the newly created block
+      const contentPattern = data.locator.replace(/\+type@.*$/, '*');
+      queryClient.invalidateQueries({ queryKey: ['contentTagsCount', contentPattern] });
       // scroll to newly added block
       setData({ id: data.locator });
       // if newly created block is chapter or section, fetch and add it to store


### PR DESCRIPTION
## Description

- Fixes this issue: https://github.com/openedx/frontend-app-authoring/issues/2234#issuecomment-4300866415
- Which user roles will this change impact? "Course Author"

<img width="1027" height="101" alt="image" src="https://github.com/user-attachments/assets/639de2e3-99f7-4c9b-bb5e-524ded888346" />

## Supporting information

- Github link: https://github.com/openedx/frontend-app-authoring/issues/2234#issuecomment-4300866415
- Internal ticket: https://tasks.opencraft.com/browse/FAL-4331

## Testing instructions

- In a library, create a unit.
- Add tags in the unit.
- Publish the unit.
- Go to the course outline of a course.
- Open the add sidebar and add the new unit.
- Verify that the tags buttons appear in the unit card.

## Other information

N/A

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [X] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [X] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [X] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [X] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [X] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [X] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [X] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
