### PR TITLE
fix: handle boolean flag from MFE Config API in CourseImportHomePage 

### DIFF
--- a/src/library-authoring/import-course/CourseImportHomePage.test.tsx
+++ b/src/library-authoring/import-course/CourseImportHomePage.test.tsx
@@ -1,3 +1,4 @@
+import { setConfig, getConfig } from '@edx/frontend-platform';
 import {
   initializeMocks,
   render as testRender,
@@ -52,5 +53,26 @@ describe('<CourseImportHomePage>', () => {
     expect(await screen.findByRole('heading', { name: /Tools.*Import/ })).toBeInTheDocument(); // Header
     expect(screen.queryByRole('heading', { name: 'Previous Imports' })).not.toBeInTheDocument();
     expect(screen.getByText('You have not imported any courses into this library.')).toBeInTheDocument();
+  });
+
+  it('should show the import course button when flag is the string "true"', async () => {
+    setConfig({ ...getConfig(), ENABLE_COURSE_IMPORT_IN_LIBRARY: 'true' });
+    render(mockGetCourseImports.emptyLibraryId);
+    // Button appears in both the SubHeader and the EmptyState call-to-action
+    expect(await screen.findAllByRole('button', { name: /import course/i })).toHaveLength(2);
+  });
+
+  it('should show the import course button when flag is the boolean true (MFE Config API)', async () => {
+    setConfig({ ...getConfig(), ENABLE_COURSE_IMPORT_IN_LIBRARY: true });
+    render(mockGetCourseImports.emptyLibraryId);
+    // Button appears in both the SubHeader and the EmptyState call-to-action
+    expect(await screen.findAllByRole('button', { name: /import course/i })).toHaveLength(2);
+  });
+
+  it('should not show the import course button when flag is disabled', async () => {
+    setConfig({ ...getConfig(), ENABLE_COURSE_IMPORT_IN_LIBRARY: 'false' });
+    render(mockGetCourseImports.emptyLibraryId);
+    await screen.findByText('You have not imported any courses into this library.');
+    expect(screen.queryAllByRole('button', { name: /import course/i })).toHaveLength(0);
   });
 });

--- a/src/library-authoring/import-course/CourseImportHomePage.tsx
+++ b/src/library-authoring/import-course/CourseImportHomePage.tsx
@@ -23,7 +23,7 @@ import messages from './messages';
 const ImportCourseButton = () => {
   const navigate = useNavigate();
 
-  if (getConfig().ENABLE_COURSE_IMPORT_IN_LIBRARY === 'true') {
+  if ([true, 'true'].includes(getConfig().ENABLE_COURSE_IMPORT_IN_LIBRARY)) {
     return (
       <Button iconBefore={Add} onClick={() => navigate('courses')}>
         <FormattedMessage {...messages.importCourseButton} />


### PR DESCRIPTION
## Description

The `ENABLE_COURSE_IMPORT_IN_LIBRARY` flag check used strict string comparison `(=== 'true')`, which fails when the value comes from the MFE Config API at runtime (JSON boolean true instead of string 'true'). Use the same 
`[true, 'true'].includes()` pattern already in other components: https://github.com/openedx/frontend-app-authoring/blob/f4b90d8aab603cc104337bff7bdf6af26a9ce729/src/header/Header.tsx#L43

## Supporting information

Fixes https://github.com/openedx/wg-build-test-release/issues/588

## Testing instructions

1. Create a library
2. Go to the specific library home 
3. Select tools > import
4. The import course button should show as shown here https://github.com/openedx/wg-build-test-release/issues/588