### PR TITLE
fix: race condition when creating a course re-run (backport)

### DIFF
--- a/src/generic/create-or-rerun-course/CreateOrRerunCourseForm.jsx
+++ b/src/generic/create-or-rerun-course/CreateOrRerunCourseForm.jsx
@@ -143,8 +143,10 @@ const CreateOrRerunCourseForm = ({
   };
 
   const handleOnClickCreate = () => {
-    const courseData = isCreateNewCourse ? values : { ...values, sourceCourseKey: courseId };
-    dispatch(updateCreateOrRerunCourseQuery(courseData));
+    const courseData = isCreateNewCourse
+      ? values
+      : { ...values, sourceCourseKey: courseId };
+    dispatch(updateCreateOrRerunCourseQuery(courseData, !isCreateNewCourse));
   };
 
   const handleOnClickCancel = () => {

--- a/src/generic/create-or-rerun-course/CreateOrRerunCourseForm.test.jsx
+++ b/src/generic/create-or-rerun-course/CreateOrRerunCourseForm.test.jsx
@@ -189,6 +189,89 @@ describe('<CreateOrRerunCourseForm />', () => {
 
       expect(mockedUsedNavigate).toHaveBeenCalledWith(`${url}${destinationCourseKey}`);
     });
+    it('should redirect to /home when re-running a course', async () => {
+      const user = userEvent.setup();
+      const rerunProps = { ...props, isCreateNewCourse: false };
+      render(<RootWrapper {...rerunProps} />);
+      await mockStore();
+      const url = '/course/';
+      const destinationCourseKey = 'courseKey';
+      const displayNameInput = screen.getByPlaceholderText(messages.courseDisplayNamePlaceholder.defaultMessage);
+      const orgInput = screen.getByText(messages.courseOrgNoOptions.defaultMessage);
+      const runInput = screen.getByPlaceholderText(messages.courseRunPlaceholder.defaultMessage);
+      const rerunBtn = screen.getByRole('button', { name: messages.rerunCreateButton.defaultMessage });
+      await axiosMock.onPost(getCreateOrRerunCourseUrl()).reply(200, { url, destinationCourseKey });
+
+      await user.type(displayNameInput, 'foo course name');
+      fireEvent.click(orgInput);
+      await user.type(runInput, '1');
+      await user.click(rerunBtn);
+      await executeThunk(updateCreateOrRerunCourseQuery({ org: 'testX', run: 'some' }, true), store.dispatch);
+
+      expect(mockedUsedNavigate).toHaveBeenCalledWith('/home');
+    });
+    it('should include sourceCourseKey in request data for rerun', async () => {
+      const user = userEvent.setup();
+      const rerunProps = {
+        ...props,
+        isCreateNewCourse: false,
+        initialValues: {
+          displayName: 'Test Course',
+          org: 'testOrg',
+          number: '101',
+          run: '',
+        },
+      };
+      render(<RootWrapper {...rerunProps} />);
+      await mockStore();
+      axiosMock.onPost(getCreateOrRerunCourseUrl()).reply(200, { url: '/home' });
+
+      const runInput = screen.getByPlaceholderText(messages.courseRunPlaceholder.defaultMessage);
+      const rerunBtn = screen.getByRole('button', { name: messages.rerunCreateButton.defaultMessage });
+
+      await user.type(runInput, '2024');
+      await user.click(rerunBtn);
+
+      await waitFor(() => {
+        const postRequest = axiosMock.history.post.find(
+          (req) => req.url === getCreateOrRerunCourseUrl(),
+        );
+        expect(postRequest).toBeDefined();
+        const requestData = JSON.parse(postRequest.data);
+        expect(requestData.source_course_key).toBe('course-id-mock');
+      });
+    });
+    it('should not include sourceCourseKey in request data for new course', async () => {
+      const user = userEvent.setup();
+      const createProps = {
+        ...props,
+        isCreateNewCourse: true,
+        initialValues: {
+          displayName: 'New Course',
+          org: 'testOrg',
+          number: '101',
+          run: '',
+        },
+      };
+      render(<RootWrapper {...createProps} />);
+      await mockStore();
+      axiosMock.onPost(getCreateOrRerunCourseUrl()).reply(200, { url: '/course/newCourseId' });
+
+      const runInput = screen.getByPlaceholderText(messages.courseRunPlaceholder.defaultMessage);
+      const createBtn = screen.getByRole('button', { name: messages.createButton.defaultMessage });
+
+      await user.type(runInput, '2024');
+      await user.click(createBtn);
+
+      await waitFor(() => {
+        const postRequest = axiosMock.history.post.find(
+          (req) => req.url === getCreateOrRerunCourseUrl(),
+        );
+        expect(postRequest).toBeDefined();
+        const requestData = JSON.parse(postRequest.data);
+        expect(requestData.source_course_key).toBeUndefined();
+      });
+    });
   });
 
   it('should be disabled create button if form not filled', async () => {

--- a/src/generic/data/thunks.js
+++ b/src/generic/data/thunks.js
@@ -37,13 +37,17 @@ export function fetchCourseRerunQuery(courseId) {
   };
 }
 
-export function updateCreateOrRerunCourseQuery(courseData) {
+export function updateCreateOrRerunCourseQuery(courseData, isRerun = false) {
   return async (dispatch) => {
     dispatch(updateSavingStatus({ status: RequestStatus.PENDING }));
 
     try {
       const response = await createOrRerunCourse(courseData);
-      dispatch(updateRedirectUrlObj('url' in response ? response : {}));
+      if (isRerun) {
+        dispatch(updateRedirectUrlObj({ url: '/home' }));
+      } else {
+        dispatch(updateRedirectUrlObj('url' in response ? response : {}));
+      }
       dispatch(updatePostErrors('errMsg' in response ? response : {}));
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       return true;

--- a/src/studio-home/processing-courses/course-item/index.jsx
+++ b/src/studio-home/processing-courses/course-item/index.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import {
   ActionRow,
   Card,
-  Hyperlink,
   Button,
   Icon,
 } from '@openedx/paragon';
@@ -52,9 +52,9 @@ const CourseItem = ({ course }) => {
           <Card.Section className="p-3.5 small text-gray-700 bg-light-200">
             {intl.formatMessage(messages.itemInProgressFooterText, {
               refresh: (
-                <Hyperlink destination="/home">
+                <Link to="/home" reloadDocument>
                   {intl.formatMessage(messages.itemInProgressFooterHyperlink)}
-                </Hyperlink>
+                </Link>
               ),
             })}
           </Card.Section>

--- a/src/studio-home/tabs-section/courses-tab/index.tsx
+++ b/src/studio-home/tabs-section/courses-tab/index.tsx
@@ -224,8 +224,8 @@ export const CoursesList: React.FC<Props> = ({
       ) :
       (
         <div className="courses-tab-container">
+          {isShowProcessing && <ProcessingCourses />}
           <div className="d-flex flex-row align-items-center justify-content-between my-4">
-            {isShowProcessing && <ProcessingCourses />}
             <CoursesFilters dispatch={dispatch} locationValue={locationValue} isLoading={isLoading} />
             <p data-testid="pagination-info" className="my-0">
               {intl.formatMessage(messages.coursesPaginationInfo, {

--- a/src/studio-home/tabs-section/index.tsx
+++ b/src/studio-home/tabs-section/index.tsx
@@ -131,7 +131,7 @@ const TabsSection = ({
     }
 
     return tabs;
-  }, [showNewCourseContainer, migrationFilter]);
+  }, [showNewCourseContainer, migrationFilter, isShowProcessing]);
 
   const handleSelectTab = (tab: TabKeyType) => {
     if (tab === TABS_LIST.courses) {


### PR DESCRIPTION
Backport of https://github.com/openedx/frontend-app-authoring/pull/3104

> Fixes a race condition when creating a course re-run that caused a 404 error page to appear.
>
> When a course is re-run, the backend creates the new course asynchronously via workers. Previously, the MFE immediately redirected the user to the new course's overview page, but because the course wasn't fully created yet, this resulted in a 404 error. This was a regression from the legacy UI behavior, which redirected to the Studio Home page instead, where a "course being processed" info card was displayed.
> 
> This PR changes the re-run redirect destination from the course overview page to the Studio Home (/home), matching both the legacy UI behavior and the [official Open edX documentation](https://docs.openedx.org/en/latest/educators/how-tos/rerun_course.html#use-the-course-re-run-option), which states:
> 
> >Select Create Re-Run. Your My Courses dashboard opens with a status message about the course creation process.
> 
> It also fixes the display position of the re-run creation status card in the courses tab so it renders correctly.
