### PR TITLE
fix(authz): hide course navigation and pages for unauthorized users

### DIFF
--- a/src/advanced-settings/AdvancedSettings.test.tsx
+++ b/src/advanced-settings/AdvancedSettings.test.tsx
@@ -191,4 +191,18 @@ describe('<AdvancedSettings />', () => {
     render();
     expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
   });
+
+  it('should show permission denied alert when the user is not authorized', async () => {
+    mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+    jest.mocked(useUserPermissions).mockReturnValue({
+      isLoading: false,
+      data: { canManageAdvancedSettings: false },
+    } as unknown as ReturnType<typeof useUserPermissions>);
+    axiosMock
+      .onGet(`${getCourseAdvancedSettingsApiUrl(courseId)}?fetch_all=0`)
+      .reply(403);
+    render();
+    expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
+    expect(screen.queryByText(/Under Construction/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/advanced-settings/AdvancedSettings.tsx
+++ b/src/advanced-settings/AdvancedSettings.tsx
@@ -106,6 +106,16 @@ const AdvancedSettings = () => {
       </div>
     );
   }
+
+  // Show permission denied alert when authz is enabled and user doesn't have permission
+  const authzIsEnabledAndNoPermission = isAuthzEnabled
+    && !isLoadingUserPermissions
+    && !userPermissions?.canManageAdvancedSettings;
+
+  if (authzIsEnabledAndNoPermission) {
+    return <PermissionDeniedAlert />;
+  }
+
   if (settingsStatusError?.response?.status === 403) {
     return (
       <div className="row justify-content-center m-6">
@@ -147,15 +157,6 @@ const AdvancedSettings = () => {
     showErrorModal(setToState);
     showSaveSettingsPrompt(true);
   };
-
-  // Show permission denied alert when authz is enabled and user doesn't have permission
-  const authzIsEnabledAndNoPermission = isAuthzEnabled
-    && !isLoadingUserPermissions
-    && !userPermissions?.canManageAdvancedSettings;
-
-  if (authzIsEnabledAndNoPermission) {
-    return <PermissionDeniedAlert />;
-  }
 
   return (
     <>

--- a/src/authz/constants.ts
+++ b/src/authz/constants.ts
@@ -17,6 +17,7 @@ export const CONTENT_LIBRARY_PERMISSIONS = {
 
 export const COURSE_PERMISSIONS = {
   VIEW_COURSE: 'courses.view_course',
+  EDIT_COURSE_CONTENT: 'courses.edit_course_content',
 
   MANAGE_ADVANCED_SETTINGS: 'courses.manage_advanced_settings',
 

--- a/src/authz/constants.ts
+++ b/src/authz/constants.ts
@@ -16,6 +16,8 @@ export const CONTENT_LIBRARY_PERMISSIONS = {
 };
 
 export const COURSE_PERMISSIONS = {
+  VIEW_COURSE: 'courses.view_course',
+
   MANAGE_ADVANCED_SETTINGS: 'courses.manage_advanced_settings',
 
   VIEW_GRADING_SETTINGS: 'courses.view_grading_settings',
@@ -33,4 +35,16 @@ export const COURSE_PERMISSIONS = {
   CREATE_FILES: 'courses.create_files',
   DELETE_FILES: 'courses.delete_files',
   EDIT_FILES: 'courses.edit_files',
+
+  MANAGE_LIBRARY_UPDATES: 'courses.manage_library_updates',
+
+  VIEW_COURSE_TEAM: 'courses.view_course_team',
+
+  MANAGE_GROUP_CONFIGURATIONS: 'courses.manage_group_configurations',
+  MANAGE_CERTIFICATES: 'courses.manage_certificates',
+
+  VIEW_CHECKLISTS: 'courses.view_checklists',
+  IMPORT_COURSE: 'courses.import_course',
+  EXPORT_COURSE: 'courses.export_course',
+  EXPORT_TAGS: 'courses.export_tags',
 };

--- a/src/authz/permissionHelpers.test.ts
+++ b/src/authz/permissionHelpers.test.ts
@@ -151,12 +151,16 @@ describe('permissionHelpers', () => {
   });
 
   describe('getCourseOutlinePermissions', () => {
-    it('returns VIEW_COURSE permission with the correct action and scope', () => {
+    it('returns VIEW_COURSE and EDIT_COURSE_CONTENT permissions with the correct actions and scope', () => {
       const result = getCourseOutlinePermissions(courseId);
 
       expect(result).toEqual({
         canViewCourse: {
           action: COURSE_PERMISSIONS.VIEW_COURSE,
+          scope: courseId,
+        },
+        canEditCourseContent: {
+          action: COURSE_PERMISSIONS.EDIT_COURSE_CONTENT,
           scope: courseId,
         },
       });

--- a/src/authz/permissionHelpers.test.ts
+++ b/src/authz/permissionHelpers.test.ts
@@ -4,6 +4,13 @@ import {
   getAdvancedSettingsPermissions,
   getCourseUpdatesPermissions,
   getFilesPermissions,
+  getCourseOutlinePermissions,
+  getLibraryUpdatesPermissions,
+  getCourseTeamPermissions,
+  getGroupConfigurationsPermissions,
+  getCertificatesPermissions,
+  getChecklistsPermissions,
+  getImportExportPermissions,
 } from './permissionHelpers';
 import { COURSE_PERMISSIONS } from './constants';
 
@@ -140,6 +147,105 @@ describe('permissionHelpers', () => {
 
       expect(result.canViewGradingSettings.action).toBe(COURSE_PERMISSIONS.VIEW_GRADING_SETTINGS);
       expect(result.canEditGradingSettings.action).toBe(COURSE_PERMISSIONS.EDIT_GRADING_SETTINGS);
+    });
+  });
+
+  describe('getCourseOutlinePermissions', () => {
+    it('returns VIEW_COURSE permission with the correct action and scope', () => {
+      const result = getCourseOutlinePermissions(courseId);
+
+      expect(result).toEqual({
+        canViewCourse: {
+          action: COURSE_PERMISSIONS.VIEW_COURSE,
+          scope: courseId,
+        },
+      });
+    });
+  });
+
+  describe('getLibraryUpdatesPermissions', () => {
+    it('returns MANAGE_LIBRARY_UPDATES permission with the correct action and scope', () => {
+      const result = getLibraryUpdatesPermissions(courseId);
+
+      expect(result).toEqual({
+        canManageLibraryUpdates: {
+          action: COURSE_PERMISSIONS.MANAGE_LIBRARY_UPDATES,
+          scope: courseId,
+        },
+      });
+    });
+  });
+
+  describe('getCourseTeamPermissions', () => {
+    it('returns VIEW_COURSE_TEAM permission with the correct action and scope', () => {
+      const result = getCourseTeamPermissions(courseId);
+
+      expect(result).toEqual({
+        canViewCourseTeam: {
+          action: COURSE_PERMISSIONS.VIEW_COURSE_TEAM,
+          scope: courseId,
+        },
+      });
+    });
+  });
+
+  describe('getGroupConfigurationsPermissions', () => {
+    it('returns MANAGE_GROUP_CONFIGURATIONS permission with the correct action and scope', () => {
+      const result = getGroupConfigurationsPermissions(courseId);
+
+      expect(result).toEqual({
+        canManageGroupConfigurations: {
+          action: COURSE_PERMISSIONS.MANAGE_GROUP_CONFIGURATIONS,
+          scope: courseId,
+        },
+      });
+    });
+  });
+
+  describe('getCertificatesPermissions', () => {
+    it('returns MANAGE_CERTIFICATES permission with the correct action and scope', () => {
+      const result = getCertificatesPermissions(courseId);
+
+      expect(result).toEqual({
+        canManageCertificates: {
+          action: COURSE_PERMISSIONS.MANAGE_CERTIFICATES,
+          scope: courseId,
+        },
+      });
+    });
+  });
+
+  describe('getChecklistsPermissions', () => {
+    it('returns VIEW_CHECKLISTS permission with the correct action and scope', () => {
+      const result = getChecklistsPermissions(courseId);
+
+      expect(result).toEqual({
+        canViewChecklists: {
+          action: COURSE_PERMISSIONS.VIEW_CHECKLISTS,
+          scope: courseId,
+        },
+      });
+    });
+  });
+
+  describe('getImportExportPermissions', () => {
+    it('returns IMPORT and EXPORT permissions with the correct actions and scope', () => {
+      const result = getImportExportPermissions(courseId);
+
+      expect(result).toEqual({
+        canImportCourse: {
+          action: COURSE_PERMISSIONS.IMPORT_COURSE,
+          scope: courseId,
+        },
+        canExportCourse: {
+          action: COURSE_PERMISSIONS.EXPORT_COURSE,
+          scope: courseId,
+        },
+        canExportTags: {
+          action: COURSE_PERMISSIONS.EXPORT_TAGS,
+          scope: courseId,
+        },
+      });
     });
   });
 });

--- a/src/authz/permissionHelpers.ts
+++ b/src/authz/permissionHelpers.ts
@@ -54,6 +54,63 @@ export const getAdvancedSettingsPermissions = (courseId: string) => ({
     scope: courseId,
   },
 });
+export const getCourseOutlinePermissions = (courseId: string) => ({
+  canViewCourse: {
+    action: COURSE_PERMISSIONS.VIEW_COURSE,
+    scope: courseId,
+  },
+});
+
+export const getLibraryUpdatesPermissions = (courseId: string) => ({
+  canManageLibraryUpdates: {
+    action: COURSE_PERMISSIONS.MANAGE_LIBRARY_UPDATES,
+    scope: courseId,
+  },
+});
+
+export const getCourseTeamPermissions = (courseId: string) => ({
+  canViewCourseTeam: {
+    action: COURSE_PERMISSIONS.VIEW_COURSE_TEAM,
+    scope: courseId,
+  },
+});
+
+export const getGroupConfigurationsPermissions = (courseId: string) => ({
+  canManageGroupConfigurations: {
+    action: COURSE_PERMISSIONS.MANAGE_GROUP_CONFIGURATIONS,
+    scope: courseId,
+  },
+});
+
+export const getCertificatesPermissions = (courseId: string) => ({
+  canManageCertificates: {
+    action: COURSE_PERMISSIONS.MANAGE_CERTIFICATES,
+    scope: courseId,
+  },
+});
+
+export const getChecklistsPermissions = (courseId: string) => ({
+  canViewChecklists: {
+    action: COURSE_PERMISSIONS.VIEW_CHECKLISTS,
+    scope: courseId,
+  },
+});
+
+export const getImportExportPermissions = (courseId: string) => ({
+  canImportCourse: {
+    action: COURSE_PERMISSIONS.IMPORT_COURSE,
+    scope: courseId,
+  },
+  canExportCourse: {
+    action: COURSE_PERMISSIONS.EXPORT_COURSE,
+    scope: courseId,
+  },
+  canExportTags: {
+    action: COURSE_PERMISSIONS.EXPORT_TAGS,
+    scope: courseId,
+  },
+});
+
 export const getFilesPermissions = (courseId: string) => ({
   canViewFiles: {
     action: COURSE_PERMISSIONS.VIEW_FILES,

--- a/src/authz/permissionHelpers.ts
+++ b/src/authz/permissionHelpers.ts
@@ -59,6 +59,10 @@ export const getCourseOutlinePermissions = (courseId: string) => ({
     action: COURSE_PERMISSIONS.VIEW_COURSE,
     scope: courseId,
   },
+  canEditCourseContent: {
+    action: COURSE_PERMISSIONS.EDIT_COURSE_CONTENT,
+    scope: courseId,
+  },
 });
 
 export const getLibraryUpdatesPermissions = (courseId: string) => ({

--- a/src/certificates/Certificates.test.tsx
+++ b/src/certificates/Certificates.test.tsx
@@ -1,5 +1,6 @@
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
 import { CertificatesProvider } from '@src/certificates/context';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 import { initializeMocks, render, screen, userEvent } from '../testUtils';
 import { getCertificatesApiUrl } from './data/api';
 import { certificatesDataMock } from './__mocks__';
@@ -8,6 +9,18 @@ import messages from './messages';
 
 let axiosMock;
 const courseId = 'course-123';
+
+jest.mock('@src/authz/hooks', () => ({
+  useCourseUserPermissions: jest.fn(),
+}));
+
+const mockPermissions = (overrides = {}) =>
+  jest.mocked(useCourseUserPermissions).mockReturnValue({
+    isLoading: false,
+    isAuthzEnabled: true,
+    canManageCertificates: true,
+    ...overrides,
+  } as ReturnType<typeof useCourseUserPermissions>);
 
 const renderComponent = () =>
   render(
@@ -21,6 +34,17 @@ const renderComponent = () =>
 describe('Certificates', () => {
   beforeEach(() => {
     ({ axiosMock } = initializeMocks());
+    mockPermissions();
+  });
+
+  it('shows PermissionDeniedAlert when user lacks manage certificates permission', async () => {
+    mockPermissions({ canManageCertificates: false });
+    axiosMock
+      .onGet(getCertificatesApiUrl(courseId))
+      .reply(200, certificatesDataMock);
+    renderComponent();
+    expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
+    expect(screen.queryByText(messages.withoutModesText.defaultMessage)).not.toBeInTheDocument();
   });
 
   it('renders WithoutModes when there are certificates but no certificate modes', async () => {

--- a/src/certificates/Certificates.tsx
+++ b/src/certificates/Certificates.tsx
@@ -1,5 +1,9 @@
 import { Helmet } from 'react-helmet';
 
+import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import { getCertificatesPermissions } from '@src/authz/permissionHelpers';
+import PermissionDeniedAlert from '@src/generic/PermissionDeniedAlert';
 import Placeholder from '../editors/Placeholder';
 import Loading from '../generic/Loading';
 import { useCertificatesData } from './hooks/useCertificates';
@@ -20,6 +24,7 @@ const MODE_COMPONENTS = {
 };
 
 const Certificates = () => {
+  const { courseId } = useCourseAuthoringContext();
   const {
     certificates,
     componentMode,
@@ -28,6 +33,15 @@ const Certificates = () => {
     pageHeadTitle,
     hasCertificateModes,
   } = useCertificatesData();
+
+  const {
+    isLoading: isLoadingUserPermissions,
+    canManageCertificates,
+  } = useCourseUserPermissions(courseId, getCertificatesPermissions(courseId));
+
+  if (!isLoadingUserPermissions && !canManageCertificates) {
+    return <PermissionDeniedAlert />;
+  }
 
   if (isLoading) {
     return <Loading />;

--- a/src/course-checklist/CourseChecklist.test.jsx
+++ b/src/course-checklist/CourseChecklist.test.jsx
@@ -6,6 +6,7 @@ import {
 import '@testing-library/jest-dom';
 import { getConfig, setConfig } from '@edx/frontend-platform';
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 import { getCourseLaunchApiUrl, getCourseBestPracticesApiUrl } from './data/api';
 import {
   courseId,
@@ -16,6 +17,18 @@ import messages from './messages';
 import CourseChecklist from './index';
 
 let axiosMock;
+
+jest.mock('@src/authz/hooks', () => ({
+  useCourseUserPermissions: jest.fn(),
+}));
+
+const mockPermissions = (overrides = {}) =>
+  jest.mocked(useCourseUserPermissions).mockReturnValue({
+    isLoading: false,
+    isAuthzEnabled: true,
+    canViewChecklists: true,
+    ...overrides,
+  });
 
 const renderComponent = () => {
   render(
@@ -34,7 +47,26 @@ describe('CourseChecklistPage', () => {
   beforeEach(async () => {
     const mocks = initializeMocks();
     axiosMock = mocks.axiosMock;
+    mockPermissions();
   });
+
+  it('shows PermissionDeniedAlert when user lacks view checklists permission', async () => {
+    mockPermissions({ canViewChecklists: false });
+    await mockStore(200);
+    renderComponent();
+    expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
+    expect(screen.queryByText(messages.launchChecklistLabel.defaultMessage)).not.toBeInTheDocument();
+  });
+
+  it('shows a loading spinner while permissions are loading', async () => {
+    mockPermissions({ isLoading: true, canViewChecklists: false });
+    await mockStore(200);
+    renderComponent();
+    expect(await screen.findByRole('status')).toBeInTheDocument();
+    expect(screen.queryByTestId('permissionDeniedAlert')).not.toBeInTheDocument();
+    expect(screen.queryByText(messages.launchChecklistLabel.defaultMessage)).not.toBeInTheDocument();
+  });
+
   describe('renders', () => {
     describe('if enable_quality prop is true', () => {
       it('two checklist components', async () => {

--- a/src/course-checklist/CourseChecklist.tsx
+++ b/src/course-checklist/CourseChecklist.tsx
@@ -3,12 +3,16 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { Helmet } from 'react-helmet';
 import { Container, Stack } from '@openedx/paragon';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import { getChecklistsPermissions } from '@src/authz/permissionHelpers';
 
 import SubHeader from '../generic/sub-header/SubHeader';
 import messages from './messages';
 import AriaLiveRegion from './AriaLiveRegion';
 import ChecklistSection from './ChecklistSection';
 import ConnectionErrorAlert from '../generic/ConnectionErrorAlert';
+import Loading from '@src/generic/Loading';
+import PermissionDeniedAlert from '@src/generic/PermissionDeniedAlert';
 import { useCourseBestPractices, useCourseLaunch } from './data/apiHooks';
 
 const CourseChecklist = () => {
@@ -28,6 +32,19 @@ const CourseChecklist = () => {
   } = useCourseLaunch({ courseId });
 
   const isLoadingDenied = launchError?.response?.status === 403;
+
+  const {
+    isLoading: isLoadingUserPermissions,
+    canViewChecklists,
+  } = useCourseUserPermissions(courseId, getChecklistsPermissions(courseId));
+
+  if (isLoadingUserPermissions) {
+    return <Loading />;
+  }
+
+  if (!canViewChecklists) {
+    return <PermissionDeniedAlert />;
+  }
 
   if (isLoadingDenied) {
     return (

--- a/src/course-libraries/CourseLibraries.test.tsx
+++ b/src/course-libraries/CourseLibraries.test.tsx
@@ -14,6 +14,7 @@ import { mockContentSearchConfig } from '@src/search-manager/data/api.mock';
 import { type ToastActionData } from '@src/generic/toast-context';
 import { libraryBlockChangesUrl } from '@src/course-unit/data/api';
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 import { CourseLibraries } from './CourseLibraries';
 import {
   mockGetEntityLinks,
@@ -48,6 +49,18 @@ jest.mock('react-router-dom', () => ({
   }],
 }));
 
+jest.mock('@src/authz/hooks', () => ({
+  useCourseUserPermissions: jest.fn(),
+}));
+
+const mockPermissions = (overrides = {}) =>
+  jest.mocked(useCourseUserPermissions).mockReturnValue({
+    isLoading: false,
+    isAuthzEnabled: true,
+    canManageLibraryUpdates: true,
+    ...overrides,
+  } as ReturnType<typeof useCourseUserPermissions>);
+
 describe('<CourseLibraries />', () => {
   beforeEach(() => {
     initializeMocks();
@@ -55,6 +68,7 @@ describe('<CourseLibraries />', () => {
     mockFetchIndexDocuments.applyMock();
     localStorage.clear();
     searchParamsGetMock.mockReturnValue('all');
+    mockPermissions();
   });
 
   const renderCourseLibrariesPage = async (courseKey?: string) => {
@@ -77,6 +91,21 @@ describe('<CourseLibraries />', () => {
     await renderCourseLibrariesPage(mockGetEntityLinks.courseKeyEmpty);
     const emptyMsg = await screen.findByText('This course does not use any content from libraries.');
     expect(emptyMsg).toBeInTheDocument();
+  });
+
+  it('shows PermissionDeniedAlert when user lacks manage library updates permission', async () => {
+    mockPermissions({ canManageLibraryUpdates: false });
+    await renderCourseLibrariesPage();
+    expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
+    expect(screen.queryByText('Libraries')).not.toBeInTheDocument();
+  });
+
+  it('shows a loading spinner while permissions are loading', async () => {
+    mockPermissions({ isLoading: true, canManageLibraryUpdates: false });
+    await renderCourseLibrariesPage();
+    expect(await screen.findByRole('status')).toBeInTheDocument();
+    expect(screen.queryByTestId('permissionDeniedAlert')).not.toBeInTheDocument();
+    expect(screen.queryByText('Libraries')).not.toBeInTheDocument();
   });
 
   it('shows alert when out of sync components are present', async () => {

--- a/src/course-libraries/CourseLibraries.tsx
+++ b/src/course-libraries/CourseLibraries.tsx
@@ -29,11 +29,14 @@ import {
 import sumBy from 'lodash/sumBy';
 import { useSearchParams } from 'react-router-dom';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import { getLibraryUpdatesPermissions } from '@src/authz/permissionHelpers';
 import { useStudioHome } from '@src/studio-home/hooks';
 import NewsstandIcon from '@src/generic/NewsstandIcon';
 import getPageHeadTitle from '@src/generic/utils';
 import SubHeader from '@src/generic/sub-header/SubHeader';
 import Loading from '@src/generic/Loading';
+import PermissionDeniedAlert from '@src/generic/PermissionDeniedAlert';
 import messages from './messages';
 import { useEntityLinksSummaryByDownstreamContext } from './data/apiHooks';
 import type { PublishableEntityLinkSummary } from './data/api';
@@ -119,6 +122,11 @@ export const CourseLibraries = () => {
     librariesV2Enabled,
   } = useStudioHome();
 
+  const {
+    isLoading: isLoadingUserPermissions,
+    canManageLibraryUpdates,
+  } = useCourseUserPermissions(courseId, getLibraryUpdatesPermissions(courseId));
+
   const onAlertReview = () => {
     setTabKey(CourseLibraryTabs.review);
   };
@@ -185,6 +193,14 @@ export const CourseLibraries = () => {
     }
     return <ReviewTabContent courseId={courseId} />;
   }, [outOfSyncCount, isLoading, tabKey]);
+
+  if (isLoadingUserPermissions) {
+    return <Loading />;
+  }
+
+  if (!canManageLibraryUpdates) {
+    return <PermissionDeniedAlert />;
+  }
 
   if (!isLoadingStudioHome && (!librariesV2Enabled || isFailedLoadingStudioHome)) {
     return (

--- a/src/export-page/CourseExportPage.test.tsx
+++ b/src/export-page/CourseExportPage.test.tsx
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet';
 import Cookies from 'universal-cookie';
 
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 import { getCourseDetailsUrl } from '@src/data/api';
 import {
   initializeMocks,
@@ -33,6 +34,20 @@ jest.mock('universal-cookie', () => {
   return jest.fn(() => mCookie);
 });
 
+jest.mock('@src/authz/hooks', () => ({
+  useCourseUserPermissions: jest.fn(),
+}));
+
+const mockPermissions = (overrides = {}) =>
+  jest.mocked(useCourseUserPermissions).mockReturnValue({
+    isLoading: false,
+    isAuthzEnabled: true,
+    canImportCourse: true,
+    canExportCourse: true,
+    canExportTags: true,
+    ...overrides,
+  } as ReturnType<typeof useCourseUserPermissions>);
+
 const renderComponent = () =>
   render(
     <CourseAuthoringProvider courseId={courseId}>
@@ -61,6 +76,7 @@ describe('<CourseExportPage />', () => {
       .reply(200, { exportStatus: EXPORT_STAGES.PREPARING });
     cookies = new Cookies();
     cookies.get.mockReturnValue(null);
+    mockPermissions();
   });
 
   it('should render page title correctly', async () => {
@@ -170,5 +186,20 @@ describe('<CourseExportPage />', () => {
     await user.click(startExportButton);
     expect(screen.getByText(stepperMessages.stepperPreparingDescription.defaultMessage)).toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows PermissionDeniedAlert when user lacks export permission', async () => {
+    mockPermissions({ canExportCourse: false });
+    renderComponent();
+    expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
+    expect(screen.queryByText(messages.headingSubtitle.defaultMessage)).not.toBeInTheDocument();
+  });
+
+  it('shows a loading spinner while permissions are loading', async () => {
+    mockPermissions({ isLoading: true, canExportCourse: false });
+    renderComponent();
+    expect(await screen.findByRole('status')).toBeInTheDocument();
+    expect(screen.queryByTestId('permissionDeniedAlert')).not.toBeInTheDocument();
+    expect(screen.queryByText(messages.headingSubtitle.defaultMessage)).not.toBeInTheDocument();
   });
 });

--- a/src/export-page/CourseExportPage.tsx
+++ b/src/export-page/CourseExportPage.tsx
@@ -12,7 +12,11 @@ import { Helmet } from 'react-helmet';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
 import InternetConnectionAlert from '@src/generic/internet-connection-alert';
 import ConnectionErrorAlert from '@src/generic/ConnectionErrorAlert';
+import Loading from '@src/generic/Loading';
+import PermissionDeniedAlert from '@src/generic/PermissionDeniedAlert';
 import SubHeader from '@src/generic/sub-header/SubHeader';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import { getImportExportPermissions } from '@src/authz/permissionHelpers';
 
 import messages from './messages';
 import ExportSidebar from './export-sidebar/ExportSidebar';
@@ -24,7 +28,7 @@ import { useCourseExportContext } from './CourseExportContext';
 
 const CourseExportPage = () => {
   const intl = useIntl();
-  const { courseDetails } = useCourseAuthoringContext();
+  const { courseId, courseDetails } = useCourseAuthoringContext();
   const {
     currentStage,
     exportTriggered,
@@ -36,6 +40,19 @@ const CourseExportPage = () => {
   } = useCourseExportContext();
 
   const isShowExportButton = !exportTriggered || fetchExportErrorMessage || currentStage === EXPORT_STAGES.SUCCESS;
+
+  const {
+    isLoading: isLoadingUserPermissions,
+    canExportCourse,
+  } = useCourseUserPermissions(courseId, getImportExportPermissions(courseId));
+
+  if (isLoadingUserPermissions) {
+    return <Loading />;
+  }
+
+  if (!canExportCourse) {
+    return <PermissionDeniedAlert />;
+  }
 
   if (isLoadingDenied) {
     return (

--- a/src/files-and-videos/videos-page/VideosPage.test.tsx
+++ b/src/files-and-videos/videos-page/VideosPage.test.tsx
@@ -15,6 +15,7 @@ import { executeThunk } from '@src/utils';
 import { RequestStatus } from '@src/data/constants';
 
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 import VideosPage from './VideosPage';
 import {
   generateFetchVideosApiResponse,
@@ -44,6 +45,16 @@ let axiosUnauthenticateMock;
 let store;
 let file;
 jest.mock('file-saver');
+
+jest.mock('@src/authz/hooks', () => ({
+  useCourseUserPermissions: jest.fn().mockReturnValue({
+    isLoading: false,
+    canViewFiles: true,
+    canEditFiles: true,
+    canDeleteFiles: true,
+    canCreateFiles: true,
+  }),
+}));
 
 const renderComponent = () => {
   render(
@@ -753,6 +764,52 @@ describe('Videos page', () => {
 
         expect(screen.getByText('Error')).toBeVisible();
       });
+    });
+  });
+
+  describe('permissions', () => {
+    beforeEach(async () => {
+      const mocks = initializeMocks({
+        initialState: {
+          ...initialState,
+          videos: {
+            ...initialState.videos,
+            videoIds: [],
+          },
+          models: {},
+        },
+      });
+      store = mocks.reduxStore;
+      axiosMock = mocks.axiosMock;
+      global.localStorage.clear();
+    });
+
+    it('should render loading spinner when permissions are loading', async () => {
+      jest.mocked(useCourseUserPermissions).mockReturnValue({
+        isLoading: true,
+        isAuthzEnabled: true,
+        canViewFiles: false,
+        canEditFiles: false,
+        canDeleteFiles: false,
+        canCreateFiles: false,
+      } as ReturnType<typeof useCourseUserPermissions>);
+      renderComponent();
+      expect(screen.getByRole('status')).toBeInTheDocument();
+      expect(screen.queryByText(videoMessages.heading.defaultMessage)).not.toBeInTheDocument();
+    });
+
+    it('should render permission alert when the user is not authorized to view files', async () => {
+      jest.mocked(useCourseUserPermissions).mockReturnValue({
+        isLoading: false,
+        isAuthzEnabled: true,
+        canViewFiles: false,
+        canEditFiles: true,
+        canDeleteFiles: true,
+        canCreateFiles: true,
+      } as ReturnType<typeof useCourseUserPermissions>);
+      await emptyMockStore(RequestStatus.SUCCESSFUL);
+      expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
+      expect(screen.queryByText(videoMessages.heading.defaultMessage)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/files-and-videos/videos-page/VideosPage.test.tsx
+++ b/src/files-and-videos/videos-page/VideosPage.test.tsx
@@ -15,7 +15,6 @@ import { executeThunk } from '@src/utils';
 import { RequestStatus } from '@src/data/constants';
 
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
-import { useCourseUserPermissions } from '@src/authz/hooks';
 import VideosPage from './VideosPage';
 import {
   generateFetchVideosApiResponse,
@@ -45,16 +44,6 @@ let axiosUnauthenticateMock;
 let store;
 let file;
 jest.mock('file-saver');
-
-jest.mock('@src/authz/hooks', () => ({
-  useCourseUserPermissions: jest.fn().mockReturnValue({
-    isLoading: false,
-    canViewFiles: true,
-    canEditFiles: true,
-    canDeleteFiles: true,
-    canCreateFiles: true,
-  }),
-}));
 
 const renderComponent = () => {
   render(
@@ -764,52 +753,6 @@ describe('Videos page', () => {
 
         expect(screen.getByText('Error')).toBeVisible();
       });
-    });
-  });
-
-  describe('permissions', () => {
-    beforeEach(async () => {
-      const mocks = initializeMocks({
-        initialState: {
-          ...initialState,
-          videos: {
-            ...initialState.videos,
-            videoIds: [],
-          },
-          models: {},
-        },
-      });
-      store = mocks.reduxStore;
-      axiosMock = mocks.axiosMock;
-      global.localStorage.clear();
-    });
-
-    it('should render loading spinner when permissions are loading', async () => {
-      jest.mocked(useCourseUserPermissions).mockReturnValue({
-        isLoading: true,
-        isAuthzEnabled: true,
-        canViewFiles: false,
-        canEditFiles: false,
-        canDeleteFiles: false,
-        canCreateFiles: false,
-      } as ReturnType<typeof useCourseUserPermissions>);
-      renderComponent();
-      expect(screen.getByRole('status')).toBeInTheDocument();
-      expect(screen.queryByText(videoMessages.heading.defaultMessage)).not.toBeInTheDocument();
-    });
-
-    it('should render permission alert when the user is not authorized to view files', async () => {
-      jest.mocked(useCourseUserPermissions).mockReturnValue({
-        isLoading: false,
-        isAuthzEnabled: true,
-        canViewFiles: false,
-        canEditFiles: true,
-        canDeleteFiles: true,
-        canCreateFiles: true,
-      } as ReturnType<typeof useCourseUserPermissions>);
-      await emptyMockStore(RequestStatus.SUCCESSFUL);
-      expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
-      expect(screen.queryByText(videoMessages.heading.defaultMessage)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/files-and-videos/videos-page/VideosPage.tsx
+++ b/src/files-and-videos/videos-page/VideosPage.tsx
@@ -14,6 +14,10 @@ import EditVideoAlertsSlot from '@src/plugin-slots/EditVideoAlertsSlot';
 
 import { DeprecatedReduxState } from '@src/store';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import { getFilesPermissions } from '@src/authz/permissionHelpers';
+import Loading from '@src/generic/Loading';
+import PermissionDeniedAlert from '@src/generic/PermissionDeniedAlert';
 import { EditFileErrors } from '../generic';
 import { fetchVideos, resetErrors } from './data/thunks';
 import messages from './messages';
@@ -31,11 +35,24 @@ const VideosPage = () => {
     errors: errorMessages,
   } = useSelector((state: DeprecatedReduxState) => state.videos);
 
+  const {
+    isLoading: isLoadingPermissions,
+    canViewFiles,
+  } = useCourseUserPermissions(courseId, getFilesPermissions(courseId));
+
   const handleErrorReset = (error) => dispatch(resetErrors(error));
 
   useEffect(() => {
     dispatch(fetchVideos(courseId));
   }, [courseId]);
+
+  if (isLoadingPermissions) {
+    return <Loading />;
+  }
+
+  if (!canViewFiles) {
+    return <PermissionDeniedAlert />;
+  }
 
   if (loadingStatus === RequestStatus.DENIED) {
     return (

--- a/src/files-and-videos/videos-page/VideosPage.tsx
+++ b/src/files-and-videos/videos-page/VideosPage.tsx
@@ -14,10 +14,6 @@ import EditVideoAlertsSlot from '@src/plugin-slots/EditVideoAlertsSlot';
 
 import { DeprecatedReduxState } from '@src/store';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
-import { useCourseUserPermissions } from '@src/authz/hooks';
-import { getFilesPermissions } from '@src/authz/permissionHelpers';
-import Loading from '@src/generic/Loading';
-import PermissionDeniedAlert from '@src/generic/PermissionDeniedAlert';
 import { EditFileErrors } from '../generic';
 import { fetchVideos, resetErrors } from './data/thunks';
 import messages from './messages';
@@ -35,24 +31,11 @@ const VideosPage = () => {
     errors: errorMessages,
   } = useSelector((state: DeprecatedReduxState) => state.videos);
 
-  const {
-    isLoading: isLoadingPermissions,
-    canViewFiles,
-  } = useCourseUserPermissions(courseId, getFilesPermissions(courseId));
-
   const handleErrorReset = (error) => dispatch(resetErrors(error));
 
   useEffect(() => {
     dispatch(fetchVideos(courseId));
   }, [courseId]);
-
-  if (isLoadingPermissions) {
-    return <Loading />;
-  }
-
-  if (!canViewFiles) {
-    return <PermissionDeniedAlert />;
-  }
 
   if (loadingStatus === RequestStatus.DENIED) {
     return (

--- a/src/group-configurations/GroupConfigurations.test.tsx
+++ b/src/group-configurations/GroupConfigurations.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 import {
   initializeMocks,
   render,
@@ -18,6 +19,18 @@ const enrollmentTrackGroups = groupConfigurationResponseMock.allGroupConfigurati
 const contentGroups = groupConfigurationResponseMock.allGroupConfigurations[1];
 const teamGroups = groupConfigurationResponseMock.allGroupConfigurations[2];
 
+jest.mock('@src/authz/hooks', () => ({
+  useCourseUserPermissions: jest.fn(),
+}));
+
+const mockPermissions = (overrides = {}) =>
+  jest.mocked(useCourseUserPermissions).mockReturnValue({
+    isLoading: false,
+    isAuthzEnabled: true,
+    canManageGroupConfigurations: true,
+    ...overrides,
+  } as ReturnType<typeof useCourseUserPermissions>);
+
 const renderComponent = () =>
   render(
     <CourseAuthoringProvider courseId={courseId}>
@@ -32,6 +45,14 @@ describe('<GroupConfigurations />', () => {
     axiosMock
       .onGet(getContentStoreApiUrl(courseId))
       .reply(200, groupConfigurationResponseMock);
+    mockPermissions();
+  });
+
+  it('shows PermissionDeniedAlert when user lacks manage group configurations permission', async () => {
+    mockPermissions({ canManageGroupConfigurations: false });
+    renderComponent();
+    expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
+    expect(screen.queryByText(messages.headingSubtitle.defaultMessage)).not.toBeInTheDocument();
   });
 
   it('renders component correctly', async () => {

--- a/src/group-configurations/index.tsx
+++ b/src/group-configurations/index.tsx
@@ -7,7 +7,10 @@ import {
 } from '@openedx/paragon';
 import { Helmet } from 'react-helmet';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import { getGroupConfigurationsPermissions } from '@src/authz/permissionHelpers';
 import { LoadingSpinner } from '@src/generic/Loading';
+import PermissionDeniedAlert from '@src/generic/PermissionDeniedAlert';
 import SubHeader from '@src/generic/sub-header/SubHeader';
 import getPageHeadTitle from '@src/generic/utils';
 import { SavingErrorAlert } from '@src/generic/saving-error-alert';
@@ -34,6 +37,11 @@ const GroupConfigurations = () => {
     isLoadingDenied,
   } = useGroupConfigurations();
 
+  const {
+    isLoading: isLoadingUserPermissions,
+    canManageGroupConfigurations,
+  } = useCourseUserPermissions(courseId, getGroupConfigurationsPermissions(courseId));
+
   document.title = getPageHeadTitle(
     courseDetails?.name ?? '',
     formatMessage(messages.headingTitle),
@@ -44,6 +52,10 @@ const GroupConfigurations = () => {
     experimentGroupConfigurations = [],
     allGroupConfigurations = [],
   } = groupConfigurations ?? {};
+
+  if (!isLoadingUserPermissions && !canManageGroupConfigurations) {
+    return <PermissionDeniedAlert />;
+  }
 
   if (isLoadingDenied) {
     return (

--- a/src/header/Header.tsx
+++ b/src/header/Header.tsx
@@ -83,6 +83,9 @@ const Header = ({
     ];
   }
 
+  // Hide dropdowns whose items were all filtered out by permissions.
+  mainMenuDropdowns = mainMenuDropdowns.filter((dropdown) => dropdown.items.length > 0);
+
   const getOutlineLink = () => {
     if (isLibrary) {
       return `/library/${contextId}`;

--- a/src/header/hooks.test.tsx
+++ b/src/header/hooks.test.tsx
@@ -56,6 +56,8 @@ describe('header utils', () => {
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
         isAuthzEnabled: false,
+        canViewCourse: true,
+        canManageLibraryUpdates: true,
         canViewPagesAndResources: true,
         canManagePagesAndResources: true,
         canViewCourseUpdates: true,
@@ -67,6 +69,7 @@ describe('header utils', () => {
       mockWaffleFlags({ enableAuthzCourseAuthoring: false });
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
+        canViewCourse: true,
         canViewCourseUpdates: true,
         canViewPagesAndResources: true,
         canViewFiles: true,
@@ -89,6 +92,7 @@ describe('header utils', () => {
       });
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
+        canViewCourse: true,
         canViewCourseUpdates: true,
         canViewPagesAndResources: true,
         canViewFiles: true,
@@ -150,6 +154,8 @@ describe('header utils', () => {
       mockWaffleFlags({ enableAuthzCourseAuthoring: false });
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
+        canViewCourse: true,
+        canManageLibraryUpdates: true,
         canViewCourseUpdates: false,
       } as any);
       jest.mocked(useSelector).mockReturnValue({
@@ -231,6 +237,24 @@ describe('header utils', () => {
         expect(result.current.map((item) => item.title)).not.toContain('Pages & Resources');
       });
     });
+    it('when authz enabled and user has no permissions should return an empty menu', () => {
+      mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+      jest.mocked(useCourseUserPermissions).mockReturnValue({
+        isLoading: false,
+        isAuthzEnabled: true,
+        canViewCourse: false,
+        canManageLibraryUpdates: false,
+        canViewCourseUpdates: false,
+        canViewPagesAndResources: false,
+        canViewFiles: false,
+      } as ReturnType<typeof useCourseUserPermissions>);
+      jest.mocked(useSelector).mockReturnValue({
+        librariesV2Enabled: true,
+      });
+      const actualItems =
+        renderHook(() => useContentMenuItems('course-123'), { wrapper: createWrapper() }).result.current;
+      expect(actualItems).toHaveLength(0);
+    });
   });
 
   describe('getSettingsMenuitems', () => {
@@ -251,6 +275,9 @@ describe('header utils', () => {
         canManageAdvancedSettings: true,
         canViewGradingSettings: true,
         canViewScheduleAndDetails: true,
+        canViewCourseTeam: true,
+        canManageGroupConfigurations: true,
+        canManageCertificates: true,
       } as ReturnType<typeof useCourseUserPermissions>);
     });
 
@@ -296,6 +323,7 @@ describe('header utils', () => {
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
         canManageAdvancedSettings: true,
+        canViewCourseTeam: true,
       } as any);
       const actualItems =
         renderHook(() => useSettingMenuItems('course-123'), { wrapper: createWrapper() }).result.current;
@@ -318,6 +346,7 @@ describe('header utils', () => {
         isLoading: false,
         isAuthzEnabled: true,
         canManageAdvancedSettings: true,
+        canViewCourseTeam: true,
       } as any);
       const courseIdWithSpecialChars = 'course-v1:org+course+run';
       const actualItems =
@@ -429,6 +458,7 @@ describe('header utils', () => {
         canManageAdvancedSettings: true,
         canViewGradingSettings: true,
         canViewScheduleAndDetails: true,
+        canViewCourseTeam: true,
       } as ReturnType<typeof useCourseUserPermissions>);
       setConfig({
         ...getConfig(),
@@ -442,9 +472,61 @@ describe('header utils', () => {
         title: 'Roles and Permissions',
       });
     });
+
+    it('when authz flag is enabled and user lacks canViewCourseTeam should not include roles and permissions option', () => {
+      mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+      jest.mocked(useCourseUserPermissions).mockReturnValue({
+        isLoading: false,
+        isAuthzEnabled: true,
+        canViewCourseTeam: false,
+      } as any);
+      const actualItemsTitle = renderHook(() => useSettingMenuItems('course-123'), { wrapper: createWrapper() }).result
+        .current.map((item) => item.title);
+      expect(actualItemsTitle).not.toContain('Roles and Permissions');
+    });
+
+    it('when authz flag is enabled and user lacks canManageGroupConfigurations should not include group configurations option', () => {
+      mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+      jest.mocked(useCourseUserPermissions).mockReturnValue({
+        isLoading: false,
+        isAuthzEnabled: true,
+        canManageGroupConfigurations: false,
+      } as any);
+      const actualItemsTitle = renderHook(() => useSettingMenuItems('course-123'), { wrapper: createWrapper() }).result
+        .current.map((item) => item.title);
+      expect(actualItemsTitle).not.toContain('Group Configurations');
+    });
+
+    it('when authz flag is enabled and user lacks canManageCertificates should not include certificates option', () => {
+      mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+      setConfig({
+        ...getConfig(),
+        ENABLE_CERTIFICATE_PAGE: 'true',
+      });
+      jest.mocked(useCourseUserPermissions).mockReturnValue({
+        isLoading: false,
+        isAuthzEnabled: true,
+        canManageCertificates: false,
+      } as any);
+      const actualItemsTitle = renderHook(() => useSettingMenuItems('course-123'), { wrapper: createWrapper() }).result
+        .current.map((item) => item.title);
+      expect(actualItemsTitle).not.toContain('Certificates');
+    });
   });
 
   describe('getToolsMenuItems', () => {
+    beforeEach(() => {
+      jest.mocked(useCourseUserPermissions).mockReturnValue({
+        isLoading: false,
+        isAuthzEnabled: false,
+        canViewCourse: true,
+        canViewChecklists: true,
+        canImportCourse: true,
+        canExportCourse: true,
+        canExportTags: true,
+      } as ReturnType<typeof useCourseUserPermissions>);
+    });
+
     it('when tags enabled should include export tags option', () => {
       setConfig({
         ...getConfig(),
@@ -491,6 +573,29 @@ describe('header utils', () => {
       const actualItemsTitle = renderHook(() => useToolsMenuItems('course-123'), { wrapper: createWrapper() }).result
         .current.map((item) => item.title);
       expect(actualItemsTitle).not.toContain(messages['header.links.optimizer'].defaultMessage);
+    });
+
+    it('when authz enabled and user has no permissions should return an empty menu', () => {
+      mockWaffleFlags({
+        enableAuthzCourseAuthoring: true,
+        enableCourseOptimizer: true,
+      });
+      setConfig({
+        ...getConfig(),
+        ENABLE_TAGGING_TAXONOMY_PAGES: 'true',
+      });
+      jest.mocked(useCourseUserPermissions).mockReturnValue({
+        isLoading: false,
+        isAuthzEnabled: true,
+        canViewCourse: false,
+        canViewChecklists: false,
+        canImportCourse: false,
+        canExportCourse: false,
+        canExportTags: false,
+      } as ReturnType<typeof useCourseUserPermissions>);
+      const actualItems = renderHook(() => useToolsMenuItems('course-123'), { wrapper: createWrapper() }).result
+        .current;
+      expect(actualItems).toHaveLength(0);
     });
   });
 

--- a/src/header/hooks.test.tsx
+++ b/src/header/hooks.test.tsx
@@ -519,7 +519,7 @@ describe('header utils', () => {
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
         isAuthzEnabled: false,
-        canViewCourse: true,
+        canEditCourseContent: true,
         canViewChecklists: true,
         canImportCourse: true,
         canExportCourse: true,
@@ -587,7 +587,7 @@ describe('header utils', () => {
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
         isAuthzEnabled: true,
-        canViewCourse: false,
+        canEditCourseContent: false,
         canViewChecklists: false,
         canImportCourse: false,
         canExportCourse: false,

--- a/src/header/hooks.test.tsx
+++ b/src/header/hooks.test.tsx
@@ -238,7 +238,14 @@ describe('header utils', () => {
       });
     });
     it('when authz enabled and user has no permissions should return an empty menu', () => {
-      mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+      mockWaffleFlags({
+        enableAuthzCourseAuthoring: true,
+        useNewVideoUploadsPage: false,
+      });
+      setConfig({
+        ...getConfig(),
+        ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN: 'false',
+      });
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
         isAuthzEnabled: true,

--- a/src/header/hooks.tsx
+++ b/src/header/hooks.tsx
@@ -184,7 +184,7 @@ export const useToolsMenuItems = (courseId: string) => {
   const waffleFlags = useWaffleFlags();
 
   const {
-    canViewCourse,
+    canEditCourseContent,
     canViewChecklists,
     canImportCourse,
     canExportCourse,
@@ -220,7 +220,7 @@ export const useToolsMenuItems = (courseId: string) => {
         title: intl.formatMessage(messages['header.links.checklists']),
       }]
       : []),
-    ...(waffleFlags.enableCourseOptimizer && canViewCourse ?
+    ...(waffleFlags.enableCourseOptimizer && canEditCourseContent ?
       [{
         href: `/course/${courseId}/optimizer`,
         title: (

--- a/src/header/hooks.tsx
+++ b/src/header/hooks.tsx
@@ -11,21 +11,7 @@ import { SidebarActions } from '@src/library-authoring/common/context/SidebarCon
 import { LibQueryParamKeys } from '@src/library-authoring/routes';
 
 import { useCourseUserPermissions } from '@src/authz/hooks';
-import {
-  getAdvancedSettingsPermissions,
-  getCertificatesPermissions,
-  getChecklistsPermissions,
-  getCourseOutlinePermissions,
-  getCourseTeamPermissions,
-  getCourseUpdatesPermissions,
-  getGradingPermissions,
-  getGroupConfigurationsPermissions,
-  getImportExportPermissions,
-  getLibraryUpdatesPermissions,
-  getPagesAndResourcesPermissions,
-  getScheduleAndDetailsPermissions,
-  getFilesPermissions,
-} from '@src/authz/permissionHelpers';
+import * as permissionHelpers from '@src/authz/permissionHelpers';
 import messages from './messages';
 
 export const useContentMenuItems = (courseId: string) => {
@@ -33,49 +19,43 @@ export const useContentMenuItems = (courseId: string) => {
   const waffleFlags = useWaffleFlags(courseId);
   const { librariesV2Enabled } = useSelector(getStudioHomeData);
 
-  const {
-    canViewCourse,
-    canManageLibraryUpdates,
-    canViewCourseUpdates,
-    canViewPagesAndResources,
-    canViewFiles,
-  } = useCourseUserPermissions(
+  const perms = useCourseUserPermissions(
     courseId,
     {
-      ...getCourseOutlinePermissions(courseId),
-      ...getLibraryUpdatesPermissions(courseId),
-      ...getPagesAndResourcesPermissions(courseId),
-      ...getCourseUpdatesPermissions(courseId),
-      ...getFilesPermissions(courseId),
+      ...permissionHelpers.getCourseOutlinePermissions(courseId),
+      ...permissionHelpers.getLibraryUpdatesPermissions(courseId),
+      ...permissionHelpers.getPagesAndResourcesPermissions(courseId),
+      ...permissionHelpers.getCourseUpdatesPermissions(courseId),
+      ...permissionHelpers.getFilesPermissions(courseId),
     },
   );
 
   const items = [
-    ...(canViewCourse
+    ...(perms.canViewCourse
       ? [{
         href: `/course/${courseId}`,
         title: intl.formatMessage(messages['header.links.outline']),
       }]
       : []),
-    ...(librariesV2Enabled && canManageLibraryUpdates
+    ...(librariesV2Enabled && perms.canManageLibraryUpdates
       ? [{
         href: `/course/${courseId}/libraries`,
         title: intl.formatMessage(messages['header.links.libraries']),
       }]
       : []),
-    ...(canViewCourseUpdates ?
+    ...(perms.canViewCourseUpdates ?
       [{
         href: `/course/${courseId}/course_info`,
         title: intl.formatMessage(messages['header.links.updates']),
       }] :
       []),
-    ...(canViewPagesAndResources
+    ...(perms.canViewPagesAndResources
       ? [{
         href: getPagePath(courseId, 'true', 'tabs'),
         title: intl.formatMessage(messages['header.links.pages']),
       }]
       : []),
-    ...(canViewFiles
+    ...(perms.canViewFiles
       ? [{
         href: `/course/${courseId}/assets`,
         title: intl.formatMessage(messages['header.links.filesAndUploads']),
@@ -102,47 +82,38 @@ export const useSettingMenuItems = (courseId: string) => {
     If authz.enable_course_authoring flag is enabled, validate permissions using AuthZ API.
     Otherwise, fallback to existing logic.
   */
-  const {
-    isLoading,
-    isAuthzEnabled,
-    canManageAdvancedSettings,
-    canViewGradingSettings,
-    canViewScheduleAndDetails,
-    canViewCourseTeam,
-    canManageGroupConfigurations,
-    canManageCertificates,
-  } = useCourseUserPermissions(courseId, {
-    ...getAdvancedSettingsPermissions(courseId),
-    ...getGradingPermissions(courseId),
-    ...getScheduleAndDetailsPermissions(courseId),
-    ...getCourseTeamPermissions(courseId),
-    ...getGroupConfigurationsPermissions(courseId),
-    ...getCertificatesPermissions(courseId),
+  const perms = useCourseUserPermissions(courseId, {
+    ...permissionHelpers.getAdvancedSettingsPermissions(courseId),
+    ...permissionHelpers.getGradingPermissions(courseId),
+    ...permissionHelpers.getScheduleAndDetailsPermissions(courseId),
+    ...permissionHelpers.getCourseTeamPermissions(courseId),
+    ...permissionHelpers.getGroupConfigurationsPermissions(courseId),
+    ...permissionHelpers.getCertificatesPermissions(courseId),
   });
 
   // While permissions (or the authz waffle flag) are loading, don't fall back to the
   // legacy value: it would briefly show the link (and the Settings dropdown) to users
   // that authz then denies.
-  const canAccessAdvancedSettings = isAuthzEnabled
-    ? canManageAdvancedSettings
-    : !isLoading && legacyCanAccessAdvancedSettings;
+  const canAccessAdvancedSettings = perms.isAuthzEnabled
+    ? perms.canManageAdvancedSettings
+    : !perms.isLoading && legacyCanAccessAdvancedSettings;
 
   const items = [
-    ...(canViewScheduleAndDetails
+    ...(perms.canViewScheduleAndDetails
       ? [{
         href: `/course/${courseId}/settings/details`,
         title: intl.formatMessage(messages['header.links.scheduleAndDetails']),
       }]
       : []),
-    ...(canViewGradingSettings
+    ...(perms.canViewGradingSettings
       ? [{
         href: `/course/${courseId}/settings/grading`,
         title: intl.formatMessage(messages['header.links.grading']),
       }]
       : []),
-    ...(canViewCourseTeam
+    ...(perms.canViewCourseTeam
       ? [
-        isAuthzEnabled
+        perms.isAuthzEnabled
           ? {
             href: `${getConfig().ADMIN_CONSOLE_URL}/authz?scope=${encodeURIComponent(courseId)}`,
             title: intl.formatMessage(messages['header.links.roles.permissions']),
@@ -153,7 +124,7 @@ export const useSettingMenuItems = (courseId: string) => {
           },
       ]
       : []),
-    ...(canManageGroupConfigurations
+    ...(perms.canManageGroupConfigurations
       ? [{
         href: `/course/${courseId}/group_configurations`,
         title: intl.formatMessage(messages['header.links.groupConfigurations']),
@@ -166,7 +137,7 @@ export const useSettingMenuItems = (courseId: string) => {
       }] :
       []),
   ];
-  if (getConfig().ENABLE_CERTIFICATE_PAGE === 'true' && canManageCertificates) {
+  if (getConfig().ENABLE_CERTIFICATE_PAGE === 'true' && perms.canManageCertificates) {
     items.push({
       href: `/course/${courseId}/certificates`,
       title: intl.formatMessage(messages['header.links.certificates']),
@@ -180,44 +151,38 @@ export const useToolsMenuItems = (courseId: string) => {
   const studioBaseUrl = getConfig().STUDIO_BASE_URL;
   const waffleFlags = useWaffleFlags();
 
-  const {
-    canEditCourseContent,
-    canViewChecklists,
-    canImportCourse,
-    canExportCourse,
-    canExportTags,
-  } = useCourseUserPermissions(courseId, {
-    ...getCourseOutlinePermissions(courseId),
-    ...getChecklistsPermissions(courseId),
-    ...getImportExportPermissions(courseId),
+  const perms = useCourseUserPermissions(courseId, {
+    ...permissionHelpers.getCourseOutlinePermissions(courseId),
+    ...permissionHelpers.getChecklistsPermissions(courseId),
+    ...permissionHelpers.getImportExportPermissions(courseId),
   });
 
   const items = [
-    ...(canImportCourse
+    ...(perms.canImportCourse
       ? [{
         href: `/course/${courseId}/import`,
         title: intl.formatMessage(messages['header.links.import']),
       }]
       : []),
-    ...(canExportCourse
+    ...(perms.canExportCourse
       ? [{
         href: `/course/${courseId}/export`,
         title: intl.formatMessage(messages['header.links.exportCourse']),
       }]
       : []),
-    ...(getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true' && canExportTags
+    ...(getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true' && perms.canExportTags
       ? [{
         href: `${studioBaseUrl}/course/${courseId}#export-tags`,
         title: intl.formatMessage(messages['header.links.exportTags']),
       }] :
       []),
-    ...(canViewChecklists
+    ...(perms.canViewChecklists
       ? [{
         href: `/course/${courseId}/checklists`,
         title: intl.formatMessage(messages['header.links.checklists']),
       }]
       : []),
-    ...(waffleFlags.enableCourseOptimizer && canEditCourseContent ?
+    ...(waffleFlags.enableCourseOptimizer && perms.canEditCourseContent ?
       [{
         href: `/course/${courseId}/optimizer`,
         title: (

--- a/src/header/hooks.tsx
+++ b/src/header/hooks.tsx
@@ -83,10 +83,7 @@ export const useContentMenuItems = (courseId: string) => {
       []),
   ];
 
-  if (
-    (getConfig().ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN === 'true' || waffleFlags.useNewVideoUploadsPage)
-    && canViewFiles
-  ) {
+  if (getConfig().ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN === 'true' || waffleFlags.useNewVideoUploadsPage) {
     items.push({
       href: `/course/${courseId}/videos`,
       title: intl.formatMessage(messages['header.links.videoUploads']),

--- a/src/header/hooks.tsx
+++ b/src/header/hooks.tsx
@@ -13,22 +13,37 @@ import { LibQueryParamKeys } from '@src/library-authoring/routes';
 import { useCourseUserPermissions } from '@src/authz/hooks';
 import {
   getAdvancedSettingsPermissions,
+  getCertificatesPermissions,
+  getChecklistsPermissions,
+  getCourseOutlinePermissions,
+  getCourseTeamPermissions,
+  getCourseUpdatesPermissions,
   getGradingPermissions,
+  getGroupConfigurationsPermissions,
+  getImportExportPermissions,
+  getLibraryUpdatesPermissions,
   getPagesAndResourcesPermissions,
   getScheduleAndDetailsPermissions,
   getFilesPermissions,
 } from '@src/authz/permissionHelpers';
 import messages from './messages';
-import { getCourseUpdatesPermissions } from '@src/authz/permissionHelpers';
 
 export const useContentMenuItems = (courseId: string) => {
   const intl = useIntl();
   const waffleFlags = useWaffleFlags(courseId);
   const { librariesV2Enabled } = useSelector(getStudioHomeData);
 
-  const { canViewCourseUpdates, canViewPagesAndResources, canViewFiles } = useCourseUserPermissions(
+  const {
+    canViewCourse,
+    canManageLibraryUpdates,
+    canViewCourseUpdates,
+    canViewPagesAndResources,
+    canViewFiles,
+  } = useCourseUserPermissions(
     courseId,
     {
+      ...getCourseOutlinePermissions(courseId),
+      ...getLibraryUpdatesPermissions(courseId),
       ...getPagesAndResourcesPermissions(courseId),
       ...getCourseUpdatesPermissions(courseId),
       ...getFilesPermissions(courseId),
@@ -36,10 +51,18 @@ export const useContentMenuItems = (courseId: string) => {
   );
 
   const items = [
-    {
-      href: `/course/${courseId}`,
-      title: intl.formatMessage(messages['header.links.outline']),
-    },
+    ...(canViewCourse
+      ? [{
+        href: `/course/${courseId}`,
+        title: intl.formatMessage(messages['header.links.outline']),
+      }]
+      : []),
+    ...(librariesV2Enabled && canManageLibraryUpdates
+      ? [{
+        href: `/course/${courseId}/libraries`,
+        title: intl.formatMessage(messages['header.links.libraries']),
+      }]
+      : []),
     ...(canViewCourseUpdates ?
       [{
         href: `/course/${courseId}/course_info`,
@@ -60,17 +83,13 @@ export const useContentMenuItems = (courseId: string) => {
       []),
   ];
 
-  if (getConfig().ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN === 'true' || waffleFlags.useNewVideoUploadsPage) {
+  if (
+    (getConfig().ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN === 'true' || waffleFlags.useNewVideoUploadsPage)
+    && canViewFiles
+  ) {
     items.push({
       href: `/course/${courseId}/videos`,
       title: intl.formatMessage(messages['header.links.videoUploads']),
-    });
-  }
-
-  if (librariesV2Enabled) {
-    items.splice(1, 0, {
-      href: `/course/${courseId}/libraries`,
-      title: intl.formatMessage(messages['header.links.libraries']),
     });
   }
 
@@ -87,19 +106,29 @@ export const useSettingMenuItems = (courseId: string) => {
     Otherwise, fallback to existing logic.
   */
   const {
+    isLoading,
     isAuthzEnabled,
     canManageAdvancedSettings,
     canViewGradingSettings,
     canViewScheduleAndDetails,
+    canViewCourseTeam,
+    canManageGroupConfigurations,
+    canManageCertificates,
   } = useCourseUserPermissions(courseId, {
     ...getAdvancedSettingsPermissions(courseId),
     ...getGradingPermissions(courseId),
     ...getScheduleAndDetailsPermissions(courseId),
+    ...getCourseTeamPermissions(courseId),
+    ...getGroupConfigurationsPermissions(courseId),
+    ...getCertificatesPermissions(courseId),
   });
 
+  // While permissions (or the authz waffle flag) are loading, don't fall back to the
+  // legacy value: it would briefly show the link (and the Settings dropdown) to users
+  // that authz then denies.
   const canAccessAdvancedSettings = isAuthzEnabled
     ? canManageAdvancedSettings
-    : legacyCanAccessAdvancedSettings;
+    : !isLoading && legacyCanAccessAdvancedSettings;
 
   const items = [
     ...(canViewScheduleAndDetails
@@ -114,19 +143,25 @@ export const useSettingMenuItems = (courseId: string) => {
         title: intl.formatMessage(messages['header.links.grading']),
       }]
       : []),
-    ...(isAuthzEnabled
+    ...(canViewCourseTeam
+      ? [
+        isAuthzEnabled
+          ? {
+            href: `${getConfig().ADMIN_CONSOLE_URL}/authz?scope=${encodeURIComponent(courseId)}`,
+            title: intl.formatMessage(messages['header.links.roles.permissions']),
+          }
+          : {
+            href: `/course/${courseId}/course_team`,
+            title: intl.formatMessage(messages['header.links.courseTeam']),
+          },
+      ]
+      : []),
+    ...(canManageGroupConfigurations
       ? [{
-        href: `${getConfig().ADMIN_CONSOLE_URL}/authz?scope=${encodeURIComponent(courseId)}`,
-        title: intl.formatMessage(messages['header.links.roles.permissions']),
+        href: `/course/${courseId}/group_configurations`,
+        title: intl.formatMessage(messages['header.links.groupConfigurations']),
       }]
-      : [{
-        href: `/course/${courseId}/course_team`,
-        title: intl.formatMessage(messages['header.links.courseTeam']),
-      }]),
-    {
-      href: `/course/${courseId}/group_configurations`,
-      title: intl.formatMessage(messages['header.links.groupConfigurations']),
-    },
+      : []),
     ...(canAccessAdvancedSettings
       ? [{
         href: `/course/${courseId}/settings/advanced`,
@@ -134,7 +169,7 @@ export const useSettingMenuItems = (courseId: string) => {
       }] :
       []),
   ];
-  if (getConfig().ENABLE_CERTIFICATE_PAGE === 'true') {
+  if (getConfig().ENABLE_CERTIFICATE_PAGE === 'true' && canManageCertificates) {
     items.push({
       href: `/course/${courseId}/certificates`,
       title: intl.formatMessage(messages['header.links.certificates']),
@@ -148,26 +183,44 @@ export const useToolsMenuItems = (courseId: string) => {
   const studioBaseUrl = getConfig().STUDIO_BASE_URL;
   const waffleFlags = useWaffleFlags();
 
+  const {
+    canViewCourse,
+    canViewChecklists,
+    canImportCourse,
+    canExportCourse,
+    canExportTags,
+  } = useCourseUserPermissions(courseId, {
+    ...getCourseOutlinePermissions(courseId),
+    ...getChecklistsPermissions(courseId),
+    ...getImportExportPermissions(courseId),
+  });
+
   const items = [
-    {
-      href: `/course/${courseId}/import`,
-      title: intl.formatMessage(messages['header.links.import']),
-    },
-    {
-      href: `/course/${courseId}/export`,
-      title: intl.formatMessage(messages['header.links.exportCourse']),
-    },
-    ...(getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true'
+    ...(canImportCourse
+      ? [{
+        href: `/course/${courseId}/import`,
+        title: intl.formatMessage(messages['header.links.import']),
+      }]
+      : []),
+    ...(canExportCourse
+      ? [{
+        href: `/course/${courseId}/export`,
+        title: intl.formatMessage(messages['header.links.exportCourse']),
+      }]
+      : []),
+    ...(getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true' && canExportTags
       ? [{
         href: `${studioBaseUrl}/course/${courseId}#export-tags`,
         title: intl.formatMessage(messages['header.links.exportTags']),
       }] :
       []),
-    {
-      href: `/course/${courseId}/checklists`,
-      title: intl.formatMessage(messages['header.links.checklists']),
-    },
-    ...(waffleFlags.enableCourseOptimizer ?
+    ...(canViewChecklists
+      ? [{
+        href: `/course/${courseId}/checklists`,
+        title: intl.formatMessage(messages['header.links.checklists']),
+      }]
+      : []),
+    ...(waffleFlags.enableCourseOptimizer && canViewCourse ?
       [{
         href: `/course/${courseId}/optimizer`,
         title: (

--- a/src/import-page/CourseImportPage.test.tsx
+++ b/src/import-page/CourseImportPage.test.tsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet';
 import Cookies from 'universal-cookie';
 
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 import { getCourseDetailsUrl } from '@src/data/api';
 import { initializeMocks, render, waitFor } from '@src/testUtils';
 import messages from './messages';
@@ -24,6 +25,20 @@ jest.mock('universal-cookie', () => {
   };
   return jest.fn(() => Cookie);
 });
+
+jest.mock('@src/authz/hooks', () => ({
+  useCourseUserPermissions: jest.fn(),
+}));
+
+const mockPermissions = (overrides = {}) =>
+  jest.mocked(useCourseUserPermissions).mockReturnValue({
+    isLoading: false,
+    isAuthzEnabled: true,
+    canImportCourse: true,
+    canExportCourse: true,
+    canExportTags: true,
+    ...overrides,
+  } as ReturnType<typeof useCourseUserPermissions>);
 
 const renderComponent = () =>
   render(
@@ -50,6 +65,7 @@ describe('<CourseImportPage />', () => {
       .reply(200, { courseId, name: courseName });
     cookies = new Cookies();
     cookies.get.mockReturnValue(null);
+    mockPermissions();
   });
 
   it('should render page title correctly', async () => {
@@ -115,5 +131,20 @@ describe('<CourseImportPage />', () => {
     cookies.get.mockReturnValue({ date: 1679787000, fileName: 'testFileName.tar.gz' });
     renderComponent();
     expect(await screen.findByText(messages.defaultErrorMessage.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('shows PermissionDeniedAlert when user lacks import permission', async () => {
+    mockPermissions({ canImportCourse: false });
+    renderComponent();
+    expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
+    expect(screen.queryByText(messages.headingSubtitle.defaultMessage)).not.toBeInTheDocument();
+  });
+
+  it('shows a loading spinner while permissions are loading', async () => {
+    mockPermissions({ isLoading: true, canImportCourse: false });
+    renderComponent();
+    expect(await screen.findByRole('status')).toBeInTheDocument();
+    expect(screen.queryByTestId('permissionDeniedAlert')).not.toBeInTheDocument();
+    expect(screen.queryByText(messages.headingSubtitle.defaultMessage)).not.toBeInTheDocument();
   });
 });

--- a/src/import-page/CourseImportPage.tsx
+++ b/src/import-page/CourseImportPage.tsx
@@ -9,7 +9,11 @@ import { Helmet } from 'react-helmet';
 import SubHeader from '@src/generic/sub-header/SubHeader';
 import InternetConnectionAlert from '@src/generic/internet-connection-alert';
 import ConnectionErrorAlert from '@src/generic/ConnectionErrorAlert';
+import Loading from '@src/generic/Loading';
+import PermissionDeniedAlert from '@src/generic/PermissionDeniedAlert';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import { getImportExportPermissions } from '@src/authz/permissionHelpers';
 
 import ImportStepper from './import-stepper/ImportStepper';
 import ImportSidebar from './import-sidebar/ImportSidebar';
@@ -19,13 +23,26 @@ import { useCourseImportContext } from './CourseImportContext';
 
 const CourseImportPage = () => {
   const intl = useIntl();
-  const { courseDetails } = useCourseAuthoringContext();
+  const { courseId, courseDetails } = useCourseAuthoringContext();
   const {
     importTriggered,
     anyRequestFailed,
     anyRequestInProgress,
     isLoadingDenied,
   } = useCourseImportContext();
+
+  const {
+    isLoading: isLoadingUserPermissions,
+    canImportCourse,
+  } = useCourseUserPermissions(courseId, getImportExportPermissions(courseId));
+
+  if (isLoadingUserPermissions) {
+    return <Loading />;
+  }
+
+  if (!canImportCourse) {
+    return <PermissionDeniedAlert />;
+  }
 
   if (isLoadingDenied) {
     return (

--- a/src/optimizer-page/CourseOptimizerPage.test.js
+++ b/src/optimizer-page/CourseOptimizerPage.test.js
@@ -46,7 +46,7 @@ const mockPermissions = (overrides = {}) =>
   jest.mocked(useCourseUserPermissions).mockReturnValue({
     isLoading: false,
     isAuthzEnabled: true,
-    canViewCourse: true,
+    canEditCourseContent: true,
     ...overrides,
   });
 
@@ -146,19 +146,29 @@ describe('CourseOptimizerPage', () => {
       mockPermissions();
     });
 
-    it('shows PermissionDeniedAlert when user lacks view course permission', async () => {
-      mockPermissions({ canViewCourse: false });
+    it('shows PermissionDeniedAlert when user lacks edit course content permission', async () => {
+      mockPermissions({ canEditCourseContent: false });
       render(<OptimizerPage />);
       expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
       expect(screen.queryByText(messages.headingTitle.defaultMessage)).not.toBeInTheDocument();
     });
 
     it('shows a loading spinner while permissions are loading', async () => {
-      mockPermissions({ isLoading: true, canViewCourse: false });
+      mockPermissions({ isLoading: true, canEditCourseContent: false });
       render(<OptimizerPage />);
       expect(await screen.findByRole('status')).toBeInTheDocument();
       expect(screen.queryByTestId('permissionDeniedAlert')).not.toBeInTheDocument();
       expect(screen.queryByText(messages.headingTitle.defaultMessage)).not.toBeInTheDocument();
+    });
+
+    it('does not fetch the link check status when user lacks edit course content permission', async () => {
+      mockPermissions({ canEditCourseContent: false });
+      render(<OptimizerPage />);
+      expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
+      const linkCheckRequests = axiosMock.history.get.filter(
+        (request) => request.url === getLinkCheckStatusApiUrl(courseId),
+      );
+      expect(linkCheckRequests).toHaveLength(0);
     });
 
     it('should render the component', () => {

--- a/src/optimizer-page/CourseOptimizerPage.test.js
+++ b/src/optimizer-page/CourseOptimizerPage.test.js
@@ -25,6 +25,7 @@ import {
 } from './mocks/mockApiResponse';
 import * as thunks from './data/thunks';
 import { useWaffleFlags } from '../data/apiHooks';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 
 let axiosMock;
 const courseId = '123';
@@ -36,6 +37,18 @@ jest.mock('../data/apiHooks', () => ({
     enableCourseOptimizerCheckPrevRunLinks: false,
   })),
 }));
+
+jest.mock('@src/authz/hooks', () => ({
+  useCourseUserPermissions: jest.fn(),
+}));
+
+const mockPermissions = (overrides = {}) =>
+  jest.mocked(useCourseUserPermissions).mockReturnValue({
+    isLoading: false,
+    isAuthzEnabled: true,
+    canViewCourse: true,
+    ...overrides,
+  });
 
 const OptimizerPage = () => (
   <CourseAuthoringProvider courseId={courseId}>
@@ -130,6 +143,22 @@ describe('CourseOptimizerPage', () => {
       axiosMock
         .onGet(getLinkCheckStatusApiUrl(courseId))
         .reply(200, mockApiResponse);
+      mockPermissions();
+    });
+
+    it('shows PermissionDeniedAlert when user lacks view course permission', async () => {
+      mockPermissions({ canViewCourse: false });
+      render(<OptimizerPage />);
+      expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
+      expect(screen.queryByText(messages.headingTitle.defaultMessage)).not.toBeInTheDocument();
+    });
+
+    it('shows a loading spinner while permissions are loading', async () => {
+      mockPermissions({ isLoading: true, canViewCourse: false });
+      render(<OptimizerPage />);
+      expect(await screen.findByRole('status')).toBeInTheDocument();
+      expect(screen.queryByTestId('permissionDeniedAlert')).not.toBeInTheDocument();
+      expect(screen.queryByText(messages.headingTitle.defaultMessage)).not.toBeInTheDocument();
     });
 
     it('should render the component', () => {

--- a/src/optimizer-page/CourseOptimizerPage.tsx
+++ b/src/optimizer-page/CourseOptimizerPage.tsx
@@ -110,8 +110,9 @@ const CourseOptimizerPage = () => {
   const { courseId, courseDetails } = useCourseAuthoringContext();
   const {
     isLoading: isLoadingUserPermissions,
-    canViewCourse,
+    canEditCourseContent,
   } = useCourseUserPermissions(courseId, getCourseOutlinePermissions(courseId));
+  const hasEditAccess = !isLoadingUserPermissions && canEditCourseContent;
   const linkCheckPresent = currentStage != null ? currentStage >= 0 : !!currentStage;
   const [showStepper, setShowStepper] = useState(false);
   const [scanResultsError, setScanResultsError] = useState<string | null>(null);
@@ -142,21 +143,30 @@ const CourseOptimizerPage = () => {
   ];
 
   useEffect(() => {
-    // when first entering the page, fetch any existing scan results
-    dispatch(fetchLinkCheckStatus(courseId));
-  }, []);
+    // when first entering the page, fetch any existing scan results,
+    // but only once the user permissions have been validated
+    if (hasEditAccess) {
+      dispatch(fetchLinkCheckStatus(courseId));
+    }
+  }, [hasEditAccess]);
 
   useEffect(() => {
     // when a scan starts, start polling for the results as long as the scan status fetched
     // signals it is still in progress
+    if (!hasEditAccess) {
+      return undefined;
+    }
     pollLinkCheckDuringScan(linkCheckInProgress, interval, dispatch, courseId);
 
     return () => {
       if (interval.current) { clearInterval(interval.current); }
     };
-  }, [linkCheckInProgress, linkCheckResult]);
+  }, [linkCheckInProgress, linkCheckResult, hasEditAccess]);
 
   useEffect(() => {
+    if (!hasEditAccess) {
+      return undefined;
+    }
     pollRerunLinkUpdateDuringUpdate(
       rerunLinkUpdateInProgress,
       rerunLinkUpdateResult,
@@ -168,7 +178,7 @@ const CourseOptimizerPage = () => {
     return () => {
       if (rerunUpdateInterval.current) { clearInterval(rerunUpdateInterval.current); }
     };
-  }, [rerunLinkUpdateInProgress, rerunLinkUpdateResult]);
+  }, [rerunLinkUpdateInProgress, rerunLinkUpdateResult, hasEditAccess]);
 
   const stepperVisibleCondition = linkCheckPresent && ((!linkCheckResult || linkCheckInProgress) && currentStage !== 2);
   useEffect(() => {
@@ -190,7 +200,7 @@ const CourseOptimizerPage = () => {
     return <Loading />;
   }
 
-  if (!canViewCourse) {
+  if (!canEditCourseContent) {
     return <PermissionDeniedAlert />;
   }
 

--- a/src/optimizer-page/CourseOptimizerPage.tsx
+++ b/src/optimizer-page/CourseOptimizerPage.tsx
@@ -19,8 +19,12 @@ import { SpinnerSimple } from '@openedx/paragon/icons';
 import { Helmet } from 'react-helmet';
 
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import { getCourseOutlinePermissions } from '@src/authz/permissionHelpers';
 import CourseStepper from '../generic/course-stepper';
 import ConnectionErrorAlert from '../generic/ConnectionErrorAlert';
+import Loading from '@src/generic/Loading';
+import PermissionDeniedAlert from '@src/generic/PermissionDeniedAlert';
 import AlertMessage from '../generic/alert-message';
 import { RequestFailureStatuses } from '../data/constants';
 import { RERUN_LINK_UPDATE_STATUSES } from './data/constants';
@@ -104,6 +108,10 @@ const CourseOptimizerPage = () => {
   const interval = useRef<number | undefined>(undefined);
   const rerunUpdateInterval = useRef<number | undefined>(undefined);
   const { courseId, courseDetails } = useCourseAuthoringContext();
+  const {
+    isLoading: isLoadingUserPermissions,
+    canViewCourse,
+  } = useCourseUserPermissions(courseId, getCourseOutlinePermissions(courseId));
   const linkCheckPresent = currentStage != null ? currentStage >= 0 : !!currentStage;
   const [showStepper, setShowStepper] = useState(false);
   const [scanResultsError, setScanResultsError] = useState<string | null>(null);
@@ -177,6 +185,14 @@ const CourseOptimizerPage = () => {
 
     return () => clearTimeout(timeout);
   }, [stepperVisibleCondition]);
+
+  if (isLoadingUserPermissions) {
+    return <Loading />;
+  }
+
+  if (!canViewCourse) {
+    return <PermissionDeniedAlert />;
+  }
 
   if (isLoadingDenied || isSavingDenied) {
     if (interval.current) { clearInterval(interval.current); }


### PR DESCRIPTION
## Description

This PR extends the AuthZ-based access validation (behind the `authz.enable_course_authoring` waffle flag) from individual settings pages to the **entire course header navigation and every page reachable from it**.  It has two parts:

**1. Header links are only rendered when the user holds the corresponding permission**

New actions were added to `COURSE_PERMISSIONS` (`src/authz/constants.ts`), matching the actions defined in the [openedx-authz](https://github.com/openedx/openedx-authz) policy, and each header menu item is now gated by the action that grants access to its page:

| Menu | Link | Permission |Notes|
|---|---|---|---|
| Content | Outline | `courses.view_course` |
| Content | Library Updates | `courses.manage_library_updates` |
| Content | Files | `courses.view_files` |
| Content | Video | `courses.view_files` | Out of the scope until deprecation decision https://github.com/openedx/frontend-app-authoring/issues/3105  |
| Settings | Course Team | `courses.view_course_team` |
| Settings | Group Configurations | `courses.manage_group_configurations` |
| Settings | Certificates | `courses.manage_certificates` |
| Tools | Import  | `courses.import_course` |
| Tools | Export |  `courses.export_course`|
| Tools | Export Tags | `courses.export_tags` |
| Tools | Checklists | `courses.view_checklists` |
| Tools | Optimizer | `courses.view_course` | No dedicated action exists so it use the global Course Edit Content |

If **all** items of a dropdown are filtered out, the dropdown button itself is hidden (`src/header/Header.tsx`). The legacy Advanced Settings fallback no longer applies while permissions are loading, which removes a flicker where the Settings button appeared and then disappeared for unauthorized users.

**2. Pages show a loader and a permission-denied alert instead of their content**

Deep links must not bypass the hidden menu items, so each page now renders the shared `PermissionDeniedAlert` when the AuthZ check denies access, and a loading spinner while the check is in flight: Import, Export, Checklists, Optimizer, Video Uploads, Library Updates, Group Configurations, and Certificates. 

Advanced Settings already had the alert, but its "Under Construction" 403 placeholder was returned first — the permission check was moved above that branch so denied users see the correct message.

**Behavior when the flag is off is unchanged**: `useCourseUserPermissions` resolves every permission to `true`, so all links and pages behave exactly as before.


## Supporting information

- Follows the pattern introduced for Grading / Schedule & Details / Pages & Resources /
  Files in previous PRs.
- It solves the Verawood release blocker https://github.com/openedx/wg-build-test-release/issues/613

## Testing instructions

1. Run an environment with the `openedx-authz` service installed and the `authz.enable_course_authoring` waffle flag **enabled** for a course.
2. Open the course from a user without any course role.
3. Open the course: the header should not display the menu.
4. Navigate directly to a restricted URL, e.g. `/course/:courseId/import`,  `/course/:courseId/certificates`, `/course/:courseId/group_configurations`,   `/course/:courseId/videos`: a spinner should appear briefly, followed by the  "You are not authorized to view this page" alert , no page content.
5. Repeat as a `course_admin`: all links and pages should be available.
6. Disable the waffle flag and verify the header and all pages behave as before.


## Screenshots 

### Unauthorized user

[Screencast from 2026-07-09 18-11-31.webm](https://github.com/user-attachments/assets/813b6d4a-ff11-426d-9281-c627e6e48564)

### Authorized user

[Screencast from 2026-07-09 18-09-27.webm](https://github.com/user-attachments/assets/dacc3ef6-fb06-4467-b1fd-2c30d0bd9b6d)


## Out of the scope

The PR only creates page view validations, it does not validate fine-grained permission for the actions  

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
