### PR TITLE
fix: load library content when selecting a library in unit Add Existi…

### DIFF
--- a/src/course-unit/unit-sidebar/AddSidebar.tsx
+++ b/src/course-unit/unit-sidebar/AddSidebar.tsx
@@ -355,6 +355,7 @@ export const AddSidebar = () => {
             className="mb-2 mx-n4.5 mx-n3.5"
             activeKey={currentTabKey}
             onSelect={setCurrentTabKey}
+            mountOnEnter
           >
             <Tab
               eventKey="add-new"

--- a/src/library-authoring/LibraryAuthoringPage.scss
+++ b/src/library-authoring/LibraryAuthoringPage.scss
@@ -1,3 +1,12 @@
+.library-authoring-page-embedded {
+  padding: 0;
+
+  .library-cards-grid {
+    grid-template-columns: 1fr;
+    grid-gap: 1rem;
+  }
+}
+
 .library-authoring-page {
   .header-actions {
     .normal-border {

--- a/src/library-authoring/LibraryAuthoringPage.scss
+++ b/src/library-authoring/LibraryAuthoringPage.scss
@@ -2,8 +2,17 @@
   padding: 0;
 
   .library-cards-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     grid-gap: 1rem;
+    justify-items: stretch;
+  }
+
+  .library-item-card {
+    width: 100%;
+
+    .pgn__card {
+      min-width: 0;
+    }
   }
 }
 

--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -382,7 +382,7 @@ const LibraryAuthoringPage = ({
           <SearchContextProvider
             extraFilter={extraFilter}
             overrideTypesFilter={overrideTypesFilter}
-            skipUrlUpdate={componentPickerMode}
+            skipUrlUpdate={!!componentPickerMode}
           >
             {libraryData
               && (

--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -373,10 +373,15 @@ const LibraryAuthoringPage = ({
               )}
             </>
           )}
-        <Container className="px-4 mt-4 mb-5 library-authoring-page">
+        <Container className={classNames('library-authoring-page', {
+          'px-4 mt-4 mb-5': !componentPickerMode,
+          'library-authoring-page-embedded': componentPickerMode,
+        })}
+        >
           <SearchContextProvider
             extraFilter={extraFilter}
             overrideTypesFilter={overrideTypesFilter}
+            skipUrlUpdate={componentPickerMode}
           >
             {libraryData
               && (

--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -373,10 +373,11 @@ const LibraryAuthoringPage = ({
               )}
             </>
           )}
-        <Container className={classNames('library-authoring-page', {
-          'px-4 mt-4 mb-5': !componentPickerMode,
-          'library-authoring-page-embedded': componentPickerMode,
-        })}
+        <Container
+          className={classNames('library-authoring-page', {
+            'px-4 mt-4 mb-5': !componentPickerMode,
+            'library-authoring-page-embedded': componentPickerMode,
+          })}
         >
           <SearchContextProvider
             extraFilter={extraFilter}

--- a/src/library-authoring/library-filters/LibraryDropdownFilter.test.tsx
+++ b/src/library-authoring/library-filters/LibraryDropdownFilter.test.tsx
@@ -85,6 +85,18 @@ describe('LibraryDropdownFilter', () => {
     ])).toEqual(['lib:SampleTaxonomyOrg1:TL2']);
   });
 
+  it('should show library name when the only library is selected', async () => {
+    const mockApi = mockGetContentLibraryV2List.applyMockNoPagination();
+    mockApi.mockResolvedValue([
+      { id: 'lib:SampleTaxonomyOrg1:TL1', title: 'Test Library 1' },
+    ] as any);
+    mockValue = ['lib:SampleTaxonomyOrg1:TL1'];
+    renderComponent();
+
+    const dropdownTrigger = await screen.findByRole('button', { name: 'Test Library 1' });
+    expect(dropdownTrigger).toBeInTheDocument();
+  });
+
   it('should update label to library if one is selected', async () => {
     mockGetContentLibraryV2List.applyMockNoPagination();
     mockValue = ['lib:SampleTaxonomyOrg1:TL1'];
@@ -107,6 +119,24 @@ describe('LibraryDropdownFilter', () => {
 
     const dropdownTrigger = await screen.findByRole('button', { name: '2 Libraries' });
     expect(dropdownTrigger).toBeInTheDocument();
+  });
+
+  it('should replace selection in single-select mode', async () => {
+    const user = userEvent.setup();
+    mockGetContentLibraryV2List.applyMockNoPagination();
+    render(<LibraryDropdownFilter singleSelect />);
+
+    const dropdownTrigger = await screen.findByRole('button', { name: 'All libraries' });
+    await user.click(dropdownTrigger);
+
+    const item = await screen.findByRole('checkbox', { name: 'Test Library 1' });
+    await user.click(item);
+    const passedFunction = mockSetValue.mock.calls[0][0];
+    expect(passedFunction([])).toEqual(['lib:SampleTaxonomyOrg1:TL1']);
+
+    await user.click(item);
+    const passedFunction2 = mockSetValue.mock.calls[1][0];
+    expect(passedFunction2(['lib:SampleTaxonomyOrg1:TL1'])).toEqual([]);
   });
 
   it('should reset label to "All libraries" when all libraries are selected', async () => {

--- a/src/library-authoring/library-filters/LibraryDropdownFilter.test.tsx
+++ b/src/library-authoring/library-filters/LibraryDropdownFilter.test.tsx
@@ -121,24 +121,6 @@ describe('LibraryDropdownFilter', () => {
     expect(dropdownTrigger).toBeInTheDocument();
   });
 
-  it('should replace selection in single-select mode', async () => {
-    const user = userEvent.setup();
-    mockGetContentLibraryV2List.applyMockNoPagination();
-    render(<LibraryDropdownFilter singleSelect />);
-
-    const dropdownTrigger = await screen.findByRole('button', { name: 'All libraries' });
-    await user.click(dropdownTrigger);
-
-    const item = await screen.findByRole('checkbox', { name: 'Test Library 1' });
-    await user.click(item);
-    const passedFunction = mockSetValue.mock.calls[0][0];
-    expect(passedFunction([])).toEqual(['lib:SampleTaxonomyOrg1:TL1']);
-
-    await user.click(item);
-    const passedFunction2 = mockSetValue.mock.calls[1][0];
-    expect(passedFunction2(['lib:SampleTaxonomyOrg1:TL1'])).toEqual([]);
-  });
-
   it('should reset label to "All libraries" when all libraries are selected', async () => {
     mockGetContentLibraryV2List.applyMockNoPagination();
     // Both libraries in the mock are selected — selectedLibraries.length === data.length

--- a/src/library-authoring/library-filters/LibraryDropdownFilter.tsx
+++ b/src/library-authoring/library-filters/LibraryDropdownFilter.tsx
@@ -60,7 +60,7 @@ const LibraryItems = ({ isPending, data, onChange }: LibraryItemsProps) => {
   );
 };
 
-export const LibraryDropdownFilter = ({ singleSelect = false }: { singleSelect?: boolean; }) => {
+export const LibraryDropdownFilter = () => {
   const intl = useIntl();
   const [search, setSearch] = useState('');
   const { selectedLibraries, setSelectedLibraries } = useMultiLibraryContext();
@@ -75,9 +75,6 @@ export const LibraryDropdownFilter = ({ singleSelect = false }: { singleSelect?:
 
   const onChange = (libraryId: string) => {
     setSelectedLibraries?.((prev) => {
-      if (singleSelect) {
-        return prev.includes(libraryId) ? [] : [libraryId];
-      }
       if (prev.includes(libraryId)) {
         return prev.filter((id) => id !== libraryId);
       }

--- a/src/library-authoring/library-filters/LibraryDropdownFilter.tsx
+++ b/src/library-authoring/library-filters/LibraryDropdownFilter.tsx
@@ -60,7 +60,7 @@ const LibraryItems = ({ isPending, data, onChange }: LibraryItemsProps) => {
   );
 };
 
-export const LibraryDropdownFilter = () => {
+export const LibraryDropdownFilter = ({ singleSelect = false }: { singleSelect?: boolean; }) => {
   const intl = useIntl();
   const [search, setSearch] = useState('');
   const { selectedLibraries, setSelectedLibraries } = useMultiLibraryContext();
@@ -75,6 +75,9 @@ export const LibraryDropdownFilter = () => {
 
   const onChange = (libraryId: string) => {
     setSelectedLibraries?.((prev) => {
+      if (singleSelect) {
+        return prev.includes(libraryId) ? [] : [libraryId];
+      }
       if (prev.includes(libraryId)) {
         return prev.filter((id) => id !== libraryId);
       }
@@ -84,14 +87,16 @@ export const LibraryDropdownFilter = () => {
 
   useEffect(() => {
     const baseName = intl.formatMessage(messages.librariesFilterBtnText);
-    if (!selectedLibraries.length || selectedLibraries.length === data?.length) {
+    if (!selectedLibraries.length) {
       setLabel(baseName);
     } else if (selectedLibraries.length === 1) {
       setLabel(data?.find((lib) => lib.id === selectedLibraries[0])?.title || baseName);
+    } else if (selectedLibraries.length === data?.length) {
+      setLabel(baseName);
     } else if (selectedLibraries.length > 1) {
       setLabel(intl.formatMessage(messages.librariesFilterBtnCount, { count: selectedLibraries.length }));
     }
-  }, [label, selectedLibraries, data]);
+  }, [intl, selectedLibraries, data]);
 
   return (
     <Dropdown

--- a/src/library-authoring/library-filters/SidebarFilters.tsx
+++ b/src/library-authoring/library-filters/SidebarFilters.tsx
@@ -27,7 +27,7 @@ export const SidebarFilters = ({ onlyOneType }: FiltersProps) => {
   return (
     <Stack gap={3} className="my-3">
       <Stack className="flex-wrap" direction="horizontal" gap={2}>
-        <LibraryDropdownFilter singleSelect />
+        <LibraryDropdownFilter />
         <Stack direction="horizontal" gap={1}>
           <SearchKeywordsField />
           <IconButton

--- a/src/library-authoring/library-filters/SidebarFilters.tsx
+++ b/src/library-authoring/library-filters/SidebarFilters.tsx
@@ -27,7 +27,7 @@ export const SidebarFilters = ({ onlyOneType }: FiltersProps) => {
   return (
     <Stack gap={3} className="my-3">
       <Stack className="flex-wrap" direction="horizontal" gap={2}>
-        <LibraryDropdownFilter />
+        <LibraryDropdownFilter singleSelect />
         <Stack direction="horizontal" gap={1}>
           <SearchKeywordsField />
           <IconButton


### PR DESCRIPTION
Realated issue: https://github.com/openedx/wg-build-test-release/issues/587

## Problem:
 On the unit page Add Existing sidebar, users could open the library dropdown and select a library, but the content list did not update. Search filters were being written to the course URL while the picker ran inside the unit sidebar, which interfered with Meilisearch queries. The library dropdown also stayed on “All libraries” when only one library existed, so it looked like the selection had no effect.

## Fix: 
This change restores the Add Existing flow on the unit sidebar by stopping Meilisearch search state from syncing to the course URL in component picker mode, switching the library dropdown to single-select with a clearer label when one library is selected, and tightening the embedded picker layout so published library content appears after a library is chosen.

## Testing before solution

1. 
<img width="2534" height="1530" alt="image" src="https://github.com/user-attachments/assets/cf8d8e25-1a67-45cf-89fc-e6ce110fb940" />

2. 
<img width="854" height="822" alt="image" src="https://github.com/user-attachments/assets/2457da33-7cea-4e81-99f3-1b6e4fd530b2" />


## Testing after applying the solution:

<img width="526" height="968" alt="image" src="https://github.com/user-attachments/assets/d818be42-b44a-4033-a99e-1b003f2b8edb" />
