### PR TITLE
fix: handle boolean flag from MFE Config API in CourseImportHomePage

### DIFF
--- a/src/library-authoring/import-course/CourseImportHomePage.test.tsx
+++ b/src/library-authoring/import-course/CourseImportHomePage.test.tsx
@@ -1,3 +1,4 @@
+import { setConfig, getConfig } from '@edx/frontend-platform';
 import {
   initializeMocks,
   render as testRender,
@@ -52,5 +53,24 @@ describe('<CourseImportHomePage>', () => {
     expect(await screen.findByRole('heading', { name: /Tools.*Import/ })).toBeInTheDocument(); // Header
     expect(screen.queryByRole('heading', { name: 'Previous Imports' })).not.toBeInTheDocument();
     expect(screen.getByText('You have not imported any courses into this library.')).toBeInTheDocument();
+  });
+
+  it('should show the import course button when flag is the string "true"', async () => {
+    setConfig({ ...getConfig(), ENABLE_COURSE_IMPORT_IN_LIBRARY: 'true' });
+    render(mockGetCourseImports.emptyLibraryId);
+    expect(await screen.findByRole('button', { name: /import course/i })).toBeInTheDocument();
+  });
+
+  it('should show the import course button when flag is the boolean true (MFE Config API)', async () => {
+    setConfig({ ...getConfig(), ENABLE_COURSE_IMPORT_IN_LIBRARY: true });
+    render(mockGetCourseImports.emptyLibraryId);
+    expect(await screen.findByRole('button', { name: /import course/i })).toBeInTheDocument();
+  });
+
+  it('should not show the import course button when flag is disabled', async () => {
+    setConfig({ ...getConfig(), ENABLE_COURSE_IMPORT_IN_LIBRARY: 'false' });
+    render(mockGetCourseImports.emptyLibraryId);
+    await screen.findByText('You have not imported any courses into this library.');
+    expect(screen.queryByRole('button', { name: /import course/i })).not.toBeInTheDocument();
   });
 });

--- a/src/library-authoring/import-course/CourseImportHomePage.test.tsx
+++ b/src/library-authoring/import-course/CourseImportHomePage.test.tsx
@@ -58,19 +58,21 @@ describe('<CourseImportHomePage>', () => {
   it('should show the import course button when flag is the string "true"', async () => {
     setConfig({ ...getConfig(), ENABLE_COURSE_IMPORT_IN_LIBRARY: 'true' });
     render(mockGetCourseImports.emptyLibraryId);
-    expect(await screen.findByRole('button', { name: /import course/i })).toBeInTheDocument();
+    // Button appears in both the SubHeader and the EmptyState call-to-action
+    expect(await screen.findAllByRole('button', { name: /import course/i })).toHaveLength(2);
   });
 
   it('should show the import course button when flag is the boolean true (MFE Config API)', async () => {
     setConfig({ ...getConfig(), ENABLE_COURSE_IMPORT_IN_LIBRARY: true });
     render(mockGetCourseImports.emptyLibraryId);
-    expect(await screen.findByRole('button', { name: /import course/i })).toBeInTheDocument();
+    // Button appears in both the SubHeader and the EmptyState call-to-action
+    expect(await screen.findAllByRole('button', { name: /import course/i })).toHaveLength(2);
   });
 
   it('should not show the import course button when flag is disabled', async () => {
     setConfig({ ...getConfig(), ENABLE_COURSE_IMPORT_IN_LIBRARY: 'false' });
     render(mockGetCourseImports.emptyLibraryId);
     await screen.findByText('You have not imported any courses into this library.');
-    expect(screen.queryByRole('button', { name: /import course/i })).not.toBeInTheDocument();
+    expect(screen.queryAllByRole('button', { name: /import course/i })).toHaveLength(0);
   });
 });

--- a/src/library-authoring/import-course/CourseImportHomePage.tsx
+++ b/src/library-authoring/import-course/CourseImportHomePage.tsx
@@ -23,7 +23,7 @@ import messages from './messages';
 const ImportCourseButton = () => {
   const navigate = useNavigate();
 
-  if (getConfig().ENABLE_COURSE_IMPORT_IN_LIBRARY === 'true') {
+  if ([true, 'true'].includes(getConfig().ENABLE_COURSE_IMPORT_IN_LIBRARY)) {
     return (
       <Button iconBefore={Add} onClick={() => navigate('courses')}>
         <FormattedMessage {...messages.importCourseButton} />


### PR DESCRIPTION
**Settings**

```yaml
GROVE_MFE_LMS_COMMON_SETTINGS: |
  MFE_CONFIG['ENABLE_COURSE_IMPORT_IN_LIBRARY'] = True
```
----

## Description

The `ENABLE_COURSE_IMPORT_IN_LIBRARY` flag check used strict string comparison `(=== 'true')`, which fails when the value comes from the MFE Config API at runtime (JSON boolean true instead of string 'true'). Use the same 
`[true, 'true'].includes()` pattern already in other components: https://github.com/openedx/frontend-app-authoring/blob/f4b90d8aab603cc104337bff7bdf6af26a9ce729/src/header/Header.tsx#L43

## Supporting information

Fixes https://github.com/openedx/wg-build-test-release/issues/588

## Testing instructions

1. Create a library
2. Go to the specific library home 
3. Select tools > import
4. The import course button should show as shown here https://github.com/openedx/wg-build-test-release/issues/588

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`