### PR TITLE
fix: restore republish on unit visibility change from outline configure modal

### DIFF
--- a/src/course-outline/data/api.ts
+++ b/src/course-outline/data/api.ts
@@ -318,7 +318,7 @@ export async function configureCourseSubsection(
  */
 export async function configureCourseUnit(variables: ConfigureUnitData): Promise<object> {
   const body = {
-    publish: variables.groupAccess ? null : variables.type,
+    publish: variables.type,
     ...(variables.type === PUBLISH_TYPES.republish ?
       {
         metadata: {

--- a/src/course-unit/CourseUnit.test.tsx
+++ b/src/course-unit/CourseUnit.test.tsx
@@ -1465,7 +1465,7 @@ describe('<CourseUnit />', () => {
 
     axiosMock
       .onPost(getXBlockBaseApiUrl(courseSectionVerticalMock.xblock_info.id), {
-        publish: null,
+        publish: 'republish',
         metadata: { visible_to_staff_only: true, group_access: { 50: [2] }, discussion_enabled: true },
       })
       .reply(200, { dummy: 'value' });


### PR DESCRIPTION
## Description

Commit 806135e introduced a ternary that set `publish: null` when `groupAccess` was truthy. Since the configure modal always passes `groupAccess` as `{}` (an empty object, which is truthy in JS), `publish` was never set to `"republish"`. The backend requires `publish: "republish"` to auto-publish visibility changes for units that already have a published version, so changes were silently saved to draft only, requiring a manual publish step to take effect for learners.

Useful information to include:

- Which user roles will this change impact? "Course Author".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).

Before

https://github.com/user-attachments/assets/1970b533-d605-426d-a5af-19f852fd9478

After

https://github.com/user-attachments/assets/47f14b2f-04a7-4795-a24b-be87f72176b3



## Supporting information

Link to other information about the change, such as GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

**Pre-conditions:** A course with at least one unit that has already been published.

**Steps:**

1. Open the course outline for the course.
2. Locate a published unit. Confirm learners can see it (visibility status shows "Published").
3. Click the three-dot menu on the unit → **Configure**.
4. Check **"Hide from learners"** → click **Save**.
5. **Do not** click Publish.
6. Open the course as a learner (or use the LMS in learner view / masquerade as a student).
7. Verify the unit is **no longer visible** to learners without requiring a separate publish step.

**Verify the fix is absent (regression check on the broken behavior):**
- On the master branch, repeating steps 1–6 would still show the unit to learners until manually published.

**Also test the reverse:**

8. Repeat steps 3–6 but **uncheck** "Hide from learners" → **Save**.
9. Verify the unit becomes **visible again** to learners immediately.

**Also test group access (ensure no regression):**

10. Configure the same unit → **Visibility** tab → set a group restriction (e.g. restrict to a specific enrollment track).
11. Save and verify the group restriction is applied correctly.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
