### PR TITLE
fix: validation added to show Roles and permissions or course team

### DIFF
--- a/src/header/hooks.test.tsx
+++ b/src/header/hooks.test.tsx
@@ -108,7 +108,7 @@ describe('header utils', () => {
       });
       const actualItems =
         renderHook(() => useSettingMenuItems('course-123'), { wrapper: createWrapper() }).result.current;
-      expect(actualItems).toHaveLength(7);
+      expect(actualItems).toHaveLength(6);
     });
     it('when certificate page disabled should not include certificates option', () => {
       setConfig({
@@ -117,7 +117,7 @@ describe('header utils', () => {
       });
       const actualItems =
         renderHook(() => useSettingMenuItems('course-123'), { wrapper: createWrapper() }).result.current;
-      expect(actualItems).toHaveLength(6);
+      expect(actualItems).toHaveLength(5);
     });
     it('when user has access to advanced settings should include advanced settings option', () => {
       const actualItemsTitle = renderHook(() => useSettingMenuItems('course-123'), { wrapper: createWrapper() }).result

--- a/src/header/hooks.tsx
+++ b/src/header/hooks.tsx
@@ -94,7 +94,7 @@ export const useSettingMenuItems = (courseId: string) => {
     },
     ...(isAuthzEnabled
       ? [{
-        href: `${getConfig().ADMIN_CONSOLE_URL}/authz?scope=${courseId}`,
+        href: `${getConfig().ADMIN_CONSOLE_URL}/authz?scope=${encodeURIComponent(courseId)}`,
         title: intl.formatMessage(messages['header.links.roles.permissions']),
       }]
       : [{

--- a/src/header/hooks.tsx
+++ b/src/header/hooks.tsx
@@ -92,14 +92,15 @@ export const useSettingMenuItems = (courseId: string) => {
       href: `/course/${courseId}/settings/grading`,
       title: intl.formatMessage(messages['header.links.grading']),
     },
-    {
-      href: `${getConfig().ADMIN_CONSOLE_URL}/authz?scope=${courseId}`,
-      title: intl.formatMessage(messages['header.links.roles.permissions']),
-    },
-    {
-      href: `/course/${courseId}/course_team`,
-      title: intl.formatMessage(messages['header.links.courseTeam']),
-    },
+    ...(isAuthzEnabled
+      ? [{
+        href: `${getConfig().ADMIN_CONSOLE_URL}/authz?scope=${courseId}`,
+        title: intl.formatMessage(messages['header.links.roles.permissions']),
+      }]
+      : [{
+        href: `/course/${courseId}/course_team`,
+        title: intl.formatMessage(messages['header.links.courseTeam']),
+      }]),
     {
       href: `/course/${courseId}/group_configurations`,
       title: intl.formatMessage(messages['header.links.groupConfigurations']),


### PR DESCRIPTION
## Description
On the Settings dropdown on course overview, we see both links to "Roles and Permissions" and "Course Team". We should only see one of those depending on the flag status for that course.

<img width="736" height="305" alt="image" src="https://github.com/user-attachments/assets/407934e3-22d5-4a61-b43e-61a08f24a023" />

## Fix
validation added to show only one option on the menu depending on the flag `waffleFlags.enableAuthzCourseAuthoring`