### PR TITLE
feat: delete tag

### DIFF
--- a/src/taxonomy/data/api.ts
+++ b/src/taxonomy/data/api.ts
@@ -99,6 +99,7 @@ export const apiUrls = {
   tagsPlanImport: (taxonomyId: number) => makeUrl(`${taxonomyId}/tags/import/plan/`),
   createTag: (taxonomyId: number) => makeUrl(`${taxonomyId}/tags/`),
   updateTag: (taxonomyId: number) => makeUrl(`${taxonomyId}/tags/`),
+  deleteTag: (taxonomyId: number) => makeUrl(`${taxonomyId}/tags/`),
 } satisfies Record<string, (...args: any[]) => string>;
 
 /**

--- a/src/taxonomy/data/apiHooks.ts
+++ b/src/taxonomy/data/apiHooks.ts
@@ -269,3 +269,23 @@ export const useUpdateTag = (taxonomyId: number) => {
     },
   });
 };
+
+export const useDeleteTag = (taxonomyId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ value, withSubtags }: { value: string; withSubtags: boolean; }) => {
+      const body = { tags: [value], with_subtags: withSubtags };
+      await getAuthenticatedHttpClient().delete(apiUrls.deleteTag(taxonomyId), {
+        data: body,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: taxonomyQueryKeys.taxonomyTagList(taxonomyId),
+      });
+      // In the metadata, 'tagsCount' (and possibly other fields) will have changed:
+      queryClient.invalidateQueries({ queryKey: taxonomyQueryKeys.taxonomyMetadata(taxonomyId) });
+    },
+  });
+};

--- a/src/taxonomy/tag-list/Actions.tsx
+++ b/src/taxonomy/tag-list/Actions.tsx
@@ -1,0 +1,138 @@
+import {
+  Icon,
+  IconButton,
+  IconButtonWithTooltip,
+  Dropdown,
+} from '@openedx/paragon';
+import {
+  AddCircle,
+  MoreVert,
+} from '@openedx/paragon/icons';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import type { Row } from '@tanstack/react-table';
+
+import type {
+  RowId,
+  TreeRowData,
+} from '@src/taxonomy/tree-table/types';
+import type { TagListRowData } from './types';
+import messages from './messages';
+
+interface ActionsHeaderProps {
+  onStartDraft: () => void;
+  setDraftError: (error: string) => void;
+  setIsCreatingTopRow: (isCreating: boolean) => void;
+  setEditingRowId: (id: RowId | null) => void;
+  setActiveActionMenuRowId: (id: RowId | null) => void;
+  hasOpenDraft: boolean;
+  draftInProgressHintId: string;
+  canAddTag: boolean;
+}
+
+const ActionsHeader = ({
+  onStartDraft,
+  setDraftError,
+  setIsCreatingTopRow,
+  setEditingRowId,
+  setActiveActionMenuRowId,
+  hasOpenDraft,
+  canAddTag,
+  draftInProgressHintId,
+}: ActionsHeaderProps) => {
+  const intl = useIntl();
+  return (
+    <div className="d-flex justify-content-end">
+      <IconButtonWithTooltip
+        tooltipPlacement="top"
+        tooltipContent={<div>{intl.formatMessage(messages.createNewTagTooltip)}</div>}
+        src={AddCircle}
+        alt={intl.formatMessage(messages.createTagButtonLabel)}
+        size="inline"
+        onClick={() => {
+          onStartDraft();
+          setDraftError('');
+          setIsCreatingTopRow(true);
+          setEditingRowId(null);
+          setActiveActionMenuRowId(null);
+        }}
+        disabled={hasOpenDraft || !canAddTag}
+        aria-describedby={hasOpenDraft ? draftInProgressHintId : undefined}
+      />
+    </div>
+  );
+};
+
+interface ActionsMenuProps {
+  rowData: TagListRowData;
+  startSubtagDraft: () => void;
+  disableAddSubtag: boolean;
+  startEditRow: () => void;
+  disableEditRow: boolean;
+  reachedMaxDepth: (row: Row<TreeRowData>) => boolean;
+  startDeleteRow: (row: Row<TreeRowData>) => void;
+  disableDeleteRow: boolean;
+  row: Row<TreeRowData>;
+}
+
+const ActionsMenu = ({
+  rowData,
+  row,
+  startSubtagDraft,
+  disableAddSubtag,
+  startEditRow,
+  disableEditRow,
+  reachedMaxDepth,
+  startDeleteRow,
+  disableDeleteRow,
+}: ActionsMenuProps) => {
+  const intl = useIntl();
+
+  const deleteRowMenuItem = (
+    <Dropdown.Item
+      onClick={() => startDeleteRow(row)}
+      disabled={disableDeleteRow}
+    >
+      {intl.formatMessage(messages.deleteTag)}
+    </Dropdown.Item>
+  );
+
+  const editRowMenuItem = (
+    <Dropdown.Item
+      onClick={startEditRow}
+      disabled={disableEditRow}
+    >
+      {intl.formatMessage(messages.renameTag)}
+    </Dropdown.Item>
+  );
+
+  return (
+    <Dropdown>
+      <Dropdown.Toggle
+        id={`dropdown-toggle-for-tag-${rowData.id}`}
+        as={IconButton}
+        src={MoreVert}
+        iconAs={Icon}
+        variant="primary"
+        aria-label={intl.formatMessage(messages.moreActionsForTag, { tagName: rowData.value })}
+        size="sm"
+      />
+      <Dropdown.Menu>
+        <Dropdown.Item
+          onClick={startSubtagDraft}
+          disabled={reachedMaxDepth(row) || disableAddSubtag}
+        >
+          {intl.formatMessage(messages.addSubtag)}
+        </Dropdown.Item>
+        {editRowMenuItem}
+        {deleteRowMenuItem}
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+};
+
+const Actions = {
+  Header: ActionsHeader,
+  Menu: ActionsMenu,
+};
+
+export default Actions;

--- a/src/taxonomy/tag-list/TagListTable.test.jsx
+++ b/src/taxonomy/tag-list/TagListTable.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AxiosError } from 'axios';
+import userEvent from '@testing-library/user-event';
 import {
   render,
   waitFor,
@@ -86,20 +87,11 @@ const mockTagsResponse = {
 
 const mockTagResponseDisallowingEdits = {
   ...mockTagsResponse,
-  results: mockTagsResponse.results.map(tag => ({
+  results: mockTagsResponse.results.map((tag) => ({
     ...tag,
     can_change_tag: false,
     can_delete_tag: false,
   })),
-};
-const mockTagsPaginationResponse = {
-  next: null,
-  previous: null,
-  count: 103,
-  num_pages: 2,
-  current_page: 1,
-  start: 0,
-  results: [],
 };
 const rootTagsListUrl =
   'http://localhost:18010/api/content_tagging/v1/taxonomies/1/tags/?full_depth_threshold=10000&include_counts=true';
@@ -124,6 +116,8 @@ const subTagsResponse = {
 const subTagsUrl =
   'http://localhost:18010/api/content_tagging/v1/taxonomies/1/tags/?full_depth_threshold=10000&parent_tag=root+tag+1';
 const createTagUrl = 'http://localhost:18010/api/content_tagging/v1/taxonomies/1/tags/';
+const deleteTagUrl = createTagUrl;
+const deleteConfirmMessage = 'Warning: are you sure you want to delete this tag and all its subtags and descendants? Any tags applied to course content will be deleted.';
 
 const renderTagListTable = (maxDepth = 3) => render(<TagListTable taxonomyId={1} maxDepth={maxDepth} />);
 
@@ -196,6 +190,25 @@ const openRenameDraftRow = async (tagName = 'root tag 1') => {
     saveButton,
     cancelButton,
   };
+};
+
+const buildTagsResponse = (results) => ({
+  ...mockTagsResponse,
+  count: results.filter((tag) => tag.depth === 0).length,
+  results,
+});
+
+const expectDeleteRequest = async ({ tagName, withSubtags }) => {
+  await waitFor(() => {
+    expect(axiosMock.history.delete.length).toBe(1);
+    expect(axiosMock.history.delete[0].url).toBe(deleteTagUrl);
+    expect(axiosMock.history.delete[0].data).toEqual(
+      JSON.stringify({
+        tags: [tagName],
+        with_subtags: withSubtags,
+      }),
+    );
+  });
 };
 
 describe('<TagListTable />', () => {
@@ -279,24 +292,6 @@ describe('<TagListTable />', () => {
         name: /table pagination/i,
       })).not.toBeInTheDocument();
     });
-  });
-
-  // temporarily skipped because pagination is not implemented yet
-  it.skip('should render pagination footer', async () => {
-    axiosMock.onGet(rootTagsListUrl).reply(200, mockTagsPaginationResponse);
-    renderTagListTable();
-    const tableFooter = await screen.findAllByRole('navigation', {
-      name: /table pagination/i,
-    });
-    expect(tableFooter[0]).toBeInTheDocument();
-  });
-
-  // temporarily skipped because pagination is not implemented yet
-  it.skip('should render correct number of items in pagination footer', async () => {
-    axiosMock.onGet(rootTagsListUrl).reply(200, mockTagsPaginationResponse);
-    renderTagListTable();
-    const paginationButtons = await screen.findByText('Page 1 of 2');
-    expect(paginationButtons).toBeInTheDocument();
   });
 
   describe('Create a new top-level tag', () => {
@@ -458,38 +453,6 @@ describe('<TagListTable />', () => {
         });
         const temporaryRow = await screen.findByText('xyz tag');
         expect(temporaryRow).toBeInTheDocument();
-      });
-
-      // temporarily skipped because pagination is not implemented yet
-      it.skip('should refresh the table and remove the temporary row when a pagination button is clicked', async () => {
-        axiosMock.onPost(createTagUrl).reply(201, {
-          ...tagDefaults,
-          value: 'xyz tag',
-          child_count: 0,
-          _id: 1234,
-        });
-        const { creatingRow, input } = await openTopLevelDraftRow();
-
-        fireEvent.change(input, { target: { value: 'xyz tag' } });
-        const saveButton = within(creatingRow).getByRole('button', { name: 'Save' });
-        fireEvent.click(saveButton);
-        const temporaryRow = await screen.findByText('xyz tag');
-        // temporaryRow should be at the top of the table, that is, the first row after the header
-        const rows = screen.getAllByRole('row');
-        expect(rows[1]).toContainElement(temporaryRow);
-
-        // Simulate clicking a pagination button
-        const paginationButton = await screen.findByRole('button', { name: 'Go to page 2' });
-        fireEvent.click(paginationButton);
-
-        await waitFor(() => {
-          // A get request should have refreshed the table data
-          expect(axiosMock.history.get.length).toBeGreaterThan(1);
-          const xyzTagRow = screen.queryByText('xyz tag');
-          expect(xyzTagRow).toBeInTheDocument();
-          // expect the row to not be the first row after the header
-          expect(rows[1]).not.toContainElement(xyzTagRow);
-        });
       });
 
       // a bit flaky when ran together with other tests - any way to improve this?
@@ -991,6 +954,165 @@ describe('<TagListTable />', () => {
       expect(within(grandchildTagRow).getByText('Add Subtag')).toHaveAttribute('aria-disabled', 'true');
     });
   });
+
+  describe('Delete Tags', () => {
+    let confirmSpy;
+
+    beforeEach(() => {
+      confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      confirmSpy.mockRestore();
+    });
+
+    const tagDepthScenarios = [
+      {
+        description: 'Delete a top-level tag',
+        tagName: 'root tag 1',
+      },
+      { description: 'Delete a sub-tag', tagName: 'the child tag' },
+      { description: 'Delete a grandchild tag', tagName: 'the grandchild tag' },
+    ];
+
+    tagDepthScenarios.forEach(({ description, tagName }) => {
+      describe(description, () => {
+        beforeEach(async () => {
+          axiosMock.resetHistory();
+        });
+
+        it('should disable delete action if tag includes `can_delete: false`', async () => {
+          axiosMock.reset();
+          axiosMock
+            .onGet(rootTagsListUrl)
+            .reply(200, mockTagResponseDisallowingEdits);
+          axiosMock.onGet(subTagsUrl).reply(200, subTagsResponse);
+          cleanup();
+          ({ axiosMock } = initializeMocks({ user: adminUser }));
+          axiosMock
+            .onGet(rootTagsListUrl)
+            .reply(200, mockTagResponseDisallowingEdits);
+          axiosMock.onGet(subTagsUrl).reply(200, subTagsResponse);
+          renderTagListTable();
+          await waitForRootTag();
+
+          openActionsMenuForTag(tagName);
+          const deleteButton = screen.getByRole('button', { name: /Delete/i });
+          expect(deleteButton).toBeInTheDocument();
+          expect(deleteButton).toHaveAttribute('aria-disabled', 'true');
+        });
+      });
+    });
+
+    it('asks for browser confirmation before deleting a leaf tag and deletes after acceptance', async () => {
+      axiosMock.reset();
+      axiosMock.onDelete(deleteTagUrl).reply(204);
+      axiosMock
+        .onGet(rootTagsListUrl)
+        .reply(
+          200,
+          buildTagsResponse(
+            mockTagsResponse.results.filter(
+              (tag) => tag.value !== 'root tag 2',
+            ),
+          ),
+        );
+
+      expect(screen.queryByText('root tag 2')).toBeInTheDocument();
+
+      openActionsMenuForTag('root tag 2');
+      fireEvent.click(screen.getByRole('button', { name: /^Delete$/i }));
+
+      expect(confirmSpy).toHaveBeenCalledWith(deleteConfirmMessage);
+      await expectDeleteRequest({ tagName: 'root tag 2', withSubtags: false });
+      expect(
+        await screen.findByText(
+          '1 tag(s) deleted. This change will be applied across all tagged content.',
+        ),
+      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByText('root tag 2')).not.toBeInTheDocument();
+      });
+    });
+
+    it('deletes a parent tag together with all rendered descendants after browser confirmation', async () => {
+      fireEvent.click(screen.getAllByText('Expand All')[0]);
+      await screen.findByText('the child tag');
+      await screen.findByText('the grandchild tag');
+
+      axiosMock.reset();
+      axiosMock.onDelete(deleteTagUrl).reply(204);
+      axiosMock
+        .onGet(rootTagsListUrl)
+        .reply(
+          200,
+          buildTagsResponse(
+            mockTagsResponse.results.filter(
+              (tag) =>
+                !['root tag 1', 'the child tag', 'the grandchild tag'].includes(
+                  tag.value,
+                ),
+            ),
+          ),
+        );
+
+      openActionsMenuForTag('root tag 1');
+      fireEvent.click(screen.getByRole('button', { name: /^Delete$/i }));
+
+      expect(confirmSpy).toHaveBeenCalledWith(deleteConfirmMessage);
+      await expectDeleteRequest({ tagName: 'root tag 1', withSubtags: true });
+      expect(
+        await screen.findByText(
+          '3 tag(s) deleted. This change will be applied across all tagged content.',
+        ),
+      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByText('root tag 1')).not.toBeInTheDocument();
+        expect(screen.queryByText('the child tag')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText('the grandchild tag'),
+        ).not.toBeInTheDocument();
+        expect(screen.getByText('root tag 2')).toBeInTheDocument();
+      });
+    });
+
+    it('does not issue a delete request when browser confirmation is canceled and leaves the table unchanged', async () => {
+      confirmSpy.mockReturnValue(false);
+
+      openActionsMenuForTag('root tag 1');
+      fireEvent.click(screen.getByRole('button', { name: /^Delete$/i }));
+
+      expect(confirmSpy).toHaveBeenCalledWith(deleteConfirmMessage);
+      expect(axiosMock.history.delete.length).toBe(0);
+      expect(screen.getByText('root tag 1')).toBeInTheDocument();
+    });
+
+    it('surfaces a failed delete through both the persistent error alert and the delete-error toast while leaving the row visible', async () => {
+      axiosMock.reset();
+      axiosMock.onDelete(deleteTagUrl).reply(() => {
+        const error = new AxiosError('Request failed with status code 500');
+        error.response = {
+          data: {
+            value: ['Delete failed'],
+          },
+        };
+        return Promise.reject(error);
+      });
+
+      openActionsMenuForTag('root tag 1');
+      fireEvent.click(screen.getByRole('button', { name: /^Delete$/i }));
+
+      expect(confirmSpy).toHaveBeenCalledWith(deleteConfirmMessage);
+      await expectDeleteRequest({ tagName: 'root tag 1', withSubtags: true });
+      expect(
+        await screen.findByText('Error saving changes'),
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText('Error deleting tag: Delete failed'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('root tag 1')).toBeInTheDocument();
+    });
+  });
 });
 
 // These async creation flows are intentionally isolated because they pass individually
@@ -1206,12 +1328,15 @@ describe('<TagListTable /> pagination transition behavior', () => {
       mutateAsync: jest.fn(),
     });
     jest.spyOn(hooksModule, 'useEditActions').mockReturnValue({
-      handleCreateTag: jest.fn(),
-      handleUpdateTag: jest.fn(),
+      handleCreateRow: jest.fn(),
+      handleUpdateRow: jest.fn(),
+      startSubtagDraft: jest.fn(),
+      startEditRow: jest.fn(),
+      startDeleteRow: jest.fn(),
       validate: jest.fn(() => true),
     });
-    jest.spyOn(treeTableModule, 'TableView').mockImplementation((props) => {
-      tableViewProps = props;
+    jest.spyOn(treeTableModule, 'TableView').mockImplementation(() => {
+      tableViewProps = React.useContext(treeTableModule.TreeTableContext);
       return <div data-testid="mock-table-view" />;
     });
   });

--- a/src/taxonomy/tag-list/TagListTable.test.jsx
+++ b/src/taxonomy/tag-list/TagListTable.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { AxiosError } from 'axios';
-import userEvent from '@testing-library/user-event';
 import {
   render,
   waitFor,
@@ -12,9 +11,9 @@ import {
   cleanup,
   initializeMocks,
 } from '@src/testUtils';
-import * as apiHooksModule from '../data/apiHooks';
+import * as apiHooksModule from '@src/taxonomy/data/apiHooks';
+import * as treeTableModule from '@src/taxonomy/tree-table';
 import * as hooksModule from './hooks';
-import * as treeTableModule from '../tree-table';
 import TagListTable from './TagListTable';
 
 let axiosMock;
@@ -117,7 +116,8 @@ const subTagsUrl =
   'http://localhost:18010/api/content_tagging/v1/taxonomies/1/tags/?full_depth_threshold=10000&parent_tag=root+tag+1';
 const createTagUrl = 'http://localhost:18010/api/content_tagging/v1/taxonomies/1/tags/';
 const deleteTagUrl = createTagUrl;
-const deleteConfirmMessage = 'Warning: are you sure you want to delete this tag and all its subtags and descendants? Any tags applied to course content will be deleted.';
+const deleteConfirmMessage =
+  'Warning: are you sure you want to delete this tag and all its subtags and descendants? Any tags applied to course content will be deleted.';
 
 const renderTagListTable = (maxDepth = 3) => render(<TagListTable taxonomyId={1} maxDepth={maxDepth} />);
 

--- a/src/taxonomy/tag-list/TagListTable.tsx
+++ b/src/taxonomy/tag-list/TagListTable.tsx
@@ -4,18 +4,17 @@ import React, {
   useEffect,
 } from 'react';
 import type { PaginationState } from '@tanstack/react-table';
-import { TableView } from '@src/taxonomy/tree-table';
-import { useTagListData, useCreateTag, useUpdateTag } from '@src/taxonomy/data/apiHooks';
-import { TagTree } from './tagTree';
+import { useTagListData, useCreateTag, useUpdateTag, useDeleteTag } from '@src/taxonomy/data/apiHooks';
+import { TableView, TreeTableContext } from '@src/taxonomy/tree-table';
 import type {
   RowId,
-  TreeColumnDef,
   TreeRowData,
 } from '../tree-table/types';
+import { TagTree } from './tagTree';
+import { getColumns } from './tagColumns';
 import {
   TABLE_MODES,
 } from './constants';
-import { getColumns } from './tagColumns';
 import { useTableModes, useEditActions } from './hooks';
 
 interface TagListTableProps {
@@ -47,7 +46,7 @@ const TagListTable = ({ taxonomyId, maxDepth }: TagListTableProps) => {
   const [toast, setToast] = useState({ show: false, message: '', variant: 'success' });
   const [tagTree, setTagTree] = useState<TagTree | null>(null);
   const [isCreatingTopTag, setIsCreatingTopTag] = useState(false);
-  const [activeActionMenuRowId, setActiveActionMenuRowId] = useState<RowId | null>(null);
+  const [, setActiveActionMenuRowId] = useState<RowId | null>(null);
   const [draftError, setDraftError] = useState('');
   const treeData = (tagTree?.getAllAsDeepCopy() || []) as unknown as TreeRowData[];
   const hasOpenDraft = isCreatingTopTag || creatingParentId !== null || editingRowId !== null;
@@ -83,59 +82,29 @@ const TagListTable = ({ taxonomyId, maxDepth }: TagListTableProps) => {
   });
   const createTagMutation = useCreateTag(taxonomyId);
   const updateTagMutation = useUpdateTag(taxonomyId);
+  const deleteTagMutation = useDeleteTag(taxonomyId);
   const pageCount = tagList?.numPages ?? -1;
-
-  // TODO: to make this more readable, introduce a React context for the TagListTable instead of passing props.
+  const canAddTag = tagList?.canAddTag !== false;
 
   // Custom Edit Actions Hook - handles table mode transitions, API calls,
   // and updating the table without a full data reload when creating or editing tags.
-  const { handleCreateTag, handleUpdateTag, validate } = useEditActions({
-    setTagTree,
-    setDraftError,
-    createTagMutation,
-    updateTagMutation,
-    enterPreviewMode,
-    setToast,
-    setIsCreatingTopTag,
-    setCreatingParentId,
-    exitDraftWithoutSave,
-    setEditingRowId,
-  });
-
-  const columns = useMemo<TreeColumnDef[]>(
-    () =>
-      getColumns({
-        setIsCreatingTopTag,
-        setCreatingParentId,
-        handleUpdateTag,
-        setEditingRowId,
-        onStartDraft: enterDraftMode,
-        setActiveActionMenuRowId,
-        hasOpenDraft,
-        canAddTag: tagList?.canAddTag !== false,
-        draftError,
-        setDraftError,
-        isSavingDraft: createTagMutation.isPending,
-        maxDepth,
-      }),
-    [
-      isCreatingTopTag,
-      tableMode,
-      activeActionMenuRowId,
-      hasOpenDraft,
-      creatingParentId,
-      tagList?.canAddTag,
-      draftError,
-      createTagMutation.isPending,
-      maxDepth,
+  const editActions = useEditActions(
+    {
+      enterDraftMode,
+      enterPreviewMode,
+      enterViewMode,
+      setTagTree,
+      setDraftError,
+      createTagMutation,
+      updateTagMutation,
+      setToast,
       setIsCreatingTopTag,
       setCreatingParentId,
-      handleUpdateTag,
+      exitDraftWithoutSave,
       setEditingRowId,
-      enterDraftMode,
       setActiveActionMenuRowId,
-      setDraftError,
-    ],
+      deleteTagMutation,
+    },
   );
 
   // RELOAD DATA IN VIEW MODE
@@ -150,33 +119,43 @@ const TagListTable = ({ taxonomyId, maxDepth }: TagListTableProps) => {
     }
   }, [tagList?.results, tableMode]);
 
+  // TreeTable context
+  const contextValueArgs = {
+    ...editActions,
+    treeData,
+    pageCount,
+    pagination,
+    handlePaginationChange,
+    isLoading,
+    isCreatingTopRow: isCreatingTopTag,
+    draftError,
+    createRowMutation: createTagMutation,
+    updateRowMutation: updateTagMutation,
+    toast,
+    setToast,
+    setIsCreatingTopRow: setIsCreatingTopTag,
+    exitDraftWithoutSave,
+    creatingParentId,
+    setCreatingParentId,
+    setDraftError,
+    editingRowId,
+    setEditingRowId,
+    onStartDraft: enterDraftMode,
+    setActiveActionMenuRowId,
+    hasOpenDraft,
+    canAddTag,
+    maxDepth,
+  };
+  const contextValue = {
+    ...contextValueArgs,
+    columns: getColumns(contextValueArgs),
+    table: null,
+  };
+
   return (
-    <TableView
-      {...{
-        treeData,
-        columns,
-        pageCount,
-        pagination,
-        handlePaginationChange,
-        isLoading,
-        isCreatingTopRow: isCreatingTopTag,
-        draftError,
-        createRowMutation: createTagMutation,
-        updateRowMutation: updateTagMutation,
-        handleCreateRow: handleCreateTag,
-        handleUpdateRow: handleUpdateTag,
-        toast,
-        setToast,
-        setIsCreatingTopRow: setIsCreatingTopTag,
-        exitDraftWithoutSave,
-        creatingParentId,
-        setCreatingParentId,
-        setDraftError,
-        validate,
-        editingRowId,
-        setEditingRowId,
-      }}
-    />
+    <TreeTableContext.Provider value={contextValue}>
+      <TableView hasAdditionalError={deleteTagMutation.isError} />
+    </TreeTableContext.Provider>
   );
 };
 

--- a/src/taxonomy/tag-list/hooks.test.tsx
+++ b/src/taxonomy/tag-list/hooks.test.tsx
@@ -44,28 +44,35 @@ describe('useTableModes', () => {
 describe('useEditActions', () => {
   const buildActions = (overrides = {}) => {
     const createTagMutation = { mutateAsync: jest.fn() };
-    // mock updateTagMutation to have a function `mutateAsync` that returns a resolved promise
     const updateTagMutation = { mutateAsync: jest.fn() };
+    const deleteTagMutation = { mutateAsync: jest.fn() };
     const setTagTree = jest.fn();
     const setDraftError = jest.fn();
+    const enterDraftMode = jest.fn();
     const enterPreviewMode = jest.fn();
+    const enterViewMode = jest.fn();
     const setToast = jest.fn();
     const setIsCreatingTopTag = jest.fn();
     const setCreatingParentId = jest.fn();
     const exitDraftWithoutSave = jest.fn();
     const setEditingRowId = jest.fn();
+    const setActiveActionMenuRowId = jest.fn();
 
     const params = {
       setTagTree,
       setDraftError,
       createTagMutation: createTagMutation as any,
+      enterDraftMode,
       enterPreviewMode,
+      enterViewMode,
       setToast,
       setIsCreatingTopTag,
       setCreatingParentId,
       exitDraftWithoutSave,
       setEditingRowId,
       updateTagMutation: updateTagMutation as any,
+      deleteTagMutation: deleteTagMutation as any,
+      setActiveActionMenuRowId,
       ...(overrides as any),
     };
 
@@ -74,14 +81,18 @@ describe('useEditActions', () => {
     return {
       actions: result.current,
       createTagMutation,
+      deleteTagMutation,
       setTagTree,
       setDraftError,
+      enterDraftMode,
       enterPreviewMode,
+      enterViewMode,
       setToast,
       setIsCreatingTopTag,
       setCreatingParentId,
       exitDraftWithoutSave,
       setEditingRowId,
+      setActiveActionMenuRowId,
     };
   };
 
@@ -122,7 +133,7 @@ describe('useEditActions', () => {
     } = buildActions();
 
     await act(async () => {
-      await actions.handleUpdateTag('  same value  ', 'same value');
+      await actions.handleUpdateRow('  same value  ', 'same value');
     });
 
     expect(enterPreviewMode).not.toHaveBeenCalled();
@@ -139,7 +150,7 @@ describe('useEditActions', () => {
     } = buildActions();
 
     await act(async () => {
-      await actions.handleUpdateTag('updated', 'original');
+      await actions.handleUpdateRow('updated', 'original');
     });
 
     await waitFor(() => {
@@ -152,17 +163,12 @@ describe('useEditActions', () => {
     expect(setEditingRowId).toHaveBeenCalledWith(null);
   });
 
-  it('keeps draft open and shows failure toast when createTag request fails', async () => {
-    const {
-      actions,
-      createTagMutation,
-      setDraftError,
-      setToast,
-    } = buildActions();
+  it('keeps draft open and shows failure toast when createRow request fails', async () => {
+    const { actions, createTagMutation, setDraftError, setToast } = buildActions();
     createTagMutation.mutateAsync.mockRejectedValue(new Error('server failed'));
 
     await act(async () => {
-      await actions.handleCreateTag('new tag');
+      await actions.handleCreateRow('new tag');
     });
 
     expect(setDraftError).toHaveBeenCalledWith('server failed');

--- a/src/taxonomy/tag-list/hooks.ts
+++ b/src/taxonomy/tag-list/hooks.ts
@@ -18,7 +18,8 @@ import messages from './messages';
 import { getTagListRowData, getTagWithDescendantsCount } from './utils';
 import { Row } from '@tanstack/react-table';
 
-const DELETE_CONFIRM_MESSAGE = 'Warning: are you sure you want to delete this tag and all its subtags and descendants? Any tags applied to course content will be deleted.';
+const DELETE_CONFIRM_MESSAGE =
+  'Warning: are you sure you want to delete this tag and all its subtags and descendants? Any tags applied to course content will be deleted.';
 
 /** Interface for table mode actions for React's `useReducer` hook.
  *

--- a/src/taxonomy/tag-list/hooks.ts
+++ b/src/taxonomy/tag-list/hooks.ts
@@ -3,8 +3,8 @@ import { AxiosError } from 'axios';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import globalMessages from '@src/messages';
-import { useCreateTag, useUpdateTag } from '@src/taxonomy/data/apiHooks';
-import type { RowId } from '@src/taxonomy/tree-table/types';
+import { useCreateTag, useDeleteTag, useUpdateTag } from '@src/taxonomy/data/apiHooks';
+import type { RowId, TreeRowData } from '@src/taxonomy/tree-table/types';
 import { TagTree } from './tagTree';
 import { TagListTableError } from './errors';
 import {
@@ -15,6 +15,10 @@ import {
 } from './constants';
 
 import messages from './messages';
+import { getTagListRowData, getTagWithDescendantsCount } from './utils';
+import { Row } from '@tanstack/react-table';
+
+const DELETE_CONFIRM_MESSAGE = 'Warning: are you sure you want to delete this tag and all its subtags and descendants? Any tags applied to course content will be deleted.';
 
 /** Interface for table mode actions for React's `useReducer` hook.
  *
@@ -41,13 +45,17 @@ interface UseEditActionsParams {
   setTagTree: React.Dispatch<React.SetStateAction<TagTree | null>>;
   setDraftError: React.Dispatch<React.SetStateAction<string>>;
   createTagMutation: ReturnType<typeof useCreateTag>;
+  enterDraftMode: () => void;
   enterPreviewMode: () => void;
+  enterViewMode: () => void;
   setToast: React.Dispatch<React.SetStateAction<{ show: boolean; message: string; }>>;
   setIsCreatingTopTag: React.Dispatch<React.SetStateAction<boolean>>;
   setCreatingParentId: React.Dispatch<React.SetStateAction<RowId | null>>;
   exitDraftWithoutSave: () => void;
   setEditingRowId: React.Dispatch<React.SetStateAction<RowId | null>>;
   updateTagMutation: ReturnType<typeof useUpdateTag>;
+  setActiveActionMenuRowId: React.Dispatch<React.SetStateAction<RowId | null>>;
+  deleteTagMutation: ReturnType<typeof useDeleteTag>;
 }
 
 const getInlineValidationMessage = (value: string, intl: ReturnType<typeof useIntl>): string => {
@@ -111,16 +119,19 @@ const useTableModes = (): UseTableModesReturn => {
 };
 
 const useEditActions = ({
+  enterDraftMode,
+  enterPreviewMode,
+  enterViewMode,
   setTagTree,
   setDraftError,
   createTagMutation,
-  enterPreviewMode,
   setToast,
   setIsCreatingTopTag,
   setCreatingParentId,
   exitDraftWithoutSave,
   setEditingRowId,
   updateTagMutation,
+  deleteTagMutation,
 }: UseEditActionsParams) => {
   const intl = useIntl();
 
@@ -255,10 +266,57 @@ const useEditActions = ({
     }
   };
 
+  const startSubtagDraft = (row: Row<TreeRowData>) => {
+    const rowData = getTagListRowData(row);
+    enterDraftMode();
+    setDraftError('');
+    setCreatingParentId(rowData.id);
+    row.toggleExpanded(true);
+  };
+
+  const startEditTag = (row: Row<TreeRowData>) => {
+    const rowData = getTagListRowData(row);
+    enterDraftMode();
+    setDraftError('');
+    setEditingRowId(`${rowData.id}:${rowData.value}`);
+  };
+
+  const startDeleteTag = (row: Row<TreeRowData>) => {
+    if (window.confirm(DELETE_CONFIRM_MESSAGE)) {
+      void handleDeleteTag(row);
+    }
+  };
+
+  const handleDeleteTag = async (row: Row<TreeRowData>) => {
+    const rowData = getTagListRowData(row);
+    const count = getTagWithDescendantsCount(rowData);
+    // If the tag in the frontend state does not have subtags,
+    // don't allow the backend to delete subtags.
+    // That prevents problems in case of stale frontend state.
+    const shouldDeleteSubtags = count > 1;
+    try {
+      // In view mode, the table reloads on change, reflecting the deletion
+      // without needing to manually update the table state
+      enterViewMode();
+      await deleteTagMutation.mutateAsync({ value: rowData.value, withSubtags: shouldDeleteSubtags });
+      setToast({
+        show: true,
+        message: intl.formatMessage(messages.tagsDeleteSuccessMessage, { count }),
+      });
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      setDraftError(errorMessage);
+      setToast({ show: true, message: intl.formatMessage(messages.tagDeleteErrorMessage, { errorMessage }) });
+    }
+  };
+
   return {
     updateTableWithoutDataReload,
-    handleCreateTag,
-    handleUpdateTag,
+    handleCreateRow: handleCreateTag,
+    handleUpdateRow: handleUpdateTag,
+    startSubtagDraft,
+    startEditRow: startEditTag,
+    startDeleteRow: startDeleteTag,
     validate,
   };
 };

--- a/src/taxonomy/tag-list/messages.ts
+++ b/src/taxonomy/tag-list/messages.ts
@@ -65,6 +65,34 @@ const messages = defineMessages({
     id: 'course-authoring.tag-list.rename-tag',
     defaultMessage: 'Rename',
   },
+  deleteTag: {
+    id: 'course-authoring.tag-list.delete-tag',
+    defaultMessage: 'Delete',
+  },
+  deleteTagDisabledTooltip: {
+    id: 'course-authoring.tag-list.delete-tag-disabled-tooltip',
+    defaultMessage: 'This tag does not allow deletion',
+  },
+  tagEditForbidden: {
+    id: 'course-authoring.tag-list.system-defined-tag-edit-disabled',
+    defaultMessage: 'Disabled because this is not allowed to be changed',
+  },
+  tagDeleteForbidden: {
+    id: 'course-authoring.tag-list.system-defined-tag-delete-disabled',
+    defaultMessage: 'Disabled because this is not allowed to be deleted',
+  },
+  hasOpenDraft: {
+    id: 'course-authoring.tag-list.has-open-draft',
+    defaultMessage: 'Disabled because tag creation or edit is in progress',
+  },
+  tagsDeleteSuccessMessage: {
+    id: 'course-authoring.tag-list.delete-success',
+    defaultMessage: '{count} tag(s) deleted. This change will be applied across all tagged content.',
+  },
+  tagDeleteErrorMessage: {
+    id: 'course-authoring.tag-list.delete-error',
+    defaultMessage: 'Error deleting tag: {errorMessage}',
+  },
 });
 
 export default messages;

--- a/src/taxonomy/tag-list/tagColumns.tsx
+++ b/src/taxonomy/tag-list/tagColumns.tsx
@@ -1,14 +1,4 @@
-import {
-  Icon,
-  IconButton,
-  IconButtonWithTooltip,
-  Dropdown,
-} from '@openedx/paragon';
-import {
-  AddCircle,
-  MoreVert,
-} from '@openedx/paragon/icons';
-import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import type { Row } from '@tanstack/react-table';
 
 import type {
@@ -16,128 +6,35 @@ import type {
   TreeColumnDef,
   TreeRowData,
 } from '@src/taxonomy/tree-table/types';
-import type { TagListRowData } from './types';
 import messages from './messages';
 import OptionalExpandLink from './OptionalExpandLink';
 import UsageCountDisplay from './UsageCountDisplay';
 import { getTagListRowData } from './utils';
+import Actions from './Actions';
 
 const EDITABLE_COLUMNS = ['value'];
 
 interface GetColumnsArgs {
-  setIsCreatingTopTag: (isCreating: boolean) => void;
-  setCreatingParentId: (id: RowId | null) => void;
-  handleUpdateTag: (value: string, originalValue: string) => void;
+  setIsCreatingTopRow: (isCreating: boolean) => void;
   setEditingRowId: (id: RowId | null) => void;
   onStartDraft: () => void;
   setActiveActionMenuRowId: (id: RowId | null) => void;
   hasOpenDraft: boolean;
   canAddTag: boolean;
-  draftError: string;
   setDraftError: (error: string) => void;
-  isSavingDraft: boolean;
   maxDepth: number;
+  startSubtagDraft: (row: Row<TreeRowData>) => void;
+  startEditRow: (row: Row<TreeRowData>) => void;
+  startDeleteRow: (row: Row<TreeRowData>) => void;
 }
-
-interface ActionsHeaderProps {
-  onStartDraft: () => void;
-  setDraftError: (error: string) => void;
-  setIsCreatingTopTag: (isCreating: boolean) => void;
-  setEditingRowId: (id: RowId | null) => void;
-  setActiveActionMenuRowId: (id: RowId | null) => void;
-  hasOpenDraft: boolean;
-  draftInProgressHintId: string;
-  canAddTag: boolean;
-}
-
-const ActionsHeader = ({
-  onStartDraft,
-  setDraftError,
-  setIsCreatingTopTag,
-  setEditingRowId,
-  setActiveActionMenuRowId,
-  hasOpenDraft,
-  canAddTag,
-  draftInProgressHintId,
-}: ActionsHeaderProps) => {
-  const intl = useIntl();
-  return (
-    <div className="d-flex justify-content-end">
-      <IconButtonWithTooltip
-        tooltipPlacement="top"
-        tooltipContent={<div>{intl.formatMessage(messages.createNewTagTooltip)}</div>}
-        src={AddCircle}
-        alt={intl.formatMessage(messages.createTagButtonLabel)}
-        size="inline"
-        onClick={() => {
-          onStartDraft();
-          setDraftError('');
-          setIsCreatingTopTag(true);
-          setEditingRowId(null);
-          setActiveActionMenuRowId(null);
-        }}
-        disabled={hasOpenDraft || !canAddTag}
-        aria-describedby={hasOpenDraft ? draftInProgressHintId : undefined}
-      />
-    </div>
-  );
-};
-
-interface ActionsMenuProps {
-  rowData: TagListRowData;
-  startSubtagDraft: () => void;
-  disableAddSubtag: boolean;
-  editTag: () => void;
-  disableEditTag: boolean;
-  reachedMaxDepth: (row: Row<TreeRowData>) => boolean;
-  row: Row<TreeRowData>;
-}
-
-const ActionsMenu = ({
-  rowData,
-  row,
-  startSubtagDraft,
-  disableAddSubtag,
-  editTag,
-  disableEditTag,
-  reachedMaxDepth,
-}: ActionsMenuProps) => {
-  const intl = useIntl();
-
-  return (
-    <Dropdown>
-      <Dropdown.Toggle
-        id={`dropdown-toggle-for-tag-${rowData.id}`}
-        as={IconButton}
-        src={MoreVert}
-        iconAs={Icon}
-        variant="primary"
-        aria-label={intl.formatMessage(messages.moreActionsForTag, { tagName: rowData.value })}
-        size="sm"
-      />
-      <Dropdown.Menu>
-        <Dropdown.Item
-          onClick={startSubtagDraft}
-          disabled={reachedMaxDepth(row) || disableAddSubtag}
-        >
-          {intl.formatMessage(messages.addSubtag)}
-        </Dropdown.Item>
-        <Dropdown.Item
-          onClick={editTag}
-          disabled={disableEditTag}
-        >
-          {intl.formatMessage(messages.renameTag)}
-        </Dropdown.Item>
-      </Dropdown.Menu>
-    </Dropdown>
-  );
-};
 
 function getColumns({
-  setIsCreatingTopTag,
-  setCreatingParentId,
+  setIsCreatingTopRow,
   setEditingRowId,
   onStartDraft,
+  startSubtagDraft,
+  startEditRow,
+  startDeleteRow,
   setActiveActionMenuRowId,
   hasOpenDraft,
   canAddTag,
@@ -172,10 +69,10 @@ function getColumns({
     {
       id: 'actions',
       header: () => (
-        <ActionsHeader
+        <Actions.Header
           onStartDraft={onStartDraft}
           setDraftError={setDraftError}
-          setIsCreatingTopTag={setIsCreatingTopTag}
+          setIsCreatingTopRow={setIsCreatingTopRow}
           setEditingRowId={setEditingRowId}
           setActiveActionMenuRowId={setActiveActionMenuRowId}
           hasOpenDraft={hasOpenDraft}
@@ -191,37 +88,21 @@ function getColumns({
         }
 
         const disableAddSubtag = hasOpenDraft || !canAddTag;
-        const disableEditTag = hasOpenDraft || rowData.canChangeTag === false;
-
-        const startSubtagDraft = () => {
-          onStartDraft();
-          setDraftError('');
-          setCreatingParentId(rowData.id);
-          setEditingRowId(null);
-          setIsCreatingTopTag(false);
-          setActiveActionMenuRowId(null);
-          row.toggleExpanded(true);
-        };
-
-        const editTag = () => {
-          onStartDraft();
-          setDraftError('');
-          setEditingRowId(`${rowData.id}:${rowData.value}`);
-          setCreatingParentId(null);
-          setIsCreatingTopTag(false);
-          setActiveActionMenuRowId(null);
-        };
+        const disableEditRow = hasOpenDraft || rowData.canChangeTag === false;
+        const disableDeleteRow = hasOpenDraft || rowData.canDeleteTag === false;
 
         return (
           <div className="d-flex align-items-center justify-content-end gap-2">
-            <ActionsMenu
+            <Actions.Menu
               rowData={rowData}
               row={row}
-              startSubtagDraft={startSubtagDraft}
+              startSubtagDraft={() => startSubtagDraft(row)}
               disableAddSubtag={disableAddSubtag}
-              editTag={editTag}
-              disableEditTag={disableEditTag}
+              startEditRow={() => startEditRow(row)}
+              disableEditRow={disableEditRow}
               reachedMaxDepth={reachedMaxDepth}
+              startDeleteRow={() => startDeleteRow(row)}
+              disableDeleteRow={disableDeleteRow}
             />
           </div>
         );

--- a/src/taxonomy/tag-list/utils.test.ts
+++ b/src/taxonomy/tag-list/utils.test.ts
@@ -1,0 +1,33 @@
+import { getTagWithDescendantsCount } from './utils';
+
+describe('getTagsWithDescendantCount', () => {
+  it('returns 1 for a leaf tag', () => {
+    expect(getTagWithDescendantsCount({ value: 'leaf', subRows: [] } as any)).toBe(1);
+  });
+
+  it('counts all descendants across multiple nested levels', () => {
+    const rowData = {
+      value: 'root',
+      subRows: [
+        {
+          value: 'child 1',
+          subRows: [
+            { value: 'grandchild 1', subRows: [] },
+            { value: 'grandchild 2', subRows: [] },
+          ],
+        },
+        {
+          value: 'child 2',
+          subRows: [
+            {
+              value: 'grandchild 3',
+              subRows: [{ value: 'great grandchild 1', subRows: [] }],
+            },
+          ],
+        },
+      ],
+    } as any;
+
+    expect(getTagWithDescendantsCount(rowData)).toBe(7);
+  });
+});

--- a/src/taxonomy/tag-list/utils.ts
+++ b/src/taxonomy/tag-list/utils.ts
@@ -1,6 +1,6 @@
-import { Row } from '@openedx/paragon';
-import { TreeRowData } from '@src/taxonomy/tree-table/types';
-import { TagListRowData } from './types';
+import type { Row } from '@tanstack/react-table';
+import type { TreeRowData } from '@src/taxonomy/tree-table/types';
+import type { TagListRowData } from './types';
 
 /** getTagListRowData
  *
@@ -10,3 +10,10 @@ import { TagListRowData } from './types';
 export const getTagListRowData = (row: Row<TreeRowData>): TagListRowData => (
   row.original as unknown as TagListRowData
 );
+
+export const getTagWithDescendantsCount = (rowData: TreeRowData): number => {
+  if (!rowData.subRows || rowData.subRows.length === 0) {
+    return 1;
+  }
+  return rowData.subRows.reduce((count, subRow) => count + getTagWithDescendantsCount(subRow), 1);
+};

--- a/src/taxonomy/tree-table/CreateRow.test.tsx
+++ b/src/taxonomy/tree-table/CreateRow.test.tsx
@@ -3,30 +3,49 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import CreateRow from './CreateRow';
+import { TreeTableContext } from './TreeTableContext';
 
 const wrapper = ({ children }: { children: React.ReactNode; }) => (
   <IntlProvider locale="en" messages={{}}>{children}</IntlProvider>
 );
 
-const baseProps = () => ({
+const baseContextValue = () => ({
+  treeData: [],
+  columns: [],
+  pageCount: -1,
+  pagination: { pageIndex: 0, pageSize: 10 },
+  handlePaginationChange: jest.fn(),
+  isLoading: false,
+  isCreatingTopRow: false,
   draftError: '',
   setDraftError: jest.fn(),
   handleCreateRow: jest.fn(),
   setIsCreatingTopRow: jest.fn(),
   exitDraftWithoutSave: jest.fn(),
   createRowMutation: { isPending: false },
+  updateRowMutation: {},
+  toast: { show: false, message: '', variant: 'success' },
+  setToast: jest.fn(),
+  creatingParentId: null,
+  setCreatingParentId: jest.fn(),
   validate: jest.fn((value: string) => value.trim().length > 0),
+  handleUpdateRow: jest.fn(),
+  editingRowId: null,
+  setEditingRowId: jest.fn(),
+  table: null,
 });
 
 describe('CreateRow', () => {
   it('saves on Enter when value is valid', () => {
-    const props = baseProps();
+    const contextValue = baseContextValue();
     render(
-      <table>
-        <tbody>
-          <CreateRow {...(props as any)} />
-        </tbody>
-      </table>,
+      <TreeTableContext.Provider value={contextValue as any}>
+        <table>
+          <tbody>
+            <CreateRow />
+          </tbody>
+        </table>
+      </TreeTableContext.Provider>,
       { wrapper },
     );
 
@@ -34,19 +53,21 @@ describe('CreateRow', () => {
     fireEvent.change(input, { target: { value: '  new tag  ' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
-    expect(props.handleCreateRow).toHaveBeenCalledWith('new tag');
+    expect(contextValue.handleCreateRow).toHaveBeenCalledWith('new tag');
   });
 
   it('does not save on Enter when mutation is pending', () => {
-    const props = baseProps();
-    props.createRowMutation = { isPending: true };
+    const contextValue = baseContextValue();
+    contextValue.createRowMutation = { isPending: true };
 
     render(
-      <table>
-        <tbody>
-          <CreateRow {...(props as any)} />
-        </tbody>
-      </table>,
+      <TreeTableContext.Provider value={contextValue as any}>
+        <table>
+          <tbody>
+            <CreateRow />
+          </tbody>
+        </table>
+      </TreeTableContext.Provider>,
       { wrapper },
     );
 
@@ -54,18 +75,20 @@ describe('CreateRow', () => {
     fireEvent.change(input, { target: { value: 'pending tag' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
-    expect(props.handleCreateRow).not.toHaveBeenCalled();
+    expect(contextValue.handleCreateRow).not.toHaveBeenCalled();
   });
 
   it('cancels on Escape and resets draft state', () => {
-    const props = baseProps();
+    const contextValue = baseContextValue();
 
     render(
-      <table>
-        <tbody>
-          <CreateRow {...(props as any)} />
-        </tbody>
-      </table>,
+      <TreeTableContext.Provider value={contextValue as any}>
+        <table>
+          <tbody>
+            <CreateRow />
+          </tbody>
+        </table>
+      </TreeTableContext.Provider>,
       { wrapper },
     );
 
@@ -73,8 +96,8 @@ describe('CreateRow', () => {
     fireEvent.change(input, { target: { value: 'will cancel' } });
     fireEvent.keyDown(input, { key: 'Escape' });
 
-    expect(props.setDraftError).toHaveBeenCalledWith('');
-    expect(props.setIsCreatingTopRow).toHaveBeenCalledWith(false);
-    expect(props.exitDraftWithoutSave).toHaveBeenCalled();
+    expect(contextValue.setDraftError).toHaveBeenCalledWith('');
+    expect(contextValue.setIsCreatingTopRow).toHaveBeenCalledWith(false);
+    expect(contextValue.exitDraftWithoutSave).toHaveBeenCalled();
   });
 });

--- a/src/taxonomy/tree-table/CreateRow.tsx
+++ b/src/taxonomy/tree-table/CreateRow.tsx
@@ -1,42 +1,41 @@
-import React from 'react';
-import type { CreateRowMutationState } from './types';
+import React, { useContext } from 'react';
 import DraftRow from './DraftRow';
+import { TreeTableContext } from './TreeTableContext';
 
 interface CreateRowProps {
-  draftError: string;
-  setDraftError: (error: string) => void;
-  handleCreateRow: (value: string) => void;
-  setIsCreatingTopRow: (isCreating: boolean) => void;
-  exitDraftWithoutSave: () => void;
-  createRowMutation: CreateRowMutationState;
+  handleCreateRow?: (value: string) => void;
+  exitDraftWithoutSave?: () => void;
   indent?: number;
-  validate: (value: string, mode?: 'soft' | 'hard') => boolean;
 }
 
 const CreateRow: React.FC<CreateRowProps> = ({
-  draftError,
-  setDraftError,
   handleCreateRow,
-  setIsCreatingTopRow,
   exitDraftWithoutSave,
-  createRowMutation,
   indent = 0,
-  validate,
 }) => {
+  const {
+    setDraftError,
+    handleCreateRow: contextHandleCreateRow,
+    setIsCreatingTopRow,
+    exitDraftWithoutSave: contextExitDraftWithoutSave,
+    createRowMutation,
+  } = useContext(TreeTableContext);
+
+  const onCreateRow = handleCreateRow ?? contextHandleCreateRow;
+  const onExitDraftWithoutSave = exitDraftWithoutSave ?? contextExitDraftWithoutSave;
+
   const handleCancel = () => {
     setDraftError('');
     setIsCreatingTopRow(false);
-    exitDraftWithoutSave();
+    onExitDraftWithoutSave();
   };
 
   return (
     <DraftRow
-      draftError={draftError}
-      onSave={handleCreateRow}
+      onSave={onCreateRow}
       onCancel={handleCancel}
       mutationState={createRowMutation}
       indent={indent}
-      validate={validate}
       rowId="creating-top-row"
       rowTestId="creating-top-row"
     />

--- a/src/taxonomy/tree-table/DraftRow.tsx
+++ b/src/taxonomy/tree-table/DraftRow.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Button, Spinner } from '@openedx/paragon';
 import { Row } from '@tanstack/react-table';
@@ -7,15 +7,14 @@ import UsageCountDisplay from '@src/taxonomy/tag-list/UsageCountDisplay';
 import { EditableCell } from './EditableCell';
 import type { CreateRowMutationState, TreeRowData } from './types';
 import messages from './messages';
+import { TreeTableContext } from './TreeTableContext';
 
 interface DraftRowProps {
-  draftError: string;
   initialValue?: string;
   onSave: (value: string) => void;
   onCancel: () => void;
   mutationState: CreateRowMutationState;
   indent?: number;
-  validate: (value: string, mode?: 'soft' | 'hard') => boolean;
   requireValueChangeToEnableSave?: boolean;
   rowTestId?: string;
   rowId?: string;
@@ -23,13 +22,11 @@ interface DraftRowProps {
 }
 
 const DraftRow: React.FC<DraftRowProps> = ({
-  draftError,
   initialValue = '',
   onSave,
   onCancel,
   mutationState,
   indent = 0,
-  validate,
   requireValueChangeToEnableSave = false,
   rowTestId,
   rowId,
@@ -38,6 +35,8 @@ const DraftRow: React.FC<DraftRowProps> = ({
   const [rowValue, setRowValue] = useState(initialValue);
   const [saveDisabled, setSaveDisabled] = useState(true);
   const intl = useIntl();
+
+  const { draftError, validate } = useContext(TreeTableContext);
 
   const updateSaveDisabled = (value: string) => {
     const trimmedValue = value.trim();

--- a/src/taxonomy/tree-table/EditRow.tsx
+++ b/src/taxonomy/tree-table/EditRow.tsx
@@ -1,31 +1,29 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Row } from '@tanstack/react-table';
-import type { CreateRowMutationState, TreeRowData } from './types';
+import type { TreeRowData } from './types';
 import DraftRow from './DraftRow';
+import { TreeTableContext } from './TreeTableContext';
 
 interface EditRowProps {
-  draftError: string;
-  setDraftError: (error: string) => void;
   initialValue: string;
   handleUpdateRow: (value: string) => void;
   cancelEditRow: () => void;
-  updateRowMutation: CreateRowMutationState;
   indent?: number;
-  validate: (value: string, mode?: 'soft' | 'hard') => boolean;
   row: Row<TreeRowData>;
 }
 
 const EditRow: React.FC<EditRowProps> = ({
-  draftError,
-  setDraftError,
   initialValue,
   handleUpdateRow,
   cancelEditRow,
-  updateRowMutation,
   indent = 0,
-  validate,
   row,
 }) => {
+  const {
+    setDraftError,
+    updateRowMutation,
+  } = useContext(TreeTableContext);
+
   const handleCancel = () => {
     setDraftError('');
     cancelEditRow();
@@ -33,13 +31,11 @@ const EditRow: React.FC<EditRowProps> = ({
 
   return (
     <DraftRow
-      draftError={draftError}
       initialValue={initialValue}
       onSave={handleUpdateRow}
       onCancel={handleCancel}
       mutationState={updateRowMutation}
       indent={indent}
-      validate={validate}
       requireValueChangeToEnableSave
       row={row}
     />

--- a/src/taxonomy/tree-table/NestedRows.test.tsx
+++ b/src/taxonomy/tree-table/NestedRows.test.tsx
@@ -3,21 +3,37 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import NestedRows from './NestedRows';
+import { TreeTableContext } from './TreeTableContext';
 
 const wrapper = ({ children }: { children: React.ReactNode; }) => (
   <IntlProvider locale="en" messages={{}}>{children}</IntlProvider>
 );
 
-const defaultRequiredProps = {
-  setIsCreatingTopRow: jest.fn(),
+const baseContextValue: any = () => ({
+  treeData: [],
+  columns: [],
+  pageCount: -1,
+  pagination: { pageIndex: 0, pageSize: 10 },
+  handlePaginationChange: jest.fn(),
+  isLoading: false,
+  isCreatingTopRow: false,
+  draftError: '',
   createRowMutation: {},
   updateRowMutation: {},
+  toast: { show: false, message: '', variant: 'success' },
+  setToast: jest.fn(),
+  setIsCreatingTopRow: jest.fn(),
+  exitDraftWithoutSave: jest.fn(),
+  handleCreateRow: jest.fn(),
+  creatingParentId: null,
+  setCreatingParentId: jest.fn(),
+  setDraftError: jest.fn(),
+  validate: jest.fn(() => true),
   handleUpdateRow: jest.fn(),
   editingRowId: null,
   setEditingRowId: jest.fn(),
-  exitDraftWithoutSave: jest.fn(),
-  validate: () => true,
-};
+  table: null,
+});
 
 const makeCell = (id: string, content: string) => ({
   id,
@@ -46,16 +62,18 @@ const makeRow = ({
 describe('NestedRows', () => {
   it('renders nothing when parent row is collapsed', () => {
     const parent = makeRow({ id: 1, value: 'parent', expanded: false });
+    const contextValue = baseContextValue();
     const { container } = render(
-      <table>
-        <tbody>
-          <NestedRows
-            parentRow={parent as any}
-            parentRowValue="parent"
-            {...defaultRequiredProps}
-          />
-        </tbody>
-      </table>,
+      <TreeTableContext.Provider value={contextValue as any}>
+        <table>
+          <tbody>
+            <NestedRows
+              parentRow={parent as any}
+              parentRowValue="parent"
+            />
+          </tbody>
+        </table>
+      </TreeTableContext.Provider>,
       { wrapper },
     );
 
@@ -70,30 +88,31 @@ describe('NestedRows', () => {
       expanded: true,
       subRows: [nestedChild],
     });
-    const setCreatingParentId = jest.fn();
+    const contextValue = baseContextValue();
+    contextValue.setCreatingParentId = jest.fn();
+    contextValue.creatingParentId = 2;
+    contextValue.createRowMutation = { isPending: false };
     const onCancelCreation = jest.fn();
 
     render(
-      <table>
-        <tbody>
-          <NestedRows
-            parentRow={parent as any}
-            parentRowValue="parent"
-            childRowsData={[nestedChild as any]}
-            creatingParentId={2}
-            setCreatingParentId={setCreatingParentId}
-            onCancelCreation={onCancelCreation}
-            {...defaultRequiredProps}
-            createRowMutation={{ isPending: false }}
-          />
-        </tbody>
-      </table>,
+      <TreeTableContext.Provider value={contextValue as any}>
+        <table>
+          <tbody>
+            <NestedRows
+              parentRow={parent as any}
+              parentRowValue="parent"
+              childRowsData={[nestedChild as any]}
+              onCancelCreation={onCancelCreation}
+            />
+          </tbody>
+        </table>
+      </TreeTableContext.Provider>,
       { wrapper },
     );
 
     fireEvent.click(screen.getByText('Cancel'));
 
-    expect(setCreatingParentId).toHaveBeenCalledWith(null);
+    expect(contextValue.setCreatingParentId).toHaveBeenCalledWith(null);
     expect(onCancelCreation).toHaveBeenCalled();
   });
 
@@ -106,18 +125,21 @@ describe('NestedRows', () => {
       subRows: [nestedChild],
     });
 
+    const contextValue = baseContextValue();
+    contextValue.editingRowId = '2:child';
+
     render(
-      <table>
-        <tbody>
-          <NestedRows
-            parentRow={parent as any}
-            parentRowValue="parent"
-            childRowsData={[nestedChild as any]}
-            {...defaultRequiredProps}
-            editingRowId="2:child"
-          />
-        </tbody>
-      </table>,
+      <TreeTableContext.Provider value={contextValue as any}>
+        <table>
+          <tbody>
+            <NestedRows
+              parentRow={parent as any}
+              parentRowValue="parent"
+              childRowsData={[nestedChild as any]}
+            />
+          </tbody>
+        </table>
+      </TreeTableContext.Provider>,
       { wrapper },
     );
 

--- a/src/taxonomy/tree-table/NestedRows.tsx
+++ b/src/taxonomy/tree-table/NestedRows.tsx
@@ -1,14 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { flexRender } from '@tanstack/react-table';
 
-import type {
-  RowId,
-  TreeRow,
-  TreeColumnDef,
-  CreateRowMutationState,
-} from './types';
+import type { TreeRow } from './types';
 import CreateRow from './CreateRow';
 import EditRow from './EditRow';
+import { TreeTableContext } from './TreeTableContext';
 
 interface NestedRowsProps {
   /** The parent row object from TanStack React Table */
