### PR TITLE
fix: remove reference of useNewCertificatesPage from test

### DIFF
--- a/src/header/hooks.test.tsx
+++ b/src/header/hooks.test.tsx
@@ -88,7 +88,6 @@ describe('header utils', () => {
       mockWaffleFlags({
         enableAuthzCourseAuthoring: false,
         useNewVideoUploadsPage: false,
-        useNewCertificatesPage: false,
       });
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
@@ -198,7 +197,6 @@ describe('header utils', () => {
       mockWaffleFlags({
         enableAuthzCourseAuthoring: false,
         useNewVideoUploadsPage: false,
-        useNewCertificatesPage: false,
       });
     });
     beforeEach(() => {


### PR DESCRIPTION
## Description

This PR fixes the CI, which started failing after the merge of https://github.com/openedx/frontend-app-authoring/pull/3066

Useful information to include:

- Which user roles will this change impact? Common user roles are "Learner", "Course Author",
  "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).

## Supporting information

Link to other information about the change, such as GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for manually testing this change.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
