### PR TITLE
fix: gate studio home roles and permissions button on authz waffle flag

### DIFF
--- a/src/studio-home/StudioHome.test.tsx
+++ b/src/studio-home/StudioHome.test.tsx
@@ -1,5 +1,6 @@
 import * as reactRedux from 'react-redux';
 import { getConfig, setConfig } from '@edx/frontend-platform';
+import { mockWaffleFlags } from '@src/data/apiHooks.mock';
 
 import {
   fireEvent,
@@ -92,16 +93,29 @@ describe('<StudioHome />', () => {
       within(header).getByRole('button', { name: 'New course' }); // will error if not found
     });
 
-    it('should render roles and permissions button', async () => {
+    it('should render roles and permissions button when authz is enabled', async () => {
       setConfig({
         ...getConfig(),
         ADMIN_CONSOLE_URL: 'https://admin-console.example.com',
       });
+      mockWaffleFlags({ enableAuthzCourseAuthoring: true });
 
       render(<StudioHome />, { path: '/home' });
       const header = getHeaderElement();
       const rolesButton = within(header).getByRole('link', { name: 'Roles and permissions' });
       expect(rolesButton).toHaveAttribute('href', 'https://admin-console.example.com/authz');
+    });
+
+    it('should not render roles and permissions button when authz is disabled', async () => {
+      setConfig({
+        ...getConfig(),
+        ADMIN_CONSOLE_URL: 'https://admin-console.example.com',
+      });
+      mockWaffleFlags({ enableAuthzCourseAuthoring: false });
+
+      render(<StudioHome />, { path: '/home' });
+      const header = getHeaderElement();
+      expect(within(header).queryByRole('link', { name: 'Roles and permissions' })).not.toBeInTheDocument();
     });
 
     it('should show verify email layout if user inactive', async () => {

--- a/src/studio-home/StudioHome.tsx
+++ b/src/studio-home/StudioHome.tsx
@@ -13,6 +13,7 @@ import { getConfig } from '@edx/frontend-platform';
 import { StudioFooterSlot } from '@edx/frontend-component-footer';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import { useWaffleFlags } from '@src/data/apiHooks';
 import Loading from '../generic/Loading';
 import InternetConnectionAlert from '../generic/internet-connection-alert';
 import Header from '../header';
@@ -48,6 +49,8 @@ const StudioHome = () => {
     librariesV2Enabled,
   } = useStudioHome();
 
+  const waffleFlags = useWaffleFlags();
+  const isAuthzEnabled = waffleFlags?.enableAuthzCourseAuthoring ?? false;
   const adminConsoleUrl = `${getConfig().ADMIN_CONSOLE_URL}/authz`;
 
   const v1LibraryTab = librariesV1Enabled && location?.pathname.split('/').pop() === 'libraries-v1';
@@ -74,20 +77,22 @@ const StudioHome = () => {
       );
     }
 
-    headerButtons.push(
-      <div className="border-right mr-3 pr-4 py-2">
-        <Button
-          as="a"
-          href={adminConsoleUrl}
-          variant="primary"
-          iconBefore={ManageAccounts}
-          size="sm"
-          target="_blank"
-        >
-          {intl.formatMessage(messages.addRolesPermissionsBtnText)}
-        </Button>
-      </div>,
-    );
+    if (isAuthzEnabled && getConfig().ADMIN_CONSOLE_URL) {
+      headerButtons.push(
+        <div className="border-right mr-3 pr-4 py-2">
+          <Button
+            as="a"
+            href={adminConsoleUrl}
+            variant="primary"
+            iconBefore={ManageAccounts}
+            size="sm"
+            target="_blank"
+          >
+            {intl.formatMessage(messages.addRolesPermissionsBtnText)}
+          </Button>
+        </div>,
+      );
+    }
 
     if (hasAbilityToCreateNewCourse) {
       headerButtons.push(
@@ -125,7 +130,7 @@ const StudioHome = () => {
     }
 
     return headerButtons;
-  }, [location, userIsActive, isFailedLoadingPage]);
+  }, [location, userIsActive, isFailedLoadingPage, isAuthzEnabled]);
 
   const headerButtons = userIsActive ? getHeaderButtons() : [];
   if (isLoadingPage && !isFiltered) {


### PR DESCRIPTION
## Description

The "Roles and permissions" button on the Studio Home page was unconditionally rendered for all active users, regardless of whether the `authz.enable_course_authoring` waffle flag was enabled.
The button is now gated on both `enableAuthzCourseAuthoring` waffle flag and `ADMIN_CONSOLE_URL` being configured, consistent with how the course-level settings menu already behaves. Tests have been updated to cover both the enabled and disabled states.

Useful information to include:

- Which user roles will this change impact? Course Author
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).

Before
<img width="1512" height="828" alt="Screenshot 2026-06-02 at 1 17 10 PM" src="https://github.com/user-attachments/assets/0db51cef-1f90-40e3-9222-30a20e93b550" />


After
<img width="1512" height="828" alt="Screenshot 2026-06-02 at 1 16 07 PM" src="https://github.com/user-attachments/assets/857d54ff-7124-4bf8-b5a8-40d78609dfc4" />


## Supporting information

https://github.com/mitodl/hq/issues/11519

## Testing instructions

- Enable the `authz.enable_course_authoring` waffle flag in Django Admin → Waffle → Flags and ensure `ADMIN_CONSOLE_URL` is set in the MFE config. Navigate to Studio Home and verify that the "Roles and permissions" button appears in the header.

- Disable the flag (or leave it unset) and verify the "Roles and permissions" button is **not** present on Studio Home.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
