### PR TITLE
feat: Add "Move Up" / "Move Down" menu items to lib unit components

### DIFF
--- a/src/library-authoring/components/ComponentMenu.tsx
+++ b/src/library-authoring/components/ComponentMenu.tsx
@@ -18,13 +18,20 @@ import {
   SidebarBodyItemId,
   useSidebarContext,
 } from '@src/library-authoring/common/context/SidebarContext';
-import { useRemoveItemsFromCollection } from '@src/library-authoring/data/apiHooks';
+import {
+  useContainerChildren,
+  useRemoveItemsFromCollection,
+  useUpdateContainerChildren,
+} from '@src/library-authoring/data/apiHooks';
 import containerMessages from '@src/library-authoring/containers/messages';
+import unitMessages from '@src/library-authoring/units/messages';
+import outlineCardMessages from '@src/course-outline/card-header/messages';
 import { useLibraryRoutes } from '@src/library-authoring/routes';
 import { canEditComponent } from './ComponentEditorModal';
 import ComponentDeleter from './ComponentDeleter';
 import ComponentRemover from './ComponentRemover';
 import messages from './messages';
+import { LibraryBlockMetadata } from '../data/api';
 
 interface Props {
   usageKey: string;
@@ -86,6 +93,24 @@ export const ComponentMenu = ({ usageKey, index }: Props) => {
 
   const containerType = containerId ? getBlockType(containerId) : 'collection';
 
+  // The following provide information about the parent container so we can implement "Move Up" and "Move Down" menu
+  // actions, if relevant.
+  const orderMutator = useUpdateContainerChildren(containerId);
+  const { data: parentContainerComponents } = useContainerChildren<LibraryBlockMetadata>(containerId);
+  // If we're in a [draft/editable] container, these handlers will move the current component up and down:
+  const moveInParent = useCallback(async (delta: number) => {
+    const newOrder = parentContainerComponents?.map(c => c.id) ?? [];
+    const [idToMove] = newOrder.splice(index!, 1); // Remove from its current position
+    newOrder.splice(index! + delta, 0, idToMove); // Insert into new position
+    try {
+      await orderMutator.mutateAsync(newOrder); // Save the new order
+    } catch {
+      showToast(intl.formatMessage(unitMessages.failedOrderUpdatedMsg));
+    }
+  }, [index, orderMutator, parentContainerComponents]);
+  const moveUp = useCallback(() => moveInParent(-1), [moveInParent]);
+  const moveDown = useCallback(() => moveInParent(1), [moveInParent]);
+
   return (
     <Dropdown id="component-card-dropdown">
       <Dropdown.Toggle
@@ -107,16 +132,6 @@ export const ComponentMenu = ({ usageKey, index }: Props) => {
         <Dropdown.Item onClick={updateClipboardClick}>
           <FormattedMessage {...messages.menuCopyToClipboard} />
         </Dropdown.Item>
-        {containerId && (
-          <Dropdown.Item onClick={openRemoveModal}>
-            <FormattedMessage {...messages.removeComponentFromUnitMenu} />
-          </Dropdown.Item>
-        )}
-        {!readOnly && (
-          <Dropdown.Item onClick={openDeleteModal}>
-            <FormattedMessage {...messages.menuDelete} />
-          </Dropdown.Item>
-        )}
         {insideCollection && !readOnly && (
           <Dropdown.Item onClick={removeFromCollection}>
             <FormattedMessage
@@ -130,6 +145,30 @@ export const ComponentMenu = ({ usageKey, index }: Props) => {
         {!readOnly && (
           <Dropdown.Item onClick={showManageCollections}>
             <FormattedMessage {...containerMessages.menuAddToCollection} />
+          </Dropdown.Item>
+        )}
+
+        {!readOnly && parentContainerComponents && index !== undefined && (
+          <Dropdown.Item onClick={moveUp} disabled={index === 0}>
+            <FormattedMessage {...outlineCardMessages.menuMoveUp} />
+          </Dropdown.Item>
+        )}
+        {!readOnly && parentContainerComponents && index !== undefined && (
+          <Dropdown.Item onClick={moveDown} disabled={index >= parentContainerComponents.length - 1}>
+            <FormattedMessage {...outlineCardMessages.menuMoveDown} />
+          </Dropdown.Item>
+        )}
+
+        {(containerId || !readOnly) && <Dropdown.Divider />}
+
+        {containerId && (
+          <Dropdown.Item onClick={openRemoveModal}>
+            <FormattedMessage {...messages.removeComponentFromUnitMenu} />
+          </Dropdown.Item>
+        )}
+        {!readOnly && (
+          <Dropdown.Item onClick={openDeleteModal}>
+            <FormattedMessage {...messages.menuDelete} />
           </Dropdown.Item>
         )}
       </Dropdown.Menu>

--- a/src/library-authoring/components/ComponentMenu.tsx
+++ b/src/library-authoring/components/ComponentMenu.tsx
@@ -99,7 +99,7 @@ export const ComponentMenu = ({ usageKey, index }: Props) => {
   const { data: parentContainerComponents } = useContainerChildren<LibraryBlockMetadata>(containerId);
   // If we're in a [draft/editable] container, these handlers will move the current component up and down:
   const moveInParent = useCallback(async (delta: number) => {
-    if (!parentContainerComponents || index === undefined) {
+    if (!parentContainerComponents || index === undefined) { // istanbul ignore next
       return;
     }
     const newOrder = parentContainerComponents.map(c => c.id);
@@ -107,7 +107,8 @@ export const ComponentMenu = ({ usageKey, index }: Props) => {
     newOrder.splice(index + delta, 0, idToMove); // Insert into new position
     try {
       await orderMutator.mutateAsync(newOrder); // Save the new order
-      if (sidebarItemInfo?.id === usageKey) {
+      if (sidebarItemInfo?.id === usageKey) { // istanbul ignore next
+        // Make sure the index in the sidebar stays in sync, or its "Move Up"/"Move Down" actions won't work correctly.
         openItemSidebar(usageKey, SidebarBodyItemId.ComponentInfo, index + delta);
       }
     } catch {

--- a/src/library-authoring/components/ComponentMenu.tsx
+++ b/src/library-authoring/components/ComponentMenu.tsx
@@ -99,15 +99,21 @@ export const ComponentMenu = ({ usageKey, index }: Props) => {
   const { data: parentContainerComponents } = useContainerChildren<LibraryBlockMetadata>(containerId);
   // If we're in a [draft/editable] container, these handlers will move the current component up and down:
   const moveInParent = useCallback(async (delta: number) => {
-    const newOrder = parentContainerComponents?.map(c => c.id) ?? [];
-    const [idToMove] = newOrder.splice(index!, 1); // Remove from its current position
-    newOrder.splice(index! + delta, 0, idToMove); // Insert into new position
+    if (!parentContainerComponents || index === undefined) {
+      return;
+    }
+    const newOrder = parentContainerComponents.map(c => c.id);
+    const [idToMove] = newOrder.splice(index, 1); // Remove from its current position
+    newOrder.splice(index + delta, 0, idToMove); // Insert into new position
     try {
       await orderMutator.mutateAsync(newOrder); // Save the new order
+      if (sidebarItemInfo?.id === usageKey) {
+        openItemSidebar(usageKey, SidebarBodyItemId.ComponentInfo, index + delta);
+      }
     } catch {
       showToast(intl.formatMessage(unitMessages.failedOrderUpdatedMsg));
     }
-  }, [index, orderMutator, parentContainerComponents]);
+  }, [index, orderMutator, parentContainerComponents, sidebarItemInfo, usageKey, openItemSidebar]);
   const moveUp = useCallback(() => moveInParent(-1), [moveInParent]);
   const moveDown = useCallback(() => moveInParent(1), [moveInParent]);
 

--- a/src/library-authoring/units/LibraryUnitPage.test.tsx
+++ b/src/library-authoring/units/LibraryUnitPage.test.tsx
@@ -352,6 +352,101 @@ describe('<LibraryUnitPage />', () => {
     await waitFor(() => expect(mockShowToast).toHaveBeenLastCalledWith('Failed to update components order'));
   });
 
+  it('should move a component down using the menu', async () => {
+    const user = userEvent.setup();
+    const url = getLibraryContainerChildrenApiUrl(mockGetContainerMetadata.unitId);
+    axiosMock.onPatch(url).reply(200);
+    renderLibraryUnitPage();
+
+    expect(await screen.findByText('text block 0')).toBeInTheDocument();
+    // Open the menu of the first component (index 0)
+    const menu = (await screen.findAllByRole('button', { name: /component actions menu/i }))[0];
+    await user.click(menu);
+
+    const moveDown = await screen.findByRole('button', { name: 'Move down' });
+    await user.click(moveDown);
+
+    await waitFor(() => { // Wait for the mocked PATCH call that would re-order the items.
+      expect(axiosMock.history.patch[0].url).toEqual(url);
+    });
+    // The first component is moved one position down, swapping it with the second.
+    expect(JSON.parse(axiosMock.history.patch[0].data).usage_keys).toEqual([
+      'lb:org1:Demo_course_generated:html:text-1',
+      'lb:org1:Demo_course_generated:html:text-0',
+      'lb:org1:Demo_course_generated:html:text-2',
+    ]);
+  });
+
+  it('should move a component up using the menu', async () => {
+    const user = userEvent.setup();
+    const url = getLibraryContainerChildrenApiUrl(mockGetContainerMetadata.unitId);
+    axiosMock.onPatch(url).reply(200);
+    renderLibraryUnitPage();
+
+    expect(await screen.findByText('text block 1')).toBeInTheDocument();
+    // Open the menu of the second component (index 1)
+    const menu = (await screen.findAllByRole('button', { name: /component actions menu/i }))[1];
+    await user.click(menu);
+
+    const moveUp = await screen.findByRole('button', { name: 'Move up' });
+    await user.click(moveUp);
+
+    await waitFor(() => { // Wait for the mocked PATCH call that would re-order the items.
+      expect(axiosMock.history.patch[0].url).toEqual(url);
+    });
+    // The second component is moved one position up, swapping it with the first.
+    expect(JSON.parse(axiosMock.history.patch[0].data).usage_keys).toEqual([
+      'lb:org1:Demo_course_generated:html:text-1',
+      'lb:org1:Demo_course_generated:html:text-0',
+      'lb:org1:Demo_course_generated:html:text-2',
+    ]);
+  });
+
+  it('should disable "Move up" for the first component', async () => {
+    const user = userEvent.setup();
+    renderLibraryUnitPage();
+
+    expect(await screen.findByText('text block 0')).toBeInTheDocument();
+    const menu = (await screen.findAllByRole('button', { name: /component actions menu/i }))[0];
+    await user.click(menu);
+
+    // The first component can't move up, but it can move down.
+    expect(await screen.findByRole('button', { name: 'Move up' })).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('button', { name: 'Move down' })).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should disable "Move down" for the last component', async () => {
+    const user = userEvent.setup();
+    renderLibraryUnitPage();
+
+    expect(await screen.findByText('text block 2')).toBeInTheDocument();
+    const menu = (await screen.findAllByRole('button', { name: /component actions menu/i }))[2];
+    await user.click(menu);
+
+    // The last component can't move down, but it can move up.
+    expect(await screen.findByRole('button', { name: 'Move down' })).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('button', { name: 'Move up' })).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should show error toast when reordering via the menu fails', async () => {
+    const user = userEvent.setup();
+    const url = getLibraryContainerChildrenApiUrl(mockGetContainerMetadata.unitId);
+    axiosMock.onPatch(url).reply(500);
+    renderLibraryUnitPage();
+
+    expect(await screen.findByText('text block 0')).toBeInTheDocument();
+    const menu = (await screen.findAllByRole('button', { name: /component actions menu/i }))[0];
+    await user.click(menu);
+
+    const moveDown = await screen.findByRole('button', { name: 'Move down' });
+    await user.click(moveDown);
+
+    await waitFor(() => {
+      expect(axiosMock.history.patch[0].url).toEqual(url);
+    });
+    expect(mockShowToast).toHaveBeenCalledWith('Failed to update components order');
+  });
+
   it('should remove a component & restore from component card', async () => {
     const user = userEvent.setup();
     const url = getLibraryContainerChildrenApiUrl(mockGetContainerMetadata.unitId);


### PR DESCRIPTION
This is a workaround for https://github.com/openedx/frontend-app-authoring/issues/1994 "Cannot drag a component past a really long component on a unit page" (Since "autoscroll" is disabled in our usage of dnd-kit due to conflicts with our custom collision detection algorithm.)

This implements the workaround proposed in https://github.com/openedx/frontend-app-authoring/issues/3110.

I also re-organized the menu to put the destructive remove/delete menu options last, below a divider, for better consistency with course authoring.

## Description

Before | After
--|--
<img width="413" height="268" alt="Screenshot 2026-06-23 at 3 55 21 PM" src="https://github.com/user-attachments/assets/091f2005-8a87-436f-9f94-9b70760a9016" /> | <img width="397" height="356" alt="After" src="https://github.com/user-attachments/assets/095157fe-c762-4301-ad64-910bf1cbecf7" />

## Testing instructions

Try using both regular drag-and-drop and the new menu items to re-order components in a library unit.


Private ref: MNG-4985
