### PR TITLE
fix(hierarchy): hide parent draft text in publish confirmation [FC-0123]

### DIFF
--- a/src/library-authoring/containers/ContainerInfo.test.tsx
+++ b/src/library-authoring/containers/ContainerInfo.test.tsx
@@ -157,7 +157,6 @@ let mockShowToast: { (message: string, action?: ToastActionData): void; mock?: a
   containerType,
   childType,
   willPublishCount,
-
 }) => {
   describe(`<ContainerInfo /> with containerType: ${containerType}`, () => {
     beforeEach(() => {
@@ -308,7 +307,6 @@ let mockShowToast: { (message: string, action?: ToastActionData): void; mock?: a
           'i',
         ),
       )).toBeInTheDocument();
-
     });
 
     it(`omits child count before publishing an empty ${containerType}`, async () => {

--- a/src/library-authoring/containers/ContainerInfo.test.tsx
+++ b/src/library-authoring/containers/ContainerInfo.test.tsx
@@ -139,32 +139,25 @@ let mockShowToast: { (message: string, action?: ToastActionData): void; mock?: a
     containerId: unitId,
     childType: 'component',
     willPublishCount: 2,
-    parentType: 'subsection',
-    parentCount: 3,
   },
   {
     containerType: ContainerType.Subsection,
     containerId: subsectionId,
     childType: 'unit',
     willPublishCount: 3,
-    parentType: 'section',
-    parentCount: 2,
   },
   {
     containerType: ContainerType.Section,
     containerId: sectionId,
     childType: 'subsection',
     willPublishCount: 4,
-    parentType: '',
-    parentCount: 0,
   },
 ].forEach(({
   containerId,
   containerType,
   childType,
   willPublishCount,
-  parentType,
-  parentCount,
+
 }) => {
   describe(`<ContainerInfo /> with containerType: ${containerType}`, () => {
     beforeEach(() => {
@@ -250,16 +243,8 @@ let mockShowToast: { (message: string, action?: ToastActionData): void; mock?: a
           'i',
         ),
       )).toBeInTheDocument();
-      if (parentCount > 0) {
-        expect(screen.getByText(
-          new RegExp(
-            `Its parent ${parentType}s will be`, // <srong>draft</strong>
-            'i',
-          ),
-        )).toBeInTheDocument();
-      }
       expect(screen.queryAllByText('Will Publish').length).toBe(willPublishCount);
-      expect(screen.queryAllByText('Draft').length).toBe(4 - willPublishCount);
+      expect(screen.queryAllByText('Draft').length).toBe(0);
 
       // Click on the confirm Cancel button
       const publishCancel = await screen.findByRole('button', { name: 'Cancel' });
@@ -306,7 +291,7 @@ let mockShowToast: { (message: string, action?: ToastActionData): void; mock?: a
       expect(mockShowToast).toHaveBeenCalledWith('Failed to publish changes');
     });
 
-    it(`shows single child / parent message before publishing the ${containerType}`, async () => {
+    it(`shows single child message before publishing the ${containerType}`, async () => {
       const user = userEvent.setup();
       render(singleChild(containerId), containerType);
 
@@ -323,14 +308,7 @@ let mockShowToast: { (message: string, action?: ToastActionData): void; mock?: a
           'i',
         ),
       )).toBeInTheDocument();
-      if (parentCount) {
-        expect(screen.getByText(
-          new RegExp(
-            `Its parent ${parentType} will be`, // <strong>draft</strong>
-            'i',
-          ),
-        )).toBeInTheDocument();
-      }
+
     });
 
     it(`omits child count before publishing an empty ${containerType}`, async () => {

--- a/src/library-authoring/hierarchy/ItemHierarchy.tsx
+++ b/src/library-authoring/hierarchy/ItemHierarchy.tsx
@@ -108,13 +108,17 @@ export const ItemHierarchy = ({
   } = data;
 
   // Returns a message describing the publish status of the given hierarchy row.
-  const publishMessage = (contents: ItemHierarchyMember[]) => {
+  const publishMessage = (
+    contents: ItemHierarchyMember[],
+    isParentOfSelectedRow = false,
+  ) => {
     // If we're not showing publish status, then we don't need a publish message
-    if (!showPublishStatus) {
+    if (!showPublishStatus || isParentOfSelectedRow) {
       return undefined;
     }
 
     // If any item has unpublished changes, mark this row as Draft.
+    // Skip Draft for parent rows of currently selected row.
     if (contents.some((item) => item.hasUnpublishedChanges)) {
       return messages.draftChipText;
     }
@@ -155,7 +159,7 @@ export const ItemHierarchy = ({
           showArrow={showSubsections}
           selected={selectedSections}
           willPublish={selectedSections}
-          publishMessage={publishMessage(sections)}
+          publishMessage={publishMessage(sections, selectedSubsections || selectedUnits || selectedComponents)}
         />
       )}
       {showSubsections && (
@@ -171,7 +175,7 @@ export const ItemHierarchy = ({
           showArrow={showUnits}
           selected={selectedSubsections}
           willPublish={selectedSubsections || selectedSections}
-          publishMessage={publishMessage(subsections)}
+          publishMessage={publishMessage(subsections, selectedUnits || selectedComponents)}
         />
       )}
       {showUnits && (
@@ -187,7 +191,7 @@ export const ItemHierarchy = ({
           showArrow={showComponents}
           selected={selectedUnits}
           willPublish={selectedUnits || selectedSubsections || selectedSections}
-          publishMessage={publishMessage(units)}
+          publishMessage={publishMessage(units, selectedComponents)}
         />
       )}
       {showComponents && (

--- a/src/library-authoring/hierarchy/ItemHierarchyPublisher.tsx
+++ b/src/library-authoring/hierarchy/ItemHierarchyPublisher.tsx
@@ -81,33 +81,10 @@ export const ItemHierarchyPublisher = ({
     );
   };
 
-  const parentWarningMessage = () => {
-    let parentCount: number;
-    let parentMessage: MessageDescriptor;
-
-    switch (itemType) {
-      case ContainerType.Section:
-        // Section has no parents
-        return undefined;
-      case ContainerType.Subsection:
-        parentMessage = messages.publishSubsectionWithParentWarning;
-        parentCount = hierarchy.sections.length;
-        break;
-      case ContainerType.Unit:
-        parentMessage = messages.publishUnitWithParentWarning;
-        parentCount = hierarchy.subsections.length;
-        break;
-      default: // The item is a component
-        parentMessage = messages.publishComponentsWithParentWarning;
-        parentCount = hierarchy.units.length;
-    }
-    return intl.formatMessage(parentMessage, { parentCount, highlight });
-  };
-
   return (
     <Container className="p-3 status-box draft-status">
       <h4>{intl.formatMessage(messages.publishConfirmHeading)}</h4>
-      <p>{childWarningMessage()} {parentWarningMessage()}</p>
+      <p>{childWarningMessage()}</p>
       <ItemHierarchy showPublishStatus />
       <ActionRow>
         <Button


### PR DESCRIPTION
## Description

Fix publish confirmation hierarchy messaging for Library Authoring sidebar.

When selected row has descendants/ancestors in hierarchy, parent rows no longer show `Draft` chip and parent warning text removed from confirmation copy. This avoids confusing message that parent rows "will be draft" while publishing selected item.

Impacted role: **Course Author**.

UI impact:
- Publish confirmation modal text now shows child warning only.
- Hierarchy status chips no longer show `Draft` on parent rows of selected item.

## Supporting information

- Related: https://github.com/openedx/frontend-app-authoring/issues/2466
- Jira: [FAL-4331](https://tasks.opencraft.com/browse/FAL-4331)

## Testing instructions

1. Open Library Authoring.
2. Pick container with unpublished changes in hierarchy (section/subsection/unit).
3. Open item sidebar and click **Publish Changes**.
4. Verify confirmation modal shows:
   - "Confirm Publish" heading.
   - Child warning sentence only.
   - No parent warning text like "Its parent ... will be draft".
5. In hierarchy widget inside confirmation modal:
   - Selected row and descendants show **Will Publish** as expected.
   - Parent rows do **not** show **Draft** chip.

## Best Practices Checklist

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
