### PR TITLE
refactor: remove useNewVideoUploadsPage waffle flag

### DIFF
--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -85,7 +85,6 @@ export const waffleFlagDefaults = {
   useNewImportPage: false,
   useNewExportPage: true,
   useNewFilesUploadsPage: true,
-  useNewVideoUploadsPage: true,
   useNewCourseOutlinePage: true,
   useNewUnitPage: false,
   useNewTextbooksPage: true,

--- a/src/editors/containers/VideoEditor/components/VideoEditorModal.tsx
+++ b/src/editors/containers/VideoEditor/components/VideoEditorModal.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
-import { useWaffleFlags } from '@src/data/apiHooks';
 import * as appHooks from '../../../hooks';
 import { thunkActions, selectors } from '../../../data/redux';
 import VideoSettingsModal from './VideoSettingsModal';
@@ -42,7 +41,6 @@ const VideoEditorModal: React.FC<Props> = ({
   const isLoaded = useSelector(
     (state) => selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchVideos }),
   );
-  const { useNewVideoUploadsPage } = useWaffleFlags();
 
   useEffect(() => {
     hooks.initialize(dispatch, selectedVideoId, selectedVideoUrl);
@@ -54,7 +52,6 @@ const VideoEditorModal: React.FC<Props> = ({
         onReturn: onSettingsReturn,
         isLibrary,
         onClose,
-        useNewVideoUploadsPage,
       }}
     />
   );

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.test.tsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.test.tsx
@@ -10,7 +10,6 @@ const defaultProps = {
   onReturn: jest.fn(),
   isLibrary: false,
   onClose: jest.fn(),
-  useNewVideoUploadsPage: true,
 };
 
 const renderComponent = (overrideProps = {}) => {
@@ -38,7 +37,7 @@ describe('<VideoSettingsModal />', () => {
     window.scrollTo = jest.fn();
   });
 
-  it('renders back button when useNewVideoUploadsPage is true and isLibrary is false', () => {
+  it('renders back button when isLibrary is false', () => {
     renderComponent();
     expect(screen.getByRole('button', { name: /replace video/i })).toBeInTheDocument();
   });

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.tsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.tsx
@@ -21,17 +21,15 @@ interface Props {
   onReturn: () => void;
   isLibrary: boolean;
   onClose?: (() => void) | null;
-  useNewVideoUploadsPage?: boolean;
 }
 
 const VideoSettingsModal: React.FC<Props> = ({
   onReturn,
   isLibrary,
   onClose,
-  useNewVideoUploadsPage,
 }) => (
   <>
-    {!isLibrary && useNewVideoUploadsPage && (
+    {!isLibrary && (
       <Button
         variant="link"
         className="text-primary-500"

--- a/src/header/hooks.test.tsx
+++ b/src/header/hooks.test.tsx
@@ -85,7 +85,6 @@ describe('header utils', () => {
     it('when video upload page disabled should not include Video Uploads option', () => {
       mockWaffleFlags({
         enableAuthzCourseAuthoring: false,
-        useNewVideoUploadsPage: false,
       });
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
@@ -237,7 +236,6 @@ describe('header utils', () => {
     beforeAll(() => {
       mockWaffleFlags({
         enableAuthzCourseAuthoring: false,
-        useNewVideoUploadsPage: false,
       });
     });
     beforeEach(() => {

--- a/src/header/hooks.tsx
+++ b/src/header/hooks.tsx
@@ -62,7 +62,7 @@ export const useContentMenuItems = (courseId: string) => {
       }] :
       []),
   ];
-  if (getConfig().ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN === 'true' || waffleFlags.useNewVideoUploadsPage) {
+  if (getConfig().ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN === 'true') {
     items.push({
       href: `/course/${courseId}/videos`,
       title: intl.formatMessage(messages['header.links.videoUploads']),


### PR DESCRIPTION
> **🛑 Closed without merging.** Removing this flag is on hold pending the upstream feature decision in **openedx/edx-platform#37972**.
>
> **openedx/edx-platform#37582** (merged) removed the *legacy* video page but **deliberately kept** `contentstore.new_studio_mfe.use_new_video_uploads_page` to keep the *new* page flagged **off** for the community (both versions only work on edx.org). Removing the MFE read now would un-gate an edX/MIT-only feature for community installs. Two of #37972's three possible outcomes (remove the page / genericize with plugin slots) would make this PR the wrong change.
>
> Full context and grooming notes: #3105. Will revisit once #37972 lands a decision.

---

**Closes #3105** *(deferred — see above)*

## Description

Removes the `useNewVideoUploadsPage` waffle flag and keep it enabled by default.

## References

- #3105 (full history) · epic #3089 · related #3063, #3069
- Upstream: openedx/edx-platform#37972, openedx/edx-platform#37582
