### PR TITLE
feat: Add Problem bank to the Unit add sidebar [FC-0123]

### DIFF
--- a/src/course-unit/CourseUnit.test.tsx
+++ b/src/course-unit/CourseUnit.test.tsx
@@ -3224,6 +3224,7 @@ describe('<CourseUnit />', () => {
       expect(openResponseCollapsible).toBeInTheDocument();
       const problemCollapsible = screen.getByTestId('problem-collapsible');
       expect(problemCollapsible).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Problem Bank' })).toBeInTheDocument();
 
       // Check text templates
       await user.click(within(textCollapsible).getByText(/text/i));
@@ -3276,6 +3277,10 @@ describe('<CourseUnit />', () => {
       {
         name: 'Drag Drop',
         blockType: 'drag-and-drop-v2',
+      },
+      {
+        name: 'Problem Bank',
+        blockType: 'itembank',
       },
     ].forEach(({ name, blockType }) => {
       it(`calls appropriate handlers on new button click for ${name} block`, async () => {

--- a/src/course-unit/unit-sidebar/AddSidebar.tsx
+++ b/src/course-unit/unit-sidebar/AddSidebar.tsx
@@ -148,6 +148,9 @@ const AddNewContent = () => {
       case COMPONENT_TYPES.openassessment:
         void handleCreateXBlock({ boilerplate: moduleName, category: type, parentLocator: blockId });
         break;
+      case COMPONENT_TYPES.itembank:
+        void handleCreateXBlock({ type, category: 'itembank', parentLocator: blockId });
+        break;
       case COMPONENT_TYPES.html:
         void handleCreateXBlock({
           type,
@@ -180,6 +183,10 @@ const AddNewContent = () => {
     {
       blockType: 'problem',
       name: intl.formatMessage(messages.sidebarAddProblemButton),
+    },
+    {
+      blockType: 'itembank',
+      name: intl.formatMessage(messages.sidebarAddProblemBankButton),
     },
     {
       blockType: 'drag-and-drop-v2',

--- a/src/course-unit/unit-sidebar/messages.ts
+++ b/src/course-unit/unit-sidebar/messages.ts
@@ -46,6 +46,11 @@ const messages = defineMessages({
     defaultMessage: 'Open Response',
     description: 'Label for the button to create a new Open Response block',
   },
+  sidebarAddProblemBankButton: {
+    id: 'course-authoring.unit-page.sidebar.add.new.problem-bank',
+    defaultMessage: 'Problem Bank',
+    description: 'Label for the button to create a new Problem Bank block',
+  },
   sidebarAddDragDropButton: {
     id: 'course-authoring.unit-page.sidebar.add.new.drag-and-drop',
     defaultMessage: 'Drag Drop',

--- a/src/generic/block-type-utils/index.scss
+++ b/src/generic/block-type-utils/index.scss
@@ -277,6 +277,7 @@
 
 .icon-with-border-problem,
 .icon-with-border-drag-and-drop-v2,
+.icon-with-border-itembank,
 .icon-with-border-openassessment {
   border: 1px solid var(--content-library-component-primary-color);
 


### PR DESCRIPTION
## Description

- Adds the Problem bank in the default blocks list in the Add sidebar for Units.
- Which user roles will this change impact? "Course Author".

<img width="524" height="779" alt="image" src="https://github.com/user-attachments/assets/3bc3c9ef-a4df-4999-907b-e8e8a048ad68" />


## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/2636#issuecomment-4194600144
- Internal ticket: https://tasks.opencraft.com/browse/FAL-4331

## Testing instructions

- Go to the course outline of a course
- Create a unit.
- Go to the unit page of the new unit.
- Open the Add sidebar, in the `Add new` tab, verify the `Problem Bank` button.
- Click in the `Poblem Bank` button and verify that a Problem bank in created in the unit.

## Other information

N/A

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [X] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [X] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [X] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [X] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [X] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [X] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [X] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
