### PR TITLE
feat: delete confirm modal

### DIFF
--- a/src/generic/TypeXToConfirmModal.test.tsx
+++ b/src/generic/TypeXToConfirmModal.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import TypeXToConfirmModal from './TypeXToConfirmModal';
+
+const defaultProps = () => ({
+  label: 'Delete item',
+  bodyText: 'Dangerous action',
+  confirmLabel: 'Delete',
+  cancelLabel: 'Cancel',
+  X: 'DELETE',
+  context: { id: 7 },
+  isOpen: true,
+  onConfirm: jest.fn(),
+  onCancel: jest.fn(),
+  setContext: jest.fn(),
+});
+
+const renderModal = (props = defaultProps()) =>
+  render(
+    <IntlProvider locale="en" messages={{}}>
+      <TypeXToConfirmModal {...props} />
+    </IntlProvider>,
+  );
+
+describe('TypeXToConfirmModal', () => {
+  it('keeps the destructive confirm button disabled until the typed value exactly matches the required confirmation phrase', () => {
+    renderModal();
+
+    const input = screen.getByRole('textbox');
+    const confirmButton = screen.getByRole('button', { name: 'Delete' });
+
+    expect(confirmButton).toBeDisabled();
+    fireEvent.change(input, { target: { value: 'DEL' } });
+    expect(confirmButton).toBeDisabled();
+    fireEvent.change(input, { target: { value: 'DELETE' } });
+    expect(confirmButton).toBeEnabled();
+  });
+
+  it('does not enable confirmation for partial, differently cased, or whitespace-padded confirmation text', () => {
+    renderModal();
+
+    const input = screen.getByRole('textbox');
+    const confirmButton = screen.getByRole('button', { name: 'Delete' });
+
+    ['DEL', 'delete', ' DELETE', 'DELETE ', ' Delete '].forEach(value => {
+      fireEvent.change(input, { target: { value } });
+      expect(confirmButton).toBeDisabled();
+    });
+  });
+
+  it('submits on Enter only after the exact confirmation phrase has been entered', async () => {
+    const user = userEvent.setup();
+    const props = defaultProps();
+    renderModal(props);
+
+    const input = screen.getByRole('textbox');
+
+    await user.click(input);
+    await user.keyboard('{Enter}');
+    expect(props.onConfirm).not.toHaveBeenCalled();
+
+    await user.type(input, 'DELETE');
+    await user.keyboard('{Enter}');
+    expect(props.onConfirm).toHaveBeenCalledWith(props.context);
+  });
+
+  it('resets confirmation state when the modal closes so a reopened dialog starts disabled again', async () => {
+    const user = userEvent.setup();
+    const props = defaultProps();
+    const { rerender } = renderModal(props);
+
+    await user.type(screen.getByRole('textbox'), 'DELETE');
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeEnabled();
+
+    rerender(
+      <IntlProvider locale="en" messages={{}}>
+        <TypeXToConfirmModal {...props} isOpen={false} />
+      </IntlProvider>,
+    );
+
+    rerender(
+      <IntlProvider locale="en" messages={{}}>
+        <TypeXToConfirmModal {...props} isOpen />
+      </IntlProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+  });
+
+  it('clears the provided context when the modal is closed without confirming', () => {
+    const props = defaultProps();
+    const { rerender } = renderModal(props);
+
+    rerender(
+      <IntlProvider locale="en" messages={{}}>
+        <TypeXToConfirmModal {...props} isOpen={false} />
+      </IntlProvider>,
+    );
+
+    expect(props.setContext).toHaveBeenCalledWith(null);
+    expect(props.onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/src/generic/TypeXToConfirmModal.tsx
+++ b/src/generic/TypeXToConfirmModal.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect } from 'react';
+import { Button, Card, Form, Icon, ModalDialog } from '@openedx/paragon';
+import { WarningFilled } from '@openedx/paragon/icons';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import messages from './messages';
+
+interface TypeXToConfirmModalProps {
+  label: string;
+  bodyText: string | React.ReactNode;
+  confirmLabel: string;
+  cancelLabel: string;
+  X: string;
+  // any additional context that the caller wants to pass to the onConfirm callback; not a React context.
+  context?: Record<string, any> | null;
+  isOpen: boolean;
+  onConfirm: (context?: Record<string, any> | null) => void;
+  onCancel: () => void;
+  setContext?: (context: Record<string, any> | null) => void;
+}
+
+const TypeXToConfirmModal: React.FC<TypeXToConfirmModalProps> = ({
+  label,
+  X,
+  bodyText,
+  confirmLabel,
+  cancelLabel,
+  isOpen,
+  context,
+  onConfirm,
+  onCancel,
+  setContext,
+}) => {
+  const [confirmedByTyping, setConfirmedByTyping] = React.useState(false);
+  const intl = useIntl();
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!confirmedByTyping) { return; }
+    if (e.key === 'Enter') {
+      onConfirm(context);
+    }
+  };
+
+  const handleConfirm = () => {
+    if (!confirmedByTyping) { return; }
+    setConfirmedByTyping(false);
+    onConfirm(context);
+  };
+
+  const handleCancel = () => {
+    setConfirmedByTyping(false);
+    onCancel();
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value === X) {
+      setConfirmedByTyping(true);
+    } else {
+      setConfirmedByTyping(false);
+    }
+  };
+
+  // Don't remove. This is necessary to prevent an old state from erroneously enabling the confirm button
+  useEffect(() => {
+    if (!isOpen) {
+      setConfirmedByTyping(false);
+      if (setContext) {
+        // reset onConfirm callback context when modal is closed
+        setContext(null);
+      }
+    }
+  }, [X, isOpen, context, setContext]);
+
+  return (
+    <ModalDialog
+      title={label}
+      isOpen={isOpen}
+      onClose={handleCancel}
+      isOverflowVisible
+    >
+      <ModalDialog.Header>
+        <ModalDialog.Title>{label}</ModalDialog.Title>
+      </ModalDialog.Header>
+      <ModalDialog.Body>
+        <Card className="bg-warning-100">
+          <Card.Section>
+            <div className="d-flex align-items-start mb-2">
+              <Icon src={WarningFilled} className="text-warning-500 mr-2" />
+              <div className="small">{bodyText}</div>
+            </div>
+          </Card.Section>
+        </Card>
+        <div className="mt-3">
+          <div>
+            {(() => {
+              const messageText = intl.formatMessage(messages.typeToConfirmInstruction, { X });
+              const parts = messageText.split(X);
+              return (
+                <>
+                  {parts[0]}
+                  <strong>{X}</strong>
+                  {parts[1]}
+                </>
+              );
+            })()}
+          </div>
+          <Form.Control
+            onKeyDown={handleKeyDown}
+            onChange={handleChange}
+            className="mt-4"
+          />
+        </div>
+        <ModalDialog.Footer>
+          <Button variant="tertiary" onClick={handleCancel}>
+            {cancelLabel}
+          </Button>
+          <Button onClick={handleConfirm} disabled={!confirmedByTyping} variant="danger">
+            {confirmLabel}
+          </Button>
+        </ModalDialog.Footer>
+      </ModalDialog.Body>
+    </ModalDialog>
+  );
+};
+
+export default React.memo(TypeXToConfirmModal);

--- a/src/generic/messages.ts
+++ b/src/generic/messages.ts
@@ -1,0 +1,10 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  typeToConfirmInstruction: {
+    id: 'course-authoring.generic.type-to-confirm-instruction',
+    defaultMessage: 'Type {X} to confirm',
+  },
+});
+
+export default messages;

