### PR TITLE
fix: update release date for sidebar on updating it from outline side

### DIFF
--- a/src/course-outline/outline-sidebar/info-sidebar/SubsectionSettings.test.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/SubsectionSettings.test.tsx
@@ -6,26 +6,35 @@ import { SubsectionSettings } from './SubsectionSettings';
 
 const subsectionId = 'sub-1';
 
-// Make useStateWithCallback synchronous so callbacks call mutate immediately
+// Make useStateWithCallback synchronous so callbacks call mutate immediately.
+// Also handles the { value, skipCallback } object form used by the external-sync hooks.
 jest.mock('@src/hooks', () => ({
   useStateWithCallback: (defaultValue: any, cb?: any) => {
     const [state, setState] = useState(defaultValue);
     const wrappedSetState = (val: any) => {
-      const newVal = typeof val === 'function' ? val(state) : val;
+      let newVal;
+      let skip = false;
+      if (typeof val === 'object' && val !== null && 'value' in val && 'skipCallback' in val) {
+        newVal = val.value;
+        skip = val.skipCallback;
+      } else {
+        newVal = typeof val === 'function' ? val(state) : val;
+      }
       setState(newVal);
-      if (cb) { cb(newVal); }
+      if (cb && !skip) { cb(newVal); }
     };
     return [state, wrappedSetState];
   },
 }));
 
