### PR TITLE
[WIP] refactor: remove useNewCourseOutlinePage flag from textbooks breadcrumb

### DIFF
--- a/src/course-checklist/ChecklistSection/ChecklistItemComment.jsx
+++ b/src/course-checklist/ChecklistSection/ChecklistItemComment.jsx
@@ -3,8 +3,6 @@ import { FormattedMessage, FormattedNumber } from '@edx/frontend-platform/i18n';
 import { Icon } from '@openedx/paragon';
 import { Link } from 'react-router-dom';
 import { ModeComment } from '@openedx/paragon/icons';
-import { getConfig } from '@edx/frontend-platform';
-import { useWaffleFlags } from '../../data/apiHooks';
 import messages from './messages';
 
 const ChecklistItemComment = ({
@@ -12,11 +10,7 @@ const ChecklistItemComment = ({
   checkId,
   data,
 }) => {
-  const waffleFlags = useWaffleFlags(courseId);
-
-  const getPathToCourseOutlinePage = (assignmentId) => (waffleFlags.useNewCourseOutlinePage
-    ? `/course/${courseId}#${assignmentId}` :
-    `${getConfig().STUDIO_BASE_URL}/course/${courseId}#${assignmentId}`);
+  const getPathToCourseOutlinePage = (assignmentId) => `/course/${courseId}#${assignmentId}`;
 
   const commentWrapper = (comment) => (
     <div className="row m-0 mt-3 pt-3 border-top align-items-center" data-identifier="comment">

--- a/src/custom-pages/CustomPages.tsx
+++ b/src/custom-pages/CustomPages.tsx
@@ -28,7 +28,6 @@ import DraggableList, { SortableItem } from '@src/generic/DraggableList';
 import ErrorAlert from '@src/editors/sharedComponents/ErrorAlerts/ErrorAlert';
 import { RequestStatus } from '@src/data/constants';
 import { useModels } from '@src/generic/model-store';
-import { useWaffleFlags } from '@src/data/apiHooks';
 import getPageHeadTitle from '@src/generic/utils';
 import { getPagePath } from '@src/utils';
 import { DeprecatedReduxState } from '@src/store';
@@ -70,8 +69,6 @@ const CustomPages = () => {
   const deletePageStatus = useSelector((state: DeprecatedReduxState) => state.customPages.deletingStatus);
   const savingStatus = useSelector(getSavingStatus);
   const loadingStatus = useSelector(getLoadingStatus);
-  const waffleFlags = useWaffleFlags(courseId);
-
   const pages = useModels('customPages', customPagesIds);
 
   const handleAddPage = () => {
@@ -128,9 +125,7 @@ const CustomPages = () => {
             links={[
               {
                 label: 'Content',
-                to: waffleFlags.useNewCourseOutlinePage
-                  ? `/course/${courseId}`
-                  : `${config.STUDIO_BASE_URL}/course/${courseId}`,
+                to: `/course/${courseId}`,
               },
               { label: 'Pages and Resources', to: getPagePath(courseId, 'true', 'tabs') },
             ]}

--- a/src/studio-home/card-item/index.tsx
+++ b/src/studio-home/card-item/index.tsx
@@ -18,7 +18,6 @@ import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
 import { Link } from 'react-router-dom';
 
-import { useWaffleFlags } from '@src/data/apiHooks';
 import { COURSE_CREATOR_STATES } from '@src/constants';
 import classNames from 'classnames';
 import { getStudioHomeData } from '../data/selectors';
@@ -248,11 +247,10 @@ export const CardItem: React.FC<Props> = ({
     courseCreatorStatus,
     rerunCreatorStatus,
   } = useSelector(getStudioHomeData);
-  const waffleFlags = useWaffleFlags();
   const cardRef = useRef<HTMLDivElement>(null);
 
   const destinationUrl: string = path ?? (
-    waffleFlags.useNewCourseOutlinePage && !isLibraries
+    !isLibraries
       ? url
       : new URL(url, getConfig().STUDIO_BASE_URL).toString()
   );

--- a/src/textbooks/Textbooks.jsx
+++ b/src/textbooks/Textbooks.jsx
@@ -12,7 +12,6 @@ import { Link } from 'react-router-dom';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
 import { RequestStatus } from '@src/data/constants';
 
-import { useWaffleFlags } from '../data/apiHooks';
 import { SavingErrorAlert } from '../generic/saving-error-alert';
 import { LoadingSpinner } from '../generic/Loading';
 import SubHeader from '../generic/sub-header/SubHeader';
@@ -28,7 +27,6 @@ import messages from './messages';
 const Textbooks = () => {
   const intl = useIntl();
   const { courseId, courseDetails } = useCourseAuthoringContext();
-  const waffleFlags = useWaffleFlags(courseId);
 
   const {
     textbooks,
@@ -44,7 +42,7 @@ const Textbooks = () => {
     handleSavingStatusDispatch,
     handleTextbookEditFormSubmit,
     handleTextbookDeleteSubmit,
-  } = useTextbooks(courseId, waffleFlags);
+  } = useTextbooks(courseId);
 
   if (isLoadingFailed) {
     return (

--- a/src/textbooks/hooks.jsx
+++ b/src/textbooks/hooks.jsx
@@ -1,6 +1,5 @@
 import { useDispatch, useSelector } from 'react-redux';
-import { useContext, useEffect } from 'react';
-import { AppContext } from '@edx/frontend-platform/react';
+import { useEffect } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { useToggle } from '@openedx/paragon';
 
@@ -20,10 +19,9 @@ import {
 } from './data/thunk';
 import messages from './messages';
 
-const useTextbooks = (courseId, waffleFlags) => {
+const useTextbooks = (courseId) => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const { config } = useContext(AppContext);
 
   const textbooks = useSelector(getTextbooksData);
   const loadingStatus = useSelector(getLoadingStatus);
@@ -35,7 +33,7 @@ const useTextbooks = (courseId, waffleFlags) => {
   const breadcrumbs = [
     {
       label: intl.formatMessage(messages.breadcrumbContent),
-      to: waffleFlags.useNewCourseOutlinePage ? `/course/${courseId}` : `${config.STUDIO_BASE_URL}/course/${courseId}`,
+      to: `/course/${courseId}`,
     },
     {
       label: intl.formatMessage(messages.breadcrumbPagesAndResources),


### PR DESCRIPTION





## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be linked here.

Useful information to include:

- Which user roles will this change impact? Common user roles are "Learner", "Course Author",
  "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).

## Supporting information

Link to other information about the change, such as GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for manually testing this change.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
