### PR TITLE
fix: fix race condition when creating a course re-run

### DIFF
--- a/src/generic/create-or-rerun-course/CreateOrRerunCourseForm.jsx
+++ b/src/generic/create-or-rerun-course/CreateOrRerunCourseForm.jsx
@@ -143,8 +143,10 @@ const CreateOrRerunCourseForm = ({
   };
 
   const handleOnClickCreate = () => {
-    const courseData = isCreateNewCourse ? values : { ...values, sourceCourseKey: courseId };
-    dispatch(updateCreateOrRerunCourseQuery(courseData));
+    const courseData = isCreateNewCourse
+      ? values
+      : { ...values, sourceCourseKey: courseId };
+    dispatch(updateCreateOrRerunCourseQuery(courseData, !isCreateNewCourse));
   };
 
   const handleOnClickCancel = () => {

--- a/src/generic/create-or-rerun-course/CreateOrRerunCourseForm.test.jsx
+++ b/src/generic/create-or-rerun-course/CreateOrRerunCourseForm.test.jsx
@@ -189,6 +189,89 @@ describe('<CreateOrRerunCourseForm />', () => {
 
       expect(mockedUsedNavigate).toHaveBeenCalledWith(`${url}${destinationCourseKey}`);
     });
+    it('should redirect to /home when re-running a course', async () => {
+      const user = userEvent.setup();
+      const rerunProps = { ...props, isCreateNewCourse: false };
+      render(<RootWrapper {...rerunProps} />);
+      await mockStore();
+      const url = '/course/';
+      const destinationCourseKey = 'courseKey';
+      const displayNameInput = screen.getByPlaceholderText(messages.courseDisplayNamePlaceholder.defaultMessage);
+      const orgInput = screen.getByText(messages.courseOrgNoOptions.defaultMessage);
+      const runInput = screen.getByPlaceholderText(messages.courseRunPlaceholder.defaultMessage);
+      const rerunBtn = screen.getByRole('button', { name: messages.rerunCreateButton.defaultMessage });
+      await axiosMock.onPost(getCreateOrRerunCourseUrl()).reply(200, { url, destinationCourseKey });
+
+      await user.type(displayNameInput, 'foo course name');
+      fireEvent.click(orgInput);
+      await user.type(runInput, '1');
+      await user.click(rerunBtn);
+      await executeThunk(updateCreateOrRerunCourseQuery({ org: 'testX', run: 'some' }, true), store.dispatch);
+
+      expect(mockedUsedNavigate).toHaveBeenCalledWith('/home');
+    });
+    it('should include sourceCourseKey in request data for rerun', async () => {
+      const user = userEvent.setup();
+      const rerunProps = {
+        ...props,
+        isCreateNewCourse: false,
+        initialValues: {
+          displayName: 'Test Course',
+          org: 'testOrg',
+          number: '101',
+          run: '',
+        },
+      };
+      render(<RootWrapper {...rerunProps} />);
+      await mockStore();
+      axiosMock.onPost(getCreateOrRerunCourseUrl()).reply(200, { url: '/home' });
+
+      const runInput = screen.getByPlaceholderText(messages.courseRunPlaceholder.defaultMessage);
+      const rerunBtn = screen.getByRole('button', { name: messages.rerunCreateButton.defaultMessage });
+
+      await user.type(runInput, '2024');
+      await user.click(rerunBtn);
+
+      await waitFor(() => {
+        const postRequest = axiosMock.history.post.find(
+          (req) => req.url === getCreateOrRerunCourseUrl(),
+        );
+        expect(postRequest).toBeDefined();
+        const requestData = JSON.parse(postRequest.data);
+        expect(requestData.source_course_key).toBe('course-id-mock');
+      });
+    });
+    it('should not include sourceCourseKey in request data for new course', async () => {
+      const user = userEvent.setup();
+      const createProps = {
+        ...props,
+        isCreateNewCourse: true,
+        initialValues: {
+          displayName: 'New Course',
+          org: 'testOrg',
+          number: '101',
+          run: '',
+        },
+      };
+      render(<RootWrapper {...createProps} />);
+      await mockStore();
+      axiosMock.onPost(getCreateOrRerunCourseUrl()).reply(200, { url: '/course/newCourseId' });
+
+      const runInput = screen.getByPlaceholderText(messages.courseRunPlaceholder.defaultMessage);
+      const createBtn = screen.getByRole('button', { name: messages.createButton.defaultMessage });
+
+      await user.type(runInput, '2024');
+      await user.click(createBtn);
+
+      await waitFor(() => {
+        const postRequest = axiosMock.history.post.find(
+          (req) => req.url === getCreateOrRerunCourseUrl(),
+        );
+        expect(postRequest).toBeDefined();
+        const requestData = JSON.parse(postRequest.data);
+        expect(requestData.source_course_key).toBeUndefined();
+      });
+    });
   });
 
   it('should be disabled create button if form not filled', async () => {

--- a/src/generic/data/thunks.js
+++ b/src/generic/data/thunks.js
@@ -37,13 +37,17 @@ export function fetchCourseRerunQuery(courseId) {
   };
 }
 
-export function updateCreateOrRerunCourseQuery(courseData) {
+export function updateCreateOrRerunCourseQuery(courseData, isRerun = false) {
   return async (dispatch) => {
     dispatch(updateSavingStatus({ status: RequestStatus.PENDING }));
 
     try {
       const response = await createOrRerunCourse(courseData);
-      dispatch(updateRedirectUrlObj('url' in response ? response : {}));
+      if (isRerun) {
+        dispatch(updateRedirectUrlObj({ url: '/home' }));
+      } else {
+        dispatch(updateRedirectUrlObj('url' in response ? response : {}));
+      }
       dispatch(updatePostErrors('errMsg' in response ? response : {}));
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       return true;

--- a/src/studio-home/processing-courses/course-item/index.jsx
+++ b/src/studio-home/processing-courses/course-item/index.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import {
   ActionRow,
   Card,
-  Hyperlink,
   Button,
   Icon,
 } from '@openedx/paragon';
@@ -14,7 +14,6 @@ import {
   RotateRight as RotateRightIcon,
 } from '@openedx/paragon/icons';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { getConfig } from '@edx/frontend-platform';
 
 import { handleDeleteNotificationQuery } from '../../data/thunks';
 import messages from './messages';
@@ -22,7 +21,6 @@ import messages from './messages';
 const CourseItem = ({ course }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const studioBaseUrl = getConfig().STUDIO_BASE_URL;
   const {
     displayName,
     org,
@@ -54,9 +52,9 @@ const CourseItem = ({ course }) => {
           <Card.Section className="p-3.5 small text-gray-700 bg-light-200">
             {intl.formatMessage(messages.itemInProgressFooterText, {
               refresh: (
-                <Hyperlink destination={`${studioBaseUrl}/home`}>
+                <Link to="/home" reloadDocument>
                   {intl.formatMessage(messages.itemInProgressFooterHyperlink)}
-                </Hyperlink>
+                </Link>
               ),
             })}
           </Card.Section>

--- a/src/studio-home/processing-courses/course-item/index.jsx
+++ b/src/studio-home/processing-courses/course-item/index.jsx
@@ -14,6 +14,7 @@ import {
   RotateRight as RotateRightIcon,
 } from '@openedx/paragon/icons';
 import { useIntl } from '@edx/frontend-platform/i18n';
+import { getConfig } from '@edx/frontend-platform';
 
 import { handleDeleteNotificationQuery } from '../../data/thunks';
 import messages from './messages';
@@ -21,6 +22,7 @@ import messages from './messages';
 const CourseItem = ({ course }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
+  const studioBaseUrl = getConfig().STUDIO_BASE_URL;
   const {
     displayName,
     org,
@@ -52,7 +54,7 @@ const CourseItem = ({ course }) => {
           <Card.Section className="p-3.5 small text-gray-700 bg-light-200">
             {intl.formatMessage(messages.itemInProgressFooterText, {
               refresh: (
-                <Hyperlink destination="/home">
+                <Hyperlink destination={`${studioBaseUrl}/home`}>
                   {intl.formatMessage(messages.itemInProgressFooterHyperlink)}
                 </Hyperlink>
               ),

--- a/src/studio-home/tabs-section/courses-tab/index.tsx
+++ b/src/studio-home/tabs-section/courses-tab/index.tsx
@@ -224,8 +224,8 @@ export const CoursesList: React.FC<Props> = ({
       ) :
       (
         <div className="courses-tab-container">
+          {isShowProcessing && <ProcessingCourses />}
           <div className="d-flex flex-row align-items-center justify-content-between my-4">
-            {isShowProcessing && <ProcessingCourses />}
             <CoursesFilters dispatch={dispatch} locationValue={locationValue} isLoading={isLoading} />
             <p data-testid="pagination-info" className="my-0">
               {intl.formatMessage(messages.coursesPaginationInfo, {

--- a/src/studio-home/tabs-section/index.tsx
+++ b/src/studio-home/tabs-section/index.tsx
@@ -101,7 +101,7 @@ const TabsSection = ({
     }
 
     return tabs;
-  }, [showNewCourseContainer]);
+  }, [showNewCourseContainer, isShowProcessing]);
 
   const handleSelectTab = (tab: TabKeyType) => {
     if (tab === TABS_LIST.courses) {


### PR DESCRIPTION
Fixes: https://github.com/openedx/frontend-app-authoring/issues/3103

## Description

Fixes a race condition when creating a course re-run that caused a 404 error page to appear.

When a course is re-run, the backend creates the new course asynchronously via workers. Previously, the MFE immediately redirected the user to the new course's overview page, but because the course wasn't fully created yet, this resulted in a 404 error. This was a regression from the legacy UI behavior, which redirected to the Studio Home page instead, where a "course being processed" info card was displayed.

This PR changes the re-run redirect destination from the course overview page to the Studio Home (`/home`), matching both the legacy UI behavior and the [official Open edX documentation](https://docs.openedx.org/en/latest/educators/how-tos/rerun_course.html#use-the-course-re-run-option), which states:

> Select **Create Re-Run**. Your **My Courses** dashboard opens with a status message about the course creation process.

It also fixes the display position of the re-run creation status card in the courses tab so it renders correctly.

**Impacted user roles:** Course Authors and Operators who use the "re-run course" feature.

**Before:** After creating a re-run, user is redirected to the new course overview → 404 error due to race condition.

<img width="665" height="502" alt="Screenshot 2026-06-19 at 11 55 07 a m" src="https://github.com/user-attachments/assets/4130bf5a-7b34-4b56-a77d-f5aec2dc5036" />

**After:** After creating a re-run, user is redirected to the Studio Home page where a status card shows that the course is being created.

<img width="1167" height="703" alt="Screenshot 2026-06-19 at 11 53 37 a m" src="https://github.com/user-attachments/assets/87e9237b-3cfa-474f-ac68-4878b591822c" />

## Supporting information

- Issue: https://github.com/openedx/frontend-app-authoring/issues/3103
- Official documentation: https://docs.openedx.org/en/latest/educators/how-tos/rerun_course.html#use-the-course-re-run-option
- Related historical context: https://github.com/openedx/frontend-app-authoring/issues/977#issuecomment-2117550283
- The race condition only manifests in non-dev (production/local) mode where async tasks run on workers. In dev mode, tasks run synchronously so the course is fully created before the redirect.

## Testing instructions

1. Set up a local Open edX environment running in **local mode** (not dev mode), or use a sandbox/stage environment.
2. Navigate to the Studio Home page.
3. Find an existing course and select the "Re-run Course" option from the 3-dot menu.
4. Fill in the re-run form and submit.
5. Verify that after submission, you are redirected to the Studio Home page (`/home`) instead of the new course overview.
6. If the course is still being processed, a "course being processed" info card is displayed on the Studio Home page.
7. Also verify that creating a **new** course (not a re-run) still redirects to the new course's overview page as before.

## Other information

- This change does not depend on other changes elsewhere.
- No new dependencies introduced.
- The fix passes the `isRerun` flag through to the thunk so it can conditionally set the redirect URL to `/home` for re-runs, while preserving the existing behavior for new course creation.
- The courses tab template fix moves the processing status component inside the card body div so it displays correctly above the pagination info.
- Co-authored by Kiro with Claude Opus 4.6: The problem was researched manually and the solution was described to the agent, which implemented the code changes, then some manual adjustments were made. Also this PR description was partially generated by the agent.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
