### PR TITLE
feat!: remove marketingEnabled flag from Schedule & Details

### DIFF
--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -239,7 +239,6 @@ export interface CourseSettingsData {
   languageOptions: [string, string][];
   lmsLinkForAboutPage: string;
   licensingEnabled: boolean;
-  marketingEnabled: boolean;
   mfeProctoredExamSettingsUrl: string;
   platformName: string;
   possiblePreRequisiteCourses: {

--- a/src/plugin-slots/PageBannerSlot/Readme.md
+++ b/src/plugin-slots/PageBannerSlot/Readme.md
@@ -51,3 +51,48 @@ const config = {
 
 export default config;
 ```
+
+## Restoring the course enrollment card
+
+Prior to the removal of `ENABLE_MKTG_SITE`, deployments running with `ENABLE_MKTG_SITE=False`
+showed a "Course summary page" card in Schedule & Details instead of the promotional banner.
+That card displayed a direct link to the LMS about/enrollment page and an "Invite your students"
+mailto button.
+
+If you want to restore that experience, you can use `CoursePromotionCard` — exported from
+`basic-section` — via this slot. The slot passes `lmsLinkForAboutPage`, `courseDisplayName`,
+and `platformName` as `pluginProps` so the card has everything it needs.
+
+```jsx
+import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
+import { CoursePromotionCard } from '@edx/frontend-app-authoring/src/schedule-and-details/basic-section';
+
+const config = {
+  pluginSlots: {
+    'org.openedx.frontend.authoring.page_banner.v1': {
+      plugins: [
+        {
+          op: PLUGIN_OPERATIONS.Hide,
+          widgetId: 'default_contents',
+        },
+        {
+          op: PLUGIN_OPERATIONS.Insert,
+          widget: {
+            id: 'course_promotion_card',
+            type: DIRECT_PLUGIN,
+            RenderWidget: ({ pluginProps }) => (
+              <CoursePromotionCard
+                lmsLinkForAboutPage={pluginProps.lmsLinkForAboutPage}
+                courseDisplayName={pluginProps.courseDisplayName}
+                platformName={pluginProps.platformName}
+              />
+            ),
+          },
+        },
+      ],
+    },
+  },
+};
+
+export default config;
+```

--- a/src/plugin-slots/PageBannerSlot/Readme.md
+++ b/src/plugin-slots/PageBannerSlot/Readme.md
@@ -10,6 +10,14 @@
 
 This slot wraps the Paragon `PageBanner` component to allow plugins to replace, modify, or hide the banner shown on pages like Schedule & Details. By default, it renders the standard `PageBanner` with the provided props and children.
 
+### Plugin Props:
+
+- `show` - Boolean. Whether the banner is currently shown.
+- `onDismiss` - Function. Callback invoked when the banner is dismissed.
+- `lmsLinkForAboutPage` - String. URL of the course about page on the LMS.
+- `courseDisplayName` - String. The course's display name.
+- `platformName` - String. The platform name configured for the site.
+
 ## Example
 
 The following `env.config.jsx` example replaces the default banner message with a custom message.
@@ -41,6 +49,51 @@ const config = {
                   This message was injected via the PageBanner plugin slot.
                 </span>
               </>
+            ),
+          },
+        },
+      ],
+    },
+  },
+};
+
+export default config;
+```
+
+## Restoring the course enrollment card
+
+Prior to the removal of `ENABLE_MKTG_SITE`, deployments running with `ENABLE_MKTG_SITE=False`
+showed a "Course summary page" card in Schedule & Details instead of the promotional banner.
+That card displayed a direct link to the LMS about/enrollment page and an "Invite your students"
+mailto button.
+
+If you want to restore that experience, you can use `CoursePromotionCard` — exported from
+`basic-section` — via this slot. The slot passes `lmsLinkForAboutPage`, `courseDisplayName`,
+and `platformName` as plugin props so the card has everything it needs.
+
+```jsx
+import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
+import { CoursePromotionCard } from '@edx/frontend-app-authoring/src/schedule-and-details/basic-section';
+
+const config = {
+  pluginSlots: {
+    'org.openedx.frontend.authoring.page_banner.v1': {
+      plugins: [
+        {
+          op: PLUGIN_OPERATIONS.Hide,
+          widgetId: 'default_contents',
+        },
+        {
+          op: PLUGIN_OPERATIONS.Insert,
+          widget: {
+            id: 'course_promotion_card',
+            type: DIRECT_PLUGIN,
+            RenderWidget: ({ lmsLinkForAboutPage, courseDisplayName, platformName }) => (
+              <CoursePromotionCard
+                lmsLinkForAboutPage={lmsLinkForAboutPage}
+                courseDisplayName={courseDisplayName}
+                platformName={platformName}
+              />
             ),
           },
         },

--- a/src/plugin-slots/PageBannerSlot/index.tsx
+++ b/src/plugin-slots/PageBannerSlot/index.tsx
@@ -6,12 +6,18 @@ export interface PageBannerSlotProps {
   show: boolean;
   onDismiss: () => void;
   children: ReactNode;
+  lmsLinkForAboutPage?: string;
+  courseDisplayName?: string;
+  platformName?: string;
 }
 
 const PageBannerSlot: React.FC<PageBannerSlotProps> = ({
   show,
   onDismiss,
   children,
+  lmsLinkForAboutPage,
+  courseDisplayName,
+  platformName,
 }) => (
   <PluginSlot
     id="org.openedx.frontend.authoring.page_banner.v1"
@@ -19,6 +25,9 @@ const PageBannerSlot: React.FC<PageBannerSlotProps> = ({
     pluginProps={{
       show,
       onDismiss,
+      lmsLinkForAboutPage,
+      courseDisplayName,
+      platformName,
     }}
   >
     <div className="align-items-start">

--- a/src/schedule-and-details/__mocks__/courseSettings.js
+++ b/src/schedule-and-details/__mocks__/courseSettings.js
@@ -25,7 +25,6 @@ module.exports = {
     ['uk', 'Ukrainian'],
   ],
   lmsLinkForAboutPage: 'http://localhost:18000/courses/course-v1:edX+M12+2T2023/about',
-  marketingEnabled: true,
   mfeProctoredExamSettingsUrl: '',
   possiblePreRequisiteCourses: [
     {

--- a/src/schedule-and-details/basic-section/BasicSection.test.jsx
+++ b/src/schedule-and-details/basic-section/BasicSection.test.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 
-import { INVITE_STUDENTS_LINK_ID } from './constants';
 import messages from './messages';
 import BasicSection from '.';
 
@@ -19,7 +18,6 @@ describe('<BasicSection />', () => {
     courseNumber: 'bar number',
     run: 'foo run',
     lmsLinkForAboutPage: 'link://to',
-    marketingEnabled: true,
     courseDisplayName: 'foo course',
     platformName: 'Your platform name here',
   };
@@ -40,41 +38,13 @@ describe('<BasicSection />', () => {
     expect(getByText(props.run)).toBeInTheDocument();
   });
 
-  it('shows the page banner if the marketingEnabled is true', () => {
-    const { getByText, queryAllByText } = render(<RootWrapper {...props} />);
+  it('shows the page banner', () => {
+    const { getByText } = render(<RootWrapper {...props} />);
     expect(
       getByText(`Promoting your course with ${props.platformName}`),
     ).toBeInTheDocument();
     expect(
       getByText(messages.basicBannerText.defaultMessage),
     ).toBeInTheDocument();
-    expect(queryAllByText('Course summary page').length).toBe(0);
-  });
-
-  it('shows the course promotion if the marketingEnabled is false', () => {
-    const initialProps = { ...props, marketingEnabled: false };
-    const { getByText, getByRole, queryAllByText } = render(
-      <RootWrapper {...initialProps} />,
-    );
-    const inviteButton = getByRole('button', {
-      name: messages.basicPromotionButton.defaultMessage,
-    });
-
-    expect(getByText(/Course Summary Page/i)).toBeInTheDocument();
-    expect(
-      getByText(/(for student enrollment and access)/i),
-    ).toBeInTheDocument();
-    expect(getByText(props.lmsLinkForAboutPage)).toBeInTheDocument();
-    expect(inviteButton).toBeInTheDocument();
-    expect(queryAllByText(`Promoting your course with ${props.platformName}`).length).toBe(0);
-  });
-
-  it('checks link link to invite', () => {
-    const initialProps = { ...props, marketingEnabled: false };
-    const { getByTestId } = render(<RootWrapper {...initialProps} />);
-    const inviteLink = getByTestId(INVITE_STUDENTS_LINK_ID);
-    expect(decodeURIComponent(inviteLink.href)).toEqual(
-      `mailto:${process.env.INVITE_STUDENTS_EMAIL_TO}?body=The course ${props.courseDisplayName}, provided by ${props.platformName}, is open for enrollment. Please navigate to this course at ${props.lmsLinkForAboutPage} to enroll.&subject=Enroll in ${props.courseDisplayName}.`,
-    );
   });
 });

--- a/src/schedule-and-details/basic-section/CoursePromotionCard.jsx
+++ b/src/schedule-and-details/basic-section/CoursePromotionCard.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
+import {
+  Button,
+  Card,
+  MailtoLink,
+  Hyperlink,
+} from '@openedx/paragon';
+import { Email as EmailIcon } from '@openedx/paragon/icons';
+
+import { INVITE_STUDENTS_LINK_ID } from './constants';
+import messages from './messages';
+
+const CoursePromotionCard = ({ lmsLinkForAboutPage, courseDisplayName, platformName }) => {
+  const intl = useIntl();
+
+  const emailSubject = intl.formatMessage(
+    {
+      id: 'course-authoring.schedule.basic.email.subject',
+      defaultMessage: 'Enroll in {courseDisplayName}.',
+    },
+    { courseDisplayName },
+  );
+
+  const emailBody = intl.formatMessage(
+    {
+      id: 'course-authoring.schedule.basic.email.body',
+      defaultMessage:
+        'The course {courseDisplayName}, provided by {platformName}, is open for enrollment. Please navigate to this course at {lmsLinkForAboutPage} to enroll.',
+    },
+    { courseDisplayName, platformName, lmsLinkForAboutPage },
+  );
+
+  const promotionTitle = (
+    <FormattedMessage
+      id="course-authoring.schedule.basic.promotion.title"
+      defaultMessage="Course summary page {smallText}"
+      values={{
+        smallText: <small>(for student enrollment and access)</small>,
+      }}
+    />
+  );
+
+  return (
+    <Card>
+      <Card.Header
+        className="h4 px-3 text-gray-500"
+        title={promotionTitle}
+        size="sm"
+      />
+      <Card.Section className="px-3 py-1">
+        <Hyperlink
+          destination={lmsLinkForAboutPage}
+          className="lead info-500 small text-decoration-none"
+          target="_blank"
+          showLaunchIcon={false}
+        >
+          {lmsLinkForAboutPage}
+        </Hyperlink>
+      </Card.Section>
+      <Card.Divider />
+      <Card.Footer className="p-3 justify-content-start">
+        <MailtoLink
+          to={process.env.INVITE_STUDENTS_EMAIL_TO}
+          subject={emailSubject}
+          body={emailBody}
+          data-testid={INVITE_STUDENTS_LINK_ID}
+        >
+          <Button variant="outline-primary" iconBefore={EmailIcon} size="sm">
+            {intl.formatMessage(messages.basicPromotionButton)}
+          </Button>
+        </MailtoLink>
+      </Card.Footer>
+    </Card>
+  );
+};
+
+CoursePromotionCard.propTypes = {
+  lmsLinkForAboutPage: PropTypes.string.isRequired,
+  courseDisplayName: PropTypes.string.isRequired,
+  platformName: PropTypes.string.isRequired,
+};
+
+export default CoursePromotionCard;

--- a/src/schedule-and-details/basic-section/CoursePromotionCard.test.jsx
+++ b/src/schedule-and-details/basic-section/CoursePromotionCard.test.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+
+import { INVITE_STUDENTS_LINK_ID } from './constants';
+import messages from './messages';
+import CoursePromotionCard from './CoursePromotionCard';
+
+describe('<CoursePromotionCard />', () => {
+  const RootWrapper = (props) => (
+    <IntlProvider locale="en">
+      <CoursePromotionCard {...props} />
+    </IntlProvider>
+  );
+
+  const props = {
+    lmsLinkForAboutPage: 'link://to',
+    courseDisplayName: 'foo course',
+    platformName: 'Your platform name here',
+  };
+
+  it('renders the course promotion card', () => {
+    const { getByText, getByRole } = render(<RootWrapper {...props} />);
+    const inviteButton = getByRole('button', {
+      name: messages.basicPromotionButton.defaultMessage,
+    });
+
+    expect(getByText(/Course Summary Page/i)).toBeInTheDocument();
+    expect(
+      getByText(/(for student enrollment and access)/i),
+    ).toBeInTheDocument();
+    expect(getByText(props.lmsLinkForAboutPage)).toBeInTheDocument();
+    expect(inviteButton).toBeInTheDocument();
+  });
+
+  it('generates correct invite mailto link', () => {
+    const { getByTestId } = render(<RootWrapper {...props} />);
+    const inviteLink = getByTestId(INVITE_STUDENTS_LINK_ID);
+    expect(decodeURIComponent(inviteLink.href)).toEqual(
+      `mailto:${process.env.INVITE_STUDENTS_EMAIL_TO}?body=The course ${props.courseDisplayName}, provided by ${props.platformName}, is open for enrollment. Please navigate to this course at ${props.lmsLinkForAboutPage} to enroll.&subject=Enroll in ${props.courseDisplayName}.`,
+    );
+  });
+});

--- a/src/schedule-and-details/basic-section/index.jsx
+++ b/src/schedule-and-details/basic-section/index.jsx
@@ -1,60 +1,25 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
-import {
-  Button,
-  Card,
-  MailtoLink,
-  Hyperlink,
-} from '@openedx/paragon';
+import { useIntl } from '@edx/frontend-platform/i18n';
+
 import PageBannerSlot from '@src/plugin-slots/PageBannerSlot';
-import { Email as EmailIcon } from '@openedx/paragon/icons';
 
 import SectionSubHeader from '../../generic/section-sub-header';
-import { INVITE_STUDENTS_LINK_ID } from './constants';
+import CoursePromotionCard from './CoursePromotionCard';
 import messages from './messages';
+
+export { CoursePromotionCard };
 
 const BasicSection = ({
   org,
   courseNumber,
   run,
   lmsLinkForAboutPage,
-  marketingEnabled,
   courseDisplayName,
   platformName,
 }) => {
   const intl = useIntl();
   const [showPageBanner, setShowPageBanner] = useState(true);
-  const emailSubject = intl.formatMessage(
-    {
-      id: 'course-authoring.schedule.basic.email.subject',
-      defaultMessage: 'Enroll in {courseDisplayName}.',
-    },
-    { courseDisplayName },
-  );
-
-  const emailBody = intl.formatMessage(
-    {
-      id: 'course-authoring.schedule.basic.email.body',
-      defaultMessage:
-        'The course {courseDisplayName}, provided by {platformName}, is open for enrollment. Please navigate to this course at {lmsLinkForAboutPage} to enroll.',
-    },
-    {
-      courseDisplayName,
-      platformName,
-      lmsLinkForAboutPage,
-    },
-  );
-
-  const promotionTitle = (
-    <FormattedMessage
-      id="course-authoring.schedule.basic.promotion.title"
-      defaultMessage="Course summary page {smallText}"
-      values={{
-        smallText: <small>(for student enrollment and access)</small>,
-      }}
-    />
-  );
 
   const courseBasicInfo = [
     {
@@ -85,45 +50,15 @@ const BasicSection = ({
     <PageBannerSlot
       show={showPageBanner}
       onDismiss={() => setShowPageBanner(false)}
+      lmsLinkForAboutPage={lmsLinkForAboutPage}
+      courseDisplayName={courseDisplayName}
+      platformName={platformName}
     >
       <h4 className="text-black">{intl.formatMessage(messages.basicBannerTitle, { platformName })}</h4>
       <span className="text text-gray-700 text-left">
         {intl.formatMessage(messages.basicBannerText)}
       </span>
     </PageBannerSlot>
-  );
-
-  const renderCoursePromotion = () => (
-    <Card>
-      <Card.Header
-        className="h4 px-3 text-gray-500"
-        title={promotionTitle}
-        size="sm"
-      />
-      <Card.Section className="px-3 py-1">
-        <Hyperlink
-          destination={lmsLinkForAboutPage}
-          className="lead info-500 small text-decoration-none"
-          target="_blank"
-          showLaunchIcon={false}
-        >
-          {lmsLinkForAboutPage}
-        </Hyperlink>
-      </Card.Section>
-      <Card.Divider />
-      <Card.Footer className="p-3 justify-content-start">
-        <MailtoLink
-          to={process.env.INVITE_STUDENTS_EMAIL_TO}
-          subject={emailSubject}
-          body={emailBody}
-          data-testid={INVITE_STUDENTS_LINK_ID}
-        >
-          <Button variant="outline-primary" iconBefore={EmailIcon} size="sm">
-            {intl.formatMessage(messages.basicPromotionButton)}
-          </Button>
-        </MailtoLink>
-      </Card.Footer>
-    </Card>
   );
 
   return (
@@ -135,7 +70,7 @@ const BasicSection = ({
       <ul className="basic-info-list">
         {courseBasicInfo.map(renderBasicInfo)}
       </ul>
-      {marketingEnabled ? renderPageBanner() : renderCoursePromotion()}
+      {renderPageBanner()}
     </section>
   );
 };
@@ -145,7 +80,6 @@ BasicSection.propTypes = {
   courseNumber: PropTypes.string.isRequired,
   run: PropTypes.string.isRequired,
   lmsLinkForAboutPage: PropTypes.string.isRequired,
-  marketingEnabled: PropTypes.bool.isRequired,
   courseDisplayName: PropTypes.string.isRequired,
   platformName: PropTypes.string.isRequired,
 };

--- a/src/schedule-and-details/index.tsx
+++ b/src/schedule-and-details/index.tsx
@@ -76,7 +76,6 @@ const ScheduleAndDetails = () => {
     isCreditCourse,
     upgradeDeadline,
     languageOptions,
-    marketingEnabled,
     licensingEnabled,
     aboutPageEditable,
     courseDisplayName,
@@ -261,7 +260,6 @@ const ScheduleAndDetails = () => {
                     courseNumber={courseNumber}
                     run={run}
                     lmsLinkForAboutPage={lmsLinkForAboutPage}
-                    marketingEnabled={marketingEnabled}
                     courseDisplayName={courseDisplayName}
                     platformName={platformName}
                   />


### PR DESCRIPTION
## Summary

The `marketingEnabled` field in the course settings API (`GET /api/contentstore/v1/course_settings/{course_id}`) was previously driven by the `ENABLE_MKTG_SITE` backend setting. That setting has been removed in openedx/openedx-platform#38720, and the API now always returns `true`.

This PR removes the `marketingEnabled` conditional from the Schedule & Details page and cleans up the dead code path.

## Changes

- **Remove `marketingEnabled` from `BasicSection`** — always renders the "Promoting your course" banner (the former `true` path); the `false` path is no longer reachable
- **Extract `CoursePromotionCard`** — the legacy enrollment card (direct LMS about-page link + "Invite your students" mailto button) is extracted into a standalone named export from `basic-section`, so operators who want to restore that UX can do so via the `PageBannerSlot`
- **Extend `PageBannerSlot`** — adds `lmsLinkForAboutPage`, `courseDisplayName`, and `platformName` as optional `pluginProps` so `CoursePromotionCard` has what it needs when used from a plugin
- **Update `PageBannerSlot` README** — documents how to restore the enrollment card via the slot for operators migrating away from `ENABLE_MKTG_SITE=False`
- **Remove `marketingEnabled` from the API type** — field dropped from `CourseSettingsData` in `api.ts`

## Compatibility

This PR is safe to merge before or after the backend change lands. Extra fields returned by the API are silently ignored at runtime — removing `marketingEnabled` from the type does not cause any errors if the API still sends it.

**BREAKING CHANGE**: the "Course summary page" card is no longer shown by default
when a marketing site is not configured. Operators can restore it via the
`PageBannerSlot` using the exported `CoursePromotionCard` (see the slot README).