### PR TITLE
fix: course sidebar slot

### DIFF
--- a/src/course-outline/CourseOutline.tsx
+++ b/src/course-outline/CourseOutline.tsx
@@ -247,7 +247,7 @@ const CourseOutline = () => {
             handleVideoSharingOptionChange={handleVideoSharingOptionChange}
           />
           <hr className="mt-4 mb-0 w-100 text-light-400" />
-          <div className="d-flex align-items-baseline">
+          <div className="d-flex align-items-start">
             <div className="flex-fill">
               <article>
                 <div>

--- a/src/plugin-slots/CourseAuthoringOutlineSidebarSlot/index.tsx
+++ b/src/plugin-slots/CourseAuthoringOutlineSidebarSlot/index.tsx
@@ -7,17 +7,19 @@ export const CourseAuthoringOutlineSidebarSlot = ({
   courseName,
   sections,
 }: CourseAuthoringOutlineSidebarSlotProps) => (
-  <PluginSlot
-    id="org.openedx.frontend.authoring.course_outline_sidebar.v1"
-    idAliases={['course_authoring_outline_sidebar_slot']}
-    pluginProps={{
-      courseId,
-      courseName,
-      sections,
-    }}
-  >
-    <OutlineSideBar />
-  </PluginSlot>
+  <div>
+    <PluginSlot
+      id="org.openedx.frontend.authoring.course_outline_sidebar.v1"
+      idAliases={['course_authoring_outline_sidebar_slot']}
+      pluginProps={{
+        courseId,
+        courseName,
+        sections,
+      }}
+    >
+      <OutlineSideBar />
+    </PluginSlot>
+  </div>
 );
 
 type Section = {


### PR DESCRIPTION
## Description

This PR fixes the rendering of the slot `org.openedx.frontend.authoring.course_outline_sidebar.v1` while using `Insert` operation.

<img width="1623" height="536" alt="image" src="https://github.com/user-attachments/assets/ced0e066-7993-4b66-af5f-4df735b81e29" />

## Supporting information

- More info here: https://openedx.slack.com/archives/C049JQZFR5E/p1778531073403519?thread_ts=1777970505.889649&cid=C049JQZFR5E
- Similar to https://github.com/openedx/frontend-app-authoring/pull/3055

## Testing instructions

- Use the following `env.config.jsx`
```
import { PLUGIN_OPERATIONS, DIRECT_PLUGIN } from '@openedx/frontend-plugin-framework';

import { Card } from "@openedx/paragon"

const config = {
  pluginSlots: {
    'org.openedx.frontend.authoring.course_outline_sidebar.v1': {
      keepDefault: true,
      plugins: [
        {
          op: PLUGIN_OPERATIONS.Insert,
          widget: {
              id: 'course-sidebar',
              priority: 1,
              type: DIRECT_PLUGIN,
              RenderWidget: () => <Card><Card.Header title="v1"/></Card>,
          },
        },
        {
            op: PLUGIN_OPERATIONS.Wrap,
            widgetId: 'default_contents',
            wrapper: ({component}) => <div style={{ border: 'thick dashed green' }}>{component}</div>,
        },
      ],
    },
  },
};

export default config;
```
- Check that the `v1` card is rendered before the sidebar, and you have a green dashed line around the sidebar.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`