@@ -25,33 +21,6 @@ interface NestedRowsProps {
   childRowsData?: TreeRow[];
   /** Current nesting depth level (used for indentation calculation) */
   depth?: number;
-  /** Error message to display in draft creation form */
-  draftError?: string;
-  /** Setter function for draft error state */
-  setDraftError?: (error: string) => void;
-  /** ID of the row currently in creation mode */
-  creatingParentId?: RowId | null;
-  /** Setter function for which row is in creation mode */
-  setCreatingParentId?: (value: RowId | null) => void;
-  /** Callback to set whether top-level row creation is active */
-  setIsCreatingTopRow: (isCreating: boolean) => void;
-  /** State object for the row creation mutation (isPending, isError, error) */
-  createRowMutation: CreateRowMutationState;
-  /** State object for the row update mutation (isPending, isError, error) */
-  updateRowMutation: CreateRowMutationState;
-  /** Callback when an existing row is updated (receives new value and original value) */
-  handleUpdateRow: (value: string, originalValue: string) => void;
-  /** ID of the row currently in edit mode */
-  editingRowId: RowId | null;
-  /** Setter function for which row is in edit mode */
-  setEditingRowId: (id: RowId | null) => void;
-  /** Callback to exit draft mode without saving changes */
-  exitDraftWithoutSave: () => void;
-  /** Column definitions for rendering cells in edit mode */
-  columns?: TreeColumnDef[];
-  /** Validation function for new row values (receives value and optional 'soft' or 'hard' mode;
-   * in 'hard' mode an exception is thrown on validation failure) */
-  validate: (value: string, mode?: 'soft' | 'hard') => boolean;
 }
 
 /**
@@ -75,20 +44,16 @@ const NestedRows = ({
   onCancelCreation = () => {},
   childRowsData = [],
   depth = 1,
-  draftError = '',
-  setDraftError = () => {},
-  creatingParentId = null,
-  setCreatingParentId = () => {},
-  setIsCreatingTopRow,
-  createRowMutation,
-  updateRowMutation,
-  handleUpdateRow,
-  editingRowId,
-  setEditingRowId,
-  exitDraftWithoutSave,
-  columns = [],
-  validate,
 }: NestedRowsProps) => {
+  const {
+    creatingParentId,
+    setCreatingParentId,
+    handleUpdateRow,
+    editingRowId,
+    setEditingRowId,
+    exitDraftWithoutSave,
+  } = useContext(TreeTableContext);
+
   if (!parentRow.getIsExpanded()) {
     return null;
   }
@@ -98,14 +63,9 @@ const NestedRows = ({
     <>
       {isCreating && (
         <CreateRow
-          draftError={draftError}
-          setDraftError={setDraftError}
           handleCreateRow={(value) => onSaveNewChildRow(value, parentRowValue)}
-          setIsCreatingTopRow={setIsCreatingTopRow}
           exitDraftWithoutSave={onCancelCreation}
-          createRowMutation={createRowMutation}
           indent={indent}
-          validate={validate}
         />
       )}
       {childRowsData?.map(row => {
@@ -115,17 +75,13 @@ const NestedRows = ({
             {editingRowId === `${row.original.id}:${String(row.original.value)}` ?
               (
                 <EditRow
-                  draftError={draftError}
-                  setDraftError={setDraftError}
                   initialValue={String(row.original.value)}
                   handleUpdateRow={(value) => handleUpdateRow(value, String(row.original.value))}
                   cancelEditRow={() => {
                     setEditingRowId(null);
                     exitDraftWithoutSave();
                   }}
-                  updateRowMutation={updateRowMutation}
                   indent={indent}
-                  validate={validate}
                   row={row}
                 />
               ) :
@@ -159,20 +115,7 @@ const NestedRows = ({
                 setCreatingParentId(null);
                 onCancelCreation();
               }}
-              creatingParentId={creatingParentId}
-              setCreatingParentId={setCreatingParentId}
               depth={depth + 1}
-              draftError={draftError}
-              setDraftError={setDraftError}
-              setIsCreatingTopRow={setIsCreatingTopRow}
-              createRowMutation={createRowMutation}
-              updateRowMutation={updateRowMutation}
-              handleUpdateRow={handleUpdateRow}
-              editingRowId={editingRowId}
-              setEditingRowId={setEditingRowId}
-              exitDraftWithoutSave={exitDraftWithoutSave}
-              columns={columns}
-              validate={validate}
             />
           </React.Fragment>
         );

--- a/src/taxonomy/tree-table/SaveErrorAlert.tsx
+++ b/src/taxonomy/tree-table/SaveErrorAlert.tsx
@@ -5,6 +5,7 @@ import {
 
 import { Info } from '@openedx/paragon/icons';
 import { useIntl } from '@edx/frontend-platform/i18n';
+// @ts-ignore
 import './TableView.scss';
 import messages from './messages';
 
@@ -12,15 +13,21 @@ interface SaveErrorAlertProps {
   draftError: string | undefined;
   isError: boolean | undefined;
   isUpdateError: boolean | undefined;
+  isAdditionalError?: boolean;
 }
-const SaveErrorAlert = ({ draftError, isError, isUpdateError }: SaveErrorAlertProps) => {
+const SaveErrorAlert = ({
+  draftError,
+  isError,
+  isUpdateError,
+  isAdditionalError = false,
+}: SaveErrorAlertProps) => {
   const intl = useIntl();
-  const hasError: boolean = Boolean((isError || isUpdateError) && !!draftError);
+  const hasError: boolean = Boolean((isError || isUpdateError || isAdditionalError) && !!draftError);
   const [alertOpen, setAlertOpen] = React.useState(hasError);
 
   useEffect(() => {
     setAlertOpen(hasError);
-  }, [hasError, isError, isUpdateError, draftError]);
+  }, [hasError, isError, isUpdateError, isAdditionalError, draftError]);
 
   if (!alertOpen) { return null; }
 

--- a/src/taxonomy/tree-table/TableBody.tsx
+++ b/src/taxonomy/tree-table/TableBody.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { flexRender } from '@tanstack/react-table';
 
@@ -6,56 +6,31 @@ import { LoadingSpinner } from '@src/generic/Loading';
 import NestedRows from './NestedRows';
 
 import messages from './messages';
+import { TreeTableContext } from './TreeTableContext';
 
-import type {
-  CreateRowMutationState,
-  RowId,
-  TreeColumnDef,
-  TreeTable,
-} from './types';
 import CreateRow from './CreateRow';
 import EditRow from './EditRow';
 
-interface TableBodyProps {
-  columns: TreeColumnDef[];
-  isCreatingTopRow: boolean;
-  draftError: string;
-  setIsCreatingTopRow: (isCreating: boolean) => void;
-  exitDraftWithoutSave: () => void;
-  handleCreateRow: (value: string, parentRowValue?: string) => void;
-  creatingParentId: RowId | null;
-  setCreatingParentId: (id: RowId | null) => void;
-  setDraftError: (error: string) => void;
-  createRowMutation: CreateRowMutationState;
-  updateRowMutation: CreateRowMutationState;
-  table: TreeTable;
-  isLoading: boolean;
-  validate: (value: string, mode?: 'soft' | 'hard') => boolean;
-  handleUpdateRow: (value: string, originalValue: string) => void;
-  editingRowId: RowId | null;
-  setEditingRowId: (id: RowId | null) => void;
-}
-
-const TableBody = ({
-  columns,
-  isCreatingTopRow,
-  draftError,
-  handleCreateRow,
-  setIsCreatingTopRow,
-  exitDraftWithoutSave,
-  creatingParentId,
-  setCreatingParentId,
-  setDraftError,
-  createRowMutation,
-  updateRowMutation,
-  table,
-  isLoading,
-  validate,
-  handleUpdateRow,
-  editingRowId,
-  setEditingRowId,
-}: TableBodyProps) => {
+const TableBody = () => {
   const intl = useIntl();
+  const {
+    columns,
+    isCreatingTopRow,
+    handleCreateRow,
+    exitDraftWithoutSave,
+    creatingParentId,
+    setCreatingParentId,
+    setDraftError,
+    table,
+    isLoading,
+    handleUpdateRow,
+    editingRowId,
+    setEditingRowId,
+  } = useContext(TreeTableContext);
+
+  if (!table) {
+    return null;
+  }
 
   if (isLoading) {
     return (
@@ -79,33 +54,19 @@ const TableBody = ({
         </tr>
       )}
 
-      {isCreatingTopRow && (
-        <CreateRow
-          draftError={draftError}
-          setDraftError={setDraftError}
-          handleCreateRow={handleCreateRow}
-          setIsCreatingTopRow={setIsCreatingTopRow}
-          exitDraftWithoutSave={exitDraftWithoutSave}
-          createRowMutation={createRowMutation}
-          validate={validate}
-        />
-      )}
+      {isCreatingTopRow && <CreateRow />}
 
       {table.getRowModel().rows.filter(row => row.depth === 0).map(row => (
         <React.Fragment key={row.id}>
           {editingRowId === `${row.original.id}:${String(row.original.value)}` ?
             (
               <EditRow
-                draftError={draftError}
-                setDraftError={setDraftError}
                 initialValue={String(row.original.value)}
                 handleUpdateRow={(value) => handleUpdateRow(value, String(row.original.value))}
                 cancelEditRow={() => {
                   setEditingRowId(null);
                   exitDraftWithoutSave();
                 }}
-                updateRowMutation={updateRowMutation}
-                validate={validate}
                 row={row}
               />
             ) :
@@ -130,20 +91,6 @@ const TableBody = ({
               setCreatingParentId(null);
               exitDraftWithoutSave();
             }}
-            creatingParentId={creatingParentId}
-            setCreatingParentId={setCreatingParentId}
-            depth={1}
-            draftError={draftError}
-            createRowMutation={createRowMutation}
-            setDraftError={setDraftError}
-            setIsCreatingTopRow={setIsCreatingTopRow}
-            validate={validate}
-            updateRowMutation={updateRowMutation}
-            handleUpdateRow={handleUpdateRow}
-            editingRowId={editingRowId}
-            setEditingRowId={setEditingRowId}
-            exitDraftWithoutSave={exitDraftWithoutSave}
-            columns={columns}
           />
         </React.Fragment>
       ))}

--- a/src/taxonomy/tree-table/TableView.test.tsx
+++ b/src/taxonomy/tree-table/TableView.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { fireEvent, render, screen } from '@testing-library/react';
 
+import { TreeTableContext } from './TreeTableContext';
 import { TableView } from './TableView';
 
 jest.mock('./TableBody', () => {
@@ -19,7 +20,7 @@ const wrapper = ({ children }: { children: React.ReactNode; }) => (
   <IntlProvider locale="en" messages={{}}>{children}</IntlProvider>
 );
 
-const baseProps = () => ({
+const baseContextValue = () => ({
   treeData: [{ id: 1, value: 'root' }],
   columns: [{ accessorKey: 'value', header: 'Tag name', cell: (info: any) => info.getValue() }],
   pageCount: 3,
@@ -42,15 +43,27 @@ const baseProps = () => ({
   handleUpdateRow: jest.fn(),
   editingRowId: null,
   setEditingRowId: jest.fn(),
+  table: null,
 });
+
+const renderTableView = (
+  contextValue = baseContextValue(),
+  props: React.ComponentProps<typeof TableView> = {},
+) =>
+  render(
+    <TreeTableContext.Provider value={contextValue}>
+      <TableView {...props} />
+    </TreeTableContext.Provider>,
+    { wrapper },
+  );
 
 describe('TableView', () => {
   it('shows and dismisses save error banner', () => {
-    const props = baseProps();
-    props.createRowMutation = { isPending: false, isError: true };
-    props.draftError = 'Request failed with status code 500';
+    const contextValue = baseContextValue();
+    contextValue.createRowMutation = { isPending: false, isError: true };
+    contextValue.draftError = 'Request failed with status code 500';
 
-    render(<TableView {...props} />, { wrapper });
+    renderTableView(contextValue);
 
     expect(screen.getByText('Error saving changes')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
@@ -58,42 +71,73 @@ describe('TableView', () => {
   });
 
   it('keeps pagination hidden by default even when multiple pages are reported', () => {
-    const props = baseProps();
-    render(<TableView {...props} />, { wrapper });
+    renderTableView();
 
     expect(screen.queryByRole('navigation', { name: /table pagination/i })).not.toBeInTheDocument();
   });
 
   it('renders pagination and updates page selection when explicitly enabled', () => {
-    const props = baseProps();
-    render(<TableView {...props} enablePagination />, { wrapper });
+    const contextValue = baseContextValue();
+    renderTableView(contextValue, { enablePagination: true });
 
     expect(screen.getByText('Page 1 of 3')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /^page 2$/i }));
-    expect(props.handlePaginationChange).toHaveBeenCalled();
+    expect(contextValue.handlePaginationChange).toHaveBeenCalled();
   });
 
   it('hides pagination when there is only one page', () => {
-    const props = baseProps();
-    props.pageCount = 1;
-    render(<TableView {...props} />, { wrapper });
+    const contextValue = baseContextValue();
+    contextValue.pageCount = 1;
+    renderTableView(contextValue);
 
     expect(screen.queryByRole('navigation', { name: /table pagination/i })).not.toBeInTheDocument();
   });
 
   it('closes toast by setting show to false', () => {
-    const props = baseProps();
-    props.toast = { show: true, message: 'created', variant: 'success' };
+    const contextValue = baseContextValue();
+    contextValue.toast = { show: true, message: 'created', variant: 'success' };
 
-    render(<TableView {...props} />, { wrapper });
+    renderTableView(contextValue);
 
     fireEvent.click(screen.getByRole('button', { name: /close/i }));
-    expect(props.setToast).toHaveBeenCalled();
-    const updater = props.setToast.mock.calls[0][0];
+    expect(contextValue.setToast).toHaveBeenCalled();
+    const updater = contextValue.setToast.mock.calls[0][0];
     expect(updater({ show: true, message: 'created', variant: 'success' })).toEqual({
       show: false,
       message: 'created',
       variant: 'success',
     });
+  });
+
+  it('shows the save error alert when a delete mutation fails and draftError is present', () => {
+    const contextValue = baseContextValue();
+    contextValue.draftError = 'Delete request failed';
+
+    renderTableView(contextValue, { hasAdditionalError: true });
+
+    expect(screen.getByText('Error saving changes')).toBeInTheDocument();
+    expect(screen.getByText('Delete request failed. Please try again.')).toBeInTheDocument();
+  });
+
+  it('reopens the save error alert when a new delete error arrives after the user previously dismissed it', () => {
+    const contextValue = baseContextValue();
+    contextValue.draftError = 'First delete failure';
+
+    const { rerender } = renderTableView(contextValue, { hasAdditionalError: true });
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(screen.queryByText('Error saving changes')).not.toBeInTheDocument();
+
+    const nextContextValue = baseContextValue();
+    nextContextValue.draftError = 'Second delete failure';
+
+    rerender(
+      <TreeTableContext.Provider value={nextContextValue}>
+        <TableView hasAdditionalError />
+      </TreeTableContext.Provider>,
+    );
+
+    expect(screen.getByText('Error saving changes')).toBeInTheDocument();
+    expect(screen.getByText('Second delete failure. Please try again.')).toBeInTheDocument();
   });
 });

--- a/src/taxonomy/tree-table/TableView.tsx
+++ b/src/taxonomy/tree-table/TableView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext, useMemo } from 'react';
 import {
   Button,
   Toast,
@@ -13,78 +13,45 @@ import {
   getCoreRowModel,
   getExpandedRowModel,
   flexRender,
-  type OnChangeFn,
-  type PaginationState,
 } from '@tanstack/react-table';
 
 import { ArrowDropUpDown } from '@openedx/paragon/icons';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import TableBody from './TableBody';
+// @ts-ignore
 import './TableView.scss';
-import type {
-  CreateRowMutationState,
-  RowId,
-  ToastState,
-  TreeColumnDef,
-  TreeRowData,
-} from './types';
 import messages from './messages';
 import SaveErrorAlert from './SaveErrorAlert';
+import { TreeTableContext } from './TreeTableContext';
+import { TreeTable } from './types';
 
 interface TableViewProps {
-  treeData: TreeRowData[];
-  columns: TreeColumnDef[];
-  pageCount: number;
   enablePagination?: boolean;
-  pagination: PaginationState;
-  handlePaginationChange: OnChangeFn<PaginationState>;
-  isLoading: boolean;
-  isCreatingTopRow: boolean;
-  draftError: string;
-  createRowMutation: CreateRowMutationState;
-  updateRowMutation: CreateRowMutationState;
-  toast: ToastState;
-  setToast: React.Dispatch<React.SetStateAction<ToastState>>;
-  setIsCreatingTopRow: (isCreating: boolean) => void;
-  exitDraftWithoutSave: () => void;
-  handleCreateRow: (value: string, parentRowValue?: string) => void;
-  creatingParentId: RowId | null;
-  setCreatingParentId: (id: RowId | null) => void;
-  setDraftError: (error: string) => void;
-  validate: (value: string, mode?: 'soft' | 'hard') => boolean;
-  handleUpdateRow: (value: string, originalValue: string) => void;
-  editingRowId: RowId | null;
-  setEditingRowId: (id: RowId | null) => void;
+  hasAdditionalError?: boolean;
 }
 
 const TableView = ({
-  treeData,
-  columns,
-  pageCount,
   enablePagination = false,
-  pagination,
-  handlePaginationChange,
-  isLoading,
-  isCreatingTopRow,
-  draftError,
-  createRowMutation,
-  updateRowMutation,
-  handleCreateRow,
-  toast,
-  setToast,
-  setIsCreatingTopRow,
-  exitDraftWithoutSave,
-  creatingParentId,
-  setCreatingParentId,
-  setDraftError,
-  validate,
-  handleUpdateRow,
-  editingRowId,
-  setEditingRowId,
+  hasAdditionalError = false,
 }: TableViewProps) => {
   const intl = useIntl();
 
-  const table = useReactTable({
+  const contextValue = useContext(TreeTableContext);
+
+  const {
+    treeData,
+    columns,
+    pageCount,
+    pagination,
+    handlePaginationChange,
+    draftError,
+    createRowMutation,
+    updateRowMutation,
+    toast,
+    setToast,
+  } = contextValue;
+
+  const table: TreeTable = useReactTable({
     data: treeData,
     columns,
     getCoreRowModel: getCoreRowModel(),
@@ -98,14 +65,27 @@ const TableView = ({
     getSubRows: (row) => row?.subRows || undefined,
   });
 
+  const nestedContextValue = useMemo(() => ({
+    ...contextValue,
+    table,
+  }), [contextValue, table]);
+
   const currentPageIndex = table.getState().pagination.pageIndex + 1;
 
   const { isError } = createRowMutation;
   const { isError: isUpdateError } = updateRowMutation;
 
   return (
-    <>
-      <SaveErrorAlert draftError={draftError} isError={isError} isUpdateError={isUpdateError} />
+    // This is a nested context provider. It is a valid pattern in React even if it looks odd,
+    // and the purpose here is to add the react-table instance to the overall context.
+    // Note that there is an outer context provider higher up in `TagListTable` as well.
+    <TreeTableContext.Provider value={nestedContextValue}>
+      <SaveErrorAlert
+        draftError={draftError}
+        isError={isError}
+        isUpdateError={isUpdateError}
+        isAdditionalError={hasAdditionalError}
+      />
       <Card className="tag-list-card">
         <Card.Section className="p-0">
           <div className="d-flex justify-content-end align-items-center p-4">
@@ -145,25 +125,7 @@ const TableView = ({
                 </tr>
               ))}
             </thead>
-            <TableBody
-              columns={columns}
-              isCreatingTopRow={isCreatingTopRow}
-              draftError={draftError}
-              handleCreateRow={handleCreateRow}
-              setIsCreatingTopRow={setIsCreatingTopRow}
-              exitDraftWithoutSave={exitDraftWithoutSave}
-              creatingParentId={creatingParentId}
-              setCreatingParentId={setCreatingParentId}
-              setDraftError={setDraftError}
-              createRowMutation={createRowMutation}
-              updateRowMutation={updateRowMutation}
-              table={table}
-              isLoading={isLoading}
-              validate={validate}
-              handleUpdateRow={handleUpdateRow}
-              editingRowId={editingRowId}
-              setEditingRowId={setEditingRowId}
-            />
+            <TableBody />
           </table>
         </Card.Section>
 
@@ -200,7 +162,7 @@ const TableView = ({
           {toast.message}
         </Toast>
       </Card>
-    </>
+    </TreeTableContext.Provider>
   );
 };
 

--- a/src/taxonomy/tree-table/TreeTableContext.tsx
+++ b/src/taxonomy/tree-table/TreeTableContext.tsx
@@ -1,0 +1,64 @@
+import { createContext } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { OnChangeFn, PaginationState } from '@tanstack/react-table';
+
+import type {
+  CreateRowMutationState,
+  RowId,
+  ToastState,
+  TreeColumnDef,
+  TreeTable,
+  TreeRowData,
+} from './types';
+
+export interface TreeTableContextValue {
+  treeData: TreeRowData[];
+  columns: TreeColumnDef[];
+  pageCount: number;
+  pagination: PaginationState;
+  handlePaginationChange: OnChangeFn<PaginationState>;
+  isLoading: boolean;
+  isCreatingTopRow: boolean;
+  draftError: string;
+  createRowMutation: CreateRowMutationState;
+  updateRowMutation: CreateRowMutationState;
+  toast: ToastState;
+  setToast: Dispatch<SetStateAction<ToastState>>;
+  setIsCreatingTopRow: (isCreating: boolean) => void;
+  exitDraftWithoutSave: () => void;
+  handleCreateRow: (value: string, parentRowValue?: string) => void;
+  creatingParentId: RowId | null;
+  setCreatingParentId: (id: RowId | null) => void;
+  setDraftError: (error: string) => void;
+  validate: (value: string, mode?: 'soft' | 'hard') => boolean;
+  handleUpdateRow: (value: string, originalValue: string) => void;
+  editingRowId: RowId | null;
+  setEditingRowId: (id: RowId | null) => void;
+  table: TreeTable | null;
+}
+
+export const TreeTableContext = createContext<TreeTableContextValue>({
+  treeData: [],
+  columns: [],
+  pageCount: -1,
+  pagination: { pageIndex: 0, pageSize: 0 },
+  handlePaginationChange: () => {},
+  isLoading: false,
+  isCreatingTopRow: false,
+  draftError: '',
+  createRowMutation: {},
+  updateRowMutation: {},
+  toast: { show: false, message: '', variant: 'success' },
+  setToast: () => {},
+  setIsCreatingTopRow: () => {},
+  exitDraftWithoutSave: () => {},
+  handleCreateRow: () => {},
+  creatingParentId: null,
+  setCreatingParentId: () => {},
+  setDraftError: () => {},
+  validate: () => true,
+  handleUpdateRow: () => {},
+  editingRowId: null,
+  setEditingRowId: () => {},
+  table: null,
+});

--- a/src/taxonomy/tree-table/index.ts
+++ b/src/taxonomy/tree-table/index.ts
@@ -1,2 +1,3 @@
 export { EditableCell } from './EditableCell';
 export { TableView } from './TableView';
+export { TreeTableContext } from './TreeTableContext';


### PR DESCRIPTION
## Description

This is part of https://github.com/openedx/modular-learning/issues/260 - a split-out so that it's smaller PRs to review.

The intention is to implement the actual deletion logic here, but not implement the Delete Modal yet.
The Delete Modal is replaced by a simple browser confirm for now, the PR to implement that is https://github.com/openedx/frontend-app-authoring/pull/3024.

To deliver the Delete functionality cleanly, I have included quite a bit of refactoring, which includes adding a React context.

Both PRs are designed to be independent, mergable in any order.

## Important

After merging the other PR, the browser confirm should be replaced with its `<DeleteModal>`.

## Note to reviewer

If there's missing test coverage, please allow me to delay addressing that until it the PR undergone a first review.

## Testing instructions

Please see AC of the related ticket for exact behavior to test: https://github.com/openedx/modular-learning/issues/260.

But: note that anything related to the delete modal is in the sister PR.

## Use of AI

- AI helped write the tests
- AI split apart the code from the delete functionality to have two independent PRs

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
