### PR TITLE
backport fix: restore republish on unit visibility change from outline configure modal

### DIFF
--- a/src/course-outline/data/api.ts
+++ b/src/course-outline/data/api.ts
@@ -318,7 +318,7 @@ export async function configureCourseSubsection(
  */
 export async function configureCourseUnit(variables: ConfigureUnitData): Promise<object> {
   const body = {
-    publish: variables.groupAccess ? null : variables.type,
+    publish: variables.type,
     ...(variables.type === PUBLISH_TYPES.republish ?
       {
         metadata: {

--- a/src/course-unit/CourseUnit.test.tsx
+++ b/src/course-unit/CourseUnit.test.tsx
@@ -1465,7 +1465,7 @@ describe('<CourseUnit />', () => {
 
     axiosMock
       .onPost(getXBlockBaseApiUrl(courseSectionVerticalMock.xblock_info.id), {
-        publish: null,
+        publish: 'republish',
         metadata: { visible_to_staff_only: true, group_access: { 50: [2] }, discussion_enabled: true },
       })
       .reply(200, { dummy: 'value' });


### PR DESCRIPTION
## Description

This PR backports https://github.com/openedx/frontend-app-authoring/pull/3026 to Verawood.

Useful information to include:

- Which user roles will this change impact? Course Author
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).

## Supporting information

See https://github.com/openedx/frontend-app-authoring/pull/3026

## Testing instructions

Same as in https://github.com/openedx/frontend-app-authoring/pull/3026

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
