### PR TITLE
fix: update legacy library deprecation warning to specify Willow release

### DIFF
--- a/src/studio-home/tabs-section/messages.ts
+++ b/src/studio-home/tabs-section/messages.ts
@@ -69,7 +69,7 @@ const messages = defineMessages({
   },
   alertDescriptionV1: {
     id: 'studio-home.libraries.migrate-alert.description-v1',
-    defaultMessage: 'In a future release, legacy libraries will no longer be supported.'
+    defaultMessage: 'In the Willow release, legacy libraries will no longer be supported.'
       + ' The new libraries experience allows you to author sections, subsections, units,'
       + ' and components to reuse across your courses. Content from legacy libraries can be'
       + ' migrated to the new experience.',


### PR DESCRIPTION
## Description

Replaces the vague phrase \"In a future release\" with the specific release name \"In the Willow release\" in the legacy libraries migration alert shown on the Legacy Libraries tab of Studio Home.

**Before:**
> In a future release, legacy libraries will no longer be supported. ...

**After:**
> In the Willow release, legacy libraries will no longer be supported. ...

## Supporting information

- Closes https://github.com/openedx/frontend-app-authoring/issues/2876
- Flagged by @crathbun428 in the issue review (Apr 13, 2026)
- File: `src/studio-home/tabs-section/messages.ts` (`alertDescriptionV1`)

## Test plan

- [ ] Navigate to Studio Home → Legacy Libraries tab
- [ ] Confirm the migration alert reads "In the Willow release, legacy libraries will no longer be supported."

🤖 Generated with [Claude Code](https://claude.com/claude-code)