--- a/src/taxonomy/tag-list/DeleteModal.test.tsx
+++ b/src/taxonomy/tag-list/DeleteModal.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { render, screen, within } from '@testing-library/react';
+
+import DeleteModal from './DeleteModal';
+
+const createRow = (rowData) =>
+  ({
+    id: String(rowData.id),
+    original: rowData,
+  }) as any;
+
+const leafRowData = {
+  id: 101,
+  value: 'leaf tag',
+  depth: 0,
+  childCount: 0,
+  subRows: [],
+};
+
+const nestedRowData = {
+  id: 201,
+  value: 'parent tag',
+  depth: 0,
+  childCount: 1,
+  subRows: [
+    {
+      id: 202,
+      value: 'child tag',
+      depth: 1,
+      childCount: 1,
+      subRows: [
+        {
+          id: 203,
+          value: 'grandchild tag',
+          depth: 2,
+          childCount: 0,
+          subRows: [],
+        },
+      ],
+    },
+  ],
+};
+
+const defaultProps = (overrides = {}) => ({
+  isOpen: true,
+  row: createRow(leafRowData),
+  setIsOpen: jest.fn(),
+  setRow: jest.fn(),
+  handleDeleteRow: jest.fn(),
+  ...overrides,
+});
+
+const renderDeleteModal = (props = defaultProps()) =>
+  render(
+    <IntlProvider locale="en" messages={{}}>
+      <DeleteModal {...(props as any)} />
+    </IntlProvider>,
+  );
+
+describe('DeleteModal', () => {
+  it('renders a singular delete title and "Delete Tag" action label when the selected row has no descendants', () => {
+    renderDeleteModal();
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('Delete "leaf tag"');
+    expect(dialog).toHaveTextContent('Warning! You are about to delete 1 tag(s).');
+    expect(dialog).toHaveTextContent('Type DELETE to confirm');
+    expect(within(dialog).getByRole('button', { name: 'Delete Tag' })).toBeDisabled();
+    expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('renders a plural delete action label and descendant warning copy when the selected row has one or more descendants', () => {
+    renderDeleteModal(defaultProps({ row: createRow(nestedRowData) }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('Delete "parent tag"');
+    expect(dialog).toHaveTextContent('Warning! You are about to delete a tag containing sub-tags.');
+    expect(dialog).toHaveTextContent('If you proceed, 3 tags will be deleted.');
+    expect(dialog).toHaveTextContent('Type DELETE ALL 3 TAGS to confirm');
+    expect(within(dialog).getByRole('button', { name: 'Delete Tags' })).toBeDisabled();
+  });
+
+  it('computes the required confirmation phrase from the recursive descendant count instead of only the immediate child count', () => {
+    renderDeleteModal(defaultProps({ row: createRow(nestedRowData) }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('If you proceed, 3 tags will be deleted.');
+    expect(dialog).toHaveTextContent('Type DELETE ALL 3 TAGS to confirm');
+    expect(dialog).not.toHaveTextContent('DELETE ALL 2 TAGS');
+  });
+
+  it('calls handleDeleteRow with the dialog row context and then closes and clears the dialog state on confirm', async () => {
+    const user = userEvent.setup();
+    const row = createRow(leafRowData);
+    const handleDeleteRow = jest.fn();
+    const setIsOpen = jest.fn();
+    const setRow = jest.fn();
+
+    renderDeleteModal(defaultProps({
+      row,
+      handleDeleteRow,
+      setIsOpen,
+      setRow,
+    }));
+
+    await user.type(screen.getByRole('textbox'), 'DELETE');
+    await user.click(screen.getByRole('button', { name: 'Delete Tag' }));
+
+    expect(handleDeleteRow).toHaveBeenCalledWith(row);
+    expect(setIsOpen).toHaveBeenCalledWith(false);
+    expect(setRow).toHaveBeenCalledWith(null);
+  });
+
+  it('closes and clears the dialog context on cancel without invoking deletion', async () => {
+    const user = userEvent.setup();
+    const handleDeleteRow = jest.fn();
+    const setIsOpen = jest.fn();
+    const setRow = jest.fn();
+
+    renderDeleteModal(defaultProps({
+      handleDeleteRow,
+      setIsOpen,
+      setRow,
+    }));
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(handleDeleteRow).not.toHaveBeenCalled();
+    expect(setIsOpen).toHaveBeenCalledWith(false);
+    expect(setRow).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/taxonomy/tag-list/DeleteModal.tsx
+++ b/src/taxonomy/tag-list/DeleteModal.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { Row } from '@tanstack/react-table';
+import { useIntl } from '@edx/frontend-platform/i18n';
+
+import TypeXToConfirmModal from '@src/generic/TypeXToConfirmModal';
+import type { TreeRowData } from '@src/taxonomy/tree-table/types';
+import messages from './messages';
+import { getTagListRowData, getTagWithDescendantsCount } from './utils';
+
+interface DeleteModalProps {
+  isOpen: boolean;
+  row: Row<TreeRowData> | null;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  setRow: Dispatch<SetStateAction<Row<TreeRowData> | null>>;
+  handleDeleteRow: (row: Row<TreeRowData>) => void | Promise<void>;
+}
+
+const DeleteModal = ({
+  isOpen,
+  row,
+  setIsOpen,
+  setRow,
+  handleDeleteRow,
+}: DeleteModalProps) => {
+  const intl = useIntl();
+
+  if (!row) {
+    return null;
+  }
+
+  const handleConfirm = (row: Row<TreeRowData>) => {
+    handleDeleteRow(row);
+    setIsOpen(false);
+    setRow(null);
+  };
+
+  const handleCancel = () => {
+    setIsOpen(false);
+    setRow(null);
+  };
+
+  const rowData = getTagListRowData(row);
+  const count = useMemo(() => getTagWithDescendantsCount(rowData), [rowData]);
+
+  const hasSubtags = count > 1;
+  const typeToDeleteText = hasSubtags
+    ? intl.formatMessage(messages.typeToConfirmDeleteTagWithSubtags, { count })
+    : intl.formatMessage(messages.typeToConfirmDeleteOneTag);
+  const messageText = hasSubtags
+    ? intl.formatMessage(messages.deleteTagWithSubtagsConfirmation, { count })
+    : intl.formatMessage(messages.deleteTagConfirmation, { count });
+  const parts = messageText.split(String(count));
+  const bodyText = (
+    <>
+      <div>
+        {parts[0]}
+        <strong>{count}</strong>
+        {parts[1]}
+      </div>
+      <div>
+        <strong>{intl.formatMessage(messages.deleteTagConfirmationEmphasizedPart)}</strong>
+      </div>
+    </>
+  );
+
+  return (
+    <TypeXToConfirmModal
+      label={intl.formatMessage(messages.confirmDeleteTitle, { tagName: rowData?.value })}
+      X={typeToDeleteText}
+      bodyText={bodyText}
+      confirmLabel={intl.formatMessage(count > 1 ? messages.deleteLabelPlural : messages.deleteLabelSingular)}
+      cancelLabel={intl.formatMessage(messages.cancelLabel)}
+      isOpen={isOpen}
+      context={row}
+      setContext={setRow}
+      onConfirm={handleConfirm}
+      onCancel={handleCancel}
+    />
+  );
+};
+
+export default DeleteModal;

--- a/src/taxonomy/tag-list/DeleteModal.tsx
+++ b/src/taxonomy/tag-list/DeleteModal.tsx
@@ -25,10 +25,6 @@ const DeleteModal = ({
 }: DeleteModalProps) => {
   const intl = useIntl();
 
-  if (!row) {
-    return null;
-  }
-
   const handleConfirm = (row: Row<TreeRowData>) => {
     handleDeleteRow(row);
     setIsOpen(false);
@@ -40,8 +36,12 @@ const DeleteModal = ({
     setRow(null);
   };
 
-  const rowData = getTagListRowData(row);
-  const count = useMemo(() => getTagWithDescendantsCount(rowData), [rowData]);
+  const rowData = row ? getTagListRowData(row) : null;
+  const count = useMemo(() => (rowData ? getTagWithDescendantsCount(rowData) : 0), [rowData]);
+
+  if (!row) {
+    return null;
+  }
 
   const hasSubtags = count > 1;
   const typeToDeleteText = hasSubtags

--- a/src/taxonomy/tag-list/TagListTable.test.jsx
+++ b/src/taxonomy/tag-list/TagListTable.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AxiosError } from 'axios';
+import userEvent from '@testing-library/user-event';
 import {
   render,
   waitFor,
@@ -218,6 +219,23 @@ describe('<TagListTable />', () => {
       const nestedTr = cell.querySelector('tr');
       expect(nestedTr).toBeNull();
     });
+  });
+
+  it('opens the temporary delete modal trigger and confirms through the test-only callback', async () => {
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: 'Test Delete Modal' }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('Delete "root tag 1"')).toBeInTheDocument();
+    expect(dialog).toHaveTextContent('Type DELETE ALL 3 TAGS to confirm');
+
+    await user.type(within(dialog).getByRole('textbox'), 'DELETE ALL 3 TAGS');
+    await user.click(within(dialog).getByRole('button', { name: 'Delete Tags' }));
+
+    expect(
+      await screen.findByText('Delete modal confirmed for "root tag 1" (test only).'),
+    ).toBeInTheDocument();
   });
 
   it('should render page correctly', async () => {

--- a/src/taxonomy/tag-list/TagListTable.tsx
+++ b/src/taxonomy/tag-list/TagListTable.tsx
@@ -155,6 +155,7 @@ const TagListTable = ({ taxonomyId, maxDepth }: TagListTableProps) => {
     }
   }, [tagList?.results, tableMode]);
 
+  // TODO: remove after testing
   const openDeleteModalTest = () => {
     const firstRow = treeData[0];
 
@@ -169,6 +170,7 @@ const TagListTable = ({ taxonomyId, maxDepth }: TagListTableProps) => {
     setIsDeleteModalOpen(true);
   };
 
+  // TODO: remove after testing
   const handleDeleteModalConfirm = (row: Row<TreeRowData>) => {
     const rowData = getTagListRowData(row);
 

--- a/src/taxonomy/tag-list/TagListTable.tsx
+++ b/src/taxonomy/tag-list/TagListTable.tsx
@@ -3,7 +3,8 @@ import React, {
   useMemo,
   useEffect,
 } from 'react';
-import type { PaginationState } from '@tanstack/react-table';
+import { Button } from '@openedx/paragon';
+import type { PaginationState, Row } from '@tanstack/react-table';
 import { TableView } from '@src/taxonomy/tree-table';
 import { useTagListData, useCreateTag, useUpdateTag } from '@src/taxonomy/data/apiHooks';
 import { TagTree } from './tagTree';
@@ -17,6 +18,8 @@ import {
 } from './constants';
 import { getColumns } from './tagColumns';
 import { useTableModes, useEditActions } from './hooks';
+import DeleteModal from './DeleteModal';
+import { getTagListRowData } from './utils';
 
 interface TagListTableProps {
   taxonomyId: number;
@@ -51,6 +54,8 @@ const TagListTable = ({ taxonomyId, maxDepth }: TagListTableProps) => {
   const [draftError, setDraftError] = useState('');
   const treeData = (tagTree?.getAllAsDeepCopy() || []) as unknown as TreeRowData[];
   const hasOpenDraft = isCreatingTopTag || creatingParentId !== null || editingRowId !== null;
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [deleteModalRow, setDeleteModalRow] = useState<Row<TreeRowData> | null>(null);
 
   // TABLE MODES
   const {
@@ -150,33 +155,77 @@ const TagListTable = ({ taxonomyId, maxDepth }: TagListTableProps) => {
     }
   }, [tagList?.results, tableMode]);
 
+  const openDeleteModalTest = () => {
+    const firstRow = treeData[0];
+
+    if (!firstRow) {
+      return;
+    }
+
+    setDeleteModalRow({
+      id: String(firstRow.id),
+      original: firstRow,
+    } as Row<TreeRowData>);
+    setIsDeleteModalOpen(true);
+  };
+
+  const handleDeleteModalConfirm = (row: Row<TreeRowData>) => {
+    const rowData = getTagListRowData(row);
+
+    setToast({
+      show: true,
+      message: `Delete modal confirmed for "${rowData.value}" (test only).`,
+      variant: 'success',
+    });
+  };
+
   return (
-    <TableView
-      {...{
-        treeData,
-        columns,
-        pageCount,
-        pagination,
-        handlePaginationChange,
-        isLoading,
-        isCreatingTopRow: isCreatingTopTag,
-        draftError,
-        createRowMutation: createTagMutation,
-        updateRowMutation: updateTagMutation,
-        handleCreateRow: handleCreateTag,
-        handleUpdateRow: handleUpdateTag,
-        toast,
-        setToast,
-        setIsCreatingTopRow: setIsCreatingTopTag,
-        exitDraftWithoutSave,
-        creatingParentId,
-        setCreatingParentId,
-        setDraftError,
-        validate,
-        editingRowId,
-        setEditingRowId,
-      }}
-    />
+    <>
+      <div className="d-flex justify-content-end mb-3">
+        {/* TODO: remove after testing */}
+        <Button
+          variant="outline-primary"
+          size="sm"
+          onClick={openDeleteModalTest}
+          disabled={!treeData.length}
+        >
+          Test Delete Modal
+        </Button>
+      </div>
+      <TableView
+        {...{
+          treeData,
+          columns,
+          pageCount,
+          pagination,
+          handlePaginationChange,
+          isLoading,
+          isCreatingTopRow: isCreatingTopTag,
+          draftError,
+          createRowMutation: createTagMutation,
+          updateRowMutation: updateTagMutation,
+          handleCreateRow: handleCreateTag,
+          handleUpdateRow: handleUpdateTag,
+          toast,
+          setToast,
+          setIsCreatingTopRow: setIsCreatingTopTag,
+          exitDraftWithoutSave,
+          creatingParentId,
+          setCreatingParentId,
+          setDraftError,
+          validate,
+          editingRowId,
+          setEditingRowId,
+        }}
+      />
+      <DeleteModal
+        isOpen={isDeleteModalOpen}
+        row={deleteModalRow}
+        setIsOpen={setIsDeleteModalOpen}
+        setRow={setDeleteModalRow}
+        handleDeleteRow={handleDeleteModalConfirm}
+      />
+    </>
   );
 };
 

--- a/src/taxonomy/tag-list/messages.ts
+++ b/src/taxonomy/tag-list/messages.ts
@@ -65,6 +65,42 @@ const messages = defineMessages({
     id: 'course-authoring.tag-list.rename-tag',
     defaultMessage: 'Rename',
   },
+  confirmDeleteTitle: {
+    id: 'course-authoring.tag-list.confirm-delete-title',
+    defaultMessage: 'Delete "{tagName}"',
+  },
+  typeToConfirmDeleteOneTag: {
+    id: 'course-authoring.tag-list.delete-one-tag-type-to-confirm',
+    defaultMessage: 'DELETE',
+  },
+  deleteTagConfirmation: {
+    id: 'course-authoring.tag-list.delete-tag-confirmation',
+    defaultMessage: 'Warning! You are about to delete {count} tag(s).',
+  },
+  deleteLabelPlural: {
+    id: 'course-authoring.tag-list.delete-label',
+    defaultMessage: 'Delete Tags',
+  },
+  deleteLabelSingular: {
+    id: 'course-authoring.tag-list.delete-label-singular',
+    defaultMessage: 'Delete Tag',
+  },
+  cancelLabel: {
+    id: 'course-authoring.tag-list.cancel-label',
+    defaultMessage: 'Cancel',
+  },
+  typeToConfirmDeleteTagWithSubtags: {
+    id: 'course-authoring.tag-list.delete-tag-with-subtags-type-to-confirm',
+    defaultMessage: 'DELETE ALL {count} TAGS',
+  },
+  deleteTagWithSubtagsConfirmation: {
+    id: 'course-authoring.tag-list.delete-tag-with-subtags-confirmation',
+    defaultMessage: 'Warning! You are about to delete a tag containing sub-tags. If you proceed, {count} tags will be deleted.',
+  },
+  deleteTagConfirmationEmphasizedPart: {
+    id: 'course-authoring.tag-list.delete-tag-confirmation-bold-part',
+    defaultMessage: 'Any tags applied to course content will be removed across all assigned organizations.',
+  },
 });
 
 export default messages;

--- a/src/taxonomy/tag-list/utils.test.ts
+++ b/src/taxonomy/tag-list/utils.test.ts
@@ -1,0 +1,33 @@
+import { getTagWithDescendantsCount } from './utils';
+
+describe('getTagsWithDescendantCount', () => {
+  it('returns 1 for a leaf tag', () => {
+    expect(getTagWithDescendantsCount({ value: 'leaf', subRows: [] } as any)).toBe(1);
+  });
+
+  it('counts all descendants across multiple nested levels', () => {
+    const rowData = {
+      value: 'root',
+      subRows: [
+        {
+          value: 'child 1',
+          subRows: [
+            { value: 'grandchild 1', subRows: [] },
+            { value: 'grandchild 2', subRows: [] },
+          ],
+        },
+        {
+          value: 'child 2',
+          subRows: [
+            {
+              value: 'grandchild 3',
+              subRows: [{ value: 'great grandchild 1', subRows: [] }],
+            },
+          ],
+        },
+      ],
+    } as any;
+
+    expect(getTagWithDescendantsCount(rowData)).toBe(7);
+  });
+});

--- a/src/taxonomy/tag-list/utils.ts
+++ b/src/taxonomy/tag-list/utils.ts
@@ -1,6 +1,6 @@
-import { Row } from '@openedx/paragon';
-import { TreeRowData } from '@src/taxonomy/tree-table/types';
-import { TagListRowData } from './types';
+import type { Row } from '@tanstack/react-table';
+import type { TreeRowData } from '@src/taxonomy/tree-table/types';
+import type { TagListRowData } from './types';
 
 /** getTagListRowData
  *
@@ -10,3 +10,10 @@ import { TagListRowData } from './types';
 export const getTagListRowData = (row: Row<TreeRowData>): TagListRowData => (
   row.original as unknown as TagListRowData
 );
+
+export const getTagWithDescendantsCount = (rowData: TreeRowData): number => {
+  if (!rowData.subRows || rowData.subRows.length === 0) {
+    return 1;
+  }
+  return rowData.subRows.reduce((count, subRow) => count + getTagWithDescendantsCount(subRow), 1);
+};


### PR DESCRIPTION
## Description

This is part of https://github.com/openedx/modular-learning/issues/260 - a split-out so that it's smaller PRs to review.

The intention is to have a type confirm modal for deletions, but keep the actual deletion logic separate.

## Important

The test button needs to be deleted before merging this.

## Testing instructions

- Go to authoring/home -> taxonomies -> click on a taxonomy -> click on "Test Delete Modal" button

## Use of AI

- AI helped write the tests
- AI split apart the code from the delete functionality to have two independent PRs

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
