### PR TITLE
chore: remove waffle flags for legacy UI

### DIFF
--- a/src/course-checklist/ChecklistSection/ChecklistItemBody.jsx
+++ b/src/course-checklist/ChecklistSection/ChecklistItemBody.jsx
@@ -5,24 +5,18 @@ import { ActionRow, Button, Icon } from '@openedx/paragon';
 import { CheckCircle, RadioButtonUnchecked } from '@openedx/paragon/icons';
 import { getConfig } from '@edx/frontend-platform';
 
-import { useWaffleFlags } from '@src/data/apiHooks';
-
 import messages from './messages';
 
-const getUpdateLinks = (courseId, waffleFlags) => {
+const getUpdateLinks = (courseId) => {
   const baseUrl = getConfig().STUDIO_BASE_URL;
-  const isLegacyCertificateUrl = !waffleFlags.useNewCertificatesPage;
-  const isLegacyOutlineUrl = !waffleFlags.useNewCourseOutlinePage;
 
   return {
     welcomeMessage: `/course/${courseId}/course_info`,
     gradingPolicy: `/course/${courseId}/settings/grading`,
-    certificate: isLegacyCertificateUrl
-      ? `${baseUrl}/certificates/${courseId}` :
-      `/course/${courseId}/certificates`,
+    certificate: `/course/${courseId}/certificates`,
     courseDates: `/course/${courseId}/settings/details/#schedule`,
     proctoringEmail: `${baseUrl}/pages-and-resources/proctoring/settings`,
-    outline: isLegacyOutlineUrl ? `${baseUrl}/course/${courseId}` : `/course/${courseId}`,
+    outline: `/course/${courseId}`,
   };
 };
 
@@ -32,8 +26,7 @@ const ChecklistItemBody = ({
   isCompleted,
 }) => {
   const intl = useIntl();
-  const waffleFlags = useWaffleFlags(courseId);
-  const updateLinks = getUpdateLinks(courseId, waffleFlags);
+  const updateLinks = getUpdateLinks(courseId);
 
   return (
     <ActionRow>

--- a/src/course-unit/add-component/AddComponent.test.tsx
+++ b/src/course-unit/add-component/AddComponent.test.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable react/prop-types */
 import userEvent, { UserEvent } from '@testing-library/user-event';
 
-import { mockWaffleFlags } from '@src/data/apiHooks.mock';
 import { RenderResult } from '@testing-library/react';
 import {
   act,
@@ -360,19 +359,6 @@ describe('<AddComponent />', () => {
     }, expect.any(Function));
   });
 
-  it('adds a PDF block and launches the legacy iframe editor', async () => {
-    const user = userEvent.setup();
-    mockWaffleFlags({ useNewPdfEditor: false });
-    const { getByRole, queryAllByRole } = renderComponent();
-    await createPdfBlock({ getByRole, queryAllByRole, user });
-    expect(handleCreateNewCourseXBlockMock).toHaveBeenCalled();
-    expect(handleCreateNewCourseXBlockMock).toHaveBeenCalledWith({
-      parentLocator: '123',
-      type: COMPONENT_TYPES.pdf,
-      // Setting the category and not supplying an additional function launches the traditional editor.
-      category: COMPONENT_TYPES.pdf,
-    });
-  });
 
   it('verifies "Text" component selection in modal', async () => {
     const user = userEvent.setup();

--- a/src/course-unit/add-component/AddComponent.tsx
+++ b/src/course-unit/add-component/AddComponent.tsx
@@ -181,16 +181,20 @@ const AddComponent = ({
         // *in code* and not just in UI seems like a mistake in retrospect.
         //
         // There will be more of these, and soon.
-        handleCreateNewCourseXBlock(
-          { type: moduleName, parentLocator: blockId },
-          /* istanbul ignore next */
-          ({ courseKey, locator }) => {
-            setCourseId(courseKey);
-            setBlockType(moduleName ?? null);
-            setNewBlockId(locator);
-            showXBlockEditorModal();
-          },
-        );
+        if (moduleName === COMPONENT_TYPES.pdf) {
+          handleCreateNewCourseXBlock(
+            { type: moduleName, parentLocator: blockId },
+            /* istanbul ignore next */
+            ({ courseKey, locator }) => {
+              setCourseId(courseKey);
+              setBlockType(moduleName ?? null);
+              setNewBlockId(locator);
+              showXBlockEditorModal();
+            },
+          );
+        } else {
+          handleCreateNewCourseXBlock({ type: moduleName, category: moduleName, parentLocator: blockId });
+        }
         break;
       case COMPONENT_TYPES.openassessment:
         handleCreateNewCourseXBlock({ boilerplate: moduleName, category: type, parentLocator: blockId });

--- a/src/course-unit/add-component/AddComponent.tsx
+++ b/src/course-unit/add-component/AddComponent.tsx
@@ -86,7 +86,7 @@ const AddComponent = ({
   const [selectedComponents, setSelectedComponents] = useState<SelectedComponent[]>([]);
   const [usageId, setUsageId] = useState(null);
   const { sendMessageToIframe } = useIframe();
-  const { useVideoGalleryFlow, useNewPdfEditor } = useWaffleFlags(courseId ?? undefined);
+  const { useVideoGalleryFlow } = useWaffleFlags(courseId ?? undefined);
 
   const courseUnit = useSelector(getCourseUnitData);
   const sequenceId = courseUnit?.ancestorInfo?.ancestors?.[0]?.id;
@@ -181,20 +181,16 @@ const AddComponent = ({
         // *in code* and not just in UI seems like a mistake in retrospect.
         //
         // There will be more of these, and soon.
-        if (moduleName === COMPONENT_TYPES.pdf && useNewPdfEditor) {
-          handleCreateNewCourseXBlock(
-            { type: moduleName, parentLocator: blockId },
-            /* istanbul ignore next */
-            ({ courseKey, locator }) => {
-              setCourseId(courseKey);
-              setBlockType(moduleName);
-              setNewBlockId(locator);
-              showXBlockEditorModal();
-            },
-          );
-        } else {
-          handleCreateNewCourseXBlock({ type: moduleName, category: moduleName, parentLocator: blockId });
-        }
+        handleCreateNewCourseXBlock(
+          { type: moduleName, parentLocator: blockId },
+          /* istanbul ignore next */
+          ({ courseKey, locator }) => {
+            setCourseId(courseKey);
+            setBlockType(moduleName ?? null);
+            setNewBlockId(locator);
+            showXBlockEditorModal();
+          },
+        );
         break;
       case COMPONENT_TYPES.openassessment:
         handleCreateNewCourseXBlock({ boilerplate: moduleName, category: type, parentLocator: blockId });

--- a/src/course-unit/breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/course-unit/breadcrumbs/Breadcrumbs.test.tsx
@@ -151,23 +151,4 @@ describe('<Breadcrumbs />', () => {
     expect(dropdownItem).toHaveAttribute('href', url);
   });
 
-  it('falls back to window.location.href when the waffle flag is disabled', async () => {
-    const user = userEvent.setup();
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { ancestor_xblocks: [{ children: [{ display_name, url }] }] } = courseSectionVerticalMock;
-    axiosMock
-      .onGet(getApiWaffleFlagsUrl(courseId))
-      .reply(200, { useNewCourseOutlinePage: false });
-
-    const { getByText, getByRole } = renderComponent();
-
-    const dropdownBtn = getByText(breadcrumbsExpected.section.displayName);
-    await user.click(dropdownBtn);
-
-    const dropdownItem = getByRole('link', { name: display_name });
-    // We need waitFor here because the waffle flag defaults to true but asynchronously loads false from our axiosMock
-    await waitFor(() => {
-      expect(dropdownItem).toHaveAttribute('href', `${getConfig().STUDIO_BASE_URL}${url}`);
-    });
-  });
 });

--- a/src/course-unit/breadcrumbs/Breadcrumbs.tsx
+++ b/src/course-unit/breadcrumbs/Breadcrumbs.tsx
@@ -5,23 +5,15 @@ import {
   ArrowDropDown as ArrowDropDownIcon,
   ChevronRight as ChevronRightIcon,
 } from '@openedx/paragon/icons';
-import { getConfig } from '@edx/frontend-platform';
-
-import { useWaffleFlags } from '../../data/apiHooks';
 import { getCourseSectionVertical } from '../data/selectors';
 import { adoptCourseSectionUrl, subsectionFirstUnitEditUrl } from '../utils';
 
 const Breadcrumbs = ({ courseId, parentUnitId }: { courseId: string; parentUnitId: string; }) => {
   const { ancestorXblocks = [] } = useSelector(getCourseSectionVertical);
-  const waffleFlags = useWaffleFlags(courseId);
 
-  const getPathToCourseOutlinePage = (url) => (waffleFlags.useNewCourseOutlinePage
-    ? url :
-    `${getConfig().STUDIO_BASE_URL}${url}`);
+  const getPathToCourseOutlinePage = (url) => url;
 
-  const getPathToCourseUnitPage = (url) => (waffleFlags.useNewUnitPage
-    ? adoptCourseSectionUrl({ url, courseId, parentUnitId })
-    : `${getConfig().STUDIO_BASE_URL}${url}`);
+  const getPathToCourseUnitPage = (url) => adoptCourseSectionUrl({ url, courseId, parentUnitId });
 
   // based on the level of breadcrumbs the url will differ
   // at the subsection level it should navigate to the first unit if available

--- a/src/header/Header.tsx
+++ b/src/header/Header.tsx
@@ -3,7 +3,6 @@ import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { type Container, useToggle } from '@openedx/paragon';
 
-import { useWaffleFlags } from '../data/apiHooks';
 import { SearchModal } from '../search-modal';
 import {
   useContentMenuItems,
@@ -38,11 +37,9 @@ const Header = ({
   readOnly = false,
 }: HeaderProps) => {
   const intl = useIntl();
-  const waffleFlags = useWaffleFlags();
 
   const [isShowSearchModalOpen, openSearchModal, closeSearchModal] = useToggle(false);
 
-  const studioBaseUrl = getConfig().STUDIO_BASE_URL;
   const meiliSearchEnabled = [true, 'true'].includes(getConfig().MEILISEARCH_ENABLED);
 
   const contentMenuItems = useContentMenuItems(contextId);
@@ -90,7 +87,7 @@ const Header = ({
     if (isLibrary) {
       return `/library/${contextId}`;
     }
-    return waffleFlags.useNewCourseOutlinePage ? `/course/${contextId}` : `${studioBaseUrl}/course/${contextId}`;
+    return `/course/${contextId}`;
   };
 
   return (
@@ -104,7 +101,7 @@ const Header = ({
         outlineLink={getOutlineLink()}
         searchButtonAction={meiliSearchEnabled ? openSearchModal : undefined}
         containerProps={containerProps}
-        isNewHomePage={waffleFlags.useNewHomePage}
+        isNewHomePage
       />
       {meiliSearchEnabled && (
         <SearchModal


### PR DESCRIPTION
## Summary

Removes all `useNew*` waffle flag checks that were gating the legacy Studio UI fallbacks. These flags are no longer needed — the new React-based UI pages are now always used.

### Changes

- **`Header.tsx`** — `getOutlineLink()` always returns `/course/${contextId}`; `isNewHomePage` hardcoded to `true`; removed `useWaffleFlags` import
- **`Breadcrumbs.tsx`** — `getPathToCourseOutlinePage` and `getPathToCourseUnitPage` always resolve to new-UI paths; removed `useWaffleFlags` and `getConfig` imports
- **`AddComponent.tsx`** — removed `useNewPdfEditor` flag; PDF blocks always open the new React editor
- **`ChecklistItemBody.jsx`** — certificate and outline links always point to new-UI routes; removed `useWaffleFlags` import

### Flags removed

`useNewCourseOutlinePage`, `useNewHomePage`, `useNewUnitPage`, `useNewPdfEditor`, `useNewCertificatesPage`

### Testing

- [ ] Course outline link in header and breadcrumbs navigates to MFE (`apps.local.openedx.io:2001`)
- [ ] Certificate link in course checklist goes to `/course/<id>/certificates`
- [ ] PDF block creation opens the React editor modal inline
- [ ] Breadcrumb navigation at section/subsection/unit levels stays within MFE

🤖 Generated with [Claude Code](https://claude.com/claude-code)