### PR TITLE
fix: Nits on the banners [FC-0123]

### DIFF
--- a/src/course-unit/CourseUnit.test.tsx
+++ b/src/course-unit/CourseUnit.test.tsx
@@ -2542,7 +2542,7 @@ describe('<CourseUnit />', () => {
       });
     await executeThunk(fetchCourseSectionVerticalData(courseId), store.dispatch);
 
-    expect(screen.getByText(/this unit can only be edited from the \./i)).toBeInTheDocument();
+    expect(screen.getByText(messages.alertLibraryUnitReadOnlyLinkText.defaultMessage)).toBeInTheDocument();
 
     // Edit button should be enabled even for library imported units
     const unitHeaderTitle = screen.getByTestId('unit-header-title');
@@ -3446,7 +3446,7 @@ describe('<CourseUnit />', () => {
       });
     await executeThunk(fetchCourseSectionVerticalData(courseId), store.dispatch);
 
-    expect(screen.getByText(/this unit can only be edited from the \./i)).toBeInTheDocument();
+    expect(screen.getByText(messages.alertLibraryUnitReadOnlyLinkText.defaultMessage)).toBeInTheDocument();
 
     // Does not render the "Add Components" section
     expect(screen.queryByText(addComponentMessages.title.defaultMessage)).not.toBeInTheDocument();

--- a/src/course-unit/CourseUnit.tsx
+++ b/src/course-unit/CourseUnit.tsx
@@ -48,6 +48,7 @@ import { UnitSidebarProvider } from './unit-sidebar/UnitSidebarContext';
 import { UnitSidebarPagesProvider } from './unit-sidebar/UnitSidebarPagesContext';
 import { UNIT_VISIBILITY_STATES } from './constants';
 import { isUnitPageNewDesignEnabled } from './utils';
+import { useHelpUrls } from '@src/help-urls/hooks';
 
 const StatusBar = ({ courseUnit }: { courseUnit: any; }) => {
   const { selectedPartitionIndex, selectedGroupsLabel } = courseUnit.userPartitionInfo ?? {};
@@ -164,6 +165,7 @@ const CourseUnit = () => {
   const intl = useIntl();
   const { blockId } = useParams();
   const { courseId } = useCourseAuthoringContext();
+  const urls = useHelpUrls(['syncLibraryUpdates']);
 
   if (courseId === undefined) {
     // istanbul ignore next - This shouldn't be possible; it's just here to satisfy the type checker.
@@ -281,6 +283,11 @@ const CourseUnit = () => {
                     link: (
                       <Alert.Link href={courseUnit.upstreamInfo.upstreamLink}>
                         <FormattedMessage {...messages.alertLibraryUnitReadOnlyLinkText} />
+                      </Alert.Link>
+                    ),
+                    learnMore: (
+                      <Alert.Link href={urls['syncLibraryUpdates']}>
+                        <FormattedMessage {...messages.alertLibraryUnitReadOnlyLearnMoreText} />
                       </Alert.Link>
                     ),
                   },

--- a/src/course-unit/messages.ts
+++ b/src/course-unit/messages.ts
@@ -45,13 +45,18 @@ const messages = defineMessages({
   },
   alertLibraryUnitReadOnlyText: {
     id: 'course-authoring.course-unit.alert.read-only.text',
-    defaultMessage: 'This unit can only be edited from the {link}.',
+    defaultMessage: 'Only certain edits are possible for {link}. {learnMore}',
     description: 'Text of the alert when the unit is read only because is a library unit',
   },
   alertLibraryUnitReadOnlyLinkText: {
     id: 'course-authoring.course-unit.alert.read-only.link.text',
-    defaultMessage: 'library',
+    defaultMessage: 'library content',
     description: 'Text of the link in the alert when the unit is read only because is a library unit',
+  },
+  alertLibraryUnitReadOnlyLearnMoreText: {
+    id: 'course-authoring.course-unit.alert.read-only.learn-more.text',
+    defaultMessage: 'Learn More',
+    description: 'Text of the learn more link in the alert when the unit is read only because is a library unit',
   },
   statusBarDraftChangesBadge: {
     id: 'course-authoring.course-unit.status-bar.publish-status.draft-changes',

--- a/src/help-urls/data/api.ts
+++ b/src/help-urls/data/api.ts
@@ -29,6 +29,7 @@ export interface HelpUrls {
   register: string;
   schedule: string;
   socialSharing: string;
+  syncLibraryUpdates: string;
   teamCourse: string;
   teamLibrary: string;
   textbooks: string;

--- a/src/library-authoring/import-course/messages.ts
+++ b/src/library-authoring/import-course/messages.ts
@@ -171,7 +171,7 @@ const messages = defineMessages({
   },
   importCourseAnalysisCompleteAllContentBody: {
     id: 'library-authoring.import-course.review-details.analysis-complete.100.body',
-    defaultMessage: 'All course content will imported into a collection in your library called {courseName}. See details below.',
+    defaultMessage: 'All course content will be imported into a collection in your library called {courseName}. See details below.',
     description: 'Body of the info card when course import analysis is complete and all data can be imported.',
   },
   importCourseAnalysisCompleteSomeContentTitle: {


### PR DESCRIPTION
## Description

- Fixes this issue: https://github.com/openedx/frontend-app-authoring/issues/2868#issuecomment-4262605325
    - Text updated in the analysis banner.
    - The text in the unit from libraries appears to have been resolved in previous PRs. And this banner is updated with a new text.
- Fixes this issue: https://github.com/openedx/frontend-app-authoring/issues/2605
- Which user roles will this change impact? "Course Author".

<img width="1235" height="157" alt="image" src="https://github.com/user-attachments/assets/0a264d47-b6d1-444c-bc99-d2f72127c779" />


## Supporting information

- Github issues:
    - https://github.com/openedx/frontend-app-authoring/issues/2868#issuecomment-4262605325
    - https://github.com/openedx/frontend-app-authoring/issues/2605
- Depends on: https://github.com/openedx/openedx-platform/pull/38438
- Internal ticket: https://tasks.opencraft.com/browse/FAL-4331

## Testing instructions


https://github.com/openedx/frontend-app-authoring/issues/2868#issuecomment-4262605325
- Create a course with a simple text component
- Go to the library home of a library
- Go to `Tools > Import`.
- Select the newly created course.
- Verify the updated text in the banner.

https://github.com/openedx/frontend-app-authoring/issues/2605
- Use this branch of edx-platform: https://github.com/openedx/openedx-platform/pull/38438
- In a library create and publish a unit
- Go to the course outline and add the unit from the library.
- Open the unit page and verify the banner. Check the links.

## Other information

N/A

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [X] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [X] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [X] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [X] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [X] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [X] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [X] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