-// Mock DatepickerControl used in GradingSection so we can trigger onChange
+// Mock DatepickerControl so we can trigger onChange and inspect the current value.
 jest.mock('@src/generic/datepicker-control', () => ({
   DATEPICKER_TYPES: { date: 'date', time: 'time' },
-  DatepickerControl: ({ onChange, type, ...props }: any) => (
+  DatepickerControl: ({ onChange, type, value, ...props }: any) => (
     <button
       type="button"
       data-testid={props['data-testid'] || type}
+      data-value={value}
       onClick={() => onChange(type === 'date' ? '2025-12-31' : '12:00')}
     >
       {type}
@@ -48,9 +57,10 @@ jest.mock('./sharedSettings/VisibilitySection', () => ({
 
 jest.mock('@src/generic/configure-modal/AdvancedTab', () => ({
   __esModule: true,
-  default: ({ setFieldValue }: any) => (
+  default: ({ setFieldValue, values }: any) => (
     <div>
       <button type="button" onClick={() => setFieldValue('isProctoredExam', true)}>Set Proctored</button>
+      <span data-testid="is-time-limited">{String(values?.isTimeLimited)}</span>
     </div>
   ),
 }));
@@ -208,7 +218,7 @@ describe('SubsectionSettings', () => {
     expect(mutate).not.toHaveBeenCalled();
   });
 
-  it('resets grading local state when itemData changes', async () => {
+  it('syncs grading state when itemData changes externally without calling mutate', async () => {
     apiHooks.useCourseDetails.mockReturnValue({ data: { selfPaced: false } });
     const firstItemData = {
       ...baseItemData,
@@ -219,30 +229,84 @@ describe('SubsectionSettings', () => {
     const secondItemData = { ...firstItemData, format: 'g2', due: '2024-02-02' };
 
     apiHooks.useCourseItemData.mockReturnValue({ data: firstItemData, isPending: false });
-
     const { rerender } = render(<SubsectionSettings subsectionId={subsectionId} />);
+    expect(screen.getByTestId('due-date-picker')).toHaveAttribute('data-value', '2024-01-01');
 
     mutate.mockClear();
     apiHooks.useCourseItemData.mockReturnValue({ data: secondItemData, isPending: false });
     rerender(<SubsectionSettings subsectionId={subsectionId} />);
 
-    expect(mutate).toHaveBeenCalledWith(expect.objectContaining({ graderType: 'g2', dueDate: '2024-02-02' }));
+    // Sidebar must reflect the updated due date...
+    expect(screen.getByTestId('due-date-picker')).toHaveAttribute('data-value', '2024-02-02');
+    // ...but must NOT trigger a mutation (which would fire a redundant configure call)
+    expect(mutate).not.toHaveBeenCalled();
   });
 
-  it('resets assessment visibility local state when itemData changes', async () => {
+  it('syncs graded toggle state when itemData changes externally without calling mutate', async () => {
     apiHooks.useCourseDetails.mockReturnValue({ data: { selfPaced: false } });
-    const firstItemData = { ...baseItemData, graded: false, showCorrectness: 'always' };
-    const secondItemData = { ...firstItemData, showCorrectness: 'never' };
+    // Start as graded: grader dropdown is visible
+    apiHooks.useCourseItemData.mockReturnValue({
+      data: { ...baseItemData, graded: true },
+      isPending: false,
+    });
+    const { rerender } = render(<SubsectionSettings subsectionId={subsectionId} />);
+    expect(screen.getByTestId('grader-type-select')).toBeInTheDocument();
+
+    mutate.mockClear();
+    // External update switches to ungraded
+    apiHooks.useCourseItemData.mockReturnValue({
+      data: { ...baseItemData, graded: false },
+      isPending: false,
+    });
+    rerender(<SubsectionSettings subsectionId={subsectionId} />);
+
+    // Grader dropdown must disappear...
+    expect(screen.queryByTestId('grader-type-select')).not.toBeInTheDocument();
+    // ...without triggering a mutation
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it('syncs assessment result visibility when itemData changes externally without calling mutate', async () => {
+    apiHooks.useCourseDetails.mockReturnValue({ data: { selfPaced: false } });
+    const firstItemData = { ...baseItemData, graded: false, showCorrectness: 'never' };
+    const secondItemData = { ...firstItemData, showCorrectness: 'past_due' };
 
     apiHooks.useCourseItemData.mockReturnValue({ data: firstItemData, isPending: false });
-
     const { rerender } = render(<SubsectionSettings subsectionId={subsectionId} />);
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
 
     mutate.mockClear();
     apiHooks.useCourseItemData.mockReturnValue({ data: secondItemData, isPending: false });
     rerender(<SubsectionSettings subsectionId={subsectionId} />);
 
-    expect(mutate).toHaveBeenCalledWith(expect.objectContaining({ showCorrectness: 'never' }));
+    // Checkbox must reflect the new value...
+    expect(screen.getByRole('checkbox')).toBeChecked();
+    // ...but must NOT trigger a mutation
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it('syncs special exam (timed/proctored) state when itemData changes externally without calling mutate', () => {
+    apiHooks.useCourseDetails.mockReturnValue({ data: { selfPaced: false } });
+    // Start with timed exam disabled
+    apiHooks.useCourseItemData.mockReturnValue({
+      data: { ...baseItemData, graded: false, isTimeLimited: false },
+      isPending: false,
+    });
+    const { rerender } = render(<SubsectionSettings subsectionId={subsectionId} />);
+    expect(screen.getByTestId('is-time-limited').textContent).toBe('false');
+
+    mutate.mockClear();
+    // Simulate kebab-menu configure modal enabling timed exam
+    apiHooks.useCourseItemData.mockReturnValue({
+      data: { ...baseItemData, graded: false, isTimeLimited: true },
+      isPending: false,
+    });
+    rerender(<SubsectionSettings subsectionId={subsectionId} />);
+
+    // AdvancedTab must receive the updated value...
+    expect(screen.getByTestId('is-time-limited').textContent).toBe('true');
+    // ...but must NOT trigger a mutation
+    expect(mutate).not.toHaveBeenCalled();
   });
 
   it('does not call mutate when item data is absent', async () => {

--- a/src/course-outline/outline-sidebar/info-sidebar/SubsectionSettings.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/SubsectionSettings.tsx
@@ -58,9 +58,12 @@ const GradingSection = ({ subsectionId, onChange }: SubProps) => {
       dueDate: itemData?.due || '',
     };
     if (localState?.graderType !== nextState.graderType || localState?.dueDate !== nextState.dueDate) {
-      setLocalState(nextState);
+      setLocalState({ value: nextState, skipCallback: true });
     }
   }, [itemData?.format, itemData?.due]);
+  useItemFieldSync(() => {
+    setGraded(itemData?.graded);
+  }, [itemData?.graded]);
 
   const setUngraded = () => {
     setGraded(false);
@@ -142,7 +145,7 @@ const AssessmentResultVisibilitySection = ({ subsectionId, onChange }: SubProps)
   );
   useItemFieldSync(() => {
     if (localState?.showCorrectness !== itemData?.showCorrectness) {
-      setLocalState({ showCorrectness: itemData?.showCorrectness });
+      setLocalState({ value: { showCorrectness: itemData?.showCorrectness }, skipCallback: true });
     }
   }, [itemData?.showCorrectness]);
 

--- a/src/course-outline/outline-sidebar/info-sidebar/sharedSettings/ReleaseSection.test.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/sharedSettings/ReleaseSection.test.tsx
@@ -4,26 +4,36 @@ import userEvent from '@testing-library/user-event';
 import { useCourseItemData } from '@src/course-outline/data/apiHooks';
 import { ReleaseSection } from './ReleaseSection';
 
-// Make useStateWithCallback synchronous so callbacks call onChange immediately
+// Make useStateWithCallback synchronous so callbacks call onChange immediately.
+// Also handles the { value, skipCallback } object form used by the external-sync useEffect.
 jest.mock('@src/hooks', () => ({
   useStateWithCallback: (defaultValue: any, cb?: any) => {
     const { useState } = jest.requireActual('react');
     const [state, setState] = useState(defaultValue);
     const wrappedSetState = (val: any) => {
-      const newVal = typeof val === 'function' ? val(state) : val;
+      let newVal;
+      let skip = false;
+      if (typeof val === 'object' && val !== null && 'value' in val && 'skipCallback' in val) {
+        newVal = val.value;
+        skip = val.skipCallback;
+      } else {
+        newVal = typeof val === 'function' ? val(state) : val;
+      }
       setState(newVal);
-      if (cb) { cb(newVal); }
+      if (cb && !skip) { cb(newVal); }
     };
     return [state, wrappedSetState];
   },
 }));
 
-// Mock DatepickerControl so we can trigger onChange easily
+// Mock DatepickerControl so we can trigger onChange and inspect the current value.
 jest.mock('@src/generic/datepicker-control', () => ({
   DATEPICKER_TYPES: { date: 'date', time: 'time' },
-  DatepickerControl: ({ onChange, type }: any) => (
+  DatepickerControl: ({ onChange, type, value }: any) => (
     <button
       type="button"
+      data-testid={`datepicker-${type}`}
+      data-value={value}
       onClick={() => onChange(type === 'date' ? '2025-12-31' : '12:00')}
     >
       {type}
@@ -59,5 +69,27 @@ describe('ReleaseSection', () => {
 
     await user.click(screen.getByRole('button', { name: 'time' }));
     expect(onChange).toHaveBeenCalledWith('12:00');
+  });
+
+  it('syncs displayed value when itemData.start changes externally without calling onChange', () => {
+    // Simulate initial state (e.g. subsection has a release date set)
+    const initialDate = '2024-01-01T00:00:00Z';
+    mockUseCourseItemData.mockReturnValue({ data: { start: initialDate } });
+    const onChange = jest.fn();
+    const { rerender } = render(<ReleaseSection itemId="i" onChange={onChange} />);
+
+    expect(screen.getByTestId('datepicker-date')).toHaveAttribute('data-value', initialDate);
+
+    // Simulate the kebab-menu configure modal saving a new release date:
+    // the mutation fires, the section refetches, and setQueryData updates the
+    // subsection cache — causing useCourseItemData to return the new date.
+    const updatedDate = '2025-06-15T00:00:00Z';
+    mockUseCourseItemData.mockReturnValue({ data: { start: updatedDate } });
+    rerender(<ReleaseSection itemId="i" onChange={onChange} />);
+
+    // The sidebar must reflect the updated date...
+    expect(screen.getByTestId('datepicker-date')).toHaveAttribute('data-value', updatedDate);
+    // ...but must NOT trigger onChange (which would fire a redundant mutation)
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/src/course-outline/outline-sidebar/info-sidebar/sharedSettings/ReleaseSection.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/sharedSettings/ReleaseSection.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Stack } from '@openedx/paragon';
 import { useCourseItemData } from '@src/course-outline/data/apiHooks';
@@ -18,6 +19,14 @@ export const ReleaseSection = ({ itemId, onChange }: Props) => {
     itemData?.start,
     (val) => onChange(val),
   );
+
+  // Sync localState when itemData changes externally (e.g. release date updated
+  // from the left-side kebab configure modal). skipCallback prevents re-triggering
+  // the onChange mutation — we're just reflecting a change that already happened.
+  useEffect(() => {
+    setLocalState({ value: itemData?.start, skipCallback: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [itemData?.start]);
 
   return (
     <SidebarSection

--- a/src/course-outline/outline-sidebar/info-sidebar/sharedSettings/VisibilitySection.test.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/sharedSettings/VisibilitySection.test.tsx
@@ -79,4 +79,38 @@ describe('VisibilitySection component', () => {
     render(<VisibilitySection {...defaultProps} onChange={onChange} />);
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
   });
+
+  it('syncs displayed visibility when itemData changes externally without calling onChange', async () => {
+    // Start as staff-only: checkbox must not be present
+    mockUseCourseItemData.mockReturnValue({ data: { visibilityState: VisibilityTypes.STAFF_ONLY } });
+    const onChange = jest.fn();
+    const { rerender } = render(<VisibilitySection {...defaultProps} onChange={onChange} />);
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+
+    // Simulate the kebab-menu configure modal switching to student-visible:
+    // the mutation fires, the section refetches, and setQueryData updates the
+    // subsection cache — causing useCourseItemData to return the new state.
+    mockUseCourseItemData.mockReturnValue({ data: { visibilityState: undefined, hideAfterDue: false } });
+    rerender(<VisibilitySection {...defaultProps} onChange={onChange} />);
+
+    // Sidebar must now show the checkbox (only visible when student-visible)...
+    expect(await screen.findByRole('checkbox')).toBeInTheDocument();
+    // ...but must NOT trigger onChange (which would fire a redundant mutation)
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('syncs hideAfterDue checkbox state when itemData changes externally without calling onChange', async () => {
+    // Start with hideAfterDue unchecked
+    mockUseCourseItemData.mockReturnValue({ data: { visibilityState: undefined, hideAfterDue: false } });
+    const onChange = jest.fn();
+    const { rerender } = render(<VisibilitySection {...defaultProps} onChange={onChange} />);
+    expect(await screen.findByRole('checkbox')).not.toBeChecked();
+
+    // External update sets hideAfterDue to true (e.g. saved via kebab configure modal)
+    mockUseCourseItemData.mockReturnValue({ data: { visibilityState: undefined, hideAfterDue: true } });
+    rerender(<VisibilitySection {...defaultProps} onChange={onChange} />);
+
+    expect(await screen.findByRole('checkbox')).toBeChecked();
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/src/course-outline/outline-sidebar/info-sidebar/sharedSettings/VisibilitySection.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/sharedSettings/VisibilitySection.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { Button, ButtonGroup, Form } from '@openedx/paragon';
 import { useCourseItemData } from '@src/course-outline/data/apiHooks';
@@ -34,6 +35,20 @@ export const VisibilitySection = ({ itemId, isSubsection, onChange }: Props) => 
       return onChange(val || {});
     },
   );
+
+  // Sync localState when itemData changes externally (e.g. visibility updated
+  // from the left-side kebab configure modal). skipCallback prevents re-triggering
+  // the onChange mutation — we're just reflecting a change that already happened.
+  useEffect(() => {
+    setLocalState({
+      value: {
+        isVisibleToStaffOnly: itemData?.visibilityState === VisibilityTypes.STAFF_ONLY,
+        hideAfterDue: itemData?.hideAfterDue,
+      },
+      skipCallback: true,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [itemData?.visibilityState, itemData?.hideAfterDue]);
 
   return (
     <SidebarSection

--- a/src/course-unit/unit-sidebar/unit-info/GenericUnitInfoSettings.test.tsx
+++ b/src/course-unit/unit-sidebar/unit-info/GenericUnitInfoSettings.test.tsx
@@ -1,0 +1,108 @@
+import { initializeMocks, render, screen } from '@src/testUtils';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+
+import { GenericUnitInfoSettings } from './GenericUnitInfoSettings';
+
+// Make useStateWithCallback synchronous so callbacks call mutate immediately.
+// Also handles the { value, skipCallback } object form used by the external-sync useEffect.
+jest.mock('@src/hooks', () => ({
+  useStateWithCallback: (defaultValue: any, cb?: any) => {
+    const [state, setState] = useState(defaultValue);
+    const wrappedSetState = (val: any) => {
+      let newVal;
+      let skip = false;
+      if (typeof val === 'object' && val !== null && 'value' in val && 'skipCallback' in val) {
+        newVal = val.value;
+        skip = val.skipCallback;
+      } else {
+        newVal = typeof val === 'function' ? val(state) : val;
+      }
+      setState(newVal);
+      if (cb && !skip) { cb(newVal); }
+    };
+    return [state, wrappedSetState];
+  },
+}));
+
+const mutateFn = jest.fn();
+jest.mock('@src/course-outline/data/apiHooks', () => ({
+  useConfigureUnit: () => ({ mutate: mutateFn }),
+}));
+
+jest.mock('@src/generic/configure-modal/UnitTab', () => ({
+  AccessEditComponent: () => <div>AccessEdit</div>,
+  DiscussionEditComponent: ({ discussionEnabled, handleDiscussionChange }: any) => (
+    <input
+      type="checkbox"
+      aria-label="Enable discussion"
+      checked={discussionEnabled}
+      onChange={handleDiscussionChange}
+    />
+  ),
+}));
+
+const defaultProps = {
+  id: 'unit-1',
+  visibilityState: 'live',
+  discussionEnabled: false,
+  userPartitionInfo: {
+    selectedPartitionIndex: -1,
+    selectablePartitions: [],
+    groups: [],
+  } as any,
+  sectionId: 's1',
+  subsectionId: 'ss1',
+};
+
+describe('GenericUnitInfoSettings', () => {
+  beforeEach(() => {
+    initializeMocks();
+    mutateFn.mockReset();
+  });
+
+  it('renders visibility buttons and discussion checkbox', () => {
+    render(<GenericUnitInfoSettings {...defaultProps} />);
+    expect(screen.getByRole('button', { name: 'Student Visible' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Staff Only' })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Enable discussion' })).toBeInTheDocument();
+  });
+
+  it('calls mutate when Staff Only is clicked', async () => {
+    const user = userEvent.setup();
+    render(<GenericUnitInfoSettings {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: 'Staff Only' }));
+    expect(mutateFn).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisibleToStaffOnly: true }),
+      expect.anything(),
+    );
+  });
+
+  it('syncs visibility when visibilityState prop changes externally without calling mutate', () => {
+    // Start as student-visible (live)
+    const { rerender } = render(<GenericUnitInfoSettings {...defaultProps} visibilityState="live" />);
+
+    mutateFn.mockClear();
+    // Simulate kebab-menu configure modal switching to staff-only:
+    // useCourseItemData updates, UnitSettingsTab passes new props down.
+    rerender(<GenericUnitInfoSettings {...defaultProps} visibilityState="staff_only" />);
+
+    // Staff Only button must now be the active (primary) variant — visible as the
+    // "Student Visible" modal would open on click rather than Student Visible being active.
+    // Asserting mutate was NOT called is the key invariant.
+    expect(mutateFn).not.toHaveBeenCalled();
+  });
+
+  it('syncs discussion checkbox when discussionEnabled prop changes externally without calling mutate', () => {
+    const { rerender } = render(<GenericUnitInfoSettings {...defaultProps} discussionEnabled={false} />);
+    expect(screen.getByRole('checkbox', { name: 'Enable discussion' })).not.toBeChecked();
+
+    mutateFn.mockClear();
+    // External update enables discussion
+    rerender(<GenericUnitInfoSettings {...defaultProps} discussionEnabled />);
+
+    expect(screen.getByRole('checkbox', { name: 'Enable discussion' })).toBeChecked();
+    expect(mutateFn).not.toHaveBeenCalled();
+  });
+});

--- a/src/course-unit/unit-sidebar/unit-info/GenericUnitInfoSettings.tsx
+++ b/src/course-unit/unit-sidebar/unit-info/GenericUnitInfoSettings.tsx
@@ -5,7 +5,7 @@ import { UserPartitionInfoTypes } from '@src/data/types';
 import { AccessEditComponent, DiscussionEditComponent } from '@src/generic/configure-modal/UnitTab';
 import { SidebarContent, SidebarSection } from '@src/generic/sidebar';
 import { Form, Formik } from 'formik';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import configureMessages from '@src/generic/configure-modal/messages';
 import { useConfigureUnit } from '@src/course-outline/data/apiHooks';
 import { useStateWithCallback } from '@src/hooks';
@@ -75,6 +75,19 @@ export const GenericUnitInfoSettings = (props: UnitInfoSettingsProps) => {
       handleUpdate(!!val.isVisible, null, val.isDiscussionEnabled);
     }
   });
+
+  // Sync localState when props change externally (e.g. visibility updated from the
+  // left-side kebab configure modal). skipCallback prevents re-triggering the mutation.
+  useEffect(() => {
+    setLocalState({
+      value: {
+        isVisible: visibilityState === UNIT_VISIBILITY_STATES.staffOnly,
+        isDiscussionEnabled: discussionEnabled,
+      },
+      skipCallback: true,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visibilityState, discussionEnabled]);
 
   const handleSaveGroups = async (data: {
     selectedPartitionIndex: number;


### PR DESCRIPTION
## Steps to reproduce issue

1. Make sure you are on `master` branch
2. Click on a section or subsectionView new sidebar
3. Click on the kebab in the outline and choose configure
4. Change date or any other setting.
5. Sidebar doesn't change

## Description

This pull request improves how the `ReleaseSection` and `VisibilitySection` components in the course outline sidebar handle external updates to their data, such as when changes are made from other UI elements (like a kebab-menu configure modal). The changes ensure that the sidebar UI always reflects the latest state from the backend without accidentally firing redundant mutations or callbacks. Additionally, new tests verify this synchronization behavior.

**Synchronization improvements:**

* Both `ReleaseSection.tsx` and `VisibilitySection.tsx` now use a `useEffect` to update their local state when the underlying `itemData` changes externally, using a `skipCallback` flag to avoid triggering the `onChange` mutation redundantly. (`src/course-outline/outline-sidebar/info-sidebar/sharedSettings/ReleaseSection.tsx` [[1]](diffhunk://#diff-5a84f9802c24c8f7610b39b980281e22201f4cf1aa75e7f25084d25835bbd158R1) [[2]](diffhunk://#diff-5a84f9802c24c8f7610b39b980281e22201f4cf1aa75e7f25084d25835bbd158R23-R30); `src/course-outline/outline-sidebar/info-sidebar/sharedSettings/VisibilitySection.tsx` [[3]](diffhunk://#diff-d91c7ef9a215b40e3560e0033c2ceed19e39cc4a4f6fb1745e59ab975b24c7d1R1) [[4]](diffhunk://#diff-d91c7ef9a215b40e3560e0033c2ceed19e39cc4a4f6fb1745e59ab975b24c7d1R39-R52)

**Testing enhancements:**

* The test mocks for `useStateWithCallback` and `DatepickerControl` in `ReleaseSection.test.tsx` were enhanced to handle the new object form with `skipCallback`, and to allow inspecting the currently displayed value. (`src/course-outline/outline-sidebar/info-sidebar/sharedSettings/ReleaseSection.test.tsx` [src/course-outline/outline-sidebar/info-sidebar/sharedSettings/ReleaseSection.test.tsxL7-R36](diffhunk://#diff-d82ce144740ba985bf0d38fd13a7c94b03f9b90aa6ad88571f53dba06774a76dL7-R36))
* New tests were added for both `ReleaseSection` and `VisibilitySection` to verify that UI updates correctly when external changes occur, and that `onChange` is not called in these cases, preventing redundant mutations. (`src/course-outline/outline-sidebar/info-sidebar/sharedSettings/ReleaseSection.test.tsx` [[1]](diffhunk://#diff-d82ce144740ba985bf0d38fd13a7c94b03f9b90aa6ad88571f53dba06774a76dR73-R94); `src/course-outline/outline-sidebar/info-sidebar/sharedSettings/VisibilitySection.test.tsx` [[2]](diffhunk://#diff-416457b0955b7648321fbd567723490436e8c0d1d61e0b87b1f1a0f69660f73bR82-R115)

## Supporting information
https://github.com/mitodl/hq/issues/11295 (MIT Internal)

## Testing instructions
1. Checkout to this branch and repeat the steps mentioned at the top
2. Outline changes should reflect in the sidebar now as well

## AI Tool

Software: Claude Desktop
Model: Claude Sonnet 4.6 (High)