### PR TITLE
refactor: sidebar back-navigation to take user to parent block

### DIFF
--- a/src/course-outline/outline-sidebar/AddSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/AddSidebar.test.tsx
@@ -21,7 +21,7 @@ import {
 } from '@src/course-outline/outline-sidebar/OutlineSidebarContext';
 import fetchMock from 'fetch-mock-jest';
 import type { ContainerType } from '@src/generic/key-utils';
-import { XBlock } from '@src/data/types';
+import { SelectionState, XBlock } from '@src/data/types';
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
 import { CourseOutlineProvider } from '@src/course-outline/CourseOutlineContext';
 import { snakeCaseKeys } from '@src/editors/utils';
@@ -70,8 +70,10 @@ jest.mock('@src/studio-home/hooks', () => ({
 let currentFlow: OutlineFlow | null = null;
 let isCurrentFlowOn = false;
 let currentItemData: Partial<XBlock> | null;
+let selectedContainerState: SelectionState | undefined;
 const clearSelection = jest.fn();
 const stopCurrentFlow = jest.fn();
+const openContainerSidebar = jest.fn();
 jest.mock('../outline-sidebar/OutlineSidebarContext', () => ({
   ...jest.requireActual('../outline-sidebar/OutlineSidebarContext'),
   useOutlineSidebarContext: () => ({
@@ -79,8 +81,10 @@ jest.mock('../outline-sidebar/OutlineSidebarContext', () => ({
     currentFlow,
     isCurrentFlowOn,
     currentItemData,
+    selectedContainerState,
     clearSelection,
     stopCurrentFlow,
+    openContainerSidebar,
   }),
 }));
 
@@ -132,6 +136,10 @@ describe('AddSidebar', () => {
       return newMockResult;
     });
     outlineChildren = courseOutlineIndexMock.courseStructure.childInfo.children;
+    selectedContainerState = undefined;
+    clearSelection.mockClear();
+    stopCurrentFlow.mockClear();
+    openContainerSidebar.mockClear();
   });
 
   it('renders the AddSidebar component without any errors', async () => {
@@ -399,7 +407,29 @@ describe('AddSidebar', () => {
 
     const back = await screen.findByRole('button', { name: 'Back' });
     await user.click(back);
-    expect(clearSelection).toHaveBeenCalled();
     expect(stopCurrentFlow).toHaveBeenCalled();
+  });
+
+  it('back from unit sets subsection index in selection', async () => {
+    const user = userEvent.setup();
+    const section = outlineChildren[0];
+    const subsection = section.childInfo.children[0];
+    const unit = subsection.childInfo.children[0];
+    selectedContainerState = {
+      currentId: unit.id,
+      subsectionId: subsection.id,
+      sectionId: section.id,
+    };
+    renderComponent();
+
+    const back = await screen.findByRole('button', { name: 'Back' });
+    await user.click(back);
+
+    expect(openContainerSidebar).toHaveBeenCalledWith(
+      subsection.id,
+      subsection.id,
+      section.id,
+      0,
+    );
   });
 });

--- a/src/course-outline/outline-sidebar/AddSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/AddSidebar.test.tsx
@@ -451,6 +451,23 @@ describe('AddSidebar', () => {
     expect(clearSelection).not.toHaveBeenCalled();
   });
 
+  it('back from subsection without section clears selection', async () => {
+    const user = userEvent.setup();
+    const section = outlineChildren[0];
+    const subsection = section.childInfo.children[0];
+    selectedContainerState = {
+      currentId: subsection.id,
+      subsectionId: subsection.id,
+    };
+    renderComponent();
+
+    const back = await screen.findByRole('button', { name: 'Back' });
+    await user.click(back);
+
+    expect(clearSelection).toHaveBeenCalled();
+    expect(openContainerSidebar).not.toHaveBeenCalled();
+  });
+
   it('back from section clears selection', async () => {
     const user = userEvent.setup();
     const section = outlineChildren[0];

--- a/src/course-outline/outline-sidebar/AddSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/AddSidebar.test.tsx
@@ -433,24 +433,6 @@ describe('AddSidebar', () => {
     );
   });
 
-  it('back from subsection opens section', async () => {
-    const user = userEvent.setup();
-    const section = outlineChildren[0];
-    const subsection = section.childInfo.children[0];
-    selectedContainerState = {
-      currentId: subsection.id,
-      subsectionId: subsection.id,
-      sectionId: section.id,
-    };
-    renderComponent();
-
-    const back = await screen.findByRole('button', { name: 'Back' });
-    await user.click(back);
-
-    expect(openContainerSidebar).toHaveBeenCalledWith(section.id, undefined, section.id, 0);
-    expect(clearSelection).not.toHaveBeenCalled();
-  });
-
   it('back from subsection without section clears selection', async () => {
     const user = userEvent.setup();
     const section = outlineChildren[0];
@@ -458,22 +440,6 @@ describe('AddSidebar', () => {
     selectedContainerState = {
       currentId: subsection.id,
       subsectionId: subsection.id,
-    };
-    renderComponent();
-
-    const back = await screen.findByRole('button', { name: 'Back' });
-    await user.click(back);
-
-    expect(clearSelection).toHaveBeenCalled();
-    expect(openContainerSidebar).not.toHaveBeenCalled();
-  });
-
-  it('back from section clears selection', async () => {
-    const user = userEvent.setup();
-    const section = outlineChildren[0];
-    selectedContainerState = {
-      currentId: section.id,
-      sectionId: section.id,
     };
     renderComponent();
 

--- a/src/course-outline/outline-sidebar/AddSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/AddSidebar.test.tsx
@@ -432,4 +432,38 @@ describe('AddSidebar', () => {
       0,
     );
   });
+
+  it('back from subsection opens section', async () => {
+    const user = userEvent.setup();
+    const section = outlineChildren[0];
+    const subsection = section.childInfo.children[0];
+    selectedContainerState = {
+      currentId: subsection.id,
+      subsectionId: subsection.id,
+      sectionId: section.id,
+    };
+    renderComponent();
+
+    const back = await screen.findByRole('button', { name: 'Back' });
+    await user.click(back);
+
+    expect(openContainerSidebar).toHaveBeenCalledWith(section.id, undefined, section.id, 0);
+    expect(clearSelection).not.toHaveBeenCalled();
+  });
+
+  it('back from section clears selection', async () => {
+    const user = userEvent.setup();
+    const section = outlineChildren[0];
+    selectedContainerState = {
+      currentId: section.id,
+      sectionId: section.id,
+    };
+    renderComponent();
+
+    const back = await screen.findByRole('button', { name: 'Back' });
+    await user.click(back);
+
+    expect(clearSelection).toHaveBeenCalled();
+    expect(openContainerSidebar).not.toHaveBeenCalled();
+  });
 });

--- a/src/course-outline/outline-sidebar/AddSidebar.tsx
+++ b/src/course-outline/outline-sidebar/AddSidebar.tsx
@@ -359,6 +359,7 @@ const AddTabs = () => {
 export const AddSidebar = () => {
   const intl = useIntl();
   const { courseDetails } = useCourseAuthoringContext();
+  const { sections } = useCourseOutlineContext();
   const {
     isCurrentFlowOn,
     currentFlow,
@@ -395,9 +396,13 @@ export const AddSidebar = () => {
     }
 
     const { currentId, subsectionId, sectionId } = selectedContainerState;
+    const sectionIndex = sections.findIndex((section) => section.id === sectionId);
+    const subsectionIndex = sections
+      .find((section) => section.id === sectionId)
+      ?.childInfo.children.findIndex((subsection) => subsection.id === subsectionId) ?? -1;
 
     if (currentId === subsectionId && sectionId) {
-      openContainerSidebar(sectionId, undefined, sectionId);
+      openContainerSidebar(sectionId, undefined, sectionId, sectionIndex >= 0 ? sectionIndex : undefined);
       return;
     }
 
@@ -407,7 +412,12 @@ export const AddSidebar = () => {
     }
 
     if (subsectionId) {
-      openContainerSidebar(subsectionId, subsectionId, sectionId);
+      openContainerSidebar(
+        subsectionId,
+        subsectionId,
+        sectionId,
+        subsectionIndex >= 0 ? subsectionIndex : undefined,
+      );
       return;
     }
 

--- a/src/course-outline/outline-sidebar/AddSidebar.tsx
+++ b/src/course-outline/outline-sidebar/AddSidebar.tsx
@@ -366,6 +366,7 @@ export const AddSidebar = () => {
     clearSelection,
     stopCurrentFlow,
     selectedContainerState,
+    openContainerSidebar,
   } = useOutlineSidebarContext();
   const { data: flowData } = useCourseItemData(currentFlow?.parentLocator);
   const titleAndIcon = useMemo(() => {
@@ -387,8 +388,30 @@ export const AddSidebar = () => {
   ]);
 
   const handleBack = () => {
-    clearSelection();
     stopCurrentFlow();
+
+    if (!selectedContainerState) {
+      return;
+    }
+
+    const { currentId, subsectionId, sectionId } = selectedContainerState;
+
+    if (currentId === subsectionId && sectionId) {
+      openContainerSidebar(sectionId, undefined, sectionId);
+      return;
+    }
+
+    if (currentId === sectionId) {
+      clearSelection();
+      return;
+    }
+
+    if (subsectionId) {
+      openContainerSidebar(subsectionId, subsectionId, sectionId);
+      return;
+    }
+
+    clearSelection();
   };
 
   return (

--- a/src/course-outline/outline-sidebar/AddSidebar.tsx
+++ b/src/course-outline/outline-sidebar/AddSidebar.tsx
@@ -397,8 +397,8 @@ export const AddSidebar = () => {
 
     const { currentId, subsectionId, sectionId } = selectedContainerState;
     const sectionIndex = sections.findIndex((section) => section.id === sectionId);
-    const subsectionIndex = sections
-      .find((section) => section.id === sectionId)
+    const section = sectionIndex >= 0 ? sections[sectionIndex] : undefined;
+    const subsectionIndex = section
       ?.childInfo.children.findIndex((subsection) => subsection.id === subsectionId) ?? -1;
 
     if (currentId === subsectionId && sectionId) {

--- a/src/course-outline/outline-sidebar/AddSidebar.tsx
+++ b/src/course-outline/outline-sidebar/AddSidebar.tsx
@@ -29,7 +29,7 @@ import { COURSE_BLOCK_NAMES } from '@src/constants';
 import { BlockCardButton } from '@src/generic/sidebar/BlockCardButton';
 import AlertMessage from '@src/generic/alert-message';
 import { useCourseItemData } from '@src/course-outline/data/apiHooks';
-import { navigateBackFromSelection } from './back-navigation';
+import { useBackNavigation } from './back-navigation';
 import { useOutlineSidebarContext } from './OutlineSidebarContext';
 import messages from './messages';
 
@@ -360,12 +360,10 @@ const AddTabs = () => {
 export const AddSidebar = () => {
   const intl = useIntl();
   const { courseDetails } = useCourseAuthoringContext();
-  const { sections } = useCourseOutlineContext();
   const {
     isCurrentFlowOn,
     currentFlow,
     currentItemData,
-    clearSelection,
     stopCurrentFlow,
     selectedContainerState,
     openContainerSidebar,
@@ -389,14 +387,13 @@ export const AddSidebar = () => {
     courseDetails,
   ]);
 
+  const handleSelectionBack = useBackNavigation({
+    openContainer: openContainerSidebar,
+  });
+
   const handleBack = () => {
     stopCurrentFlow();
-    navigateBackFromSelection({
-      selectedContainerState,
-      sections,
-      openContainer: openContainerSidebar,
-      clearSelection,
-    });
+    handleSelectionBack();
   };
 
   return (

--- a/src/course-outline/outline-sidebar/AddSidebar.tsx
+++ b/src/course-outline/outline-sidebar/AddSidebar.tsx
@@ -29,6 +29,7 @@ import { COURSE_BLOCK_NAMES } from '@src/constants';
 import { BlockCardButton } from '@src/generic/sidebar/BlockCardButton';
 import AlertMessage from '@src/generic/alert-message';
 import { useCourseItemData } from '@src/course-outline/data/apiHooks';
+import { navigateBackFromSelection } from './back-navigation';
 import { useOutlineSidebarContext } from './OutlineSidebarContext';
 import messages from './messages';
 
@@ -390,42 +391,12 @@ export const AddSidebar = () => {
 
   const handleBack = () => {
     stopCurrentFlow();
-
-    if (!selectedContainerState) {
-      return;
-    }
-
-    const { currentId, subsectionId, sectionId } = selectedContainerState;
-    const sectionIndex = sections.findIndex((section) => section.id === sectionId);
-    const section = sectionIndex >= 0 ? sections[sectionIndex] : undefined;
-    const subsectionIndex = section
-      ?.childInfo.children.findIndex((subsection) => subsection.id === subsectionId) ?? -1;
-
-    if (currentId === subsectionId) {
-      if (sectionId) {
-        openContainerSidebar(sectionId, undefined, sectionId, sectionIndex >= 0 ? sectionIndex : undefined);
-        return;
-      }
-      clearSelection();
-      return;
-    }
-
-    if (currentId === sectionId) {
-      clearSelection();
-      return;
-    }
-
-    if (subsectionId) {
-      openContainerSidebar(
-        subsectionId,
-        subsectionId,
-        sectionId,
-        subsectionIndex >= 0 ? subsectionIndex : undefined,
-      );
-      return;
-    }
-
-    clearSelection();
+    navigateBackFromSelection({
+      selectedContainerState,
+      sections,
+      openContainer: openContainerSidebar,
+      clearSelection,
+    });
   };
 
   return (

--- a/src/course-outline/outline-sidebar/AddSidebar.tsx
+++ b/src/course-outline/outline-sidebar/AddSidebar.tsx
@@ -401,8 +401,12 @@ export const AddSidebar = () => {
     const subsectionIndex = section
       ?.childInfo.children.findIndex((subsection) => subsection.id === subsectionId) ?? -1;
 
-    if (currentId === subsectionId && sectionId) {
-      openContainerSidebar(sectionId, undefined, sectionId, sectionIndex >= 0 ? sectionIndex : undefined);
+    if (currentId === subsectionId) {
+      if (sectionId) {
+        openContainerSidebar(sectionId, undefined, sectionId, sectionIndex >= 0 ? sectionIndex : undefined);
+        return;
+      }
+      clearSelection();
       return;
     }
 

--- a/src/course-outline/outline-sidebar/OutlineAlignSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/OutlineAlignSidebar.test.tsx
@@ -34,6 +34,16 @@ describe('OutlineAlignSidebar', () => {
       .spyOn(CourseOutlineContext, 'useCourseOutlineContext')
       .mockReturnValue({
         setCurrentSelection,
+        sections: [
+          {
+            id: 'section-1',
+            childInfo: {
+              children: [
+                { id: 'subsection-1', childInfo: { children: [{ id: 'unit-1' }] } },
+              ],
+            },
+          },
+        ],
       } as any);
     jest
       .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')
@@ -112,11 +122,12 @@ describe('OutlineAlignSidebar', () => {
     const backButton = await screen.findByRole('button', { name: /back/i });
     backButton.click();
 
-    expect(openContainerSidebar).toHaveBeenCalledWith('subsection-1', 'subsection-1', 'section-1');
+    expect(openContainerSidebar).toHaveBeenCalledWith('subsection-1', 'subsection-1', 'section-1', 0);
     expect(setCurrentSelection).toHaveBeenCalledWith({
       currentId: 'subsection-1',
       subsectionId: 'subsection-1',
       sectionId: 'section-1',
+      index: 0,
     });
   });
 });

--- a/src/course-outline/outline-sidebar/OutlineAlignSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/OutlineAlignSidebar.test.tsx
@@ -16,8 +16,15 @@ jest.mock('@src/content-tags-drawer', () => ({
 }));
 
 describe('OutlineAlignSidebar', () => {
+  const setCurrentSelection = jest.fn();
+  const clearSelection = jest.fn();
+  const openContainerSidebar = jest.fn();
+
   beforeEach(() => {
     initializeMocks();
+    setCurrentSelection.mockReset();
+    clearSelection.mockReset();
+    openContainerSidebar.mockReset();
     jest
       .spyOn(CourseAuthoringContext, 'useCourseAuthoringContext')
       .mockReturnValue({
@@ -26,7 +33,7 @@ describe('OutlineAlignSidebar', () => {
     jest
       .spyOn(CourseOutlineContext, 'useCourseOutlineContext')
       .mockReturnValue({
-        setCurrentSelection: jest.fn(),
+        setCurrentSelection,
       } as any);
     jest
       .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')
@@ -34,6 +41,8 @@ describe('OutlineAlignSidebar', () => {
         selectedContainerState: {
           currentId: 'block-v1:test+course+run+type@sequential+block@seq1',
         },
+        clearSelection,
+        openContainerSidebar,
       } as any);
     jest
       .spyOn(CourseDetailsApi, 'useCourseDetails')
@@ -67,6 +76,8 @@ describe('OutlineAlignSidebar', () => {
       .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')
       .mockReturnValue({
         selectedContainerState: undefined,
+        clearSelection,
+        openContainerSidebar,
       } as any);
     jest
       .spyOn(CourseDetailsApi, 'useCourseDetails')
@@ -81,5 +92,31 @@ describe('OutlineAlignSidebar', () => {
     render(<OutlineAlignSidebar />);
 
     expect(await screen.findByText('Test Course')).toBeInTheDocument();
+  });
+
+  it('back button selects parent block in align sidebar', async () => {
+    jest
+      .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')
+      .mockReturnValue({
+        selectedContainerState: {
+          currentId: 'unit-1',
+          subsectionId: 'subsection-1',
+          sectionId: 'section-1',
+        },
+        clearSelection,
+        openContainerSidebar,
+      } as any);
+
+    render(<OutlineAlignSidebar />);
+
+    const backButton = await screen.findByRole('button', { name: /back/i });
+    backButton.click();
+
+    expect(openContainerSidebar).toHaveBeenCalledWith('subsection-1', 'subsection-1', 'section-1');
+    expect(setCurrentSelection).toHaveBeenCalledWith({
+      currentId: 'subsection-1',
+      subsectionId: 'subsection-1',
+      sectionId: 'section-1',
+    });
   });
 });

--- a/src/course-outline/outline-sidebar/OutlineAlignSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/OutlineAlignSidebar.test.tsx
@@ -157,6 +157,28 @@ describe('OutlineAlignSidebar', () => {
     });
   });
 
+  it('back button from subsection without section clears selection', async () => {
+    jest
+      .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')
+      .mockReturnValue({
+        selectedContainerState: {
+          currentId: 'subsection-1',
+          subsectionId: 'subsection-1',
+        },
+        clearSelection,
+        openContainerSidebar,
+      } as any);
+
+    render(<OutlineAlignSidebar />);
+
+    const backButton = await screen.findByRole('button', { name: /back/i });
+    backButton.click();
+
+    expect(clearSelection).toHaveBeenCalled();
+    expect(setCurrentSelection).toHaveBeenCalledWith(undefined);
+    expect(openContainerSidebar).not.toHaveBeenCalled();
+  });
+
   it('back button from section clears selection', async () => {
     jest
       .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')

--- a/src/course-outline/outline-sidebar/OutlineAlignSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/OutlineAlignSidebar.test.tsx
@@ -130,4 +130,78 @@ describe('OutlineAlignSidebar', () => {
       index: 0,
     });
   });
+
+  it('back button from subsection selects section', async () => {
+    jest
+      .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')
+      .mockReturnValue({
+        selectedContainerState: {
+          currentId: 'subsection-1',
+          subsectionId: 'subsection-1',
+          sectionId: 'section-1',
+        },
+        clearSelection,
+        openContainerSidebar,
+      } as any);
+
+    render(<OutlineAlignSidebar />);
+
+    const backButton = await screen.findByRole('button', { name: /back/i });
+    backButton.click();
+
+    expect(openContainerSidebar).toHaveBeenCalledWith('section-1', undefined, 'section-1', 0);
+    expect(setCurrentSelection).toHaveBeenCalledWith({
+      currentId: 'section-1',
+      sectionId: 'section-1',
+      index: 0,
+    });
+  });
+
+  it('back button from section clears selection', async () => {
+    jest
+      .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')
+      .mockReturnValue({
+        selectedContainerState: {
+          currentId: 'section-1',
+          sectionId: 'section-1',
+        },
+        clearSelection,
+        openContainerSidebar,
+      } as any);
+
+    render(<OutlineAlignSidebar />);
+
+    const backButton = await screen.findByRole('button', { name: /back/i });
+    backButton.click();
+
+    expect(clearSelection).toHaveBeenCalled();
+    expect(setCurrentSelection).toHaveBeenCalledWith(undefined);
+  });
+
+  it('back button handles missing section when selecting subsection parent', async () => {
+    jest
+      .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')
+      .mockReturnValue({
+        selectedContainerState: {
+          currentId: 'unit-1',
+          subsectionId: 'subsection-1',
+          sectionId: 'missing-section',
+        },
+        clearSelection,
+        openContainerSidebar,
+      } as any);
+
+    render(<OutlineAlignSidebar />);
+
+    const backButton = await screen.findByRole('button', { name: /back/i });
+    backButton.click();
+
+    expect(openContainerSidebar).toHaveBeenCalledWith('subsection-1', 'subsection-1', 'missing-section', undefined);
+    expect(setCurrentSelection).toHaveBeenCalledWith({
+      currentId: 'subsection-1',
+      subsectionId: 'subsection-1',
+      sectionId: 'missing-section',
+      index: undefined,
+    });
+  });
 });

--- a/src/course-outline/outline-sidebar/OutlineAlignSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/OutlineAlignSidebar.test.tsx
@@ -19,6 +19,9 @@ describe('OutlineAlignSidebar', () => {
   const setCurrentSelection = jest.fn();
   const clearSelection = jest.fn();
   const openContainerSidebar = jest.fn();
+  const sectionId = 'block-v1:test+course+run+type@chapter+block@section-1';
+  const subsectionId = 'block-v1:test+course+run+type@sequential+block@subsection-1';
+  const unitId = 'block-v1:test+course+run+type@vertical+block@unit-1';
 
   beforeEach(() => {
     initializeMocks();
@@ -36,10 +39,10 @@ describe('OutlineAlignSidebar', () => {
         setCurrentSelection,
         sections: [
           {
-            id: 'section-1',
+            id: sectionId,
             childInfo: {
               children: [
-                { id: 'subsection-1', childInfo: { children: [{ id: 'unit-1' }] } },
+                { id: subsectionId, childInfo: { children: [{ id: unitId }] } },
               ],
             },
           },
@@ -109,9 +112,9 @@ describe('OutlineAlignSidebar', () => {
       .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')
       .mockReturnValue({
         selectedContainerState: {
-          currentId: 'unit-1',
-          subsectionId: 'subsection-1',
-          sectionId: 'section-1',
+          currentId: unitId,
+          subsectionId,
+          sectionId,
         },
         clearSelection,
         openContainerSidebar,
@@ -122,11 +125,11 @@ describe('OutlineAlignSidebar', () => {
     const backButton = await screen.findByRole('button', { name: /back/i });
     backButton.click();
 
-    expect(openContainerSidebar).toHaveBeenCalledWith('subsection-1', 'subsection-1', 'section-1', 0);
+    expect(openContainerSidebar).toHaveBeenCalledWith(subsectionId, subsectionId, sectionId, 0);
     expect(setCurrentSelection).toHaveBeenCalledWith({
-      currentId: 'subsection-1',
-      subsectionId: 'subsection-1',
-      sectionId: 'section-1',
+      currentId: subsectionId,
+      subsectionId,
+      sectionId,
       index: 0,
     });
   });
@@ -136,8 +139,8 @@ describe('OutlineAlignSidebar', () => {
       .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')
       .mockReturnValue({
         selectedContainerState: {
-          currentId: 'section-1',
-          sectionId: 'section-1',
+          currentId: sectionId,
+          sectionId,
         },
         clearSelection,
         openContainerSidebar,

--- a/src/course-outline/outline-sidebar/OutlineAlignSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/OutlineAlignSidebar.test.tsx
@@ -131,55 +131,7 @@ describe('OutlineAlignSidebar', () => {
     });
   });
 
-  it('back button from subsection selects section', async () => {
-    jest
-      .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')
-      .mockReturnValue({
-        selectedContainerState: {
-          currentId: 'subsection-1',
-          subsectionId: 'subsection-1',
-          sectionId: 'section-1',
-        },
-        clearSelection,
-        openContainerSidebar,
-      } as any);
-
-    render(<OutlineAlignSidebar />);
-
-    const backButton = await screen.findByRole('button', { name: /back/i });
-    backButton.click();
-
-    expect(openContainerSidebar).toHaveBeenCalledWith('section-1', undefined, 'section-1', 0);
-    expect(setCurrentSelection).toHaveBeenCalledWith({
-      currentId: 'section-1',
-      sectionId: 'section-1',
-      index: 0,
-    });
-  });
-
-  it('back button from subsection without section clears selection', async () => {
-    jest
-      .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')
-      .mockReturnValue({
-        selectedContainerState: {
-          currentId: 'subsection-1',
-          subsectionId: 'subsection-1',
-        },
-        clearSelection,
-        openContainerSidebar,
-      } as any);
-
-    render(<OutlineAlignSidebar />);
-
-    const backButton = await screen.findByRole('button', { name: /back/i });
-    backButton.click();
-
-    expect(clearSelection).toHaveBeenCalled();
-    expect(setCurrentSelection).toHaveBeenCalledWith(undefined);
-    expect(openContainerSidebar).not.toHaveBeenCalled();
-  });
-
-  it('back button from section clears selection', async () => {
+  it('back button clears align selection when parent selection does not exist', async () => {
     jest
       .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')
       .mockReturnValue({
@@ -198,32 +150,6 @@ describe('OutlineAlignSidebar', () => {
 
     expect(clearSelection).toHaveBeenCalled();
     expect(setCurrentSelection).toHaveBeenCalledWith(undefined);
-  });
-
-  it('back button handles missing section when selecting subsection parent', async () => {
-    jest
-      .spyOn(OutlineSidebarContext, 'useOutlineSidebarContext')
-      .mockReturnValue({
-        selectedContainerState: {
-          currentId: 'unit-1',
-          subsectionId: 'subsection-1',
-          sectionId: 'missing-section',
-        },
-        clearSelection,
-        openContainerSidebar,
-      } as any);
-
-    render(<OutlineAlignSidebar />);
-
-    const backButton = await screen.findByRole('button', { name: /back/i });
-    backButton.click();
-
-    expect(openContainerSidebar).toHaveBeenCalledWith('subsection-1', 'subsection-1', 'missing-section', undefined);
-    expect(setCurrentSelection).toHaveBeenCalledWith({
-      currentId: 'subsection-1',
-      subsectionId: 'subsection-1',
-      sectionId: 'missing-section',
-      index: undefined,
-    });
+    expect(openContainerSidebar).not.toHaveBeenCalled();
   });
 });

--- a/src/course-outline/outline-sidebar/OutlineAlignSidebar.tsx
+++ b/src/course-outline/outline-sidebar/OutlineAlignSidebar.tsx
@@ -10,14 +10,39 @@ import { useOutlineSidebarContext } from './OutlineSidebarContext';
 export const OutlineAlignSidebar = () => {
   const { courseId } = useCourseAuthoringContext();
   const { setCurrentSelection } = useCourseOutlineContext();
-  const { selectedContainerState, clearSelection } = useOutlineSidebarContext();
+  const { selectedContainerState, clearSelection, openContainerSidebar } = useOutlineSidebarContext();
 
   const sidebarContentId = selectedContainerState?.currentId || courseId;
 
   const { data: contentData } = useContentData(sidebarContentId);
 
-  // istanbul ignore next
   const handleBack = () => {
+    const { currentId, subsectionId, sectionId } = selectedContainerState || {};
+
+    if (!currentId) {
+      clearSelection();
+      setCurrentSelection(undefined);
+      return;
+    }
+
+    if (currentId === subsectionId && sectionId) {
+      openContainerSidebar(sectionId, undefined, sectionId);
+      setCurrentSelection({ currentId: sectionId, sectionId });
+      return;
+    }
+
+    if (currentId === sectionId) {
+      clearSelection();
+      setCurrentSelection(undefined);
+      return;
+    }
+
+    if (subsectionId) {
+      openContainerSidebar(subsectionId, subsectionId, sectionId);
+      setCurrentSelection({ currentId: subsectionId, subsectionId, sectionId });
+      return;
+    }
+
     clearSelection();
     setCurrentSelection(undefined);
   };

--- a/src/course-outline/outline-sidebar/OutlineAlignSidebar.tsx
+++ b/src/course-outline/outline-sidebar/OutlineAlignSidebar.tsx
@@ -9,7 +9,7 @@ import { useOutlineSidebarContext } from './OutlineSidebarContext';
  */
 export const OutlineAlignSidebar = () => {
   const { courseId } = useCourseAuthoringContext();
-  const { setCurrentSelection } = useCourseOutlineContext();
+  const { setCurrentSelection, sections } = useCourseOutlineContext();
   const { selectedContainerState, clearSelection, openContainerSidebar } = useOutlineSidebarContext();
 
   const sidebarContentId = selectedContainerState?.currentId || courseId;
@@ -18,6 +18,10 @@ export const OutlineAlignSidebar = () => {
 
   const handleBack = () => {
     const { currentId, subsectionId, sectionId } = selectedContainerState || {};
+    const sectionIndex = sections.findIndex((section) => section.id === sectionId);
+    const subsectionIndex = sections
+      .find((section) => section.id === sectionId)
+      ?.childInfo.children.findIndex((subsection) => subsection.id === subsectionId) ?? -1;
 
     if (!currentId) {
       clearSelection();
@@ -26,8 +30,12 @@ export const OutlineAlignSidebar = () => {
     }
 
     if (currentId === subsectionId && sectionId) {
-      openContainerSidebar(sectionId, undefined, sectionId);
-      setCurrentSelection({ currentId: sectionId, sectionId });
+      openContainerSidebar(sectionId, undefined, sectionId, sectionIndex >= 0 ? sectionIndex : undefined);
+      setCurrentSelection({
+        currentId: sectionId,
+        sectionId,
+        index: sectionIndex >= 0 ? sectionIndex : undefined,
+      });
       return;
     }
 
@@ -38,8 +46,18 @@ export const OutlineAlignSidebar = () => {
     }
 
     if (subsectionId) {
-      openContainerSidebar(subsectionId, subsectionId, sectionId);
-      setCurrentSelection({ currentId: subsectionId, subsectionId, sectionId });
+      openContainerSidebar(
+        subsectionId,
+        subsectionId,
+        sectionId,
+        subsectionIndex >= 0 ? subsectionIndex : undefined,
+      );
+      setCurrentSelection({
+        currentId: subsectionId,
+        subsectionId,
+        sectionId,
+        index: subsectionIndex >= 0 ? subsectionIndex : undefined,
+      });
       return;
     }
 

--- a/src/course-outline/outline-sidebar/OutlineAlignSidebar.tsx
+++ b/src/course-outline/outline-sidebar/OutlineAlignSidebar.tsx
@@ -2,7 +2,7 @@ import { useContentData } from '@src/content-tags-drawer/data/apiHooks';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
 import { useCourseOutlineContext } from '@src/course-outline/CourseOutlineContext';
 import { AlignSidebar } from '@src/generic/sidebar/AlignSidebar';
-import { navigateBackFromSelection } from './back-navigation';
+import { useBackNavigation } from './back-navigation';
 import { useOutlineSidebarContext } from './OutlineSidebarContext';
 
 /**
@@ -10,22 +10,17 @@ import { useOutlineSidebarContext } from './OutlineSidebarContext';
  */
 export const OutlineAlignSidebar = () => {
   const { courseId } = useCourseAuthoringContext();
-  const { setCurrentSelection, sections } = useCourseOutlineContext();
-  const { selectedContainerState, clearSelection, openContainerSidebar } = useOutlineSidebarContext();
+  const { setCurrentSelection } = useCourseOutlineContext();
+  const { selectedContainerState, openContainerSidebar } = useOutlineSidebarContext();
 
   const sidebarContentId = selectedContainerState?.currentId || courseId;
 
   const { data: contentData } = useContentData(sidebarContentId);
 
-  const handleBack = () => {
-    navigateBackFromSelection({
-      selectedContainerState,
-      sections,
-      openContainer: openContainerSidebar,
-      clearSelection,
-      onSelectionChange: setCurrentSelection,
-    });
-  };
+  const handleBack = useBackNavigation({
+    openContainer: openContainerSidebar,
+    onSelectionChange: setCurrentSelection,
+  });
 
   return (
     <AlignSidebar

--- a/src/course-outline/outline-sidebar/OutlineAlignSidebar.tsx
+++ b/src/course-outline/outline-sidebar/OutlineAlignSidebar.tsx
@@ -23,6 +23,7 @@ export const OutlineAlignSidebar = () => {
     const subsectionIndex = section
       ?.childInfo.children.findIndex((subsection) => subsection.id === subsectionId) ?? -1;
 
+    // istanbul ignore next
     if (!currentId) {
       clearSelection();
       setCurrentSelection(undefined);
@@ -61,7 +62,9 @@ export const OutlineAlignSidebar = () => {
       return;
     }
 
+    // istanbul ignore next
     clearSelection();
+    // istanbul ignore next
     setCurrentSelection(undefined);
   };
 

--- a/src/course-outline/outline-sidebar/OutlineAlignSidebar.tsx
+++ b/src/course-outline/outline-sidebar/OutlineAlignSidebar.tsx
@@ -2,6 +2,7 @@ import { useContentData } from '@src/content-tags-drawer/data/apiHooks';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
 import { useCourseOutlineContext } from '@src/course-outline/CourseOutlineContext';
 import { AlignSidebar } from '@src/generic/sidebar/AlignSidebar';
+import { navigateBackFromSelection } from './back-navigation';
 import { useOutlineSidebarContext } from './OutlineSidebarContext';
 
 /**
@@ -17,60 +18,13 @@ export const OutlineAlignSidebar = () => {
   const { data: contentData } = useContentData(sidebarContentId);
 
   const handleBack = () => {
-    const { currentId, subsectionId, sectionId } = selectedContainerState || {};
-    const sectionIndex = sections.findIndex((section) => section.id === sectionId);
-    const section = sectionIndex >= 0 ? sections[sectionIndex] : undefined;
-    const subsectionIndex = section
-      ?.childInfo.children.findIndex((subsection) => subsection.id === subsectionId) ?? -1;
-
-    // istanbul ignore next
-    if (!currentId) {
-      clearSelection();
-      setCurrentSelection(undefined);
-      return;
-    }
-
-    if (currentId === subsectionId) {
-      if (sectionId) {
-        openContainerSidebar(sectionId, undefined, sectionId, sectionIndex >= 0 ? sectionIndex : undefined);
-        setCurrentSelection({
-          currentId: sectionId,
-          sectionId,
-          index: sectionIndex >= 0 ? sectionIndex : undefined,
-        });
-        return;
-      }
-      clearSelection();
-      setCurrentSelection(undefined);
-      return;
-    }
-
-    if (currentId === sectionId) {
-      clearSelection();
-      setCurrentSelection(undefined);
-      return;
-    }
-
-    if (subsectionId) {
-      openContainerSidebar(
-        subsectionId,
-        subsectionId,
-        sectionId,
-        subsectionIndex >= 0 ? subsectionIndex : undefined,
-      );
-      setCurrentSelection({
-        currentId: subsectionId,
-        subsectionId,
-        sectionId,
-        index: subsectionIndex >= 0 ? subsectionIndex : undefined,
-      });
-      return;
-    }
-
-    // istanbul ignore next
-    clearSelection();
-    // istanbul ignore next
-    setCurrentSelection(undefined);
+    navigateBackFromSelection({
+      selectedContainerState,
+      sections,
+      openContainer: openContainerSidebar,
+      clearSelection,
+      onSelectionChange: setCurrentSelection,
+    });
   };
 
   return (

--- a/src/course-outline/outline-sidebar/OutlineAlignSidebar.tsx
+++ b/src/course-outline/outline-sidebar/OutlineAlignSidebar.tsx
@@ -30,13 +30,18 @@ export const OutlineAlignSidebar = () => {
       return;
     }
 
-    if (currentId === subsectionId && sectionId) {
-      openContainerSidebar(sectionId, undefined, sectionId, sectionIndex >= 0 ? sectionIndex : undefined);
-      setCurrentSelection({
-        currentId: sectionId,
-        sectionId,
-        index: sectionIndex >= 0 ? sectionIndex : undefined,
-      });
+    if (currentId === subsectionId) {
+      if (sectionId) {
+        openContainerSidebar(sectionId, undefined, sectionId, sectionIndex >= 0 ? sectionIndex : undefined);
+        setCurrentSelection({
+          currentId: sectionId,
+          sectionId,
+          index: sectionIndex >= 0 ? sectionIndex : undefined,
+        });
+        return;
+      }
+      clearSelection();
+      setCurrentSelection(undefined);
       return;
     }
 

--- a/src/course-outline/outline-sidebar/OutlineAlignSidebar.tsx
+++ b/src/course-outline/outline-sidebar/OutlineAlignSidebar.tsx
@@ -19,8 +19,8 @@ export const OutlineAlignSidebar = () => {
   const handleBack = () => {
     const { currentId, subsectionId, sectionId } = selectedContainerState || {};
     const sectionIndex = sections.findIndex((section) => section.id === sectionId);
-    const subsectionIndex = sections
-      .find((section) => section.id === sectionId)
+    const section = sectionIndex >= 0 ? sections[sectionIndex] : undefined;
+    const subsectionIndex = section
       ?.childInfo.children.findIndex((subsection) => subsection.id === subsectionId) ?? -1;
 
     if (!currentId) {

--- a/src/course-outline/outline-sidebar/back-navigation.test.ts
+++ b/src/course-outline/outline-sidebar/back-navigation.test.ts
@@ -1,0 +1,154 @@
+import { SelectionState } from '@src/data/types';
+import { getBackSelectionState, navigateBackFromSelection } from './back-navigation';
+
+describe('back-navigation', () => {
+  const sections = [
+    {
+      id: 'section-1',
+      childInfo: {
+        children: [
+          { id: 'subsection-1' },
+          { id: 'subsection-2' },
+        ],
+      },
+    },
+  ] as any;
+
+  describe('getBackSelectionState', () => {
+    it('returns undefined when currentId missing', () => {
+      expect(getBackSelectionState(undefined, sections)).toBeUndefined();
+    });
+
+    it('returns section selection when current is subsection', () => {
+      const state: SelectionState = {
+        currentId: 'subsection-1',
+        subsectionId: 'subsection-1',
+        sectionId: 'section-1',
+      };
+
+      expect(getBackSelectionState(state, sections)).toEqual({
+        currentId: 'section-1',
+        sectionId: 'section-1',
+        index: 0,
+      });
+    });
+
+    it('returns undefined when subsection has no section', () => {
+      const state: SelectionState = {
+        currentId: 'subsection-1',
+        subsectionId: 'subsection-1',
+      };
+
+      expect(getBackSelectionState(state, sections)).toBeUndefined();
+    });
+
+    it('returns undefined when current is section', () => {
+      const state: SelectionState = {
+        currentId: 'section-1',
+        sectionId: 'section-1',
+      };
+
+      expect(getBackSelectionState(state, sections)).toBeUndefined();
+    });
+
+    it('returns subsection selection when current is unit', () => {
+      const state: SelectionState = {
+        currentId: 'unit-1',
+        subsectionId: 'subsection-2',
+        sectionId: 'section-1',
+      };
+
+      expect(getBackSelectionState(state, sections)).toEqual({
+        currentId: 'subsection-2',
+        subsectionId: 'subsection-2',
+        sectionId: 'section-1',
+        index: 1,
+      });
+    });
+
+    it('returns subsection selection with undefined index when section missing', () => {
+      const state: SelectionState = {
+        currentId: 'unit-1',
+        subsectionId: 'subsection-2',
+        sectionId: 'missing-section',
+      };
+
+      expect(getBackSelectionState(state, sections)).toEqual({
+        currentId: 'subsection-2',
+        subsectionId: 'subsection-2',
+        sectionId: 'missing-section',
+        index: undefined,
+      });
+    });
+
+    it('uses selectedSection for index when sections list lacks children', () => {
+      const state: SelectionState = {
+        currentId: 'unit-1',
+        subsectionId: 'subsection-2',
+        sectionId: 'section-1',
+      };
+
+      const selectedSection = {
+        id: 'section-1',
+        childInfo: { children: [{ id: 'subsection-1' }, { id: 'subsection-2' }] },
+      } as any;
+
+      expect(getBackSelectionState(state, [{ id: 'section-1' }] as any, selectedSection)).toEqual({
+        currentId: 'subsection-2',
+        subsectionId: 'subsection-2',
+        sectionId: 'section-1',
+        index: 1,
+      });
+    });
+  });
+
+  describe('navigateBackFromSelection', () => {
+    it('opens parent and propagates selection when back target exists', () => {
+      const openContainer = jest.fn();
+      const clearSelection = jest.fn();
+      const onSelectionChange = jest.fn();
+
+      navigateBackFromSelection({
+        selectedContainerState: {
+          currentId: 'unit-1',
+          subsectionId: 'subsection-1',
+          sectionId: 'section-1',
+        },
+        sections,
+        openContainer,
+        clearSelection,
+        onSelectionChange,
+      });
+
+      expect(openContainer).toHaveBeenCalledWith('subsection-1', 'subsection-1', 'section-1', 0);
+      expect(onSelectionChange).toHaveBeenCalledWith({
+        currentId: 'subsection-1',
+        subsectionId: 'subsection-1',
+        sectionId: 'section-1',
+        index: 0,
+      });
+      expect(clearSelection).not.toHaveBeenCalled();
+    });
+
+    it('clears selection and propagates undefined when no back target', () => {
+      const openContainer = jest.fn();
+      const clearSelection = jest.fn();
+      const onSelectionChange = jest.fn();
+
+      navigateBackFromSelection({
+        selectedContainerState: {
+          currentId: 'section-1',
+          sectionId: 'section-1',
+        },
+        sections,
+        openContainer,
+        clearSelection,
+        onSelectionChange,
+      });
+
+      expect(clearSelection).toHaveBeenCalled();
+      expect(onSelectionChange).toHaveBeenCalledWith(undefined);
+      expect(openContainer).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/course-outline/outline-sidebar/back-navigation.test.ts
+++ b/src/course-outline/outline-sidebar/back-navigation.test.ts
@@ -1,5 +1,5 @@
 import { SelectionState } from '@src/data/types';
-import { getBackSelectionState, navigateBackFromSelection } from './back-navigation';
+import { getBackSelectionState, openSelectionState } from './back-navigation';
 
 describe('back-navigation', () => {
   const sections = [
@@ -102,53 +102,18 @@ describe('back-navigation', () => {
     });
   });
 
-  describe('navigateBackFromSelection', () => {
-    it('opens parent and propagates selection when back target exists', () => {
+  describe('openSelectionState', () => {
+    it('opens container with SelectionState payload', () => {
       const openContainer = jest.fn();
-      const clearSelection = jest.fn();
-      const onSelectionChange = jest.fn();
 
-      navigateBackFromSelection({
-        selectedContainerState: {
-          currentId: 'unit-1',
-          subsectionId: 'subsection-1',
-          sectionId: 'section-1',
-        },
-        sections,
-        openContainer,
-        clearSelection,
-        onSelectionChange,
-      });
-
-      expect(openContainer).toHaveBeenCalledWith('subsection-1', 'subsection-1', 'section-1', 0);
-      expect(onSelectionChange).toHaveBeenCalledWith({
+      openSelectionState(openContainer, {
         currentId: 'subsection-1',
         subsectionId: 'subsection-1',
         sectionId: 'section-1',
         index: 0,
       });
-      expect(clearSelection).not.toHaveBeenCalled();
-    });
 
-    it('clears selection and propagates undefined when no back target', () => {
-      const openContainer = jest.fn();
-      const clearSelection = jest.fn();
-      const onSelectionChange = jest.fn();
-
-      navigateBackFromSelection({
-        selectedContainerState: {
-          currentId: 'section-1',
-          sectionId: 'section-1',
-        },
-        sections,
-        openContainer,
-        clearSelection,
-        onSelectionChange,
-      });
-
-      expect(clearSelection).toHaveBeenCalled();
-      expect(onSelectionChange).toHaveBeenCalledWith(undefined);
-      expect(openContainer).not.toHaveBeenCalled();
+      expect(openContainer).toHaveBeenCalledWith('subsection-1', 'subsection-1', 'section-1', 0);
     });
   });
 });

--- a/src/course-outline/outline-sidebar/back-navigation.ts
+++ b/src/course-outline/outline-sidebar/back-navigation.ts
@@ -1,4 +1,8 @@
+import { useCallback } from 'react';
+import { useCourseOutlineContext } from '@src/course-outline/CourseOutlineContext';
 import { SelectionState, XBlock } from '@src/data/types';
+import { useCourseItemData } from '@src/course-outline/data/apiHooks';
+import { useOutlineSidebarContext } from './OutlineSidebarContext';
 
 /**
  * Function signature shared by sidebar container openers.
@@ -15,22 +19,11 @@ type OpenContainerFn = (
 ) => void;
 
 /**
- * Inputs for generic "back" navigation resolution.
+ * Inputs for useBackNavigation hook.
  */
-type NavigateBackOptions = {
-  /** Current selection state in sidebar context. */
-  selectedContainerState: SelectionState | undefined;
-  /** Sections list from course outline context (used for parent index lookup). */
-  sections: Array<XBlock>;
+type UseBackNavigationOptions = {
   /** Callback used to open a container sidebar (align/info/add flavors). */
   openContainer: OpenContainerFn;
-  /** Fallback action when no parent target exists. */
-  clearSelection: () => void;
-  /**
-   * Optional authoritative selected section payload.
-   * Useful when section list is partial/minimal in tests or callers.
-   */
-  selectedSection?: XBlock;
   /** Optional hook to sync external selection state (e.g. align view selection). */
   onSelectionChange?: (selectionState?: SelectionState) => void;
 };
@@ -51,31 +44,34 @@ export const openSelectionState = (
 };
 
 /**
- * Execute generic back navigation for outline sidebars.
+ * Hook that returns standardized sidebar "back" handler.
  *
- * Flow:
- * 1) Compute parent selection state.
- * 2) If parent exists, open parent and optionally sync external selection.
- * 3) Else clear selection and optionally sync undefined.
+ * It pulls required state from context/hooks:
+ * - selectedContainerState + clearSelection (sidebar context)
+ * - sections (course outline context)
+ * - selected section data via useCourseItemData (React Query cache)
  */
-export const navigateBackFromSelection = ({
-  selectedContainerState,
-  sections,
-  openContainer,
-  clearSelection,
-  selectedSection,
-  onSelectionChange,
-}: NavigateBackOptions) => {
-  const backSelectionState = getBackSelectionState(selectedContainerState, sections, selectedSection);
+export const useBackNavigation = ({ openContainer, onSelectionChange }: UseBackNavigationOptions) => {
+  const { sections } = useCourseOutlineContext();
+  const { selectedContainerState, clearSelection } = useOutlineSidebarContext();
+  const { data: selectedSection } = useCourseItemData<XBlock>(
+    selectedContainerState?.sectionId,
+    undefined,
+    Boolean(selectedContainerState?.sectionId),
+  );
 
-  if (backSelectionState) {
-    openSelectionState(openContainer, backSelectionState);
-    onSelectionChange?.(backSelectionState);
-    return;
-  }
+  return useCallback(() => {
+    const backSelectionState = getBackSelectionState(selectedContainerState, sections, selectedSection);
 
-  clearSelection();
-  onSelectionChange?.(undefined);
+    if (backSelectionState) {
+      openSelectionState(openContainer, backSelectionState);
+      onSelectionChange?.(backSelectionState);
+      return;
+    }
+
+    clearSelection();
+    onSelectionChange?.(undefined);
+  }, [selectedContainerState, sections, selectedSection, openContainer, onSelectionChange, clearSelection]);
 };
 
 /**

--- a/src/course-outline/outline-sidebar/back-navigation.ts
+++ b/src/course-outline/outline-sidebar/back-navigation.ts
@@ -1,0 +1,137 @@
+import { SelectionState, XBlock } from '@src/data/types';
+
+/**
+ * Function signature shared by sidebar container openers.
+ *
+ * Example implementations:
+ * - openContainerSidebar
+ * - openContainerInfoSidebar
+ */
+type OpenContainerFn = (
+  containerId: string,
+  subsectionId?: string,
+  sectionId?: string,
+  index?: number,
+) => void;
+
+/**
+ * Inputs for generic "back" navigation resolution.
+ */
+type NavigateBackOptions = {
+  /** Current selection state in sidebar context. */
+  selectedContainerState: SelectionState | undefined;
+  /** Sections list from course outline context (used for parent index lookup). */
+  sections: Array<XBlock>;
+  /** Callback used to open a container sidebar (align/info/add flavors). */
+  openContainer: OpenContainerFn;
+  /** Fallback action when no parent target exists. */
+  clearSelection: () => void;
+  /**
+   * Optional authoritative selected section payload.
+   * Useful when section list is partial/minimal in tests or callers.
+   */
+  selectedSection?: XBlock;
+  /** Optional hook to sync external selection state (e.g. align view selection). */
+  onSelectionChange?: (selectionState?: SelectionState) => void;
+};
+
+/**
+ * Open sidebar using an already-computed SelectionState.
+ */
+export const openSelectionState = (
+  openContainer: OpenContainerFn,
+  selectionState: SelectionState,
+) => {
+  openContainer(
+    selectionState.currentId,
+    selectionState.subsectionId,
+    selectionState.sectionId,
+    selectionState.index,
+  );
+};
+
+/**
+ * Execute generic back navigation for outline sidebars.
+ *
+ * Flow:
+ * 1) Compute parent selection state.
+ * 2) If parent exists, open parent and optionally sync external selection.
+ * 3) Else clear selection and optionally sync undefined.
+ */
+export const navigateBackFromSelection = ({
+  selectedContainerState,
+  sections,
+  openContainer,
+  clearSelection,
+  selectedSection,
+  onSelectionChange,
+}: NavigateBackOptions) => {
+  const backSelectionState = getBackSelectionState(selectedContainerState, sections, selectedSection);
+
+  if (backSelectionState) {
+    openSelectionState(openContainer, backSelectionState);
+    onSelectionChange?.(backSelectionState);
+    return;
+  }
+
+  clearSelection();
+  onSelectionChange?.(undefined);
+};
+
+/**
+ * Resolve parent SelectionState for "back" action.
+ *
+ * Rules:
+ * - unit -> subsection
+ * - subsection -> section
+ * - section -> undefined (clear)
+ * - missing ancestry -> undefined (clear)
+ */
+export const getBackSelectionState = (
+  selectedContainerState: SelectionState | undefined,
+  sections: Array<XBlock>,
+  selectedSection?: XBlock,
+): SelectionState | undefined => {
+  const { currentId, subsectionId, sectionId } = selectedContainerState || {};
+
+  if (!currentId) {
+    return undefined;
+  }
+
+  const sectionIndex = sections.findIndex((section) => section.id === sectionId);
+  const section = sectionIndex >= 0 ? sections[sectionIndex] : undefined;
+  const sectionChildren = selectedSection?.id === sectionId
+    ? selectedSection?.childInfo?.children
+    : section?.childInfo?.children;
+  const subsectionIndex = sectionChildren?.findIndex((subsection) => subsection.id === subsectionId) ?? -1;
+
+  // Back from subsection -> section parent.
+  if (currentId === subsectionId) {
+    if (!sectionId) {
+      return undefined;
+    }
+
+    return {
+      currentId: sectionId,
+      sectionId,
+      index: sectionIndex >= 0 ? sectionIndex : undefined,
+    };
+  }
+
+  // Back from section -> no parent container in sidebar hierarchy.
+  if (currentId === sectionId) {
+    return undefined;
+  }
+
+  // Back from unit (or any deeper child) -> subsection parent.
+  if (subsectionId) {
+    return {
+      currentId: subsectionId,
+      subsectionId,
+      sectionId,
+      index: subsectionIndex >= 0 ? subsectionIndex : undefined,
+    };
+  }
+
+  return undefined;
+};

--- a/src/course-outline/outline-sidebar/info-sidebar/InfoSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/InfoSidebar.test.tsx
@@ -15,6 +15,7 @@ jest.mock('@src/course-outline/outline-sidebar/OutlineSidebarContext', () => ({
     selectedContainerState,
     clearSelection: jest.fn(),
     setSelectedContainerState: mockSetSelectedContainerState,
+    openContainerInfoSidebar: mockOpenContainerInfoSidebar,
   }),
 }));
 
@@ -39,6 +40,7 @@ const updateUnitOrderByIndex = jest.fn();
 const updateSubsectionOrderByIndex = jest.fn();
 const updateSectionOrderByIndex = jest.fn();
 const mockSetSelectedContainerState = jest.fn();
+const mockOpenContainerInfoSidebar = jest.fn();
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let mockSections: any[] = [];
 
@@ -91,6 +93,7 @@ describe('InfoSidebar component', () => {
     updateSubsectionOrderByIndex.mockClear();
     updateSectionOrderByIndex.mockClear();
     mockSetSelectedContainerState.mockClear();
+    mockOpenContainerInfoSidebar.mockClear();
     mockSections = [];
   });
 
@@ -452,6 +455,26 @@ describe('InfoSidebar component', () => {
       await screen.findByText(data.displayName);
       await screen.findByRole('button', { name: 'Item Menu' });
     };
+
+    it('goes back to parent section with section index', async () => {
+      const user = userEvent.setup();
+      mockSections = [{
+        id: 'block-v1:UNIX+UX1+2025_T3+type@chapter+block@ch1',
+        actions: { childAddable: true },
+        upstreamInfo: null,
+        childInfo: { children: [] },
+      }];
+      await renderSubsectionMenu();
+
+      await user.click(screen.getByRole('button', { name: /back/i }));
+
+      expect(mockOpenContainerInfoSidebar).toHaveBeenCalledWith(
+        'block-v1:UNIX+UX1+2025_T3+type@chapter+block@ch1',
+        undefined,
+        'block-v1:UNIX+UX1+2025_T3+type@chapter+block@ch1',
+        0,
+      );
+    });
 
     it('calls openDeleteModal when Delete is clicked in subsection menu', async () => {
       const user = userEvent.setup();

--- a/src/course-outline/outline-sidebar/info-sidebar/InfoSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/InfoSidebar.test.tsx
@@ -8,12 +8,13 @@ import { getDownstreamApiUrl } from '@src/generic/unlink-modal/data/api';
 import { InfoSidebar } from './InfoSidebar';
 
 let selectedContainerState: SelectionState | undefined;
+const mockClearSelection = jest.fn();
 jest.mock('@src/course-outline/outline-sidebar/OutlineSidebarContext', () => ({
   ...jest.requireActual('@src/course-outline/outline-sidebar/OutlineSidebarContext'),
   useOutlineSidebarContext: () => ({
     ...jest.requireActual('@src/course-outline/outline-sidebar/OutlineSidebarContext').useOutlineSidebarContext(),
     selectedContainerState,
-    clearSelection: jest.fn(),
+    clearSelection: mockClearSelection,
     setSelectedContainerState: mockSetSelectedContainerState,
     openContainerInfoSidebar: mockOpenContainerInfoSidebar,
   }),
@@ -94,6 +95,7 @@ describe('InfoSidebar component', () => {
     updateSectionOrderByIndex.mockClear();
     mockSetSelectedContainerState.mockClear();
     mockOpenContainerInfoSidebar.mockClear();
+    mockClearSelection.mockClear();
     mockSections = [];
   });
 
@@ -474,6 +476,22 @@ describe('InfoSidebar component', () => {
         'block-v1:UNIX+UX1+2025_T3+type@chapter+block@ch1',
         0,
       );
+    });
+
+    it('clears selection on back when subsection has no sectionId', async () => {
+      const user = userEvent.setup();
+      selectedContainerState = {
+        currentId: subsectionId,
+        subsectionId,
+      };
+      axiosMock.onGet(getXBlockApiUrl(subsectionId)).reply(200, subsectionData);
+      renderComponent();
+      await screen.findByText(subsectionData.displayName);
+
+      await user.click(screen.getByRole('button', { name: /back/i }));
+
+      expect(mockClearSelection).toHaveBeenCalled();
+      expect(mockOpenContainerInfoSidebar).not.toHaveBeenCalled();
     });
 
     it('calls openDeleteModal when Delete is clicked in subsection menu', async () => {

--- a/src/course-outline/outline-sidebar/info-sidebar/InfoSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/InfoSidebar.test.tsx
@@ -478,22 +478,6 @@ describe('InfoSidebar component', () => {
       );
     });
 
-    it('clears selection on back when subsection has no sectionId', async () => {
-      const user = userEvent.setup();
-      selectedContainerState = {
-        currentId: subsectionId,
-        subsectionId,
-      };
-      axiosMock.onGet(getXBlockApiUrl(subsectionId)).reply(200, subsectionData);
-      renderComponent();
-      await screen.findByText(subsectionData.displayName);
-
-      await user.click(screen.getByRole('button', { name: /back/i }));
-
-      expect(mockClearSelection).toHaveBeenCalled();
-      expect(mockOpenContainerInfoSidebar).not.toHaveBeenCalled();
-    });
-
     it('calls openDeleteModal when Delete is clicked in subsection menu', async () => {
       const user = userEvent.setup();
       await renderSubsectionMenu();

--- a/src/course-outline/outline-sidebar/info-sidebar/SubsectionInfoSidebar.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/SubsectionInfoSidebar.tsx
@@ -128,7 +128,12 @@ export const SubsectionSidebar = () => {
 
   const handleBack = () => {
     if (selectedContainerState?.sectionId) {
-      openContainerInfoSidebar(selectedContainerState.sectionId, undefined, selectedContainerState.sectionId);
+      openContainerInfoSidebar(
+        selectedContainerState.sectionId,
+        undefined,
+        selectedContainerState.sectionId,
+        sectionIndex >= 0 ? sectionIndex : undefined,
+      );
       return;
     }
     clearSelection();

--- a/src/course-outline/outline-sidebar/info-sidebar/SubsectionInfoSidebar.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/SubsectionInfoSidebar.tsx
@@ -31,6 +31,7 @@ export const SubsectionSidebar = () => {
     setCurrentTabKey,
     selectedContainerState,
     setSelectedContainerState,
+    openContainerInfoSidebar,
   } = useOutlineSidebarContext();
   const { subsectionId = '', index } = selectedContainerState ?? {};
 
@@ -125,12 +126,20 @@ export const SubsectionSidebar = () => {
     }
   };
 
+  const handleBack = () => {
+    if (selectedContainerState?.sectionId) {
+      openContainerInfoSidebar(selectedContainerState.sectionId, undefined, selectedContainerState.sectionId);
+      return;
+    }
+    clearSelection();
+  };
+
   return (
     <>
       <SidebarTitle
         title={subsectionData?.displayName || ''}
         icon={getItemIcon(subsectionData?.category || '')}
-        onBackBtnClick={clearSelection}
+        onBackBtnClick={handleBack}
         menuProps={{
           itemId: subsectionId,
           index: index ?? -1,

--- a/src/course-outline/outline-sidebar/info-sidebar/SubsectionInfoSidebar.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/SubsectionInfoSidebar.tsx
@@ -15,7 +15,7 @@ import { useOutlineSidebarContext } from '@src/course-outline/outline-sidebar/Ou
 import { getLibraryId } from '@src/generic/key-utils';
 import { possibleSubsectionMoves } from '@src/course-outline/drag-helper/utils';
 import { XBlock } from '@src/data/types';
-import { navigateBackFromSelection } from '../back-navigation';
+import { useBackNavigation } from '../back-navigation';
 
 import { InfoSection } from './InfoSection';
 import { PublishButon } from './PublishButon';
@@ -27,7 +27,6 @@ export const SubsectionSidebar = () => {
   const navigate = useNavigate();
 
   const {
-    clearSelection,
     currentTabKey,
     setCurrentTabKey,
     selectedContainerState,
@@ -59,6 +58,10 @@ export const SubsectionSidebar = () => {
     openDeleteModal,
   } = useCourseOutlineContext();
   const sectionIndex = sections.findIndex((s) => s.id === selectedContainerState?.sectionId);
+
+  const handleBack = useBackNavigation({
+    openContainer: openContainerInfoSidebar,
+  });
 
   const handlePublish = () => {
     if (selectedContainerState?.sectionId && subsectionData?.hasChanges) {
@@ -125,16 +128,6 @@ export const SubsectionSidebar = () => {
         );
       }
     }
-  };
-
-  const handleBack = () => {
-    navigateBackFromSelection({
-      selectedContainerState,
-      sections,
-      selectedSection: section,
-      openContainer: openContainerInfoSidebar,
-      clearSelection,
-    });
   };
 
   return (

--- a/src/course-outline/outline-sidebar/info-sidebar/SubsectionInfoSidebar.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/SubsectionInfoSidebar.tsx
@@ -15,6 +15,7 @@ import { useOutlineSidebarContext } from '@src/course-outline/outline-sidebar/Ou
 import { getLibraryId } from '@src/generic/key-utils';
 import { possibleSubsectionMoves } from '@src/course-outline/drag-helper/utils';
 import { XBlock } from '@src/data/types';
+import { navigateBackFromSelection } from '../back-navigation';
 
 import { InfoSection } from './InfoSection';
 import { PublishButon } from './PublishButon';
@@ -127,16 +128,13 @@ export const SubsectionSidebar = () => {
   };
 
   const handleBack = () => {
-    if (selectedContainerState?.sectionId) {
-      openContainerInfoSidebar(
-        selectedContainerState.sectionId,
-        undefined,
-        selectedContainerState.sectionId,
-        sectionIndex >= 0 ? sectionIndex : undefined,
-      );
-      return;
-    }
-    clearSelection();
+    navigateBackFromSelection({
+      selectedContainerState,
+      sections,
+      selectedSection: section,
+      openContainer: openContainerInfoSidebar,
+      clearSelection,
+    });
   };
 
   return (

--- a/src/course-outline/outline-sidebar/info-sidebar/UnitInfoSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/UnitInfoSidebar.test.tsx
@@ -169,4 +169,81 @@ describe('UnitSidebar', () => {
     await user.click(screen.getByRole('tab', { name: /Settings/i }));
     expect(screen.getByText('GenericUnitInfoSettings')).toBeInTheDocument();
   });
+
+  it('back opens subsection info sidebar when subsectionId exists', async () => {
+    const user = userEvent.setup();
+    const openContainerInfoSidebar = jest.fn();
+    outlineContext.useOutlineSidebarContext.mockReturnValue({
+      selectedContainerState: { currentId: 'unit-5', sectionId: 's1', subsectionId: 'ss1' },
+      clearSelection: jest.fn(),
+      openContainerInfoSidebar,
+      setSelectedContainerState: jest.fn(),
+      currentTabKey: 'info',
+      setCurrentTabKey: jest.fn(),
+    });
+    outlineCtx.useCourseOutlineContext.mockReturnValue({
+      openPublishModal: jest.fn(),
+      handleDuplicateUnitSubmit: jest.fn(),
+      sections: [{ id: 's1' }],
+      updateUnitOrderByIndex: jest.fn(),
+      openDeleteModal: jest.fn(),
+    });
+    apiHooks.useCourseItemData.mockImplementation((id: string) => {
+      if (id === 's1') {
+        return {
+          data: { id: 's1', childInfo: { children: [{ id: 'ss1' }] } },
+          isPending: false,
+        };
+      }
+      if (id === 'ss1') {
+        return {
+          data: { id: 'ss1', childInfo: { children: [] } },
+          isPending: false,
+        };
+      }
+      return {
+        data: {
+          displayName: 'Unit 5',
+          hasChanges: false,
+          category: 'vertical',
+          id: 'unit-5',
+          actions: { deletable: true, duplicable: true },
+        },
+        isPending: false,
+      };
+    });
+
+    render(<UnitSidebar />);
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+
+    expect(openContainerInfoSidebar).toHaveBeenCalledWith('ss1', 'ss1', 's1', 0);
+  });
+
+  it('back clears selection when subsectionId missing', async () => {
+    const user = userEvent.setup();
+    const clearSelection = jest.fn();
+    outlineContext.useOutlineSidebarContext.mockReturnValue({
+      selectedContainerState: { currentId: 'unit-6', sectionId: 's1' },
+      clearSelection,
+      openContainerInfoSidebar: jest.fn(),
+      setSelectedContainerState: jest.fn(),
+      currentTabKey: 'info',
+      setCurrentTabKey: jest.fn(),
+    });
+    apiHooks.useCourseItemData.mockReturnValue({
+      data: {
+        displayName: 'Unit 6',
+        hasChanges: false,
+        category: 'vertical',
+        id: 'unit-6',
+        actions: { deletable: true, duplicable: true },
+      },
+      isPending: false,
+    });
+
+    render(<UnitSidebar />);
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+
+    expect(clearSelection).toHaveBeenCalled();
+  });
 });

--- a/src/course-outline/outline-sidebar/info-sidebar/UnitInfoSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/UnitInfoSidebar.test.tsx
@@ -218,32 +218,4 @@ describe('UnitSidebar', () => {
 
     expect(openContainerInfoSidebar).toHaveBeenCalledWith('ss1', 'ss1', 's1', 0);
   });
-
-  it('back clears selection when subsectionId missing', async () => {
-    const user = userEvent.setup();
-    const clearSelection = jest.fn();
-    outlineContext.useOutlineSidebarContext.mockReturnValue({
-      selectedContainerState: { currentId: 'unit-6', sectionId: 's1' },
-      clearSelection,
-      openContainerInfoSidebar: jest.fn(),
-      setSelectedContainerState: jest.fn(),
-      currentTabKey: 'info',
-      setCurrentTabKey: jest.fn(),
-    });
-    apiHooks.useCourseItemData.mockReturnValue({
-      data: {
-        displayName: 'Unit 6',
-        hasChanges: false,
-        category: 'vertical',
-        id: 'unit-6',
-        actions: { deletable: true, duplicable: true },
-      },
-      isPending: false,
-    });
-
-    render(<UnitSidebar />);
-    await user.click(screen.getByRole('button', { name: 'Back' }));
-
-    expect(clearSelection).toHaveBeenCalled();
-  });
 });

--- a/src/course-outline/outline-sidebar/info-sidebar/UnitInfoSidebar.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/UnitInfoSidebar.tsx
@@ -75,6 +75,7 @@ export const UnitSidebar = () => {
     currentTabKey,
     setCurrentTabKey,
     setSelectedContainerState,
+    openContainerInfoSidebar,
   } = useOutlineSidebarContext();
   const {
     currentId: unitId = /* istanbul ignore next */ '',
@@ -209,12 +210,25 @@ export const UnitSidebar = () => {
     showToast(intl.formatMessage(messages.locationCopiedText));
   };
 
+  const handleBack = () => {
+    if (selectedContainerState?.subsectionId) {
+      openContainerInfoSidebar(
+        selectedContainerState.subsectionId,
+        selectedContainerState.subsectionId,
+        selectedContainerState.sectionId,
+        subsectionIndex >= 0 ? subsectionIndex : undefined,
+      );
+      return;
+    }
+    clearSelection();
+  };
+
   return (
     <>
       <SidebarTitle
         title={unitData?.displayName || ''}
         icon={getItemIcon(unitData?.category || '')}
-        onBackBtnClick={clearSelection}
+        onBackBtnClick={handleBack}
         menuProps={{
           itemId: unitId,
           index: index ?? -1,

--- a/src/course-outline/outline-sidebar/info-sidebar/UnitInfoSidebar.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/UnitInfoSidebar.tsx
@@ -35,6 +35,7 @@ import { InfoSection } from './InfoSection';
 import { useClipboard } from '@src/generic/clipboard';
 import { ToastContext } from '@src/generic/toast-context';
 import { XBlock } from '@src/data/types';
+import { navigateBackFromSelection } from '../back-navigation';
 interface Props {
   unitId: string;
 }
@@ -211,16 +212,13 @@ export const UnitSidebar = () => {
   };
 
   const handleBack = () => {
-    if (selectedContainerState?.subsectionId) {
-      openContainerInfoSidebar(
-        selectedContainerState.subsectionId,
-        selectedContainerState.subsectionId,
-        selectedContainerState.sectionId,
-        subsectionIndex >= 0 ? subsectionIndex : undefined,
-      );
-      return;
-    }
-    clearSelection();
+    navigateBackFromSelection({
+      selectedContainerState,
+      sections,
+      selectedSection: section,
+      openContainer: openContainerInfoSidebar,
+      clearSelection,
+    });
   };
 
   return (

--- a/src/course-outline/outline-sidebar/info-sidebar/UnitInfoSidebar.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/UnitInfoSidebar.tsx
@@ -35,7 +35,7 @@ import { InfoSection } from './InfoSection';
 import { useClipboard } from '@src/generic/clipboard';
 import { ToastContext } from '@src/generic/toast-context';
 import { XBlock } from '@src/data/types';
-import { navigateBackFromSelection } from '../back-navigation';
+import { useBackNavigation } from '../back-navigation';
 interface Props {
   unitId: string;
 }
@@ -72,7 +72,6 @@ export const UnitSidebar = () => {
   const navigate = useNavigate();
   const {
     selectedContainerState,
-    clearSelection,
     currentTabKey,
     setCurrentTabKey,
     setSelectedContainerState,
@@ -112,6 +111,10 @@ export const UnitSidebar = () => {
   ) ?? -1;
   const { copyToClipboard } = useClipboard();
   const { showToast } = useContext(ToastContext);
+
+  const handleBack = useBackNavigation({
+    openContainer: openContainerInfoSidebar,
+  });
 
   const handlePublish = () => {
     if (unitData?.hasChanges) {
@@ -209,16 +212,6 @@ export const UnitSidebar = () => {
       document.body.removeChild(textarea);
     }
     showToast(intl.formatMessage(messages.locationCopiedText));
-  };
-
-  const handleBack = () => {
-    navigateBackFromSelection({
-      selectedContainerState,
-      sections,
-      selectedSection: section,
-      openContainer: openContainerInfoSidebar,
-      clearSelection,
-    });
   };
 
   return (

--- a/src/studio-home/tabs-section/messages.ts
+++ b/src/studio-home/tabs-section/messages.ts
@@ -69,7 +69,7 @@ const messages = defineMessages({
   },
   alertDescriptionV1: {
     id: 'studio-home.libraries.migrate-alert.description-v1',
-    defaultMessage: 'In a future release, legacy libraries will no longer be supported.'
+    defaultMessage: 'In the Willow release, legacy libraries will no longer be supported.'
       + ' The new libraries experience allows you to author sections, subsections, units,'
       + ' and components to reuse across your courses. Content from legacy libraries can be'
       + ' migrated to the new experience.',


### PR DESCRIPTION
## Description

Fix sidebar back-navigation behavior in Course Outline so parent container selection stays consistent.

Latest changes:
- Add/back flows now navigate to correct parent container instead of always clearing selection.
- Preserve and pass parent index when navigating back (`section` / `subsection`) so sidebar state remains stable.
- Apply same behavior across:
  - Align sidebar (`OutlineAlignSidebar`)
  - Add sidebar (`AddSidebar`)
  - Info sidebars (`SubsectionInfoSidebar`, `UnitInfoSidebar`)

Also update legacy libraries warning copy in Studio Home tabs section.

Change text from generic future release message to Willow-specific timeline:

* Before: In a future release, legacy libraries will no longer be supported.
* After: In the Willow release, legacy libraries will no longer be supported.

Impact:
- Role: Course Author

## Supporting information

- Fixes https://github.com/openedx/frontend-app-authoring/issues/2876#issuecomment-4238853996
- Fixes https://github.com/openedx/frontend-app-authoring/issues/2787#issuecomment-4245936448
- `Private-ref`: https://tasks.opencraft.com/browse/FAL-4338

## Testing instructions

1. Open Course Outline and select a unit/subsection/section.
2. Use back navigation from:
   - Align sidebar
   - Add sidebar
   - Subsection/Unit info sidebars
3. Verify navigation returns to correct parent container.
4. Verify parent index is preserved (no jump/reset in sidebar selection).

For warning update:

1. Open Studio Home where libraries migration alert appears.
1. Verify alert body shows: In the Willow release, legacy libraries will no longer be supported.
1. Confirm remaining alert paragraph text unchanged.


## Other information

- Dependencies: None.

## Best Practices Checklist

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
