### PR TITLE
fix: make sidebar sticky, fix styles, responsiveness, scroll and remove padding

### DIFF
--- a/src/generic/resizable/Resizable.tsx
+++ b/src/generic/resizable/Resizable.tsx
@@ -62,13 +62,13 @@ export const ResizableBox = ({
 
   return (
     <div
-      className="resizable"
+      className="resizable align-self-stretch d-flex"
       ref={boxRef}
       style={{ width: `${width}px` }}
     >
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex, jsx-a11y/no-static-element-interactions */}
       <div className="resizable-handle" onMouseDown={onMouseDown} />
-      <div className="w-100">
+      <div className="w-100 d-flex">
         {children}
       </div>
     </div>

--- a/src/generic/sidebar/Sidebar.tsx
+++ b/src/generic/sidebar/Sidebar.tsx
@@ -96,7 +96,7 @@ export function Sidebar<T extends SidebarPages>({
   const activeKey = isOpen ? currentPageKey : undefined;
 
   return (
-    <Stack direction="horizontal" className="sidebar align-items-baseline ml-3" gap={2}>
+    <Stack direction="horizontal" className="align-items-baseline flex-fill overflow-hidden" gap={2}>
       {(isOpen && !!currentPageKey) ?
         (
           <ResizableBox>

--- a/src/generic/sidebar/index.scss
+++ b/src/generic/sidebar/index.scss
@@ -2,14 +2,16 @@
   position: sticky;
   top: 0;
   align-self: flex-start;
+  height: 100vh;
   max-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  margin-left: 1rem;
 
   .sidebar-content {
     flex: 0 1 auto;
     min-width: 440px;
-    overflow-y: auto;
-    height: 100vh;
-    max-height: 100vh;
+    overflow: hidden auto;
 
     /*
      * Change the styles for tabs in all sidebars.

--- a/src/plugin-slots/CourseAuthoringOutlineSidebarSlot/index.tsx
+++ b/src/plugin-slots/CourseAuthoringOutlineSidebarSlot/index.tsx
@@ -7,7 +7,7 @@ export const CourseAuthoringOutlineSidebarSlot = ({
   courseName,
   sections,
 }: CourseAuthoringOutlineSidebarSlotProps) => (
-  <div>
+  <div className="sidebar">
     <PluginSlot
       id="org.openedx.frontend.authoring.course_outline_sidebar.v1"
       idAliases={['course_authoring_outline_sidebar_slot']}

--- a/src/plugin-slots/CourseAuthoringUnitSidebarSlot/index.tsx
+++ b/src/plugin-slots/CourseAuthoringUnitSidebarSlot/index.tsx
@@ -1,5 +1,8 @@
 import { PluginSlot } from '@openedx/frontend-plugin-framework/dist';
+import classNames from 'classnames';
+
 import { UnitSidebar } from '@src/course-unit/unit-sidebar/UnitSidebar';
+import { isUnitPageNewDesignEnabled } from '@src/course-unit/utils';
 
 export const CourseAuthoringUnitSidebarSlot = (
   {
@@ -12,7 +15,8 @@ export const CourseAuthoringUnitSidebarSlot = (
     isSplitTestType,
   }: CourseAuthoringUnitSidebarSlotProps,
 ) => (
-  <div className="pt-1" // This is to fix the vertical alignment of the sidebar
+  <div
+    className={classNames({ 'sidebar': isUnitPageNewDesignEnabled() })}
   >
     <PluginSlot
       id="org.openedx.frontend.authoring.course_unit_sidebar.v2"


### PR DESCRIPTION
## Description

This PR fixes an issue introduced by https://github.com/openedx/frontend-app-authoring/pull/3056 and https://github.com/openedx/frontend-app-authoring/pull/3055, in which the sidebar lost its sticky style after adding a div to wrap it, alongside some styles, responsiveness, and scroll.

It also removes the padding added by #3055, which causes misalignment with the main content on the left.

## Supporting information

- Related to https://github.com/openedx/frontend-app-authoring/pull/3055#issuecomment-4426845043

## Testing instructions
- Checkout this PR and run `npm run build`
- Check with the following `env.config.jsx` to see the behaviour with insert/wrapping components:
```
import { PLUGIN_OPERATIONS, DIRECT_PLUGIN } from '@openedx/frontend-plugin-framework';

import { Card } from "@openedx/paragon"

const config = {
  pluginSlots: {
    'org.openedx.frontend.authoring.course_unit_sidebar.v2': {
      keepDefault: true,
      plugins: [
        {
          op: PLUGIN_OPERATIONS.Insert,
          widget: {
              id: 'course-unit-sidebar',
              priority: 1,
              type: DIRECT_PLUGIN,
              RenderWidget: () => <Card><Card.Header title="v2"/></Card>,
          },
        },
        {
            op: PLUGIN_OPERATIONS.Wrap,
            widgetId: 'default_contents',
            wrapper: ({component}) => (
                <div className="flex-fill d-flex overflow-hidden" style={{ border: 'thick dashed green' }}>
                    {component}
                </div>
            ),
        },
      ],
    },
    'org.openedx.frontend.authoring.course_outline_sidebar.v1': {
      keepDefault: true,
      plugins: [
        {
          op: PLUGIN_OPERATIONS.Insert,
          widget: {
              id: 'course-sidebar',
              priority: 1,
              type: DIRECT_PLUGIN,
              RenderWidget: () => <Card><Card.Header title="v2"/></Card>,
          },
        },
        {
            op: PLUGIN_OPERATIONS.Wrap,
            widgetId: 'default_contents',
            wrapper: ({component}) => (
                <div className="flex-fill d-flex overflow-hidden" style={{ border: 'thick dashed green' }}>
                    {component}
                </div>
            ),
        },
      ],
    },
  },
};

export default config;
```
**Note**: The flex classes in the wrapping divs are necessary so the content adapts to the remaining space correctly.

- Check that the sidebar on both Course Outline and Unit Outline has `100vh` and occupies the whole left while scrolling.
- Resize your browser vertically and check if a scrollbar is shown inside the sidebar, and you can see the whole content.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`