### PR TITLE
fix: course unit sidebar slot

### DIFF
--- a/src/course-unit/CourseUnit.tsx
+++ b/src/course-unit/CourseUnit.tsx
@@ -333,7 +333,7 @@ const CourseUnit = () => {
                 showPasteUnit={showPasteUnit}
               />
             )}
-            <div className="d-flex align-items-baseline">
+            <div className="d-flex align-items-start">
               <div className="flex-fill">
                 {currentlyVisibleToStudents && (
                   <AlertMessage

--- a/src/plugin-slots/CourseAuthoringUnitSidebarSlot/index.tsx
+++ b/src/plugin-slots/CourseAuthoringUnitSidebarSlot/index.tsx
@@ -12,28 +12,31 @@ export const CourseAuthoringUnitSidebarSlot = (
     isSplitTestType,
   }: CourseAuthoringUnitSidebarSlotProps,
 ) => (
-  <PluginSlot
-    id="org.openedx.frontend.authoring.course_unit_sidebar.v2"
-    pluginProps={{
-      blockId,
-      courseId,
-      unitTitle,
-      xBlocks,
-      readOnly,
-      isUnitVerticalType,
-      isSplitTestType,
-    }}
+  <div className="pt-1" // This is to fix the vertical alignment of the sidebar
   >
-    <UnitSidebar
-      legacySidebarProps={{
+    <PluginSlot
+      id="org.openedx.frontend.authoring.course_unit_sidebar.v2"
+      pluginProps={{
+        blockId,
+        courseId,
         unitTitle,
         xBlocks,
         readOnly,
         isUnitVerticalType,
         isSplitTestType,
       }}
-    />
-  </PluginSlot>
+    >
+      <UnitSidebar
+        legacySidebarProps={{
+          unitTitle,
+          xBlocks,
+          readOnly,
+          isUnitVerticalType,
+          isSplitTestType,
+        }}
+      />
+    </PluginSlot>
+  </div>
 );
 
 type XBlock = {


### PR DESCRIPTION
## Description

This PR fixes the rendering of the slot `org.openedx.frontend.authoring.course_unit_sidebar.v2` while using `Insert` operation.

<img width="1614" height="590" alt="image" src="https://github.com/user-attachments/assets/66e91b3a-c242-454d-b054-607b020bc699" />

## Supporting information

- More info here: https://openedx.slack.com/archives/C049JQZFR5E/p1778531073403519?thread_ts=1777970505.889649&cid=C049JQZFR5E
- Similar to https://github.com/openedx/frontend-app-authoring/pull/3056

## Testing instructions

- Use the following `env.config.jsx`
```
import { PLUGIN_OPERATIONS, DIRECT_PLUGIN } from '@openedx/frontend-plugin-framework';

import { Card } from "@openedx/paragon"

const config = {
  pluginSlots: {
    'org.openedx.frontend.authoring.course_unit_sidebar.v2': {
      keepDefault: true,
      plugins: [
        {
          op: PLUGIN_OPERATIONS.Insert,
          widget: {
              id: 'course-unit-sidebar',
              priority: 1,
              type: DIRECT_PLUGIN,
              RenderWidget: () => <Card><Card.Header title="v2"/></Card>,
          },
        },
        {
            op: PLUGIN_OPERATIONS.Wrap,
            widgetId: 'default_contents',
            wrapper: ({component}) => <div style={{ border: 'thick dashed green' }}>{component}</div>,
        },
      ],
    },
  },
};

export default config;
```
- Check that the `v2` card is rendered before the sidebar, and you have a green dashed line around the sidebar.
- This should work for the `ENABLE_UNIT_PAGE_NEW_DESIGN` flag set to `true` or `false`.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
