### PR TITLE
fix: hydrate authenticated user in Studio

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -198,4 +198,5 @@ initialize({
   },
   messages,
   requireAuthenticatedUser: true,
+  hydrateAuthenticatedUser: true,
 });


### PR DESCRIPTION
## Description

Studio needs hydrated authenticated-user account data so the header can receive uploaded Open edX profile image metadata.

The initial JWT-derived `authenticatedUser` object contains sparse identity data, but uploaded profile image URLs are exposed by the account API under `authenticatedUser.profileImage` after authenticated-user hydration. This change enables that existing `frontend-platform` hydration path for Studio by adding:

```js
hydrateAuthenticatedUser: true
```

to the app initialization options.

## Dependency / Staging Note

Draft until the header package change is released.

This PR depends on:

- https://github.com/openedx/frontend-component-header/pull/670

That PR teaches `StudioHeader` to use hydrated `authenticatedUser.profileImage` data while preserving the legacy `authenticatedUser.avatar` contract.

Before this PR is ready to merge, `frontend-app-authoring` should update `@edx/frontend-component-header` and `package-lock.json` to the released package version that includes the header normalization. Without that package update, this PR enables hydration but the app still consumes the currently locked header package, so the uploaded avatar will not render yet.

## Testing

```bash
npm run types
```

Related package verification from `frontend-component-header`:

```bash
npm test -- --runTestsByPath src/studio-header/StudioHeader.test.tsx --runInBand
npm run types
```

## AI Use Disclosure
Codex was used in the generation of the PR text. 