### PR TITLE
fix: Sync pagination state after course data fetch

### DIFF
--- a/src/studio-home/data/thunks.js
+++ b/src/studio-home/data/thunks.js
@@ -44,7 +44,9 @@ function fetchStudioHomeData(
       try {
         const coursesData = await getStudioHomeCoursesV2(search || '', requestParams);
         dispatch(fetchCourseDataSuccessV2(coursesData));
-        dispatch(updateStudioHomeCoursesCustomParams({ currentPage: requestParams.page || 1 }));
+        const searchPage = search ? parseInt(new URLSearchParams(search).get('page'), 10) : NaN;
+        const fetchedPage = requestParams.page || (!Number.isNaN(searchPage) && searchPage > 0 ? searchPage : 1);
+        dispatch(updateStudioHomeCoursesCustomParams({ currentPage: fetchedPage }));
         dispatch(updateLoadingStatuses({ courseLoadingStatus: RequestStatus.SUCCESSFUL }));
       } catch {
         dispatch(updateLoadingStatuses({ courseLoadingStatus: RequestStatus.FAILED }));

--- a/src/studio-home/data/thunks.js
+++ b/src/studio-home/data/thunks.js
@@ -10,6 +10,7 @@ import {
   updateLoadingStatuses,
   updateSavingStatuses,
   fetchCourseDataSuccessV2,
+  updateStudioHomeCoursesCustomParams,
 } from './slice';
 
 /**
@@ -43,6 +44,7 @@ function fetchStudioHomeData(
       try {
         const coursesData = await getStudioHomeCoursesV2(search || '', requestParams);
         dispatch(fetchCourseDataSuccessV2(coursesData));
+        dispatch(updateStudioHomeCoursesCustomParams({ currentPage: requestParams.page || 1 }));
         dispatch(updateLoadingStatuses({ courseLoadingStatus: RequestStatus.SUCCESSFUL }));
       } catch {
         dispatch(updateLoadingStatuses({ courseLoadingStatus: RequestStatus.FAILED }));

--- a/src/studio-home/data/thunks.test.js
+++ b/src/studio-home/data/thunks.test.js
@@ -1,0 +1,78 @@
+import MockAdapter from 'axios-mock-adapter';
+import { initializeMockApp } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+import { fetchStudioHomeData } from './thunks';
+import { getApiBaseUrl, getStudioHomeApiUrl } from './api';
+import {
+  generateGetStudioCoursesApiResponseV2,
+  generateGetStudioHomeDataApiResponse,
+} from '../factories/mockApiResponses';
+
+let axiosMock;
+let dispatch;
+
+describe('fetchStudioHomeData thunk', () => {
+  beforeEach(() => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: true,
+        roles: [],
+      },
+    });
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    dispatch = jest.fn();
+
+    axiosMock.onGet(getStudioHomeApiUrl()).reply(200, generateGetStudioHomeDataApiResponse());
+    axiosMock.onGet(new RegExp(`${getApiBaseUrl()}/api/contentstore/v2/home/courses.*`))
+      .reply(200, generateGetStudioCoursesApiResponseV2());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should sync currentPage from requestParams.page after fetching courses', async () => {
+    const requestParams = { page: 3 };
+    await fetchStudioHomeData('', false, requestParams)(dispatch);
+
+    const updateParamsCall = dispatch.mock.calls.find(
+      ([action]) => action.type === 'studioHome/updateStudioHomeCoursesCustomParams',
+    );
+    expect(updateParamsCall).toBeDefined();
+    expect(updateParamsCall[0].payload).toEqual({ currentPage: 3 });
+  });
+
+  it('should sync currentPage from search query string when page is not in requestParams', async () => {
+    await fetchStudioHomeData('?page=2', false, {})(dispatch);
+
+    const updateParamsCall = dispatch.mock.calls.find(
+      ([action]) => action.type === 'studioHome/updateStudioHomeCoursesCustomParams',
+    );
+    expect(updateParamsCall).toBeDefined();
+    expect(updateParamsCall[0].payload).toEqual({ currentPage: 2 });
+  });
+
+  it('should default currentPage to 1 when page is not specified anywhere', async () => {
+    await fetchStudioHomeData('', false, {})(dispatch);
+
+    const updateParamsCall = dispatch.mock.calls.find(
+      ([action]) => action.type === 'studioHome/updateStudioHomeCoursesCustomParams',
+    );
+    expect(updateParamsCall).toBeDefined();
+    expect(updateParamsCall[0].payload).toEqual({ currentPage: 1 });
+  });
+
+  it('should prefer requestParams.page over search query string page', async () => {
+    const requestParams = { page: 5 };
+    await fetchStudioHomeData('?page=2', false, requestParams)(dispatch);
+
+    const updateParamsCall = dispatch.mock.calls.find(
+      ([action]) => action.type === 'studioHome/updateStudioHomeCoursesCustomParams',
+    );
+    expect(updateParamsCall).toBeDefined();
+    expect(updateParamsCall[0].payload).toEqual({ currentPage: 5 });
+  });
+});


### PR DESCRIPTION
## Description

[Edly-8271](https://projects.arbisoft.com/arbisoft/browse/EDLYPRODUCT-8271/)

When a user navigates to page 2+ on the Studio course listing page and then navigates away (via browser back button or clicking the Studio logo), returning to the listing page loads page 1 content correctly but the pagination UI still highlights the previously selected page number. This creates a mismatch between the displayed content and the active pagination indicator.

**Root cause:** The `fetchStudioHomeData` thunk fetches courses for a specific page but never syncs `currentPage` in the Redux store after a successful fetch. The `currentPage` was only being updated manually in `handlePageSelected` (on user click), but not when courses were fetched on component mount or other triggers.

**Fix:** After successfully fetching course data in the thunk, dispatch `updateStudioHomeCoursesCustomParams({ currentPage: requestParams.page || 1 })` to keep the pagination UI state in sync with the actually fetched page.

**Impacted user role:** Course Author

## Supporting information

This bug is reproducible on any Studio instance with enough courses to trigger pagination (more than one page).

## Testing instructions

1. Log in to Studio and navigate to the course listing page (`/home`). Ensure there are enough courses to have multiple pages.
2. Click **page 2** (or any page beyond 1) in the pagination control.
3. Verify page 2 content loads and page 2 is highlighted in the pagination bar.
4. Either click the **browser back button** or click the **Studio logo** to return to the listing page.
5. **Expected:** Both the content and the pagination indicator should show **page 1**.
6. **Before fix:** Page 1 content loads but the pagination bar still highlights the previously selected page.

## Other information

- This change does not depend on other changes elsewhere.
- No deprecations, migrations, security, or accessibility concerns.
- The fix is a single dispatch call added to the existing thunk, minimal surface area for side effects.

## Best Practices Checklist

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`). *(No new files added)*
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components. *(This fix updates an existing Redux field, not adding new state. Ideally this should be migrated to React Context in the future, but that's a larger refactor.)*
- [ ] Use React Query to load data from REST APIs. *(The existing thunk pattern is maintained; migrating to React Query is tracked as a TODO in the codebase.)*
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use. *(No new messages)*
- [x] Avoid using `../` in import paths.

---
