### PR TITLE
[BB-10928] Allow downloads from modal iframes

### DIFF
--- a/src/generic/modal-iframe/ModalIframe.test.tsx
+++ b/src/generic/modal-iframe/ModalIframe.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { IFRAME_FEATURE_POLICY } from '../../constants';
 import ModalIframe, { SANDBOX_OPTIONS } from '.';
@@ -26,11 +26,10 @@ describe('ModalIframe Component', () => {
     expect(iframe).toHaveAttribute('scrolling', 'no');
   });
 
-  it('allows downloads initiated from the sandboxed iframe', () => {
-    const { getByTitle } = render(<ModalIframe title={title} src={src} />);
-    expect(getByTitle(title).getAttribute('sandbox')).toContain('allow-downloads');
+  it('allows downloads initiated from the sandboxed iframe', async () => {
+    render(<ModalIframe title={title} src={src} />);
+    expect((await screen.findByTitle(title)).getAttribute('sandbox')).toContain('allow-downloads');
   });
-
   it('does not render when showLegacyEditModal is false', () => {
     const { container } = render(<ModalIframe title={title} src={src} />);
 

--- a/src/generic/modal-iframe/ModalIframe.test.tsx
+++ b/src/generic/modal-iframe/ModalIframe.test.tsx
@@ -26,6 +26,11 @@ describe('ModalIframe Component', () => {
     expect(iframe).toHaveAttribute('scrolling', 'no');
   });
 
+  it('allows downloads initiated from the sandboxed iframe', () => {
+    const { getByTitle } = render(<ModalIframe title={title} src={src} />);
+    expect(getByTitle(title).getAttribute('sandbox')).toContain('allow-downloads');
+  });
+
   it('does not render when showLegacyEditModal is false', () => {
     const { container } = render(<ModalIframe title={title} src={src} />);
 

--- a/src/generic/modal-iframe/index.tsx
+++ b/src/generic/modal-iframe/index.tsx
@@ -9,6 +9,7 @@ interface ModalIframeProps extends IframeHTMLAttributes<HTMLIFrameElement> {
 }
 
 export const SANDBOX_OPTIONS = [
+  'allow-downloads',
   'allow-forms',
   'allow-modals',
   'allow-popups',


### PR DESCRIPTION
## Description

This PR adds `allow-downloads` to `SANDBOX_OPTIONS` so author-initiated downloads from the edit modal work wherever the option exists.

## Supporting information

OpenCraft Internal Jira task: [BB-10928](https://tasks.opencraft.com/browse/BB-10928)

## Testing instructions

1. Install an XBlock whose Studio editor triggers a file download, e.g. one with an "Export as JSON" button like https://github.com/open-craft/branching-xblock
2. In Studio, open a unit containing such an XBlock (new unit page / authoring MFE enabled).
3. Trigger the editor's download action.
4. Before this change: no file downloads; the browser console shows the `allow-downloads` warning. After: the file downloads normally.
