### PR TITLE
Fix oxlint, which was only partially enabled

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -3,7 +3,15 @@
   "categories": {
     "correctness": "warn"
   },
-  "plugins": ["react"],
+  "plugins": [
+    "react",
+    "typescript",
+    "oxc",
+    "unicorn",
+    "jest"
+    // TODO: enable this plugin and fix the a11y lint issues
+    // "jsx-a11y"
+  ],
   "rules": {
     "eslint/no-unused-vars": ["warn", {
       // Allow using {ignoredProp, ...keepTheRest} to omit a prop like 'ignoredProp' from an object.
@@ -23,7 +31,17 @@
         // want to await this.
         "invalidateQueries"
       ]
-    }]
+    }],
+    // no-conditional-expect is disabled because the existing code had a lot of violations. Enable in the future?
+    "jest/no-conditional-expect": "off",
+    // unbound-method is disabled since it's noisy and our existing code has lots of violations.
+    "typescript/unbound-method": "off",
+    // Don't require expect() assertions in each test case; this repo currently uses a pattern where the test
+    // passes if it doesn't raise any exceptions, and/or put assertions into helper functions.
+    "jest/expect-expect": "off",
+    // It's OK to use `expect()` in `beforeEach()` - it does properly assert. However, it seems we can't configure that
+    // so for now this whole rule is disabled.
+    "jest/no-standalone-expect": ["off"]
   },
   "ignorePatterns": [
     "webpack.dev-tutor.config.js"

--- a/plugins/course-apps/live/BbbSettings.test.jsx
+++ b/plugins/course-apps/live/BbbSettings.test.jsx
@@ -107,7 +107,7 @@ describe('BBB Settings', () => {
   );
 
   test(
-    'Connect to support and PII sharing message is visible and plans selection is disabled, When pii sharing is disabled, ',
+    'Connect to support and PII sharing message is visible and plans selection is disabled, When pii sharing is disabled',
     async () => {
       await mockStore({ piiSharingAllowed: false });
       renderComponent();

--- a/src/certificates/certificate-create-form/hooks/useCertificateCreateForm.tsx
+++ b/src/certificates/certificate-create-form/hooks/useCertificateCreateForm.tsx
@@ -19,7 +19,7 @@ const useCertificateCreateForm = () => {
   const handleCertificateSubmit = (values) => {
     const signatoriesWithoutIds = values.signatories.map(({ id, ...rest }) => rest);
     const newValues = { ...values, signatories: signatoriesWithoutIds };
-    createCertificateMutation.mutateAsync(newValues);
+    void createCertificateMutation.mutateAsync(newValues);
   };
 
   const handleFormCancel = (resetForm) => {

--- a/src/certificates/certificate-details/hooks/useCertificateDetails.tsx
+++ b/src/certificates/certificate-details/hooks/useCertificateDetails.tsx
@@ -25,7 +25,7 @@ const useCertificateDetails = (certificateId) => {
 
   const handleDeleteCard = () => {
     if (certificateId) {
-      deleteCertificateMutation.mutateAsync(certificateId);
+      void deleteCertificateMutation.mutateAsync(certificateId);
     }
   };
 

--- a/src/certificates/certificate-edit-form/hooks/useCertificateEditForm.tsx
+++ b/src/certificates/certificate-edit-form/hooks/useCertificateEditForm.tsx
@@ -38,7 +38,7 @@ const useCertificateEditForm = () => {
       signatories: signatoriesWithoutLocalIds,
     };
 
-    updateCertificateMutation.mutateAsync(newValues);
+    void updateCertificateMutation.mutateAsync(newValues);
   };
 
   const handleCertificateUpdateCancel = (resetForm) => {

--- a/src/certificates/certificates-list/hooks/useCertificatesList.tsx
+++ b/src/certificates/certificates-list/hooks/useCertificatesList.tsx
@@ -33,7 +33,7 @@ const useCertificatesList = () => {
   }));
 
   const handleSubmit = async (values) => {
-    await updateCertificateMutation.mutate(values);
+    await updateCertificateMutation.mutateAsync(values);
     setEditModes({});
     setComponentMode(MODE_STATES.view);
   };

--- a/src/certificates/layout/certificates-sidebar/sidebar-block/SidebarBlock.tsx
+++ b/src/certificates/layout/certificates-sidebar/sidebar-block/SidebarBlock.tsx
@@ -15,8 +15,9 @@ const SidebarBlock = ({
     <h4 className="help-sidebar-about-title">
       {title}
     </h4>
-    {paragraphs.map((text) => (
-      <p key={text.toString()} className="help-sidebar-about-descriptions">
+    {paragraphs.map((text, index) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <p key={index} className="help-sidebar-about-descriptions">
         {text}
       </p>
     ))}

--- a/src/certificates/layout/header-buttons/hooks/useHeaderButtons.tsx
+++ b/src/certificates/layout/header-buttons/hooks/useHeaderButtons.tsx
@@ -25,6 +25,7 @@ const useHeaderButtons = () => {
   const handleActivationStatus = () => {
     const status = !isCertificateActive;
 
+    // oxlint-disable-next-line typescript/no-floating-promises
     activationStatusMutation.mutateAsync({
       path: certificateActivationHandlerUrl ?? '',
       activationStatus: status,

--- a/src/container-comparison/utils.test.ts
+++ b/src/container-comparison/utils.test.ts
@@ -1,7 +1,7 @@
 import { ContainerChildBase, CourseContainerChildBase } from './types';
 import { diffPreviewContainerChildren } from './utils';
 
-export const getMockCourseContainerData = (
+const getMockCourseContainerData = (
   type: 'added|deleted' | 'moved|deleted' | 'all' | 'locallyEdited',
 ): [CourseContainerChildBase[], ContainerChildBase[]] => {
   switch (type) {

--- a/src/content-tags-drawer/ContentTagsDrawer.test.jsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.test.jsx
@@ -112,8 +112,8 @@ describe('<ContentTagsDrawer />', () => {
   it('should be read only on first render on drawer variant', async () => {
     renderDrawer(stagedTagsId);
     expect(await screen.findByText('Taxonomy 1')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /close/i }));
-    expect(screen.getByRole('button', { name: /edit tags/i }));
+    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit tags/i })).toBeInTheDocument();
 
     // Not show delete tag buttons
     expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
@@ -131,7 +131,7 @@ describe('<ContentTagsDrawer />', () => {
   it('should be read only on first render on component variant', async () => {
     renderDrawer(stagedTagsId, { variant: 'component' });
     expect(await screen.findByText('Taxonomy 1')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /manage tags/i }));
+    expect(screen.getByRole('button', { name: /manage tags/i })).toBeInTheDocument();
 
     // Not show delete tag buttons
     expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();

--- a/src/course-checklist/ChecklistSection/utils/getFilteredChecklist.test.js
+++ b/src/course-checklist/ChecklistSection/utils/getFilteredChecklist.test.js
@@ -55,7 +55,7 @@ describe('getFilteredChecklist utility function', () => {
       expect(
         item.pacingTypeFilter === filters.ALL
           || item.pacingTypeFilter === filters.SELF_PACED,
-      )
+      ).toBeTruthy()
     );
 
     expect(filteredChecklist.filter(item => item.pacingTypeFilter === filters.ALL).length)
@@ -78,7 +78,7 @@ describe('getFilteredChecklist utility function', () => {
       expect(
         item.pacingTypeFilter === filters.ALL
           || item.pacingTypeFilter === filters.INSTRUCTOR_PACED,
-      )
+      ).toBeTruthy()
     );
 
     expect(filteredChecklist.filter(item => item.pacingTypeFilter === filters.ALL).length)

--- a/src/course-checklist/CourseChecklist.test.jsx
+++ b/src/course-checklist/CourseChecklist.test.jsx
@@ -37,7 +37,7 @@ describe('CourseChecklistPage', () => {
   });
   describe('renders', () => {
     describe('if enable_quality prop is true', () => {
-      it('two checklist components ', async () => {
+      it('two checklist components', async () => {
         await mockStore(200);
         renderComponent();
 
@@ -79,7 +79,7 @@ describe('CourseChecklistPage', () => {
         });
       });
 
-      it('one checklist components ', async () => {
+      it('one checklist components', async () => {
         renderComponent();
         await mockStore(200);
 

--- a/src/course-outline/__mocks__/helpers.ts
+++ b/src/course-outline/__mocks__/helpers.ts
@@ -140,7 +140,7 @@ function buildNode(spec: NodeSpec, category: string): Record<string, unknown> {
     displayName,
     category,
     hasChildren: children.length > 0,
-    ...(spec.overrides || {}),
+    ...spec.overrides,
   };
 
   // Every node gets childInfo — leaf nodes get empty children array.

--- a/src/course-outline/drag-helper/utils.ts
+++ b/src/course-outline/drag-helper/utils.ts
@@ -486,9 +486,9 @@ export function applyReorderMove(
   const ids = newItems.map((s: XBlock) => s.id);
   if (subsectionId) {
     // Unit reorder
-    commitReorder(sectionId, currentSection.id, subsectionId, ids);
+    void commitReorder(sectionId, currentSection.id, subsectionId, ids);
   } else {
     // Subsection reorder
-    commitReorder(sectionId, currentSection.id, ids);
+    void commitReorder(sectionId, currentSection.id, ids);
   }
 }

--- a/src/course-outline/outline-level.test.ts
+++ b/src/course-outline/outline-level.test.ts
@@ -191,7 +191,9 @@ describe('buildSelectionState', () => {
 
   it('throws on depth 2 when subsection is missing', () => {
     const badAncestors: OutlineNodeAncestors = { section: sectionBlock, subsection: undefined };
-    expect(() => buildSelectionState(unitBlock, 2, 0, badAncestors)).toThrow();
+    expect(
+      () => buildSelectionState(unitBlock, 2, 0, badAncestors),
+    ).toThrow('outline-level: subsection ancestor required at depth 2');
   });
 });
 
@@ -250,7 +252,9 @@ describe('buildOutlineActionSelection', () => {
 
   it('throws on depth 2 when subsection is missing', () => {
     const badAncestors: OutlineNodeAncestors = { section: sectionBlock, subsection: undefined };
-    expect(() => buildOutlineActionSelection(unitBlock, 2, 0, badAncestors)).toThrow();
+    expect(
+      () => buildOutlineActionSelection(unitBlock, 2, 0, badAncestors),
+    ).toThrow('outline-level: subsection ancestor required at depth 2');
   });
 });
 
@@ -272,7 +276,9 @@ describe('buildPublishPayload', () => {
 
   it('throws on depth 2 when subsection is missing', () => {
     const badAncestors: OutlineNodeAncestors = { section: sectionBlock, subsection: undefined };
-    expect(() => buildPublishPayload(unitBlock, 2, badAncestors)).toThrow();
+    expect(
+      () => buildPublishPayload(unitBlock, 2, badAncestors),
+    ).toThrow('outline-level: subsection ancestor required at depth 2');
   });
 });
 
@@ -293,7 +299,9 @@ describe('buildUnlinkPayload', () => {
 
   it('throws on depth 2 when subsection is missing', () => {
     const badAncestors: OutlineNodeAncestors = { section: sectionBlock, subsection: undefined };
-    expect(() => buildUnlinkPayload(unitBlock, 2, badAncestors)).toThrow();
+    expect(
+      () => buildUnlinkPayload(unitBlock, 2, badAncestors),
+    ).toThrow('outline-level: subsection ancestor required at depth 2');
   });
 });
 
@@ -324,7 +332,9 @@ describe('buildDuplicateParams', () => {
 
   it('throws on depth 2 when subsection is missing', () => {
     const badAncestors: OutlineNodeAncestors = { section: sectionBlock, subsection: undefined };
-    expect(() => buildDuplicateParams(unitBlock, 2, COURSE_ID, badAncestors)).toThrow();
+    expect(
+      () => buildDuplicateParams(unitBlock, 2, COURSE_ID, badAncestors),
+    ).toThrow('outline-level: subsection ancestor required at depth 2');
   });
 });
 

--- a/src/course-outline/outline-sidebar/info-sidebar/InfoSidebar.test.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/InfoSidebar.test.tsx
@@ -159,7 +159,7 @@ function describeSidebarMenus(config: SidebarMenuConfig): void {
       const user = userEvent.setup();
       const withUpstream = {
         ...config.defaultData,
-        actions: { ...(config.defaultData.actions as Record<string, unknown> || {}), unlinkable: true },
+        actions: { ...(config.defaultData.actions as Record<string, unknown>), unlinkable: true },
         upstreamInfo: { upstreamRef: config.upstreamRef },
       };
       await renderMenu(withUpstream);

--- a/src/course-outline/outline-sidebar/info-sidebar/SectionInfoSidebar.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/SectionInfoSidebar.tsx
@@ -67,7 +67,7 @@ export const SectionSidebar = () => {
       const nextSections = arrayMove(sections, index, index + step);
       const sectionListIds = nextSections.map((s: any) => s.id);
       previewSections(nextSections);
-      commitSectionReorder(sectionListIds);
+      void commitSectionReorder(sectionListIds);
       setSelectedContainerState(
         selectedContainerState ? { ...selectedContainerState, index: index + step } : undefined,
       );

--- a/src/course-outline/utils/getChecklistValues.test.js
+++ b/src/course-outline/utils/getChecklistValues.test.js
@@ -49,7 +49,7 @@ describe('getChecklistValues utility function', () => {
       expect(
         item.pacingTypeFilter === CHECKLIST_FILTERS.ALL
           || item.pacingTypeFilter === CHECKLIST_FILTERS.SELF_PACED,
-      )
+      ).toBeTruthy()
     );
 
     expect(filteredChecklist.filter(item => item.pacingTypeFilter === CHECKLIST_FILTERS.ALL).length)
@@ -66,7 +66,7 @@ describe('getChecklistValues utility function', () => {
       expect(
         item.pacingTypeFilter === CHECKLIST_FILTERS.ALL
           || item.pacingTypeFilter === CHECKLIST_FILTERS.INSTRUCTOR_PACED,
-      )
+      ).toBeTruthy()
     );
 
     expect(filteredChecklist.filter(item => item.pacingTypeFilter === CHECKLIST_FILTERS.ALL).length)

--- a/src/course-rerun/CourseRerun.test.jsx
+++ b/src/course-rerun/CourseRerun.test.jsx
@@ -33,7 +33,7 @@ describe('<CourseRerun />', () => {
 
   it('should render successfully', () => {
     const { getByText, getAllByRole } = render(<CourseRerun />);
-    expect(getByText(messages.rerunTitle.defaultMessage));
+    expect(getByText(messages.rerunTitle.defaultMessage)).toBeInTheDocument();
     expect(getAllByRole('button', { name: messages.cancelButton.defaultMessage }).length).toBe(2);
   });
 

--- a/src/course-team/CourseTeam.test.tsx
+++ b/src/course-team/CourseTeam.test.tsx
@@ -160,7 +160,7 @@ describe('<CourseTeam />', () => {
     expect(deleteButton).toBeInTheDocument();
     await user.click(deleteButton);
 
-    expect(await screen.findByText('Delete course team member'));
+    expect(await screen.findByText('Delete course team member')).toBeInTheDocument();
     const confirmDelete = screen.getByRole('button', { name: /delete/i });
     expect(confirmDelete).toBeInTheDocument();
     await user.click(confirmDelete);

--- a/src/course-unit/CourseUnit.test.tsx
+++ b/src/course-unit/CourseUnit.test.tsx
@@ -3017,7 +3017,7 @@ describe('<CourseUnit />', () => {
       await screen.findByText(
         /access to some content in this unit is restricted to specific groups of learners\./i,
       ),
-    );
+    ).toBeInTheDocument();
   });
 
   it('should render never published state in the unit sidebar', async () => {
@@ -3270,8 +3270,10 @@ describe('<CourseUnit />', () => {
 
       // Moving to the add sidebar
       const sidebarToggle = await screen.findByTestId('sidebar-toggle');
+      // oxlint-disable-next-line jest/no-standalone-expect - expect() does work correctly inside beforeEach()
       expect(sidebarToggle).toBeInTheDocument();
       const addButton = within(sidebarToggle).getByRole('button', { name: 'Add' });
+      // oxlint-disable-next-line jest/no-standalone-expect - expect() does work correctly inside beforeEach()
       expect(addButton).toBeInTheDocument();
       await user.click(addButton);
     });
@@ -3291,26 +3293,26 @@ describe('<CourseUnit />', () => {
 
       // Check text templates
       await user.click(within(textCollapsible).getByText(/text/i));
-      expect(within(textCollapsible).getByText('Raw HTML'));
-      expect(within(textCollapsible).getByText('IFrame Tool'));
-      expect(within(textCollapsible).getByText('Anonymous User ID'));
-      expect(within(textCollapsible).getByText('Announcement'));
+      expect(within(textCollapsible).getByText('Raw HTML')).toBeInTheDocument();
+      expect(within(textCollapsible).getByText('IFrame Tool')).toBeInTheDocument();
+      expect(within(textCollapsible).getByText('Anonymous User ID')).toBeInTheDocument();
+      expect(within(textCollapsible).getByText('Announcement')).toBeInTheDocument();
 
       // Check Open response templates
       await user.click(within(openResponseCollapsible).getByText(/open response/i));
-      expect(within(openResponseCollapsible).getByText('Peer Assessment Only'));
-      expect(within(openResponseCollapsible).getByText('Self Assessment Only'));
-      expect(within(openResponseCollapsible).getByText('Staff Assessment Only'));
-      expect(within(openResponseCollapsible).getByText('Self Assessment to Peer Assessment'));
-      expect(within(openResponseCollapsible).getByText('Self Assessment to Staff Assessment'));
+      expect(within(openResponseCollapsible).getByText('Peer Assessment Only')).toBeInTheDocument();
+      expect(within(openResponseCollapsible).getByText('Self Assessment Only')).toBeInTheDocument();
+      expect(within(openResponseCollapsible).getByText('Staff Assessment Only')).toBeInTheDocument();
+      expect(within(openResponseCollapsible).getByText('Self Assessment to Peer Assessment')).toBeInTheDocument();
+      expect(within(openResponseCollapsible).getByText('Self Assessment to Staff Assessment')).toBeInTheDocument();
 
       // Check problem templates
       await user.click(within(problemCollapsible).getByText(/problem/i));
-      expect(within(problemCollapsible).getByText('Single select'));
-      expect(within(problemCollapsible).getByText('Multi-select'));
-      expect(within(problemCollapsible).getByText('Dropdown'));
-      expect(within(problemCollapsible).getByText('Text input'));
-      expect(within(problemCollapsible).getByText('Advanced Problem'));
+      expect(within(problemCollapsible).getByText('Single select')).toBeInTheDocument();
+      expect(within(problemCollapsible).getByText('Multi-select')).toBeInTheDocument();
+      expect(within(problemCollapsible).getByText('Dropdown')).toBeInTheDocument();
+      expect(within(problemCollapsible).getByText('Text input')).toBeInTheDocument();
+      expect(within(problemCollapsible).getByText('Advanced Problem')).toBeInTheDocument();
 
       // Check Advanced blocks
       const advancedButton = screen.getByRole('button', { name: 'Advanced' });

--- a/src/course-updates/CourseUpdates.test.tsx
+++ b/src/course-updates/CourseUpdates.test.tsx
@@ -239,7 +239,7 @@ describe('<CourseUpdates />', () => {
       render(<RootWrapper />);
 
       const newButton = await screen.findByRole('button', { name: messages.newUpdateButton.defaultMessage });
-      expect(screen.getByText(messages.loadingUpdatesErrorTitle.defaultMessage));
+      expect(screen.getByText(messages.loadingUpdatesErrorTitle.defaultMessage)).toBeInTheDocument();
       expect(newButton).toBeDisabled();
       expect(screen.getByText(messages.noCourseUpdates.defaultMessage)).toBeVisible();
       expect(screen.queryByTestId('course-update')).toBeNull();
@@ -256,7 +256,7 @@ describe('<CourseUpdates />', () => {
       render(<RootWrapper />);
 
       await waitFor(() => {
-        expect(screen.getByText(messages.loadingHandoutsErrorTitle.defaultMessage));
+        expect(screen.getByText(messages.loadingHandoutsErrorTitle.defaultMessage)).toBeInTheDocument();
       });
       expect(screen.getByTestId('course-handouts-edit-button')).toBeDisabled();
     });
@@ -360,7 +360,7 @@ describe('<CourseUpdates />', () => {
       await executeThunk(editCourseHandoutsQuery(courseId, data), store.dispatch);
       expect(screen.queryByText('Some handouts 1')).toBeNull();
       expect(screen.getByText(courseHandoutsMock.data)).toBeVisible();
-      expect(await screen.findByText(messages.savingHandoutsErrorDescription.defaultMessage));
+      expect(await screen.findByText(messages.savingHandoutsErrorDescription.defaultMessage)).toBeInTheDocument();
     });
   });
 

--- a/src/course-updates/update-form/UpdateForm.test.jsx
+++ b/src/course-updates/update-form/UpdateForm.test.jsx
@@ -74,8 +74,8 @@ describe('<UpdateForm />', () => {
     expect(getByText(messages.addNewUpdateTitle.defaultMessage)).toBeInTheDocument();
     expect(getByText(messages.updateFormDate.defaultMessage)).toBeInTheDocument();
     expect(getByDisplayValue(formattedDate)).toBeInTheDocument();
-    expect(getByRole('button', { name: messages.cancelButton.defaultMessage }));
-    expect(getByRole('button', { name: messages.postButton.defaultMessage }));
+    expect(getByRole('button', { name: messages.cancelButton.defaultMessage })).toBeInTheDocument();
+    expect(getByRole('button', { name: messages.postButton.defaultMessage })).toBeInTheDocument();
   });
 
   it('render Edit update form correctly', async () => {
@@ -84,8 +84,8 @@ describe('<UpdateForm />', () => {
     expect(getByText(messages.editUpdateTitle.defaultMessage)).toBeInTheDocument();
     expect(getByText(messages.updateFormDate.defaultMessage)).toBeInTheDocument();
     expect(getByDisplayValue(formattedDateMock)).toBeInTheDocument();
-    expect(getByRole('button', { name: messages.cancelButton.defaultMessage }));
-    expect(getByRole('button', { name: messages.postButton.defaultMessage }));
+    expect(getByRole('button', { name: messages.cancelButton.defaultMessage })).toBeInTheDocument();
+    expect(getByRole('button', { name: messages.postButton.defaultMessage })).toBeInTheDocument();
   });
 
   it('render Edit handouts form correctly', async () => {
@@ -99,8 +99,8 @@ describe('<UpdateForm />', () => {
     expect(getByText(messages.editHandoutsTitle.defaultMessage)).toBeInTheDocument();
     expect(queryByText(messages.updateFormDate.defaultMessage)).not.toBeInTheDocument();
     expect(queryByTestId('course-updates-datepicker')).not.toBeInTheDocument();
-    expect(getByRole('button', { name: messages.cancelButton.defaultMessage }));
-    expect(getByRole('button', { name: messages.saveButton.defaultMessage }));
+    expect(getByRole('button', { name: messages.cancelButton.defaultMessage })).toBeInTheDocument();
+    expect(getByRole('button', { name: messages.saveButton.defaultMessage })).toBeInTheDocument();
   });
 
   it('calls closeMock when clicking cancel button', () => {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -48,10 +48,10 @@ describe('Problem settings hooks', () => {
     beforeEach(() => {
       output = hooks.showAdvancedSettingsCards();
     });
-    test('test default state is false', () => {
+    test('default state is false', () => {
       expect(output.isAdvancedCardsVisible).toBeFalsy();
     });
-    test('test showAdvancedCards sets state to true', () => {
+    test('showAdvancedCards sets state to true', () => {
       output.showAdvancedCards();
       expect(state.setState[state.keys.showAdvanced]).toHaveBeenCalledWith(true);
     });
@@ -60,14 +60,14 @@ describe('Problem settings hooks', () => {
     beforeEach(() => {
       output = hooks.showFullCard();
     });
-    test('test default state is false', () => {
+    test('default state is false', () => {
       expect(output.isCardCollapsibleOpen).toBeFalsy();
     });
-    test('test toggleCardCollapse to true', () => {
+    test('toggleCardCollapse to true', () => {
       output.toggleCardCollapse();
       expect(state.setState[state.keys.cardCollapsed]).toHaveBeenCalledWith(true);
     });
-    test('test toggleCardCollapse to true', () => {
+    test('toggleCardCollapse to true', () => {
       output = hooks.showFullCard(true);
       output.toggleCardCollapse();
       expect(state.setState[state.keys.cardCollapsed]).toHaveBeenCalledWith(true);
@@ -75,7 +75,7 @@ describe('Problem settings hooks', () => {
   });
 
   describe('Hint card hooks', () => {
-    test('test useEffect triggers set hints summary no hint', () => {
+    test('useEffect triggers set hints summary no hint', () => {
       const hints = [];
       hooks.hintsCardHooks(hints, updateSettings);
       expect(state.setState[state.keys.summary]).not.toHaveBeenCalled();
@@ -85,7 +85,7 @@ describe('Problem settings hooks', () => {
       expect(state.setState[state.keys.summary])
         .toHaveBeenCalledWith({ message: messages.noHintSummary, values: {} });
     });
-    test('test useEffect triggers set hints summary', () => {
+    test('useEffect triggers set hints summary', () => {
       const hints = [{ id: 1, value: 'hint1' }];
       output = hooks.hintsCardHooks(hints, updateSettings);
       expect(state.setState[state.keys.summary]).not.toHaveBeenCalled();
@@ -98,7 +98,7 @@ describe('Problem settings hooks', () => {
           values: { hint: hints[0].value, count: hints.length - 1 },
         });
     });
-    test('test handleAdd triggers updateSettings', () => {
+    test('handleAdd triggers updateSettings', () => {
       const hint1 = { id: 1, value: 'hint1' };
       const hint2 = { id: 2, value: '' };
       const hints = [hint1];
@@ -116,11 +116,11 @@ describe('Problem settings hooks', () => {
     beforeEach(() => {
       output = hooks.hintsRowHooks(2, hints, updateSettings);
     });
-    test('test handleChange', () => {
+    test('handleChange', () => {
       output.handleChange(value);
       expect(updateSettings).toHaveBeenCalledWith({ hints: [hint1, modifiedHint] });
     });
-    test('test handleDelete', () => {
+    test('handleDelete', () => {
       output.handleDelete();
       expect(updateSettings).toHaveBeenCalledWith({ hints: [hint1] });
     });
@@ -130,11 +130,11 @@ describe('Problem settings hooks', () => {
     beforeEach(() => {
       output = hooks.resetCardHooks(updateSettings);
     });
-    test('test setResetTrue', () => {
+    test('setResetTrue', () => {
       output.setResetTrue();
       expect(updateSettings).toHaveBeenCalledWith({ showResetButton: true });
     });
-    test('test setResetFalse', () => {
+    test('setResetFalse', () => {
       output.setResetFalse();
       expect(updateSettings).toHaveBeenCalledWith({ showResetButton: false });
     });
@@ -150,22 +150,22 @@ describe('Problem settings hooks', () => {
       gradingMethod: 'last_score',
     };
     const defaultValue = 1;
-    test('test scoringCardHooks initializes display value when attempts.number is null', () => {
+    test('scoringCardHooks initializes display value when attempts.number is null', () => {
       const nilScoring = { ...scoring, attempts: { unlimited: false, number: null } };
       output = hooks.scoringCardHooks(nilScoring, updateSettings, defaultValue);
       expect(state.stateVals[state.keys.attemptDisplayValue]).toEqual(`${defaultValue} (Default)`);
     });
-    test('test scoringCardHooks initializes display value when attempts.number is blank', () => {
+    test('scoringCardHooks initializes display value when attempts.number is blank', () => {
       const nilScoring = { ...scoring, attempts: { unlimited: false, number: '' } };
       output = hooks.scoringCardHooks(nilScoring, updateSettings, defaultValue);
       expect(state.stateVals[state.keys.attemptDisplayValue]).toEqual(`${defaultValue} (Default)`);
     });
-    test('test scoringCardHooks initializes display value when attempts.number is not null', () => {
+    test('scoringCardHooks initializes display value when attempts.number is not null', () => {
       const nonNilScoring = { ...scoring, attempts: { unlimited: false, number: 2 } };
       output = hooks.scoringCardHooks(nonNilScoring, updateSettings, defaultValue);
       expect(state.stateVals[state.keys.attemptDisplayValue]).toEqual(2);
     });
-    test('test scoringCardHooks initializes display value when attempts.number and defaultValue is null', () => {
+    test('scoringCardHooks initializes display value when attempts.number and defaultValue is null', () => {
       const nonNilScoring = { ...scoring, attempts: { unlimited: false, number: null } };
       output = hooks.scoringCardHooks(nonNilScoring, updateSettings, null);
       expect(state.stateVals[state.keys.attemptDisplayValue]).toEqual('');
@@ -173,61 +173,61 @@ describe('Problem settings hooks', () => {
     beforeEach(() => {
       output = hooks.scoringCardHooks(scoring, updateSettings, defaultValue);
     });
-    test('test handleUnlimitedChange sets attempts.unlimited to true when checked', () => {
+    test('handleUnlimitedChange sets attempts.unlimited to true when checked', () => {
       output.handleUnlimitedChange({ target: { checked: true } });
       expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith('');
       expect(updateSettings)
         .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: null, unlimited: true } } });
     });
-    test('test handleUnlimitedChange sets attempts.unlimited to false when unchecked', () => {
+    test('handleUnlimitedChange sets attempts.unlimited to false when unchecked', () => {
       output.handleUnlimitedChange({ target: { checked: false } });
       expect(updateSettings)
         .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: null, unlimited: false } } });
     });
-    test('test handleMaxAttemptChange', () => {
+    test('handleMaxAttemptChange', () => {
       const value = 6;
       output.handleMaxAttemptChange({ target: { value } });
       expect(updateSettings)
         .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: value, unlimited: false } } });
     });
-    test('test handleMaxAttemptChange set attempts to zero', () => {
+    test('handleMaxAttemptChange set attempts to zero', () => {
       const value = 0;
       output.handleMaxAttemptChange({ target: { value } });
       expect(updateSettings)
         .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: value, unlimited: false } } });
     });
-    test('test handleMaxAttemptChange set attempts to null value when default max_attempts is present', () => {
+    test('handleMaxAttemptChange set attempts to null value when default max_attempts is present', () => {
       const value = null;
       output.handleMaxAttemptChange({ target: { value } });
       expect(updateSettings)
         .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: null, unlimited: false } } });
     });
-    test('test handleMaxAttemptChange set attempts to null when default value is inputted', () => {
+    test('handleMaxAttemptChange set attempts to null when default value is inputted', () => {
       const value = '1 (Default)';
       output.handleMaxAttemptChange({ target: { value } });
       expect(updateSettings)
         .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: null, unlimited: false } } });
     });
-    test('test handleMaxAttemptChange set attempts to non-numeric value', () => {
+    test('handleMaxAttemptChange set attempts to non-numeric value', () => {
       const value = 'abc';
       output.handleMaxAttemptChange({ target: { value } });
       expect(updateSettings)
         .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: null, unlimited: false } } });
     });
-    test('test handleMaxAttemptChange set attempts to empty value', () => {
+    test('handleMaxAttemptChange set attempts to empty value', () => {
       const value = '';
       output.handleMaxAttemptChange({ target: { value } });
       expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith(`${defaultValue} (Default)`);
       expect(updateSettings)
         .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: null, unlimited: false } } });
     });
-    test('test handleMaxAttemptChange set attempts to negative value', () => {
+    test('handleMaxAttemptChange set attempts to negative value', () => {
       const value = -1;
       output.handleMaxAttemptChange({ target: { value } });
       expect(updateSettings)
         .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: 0, unlimited: false } } });
     });
-    test('test handleMaxAttemptChange set attempts to empty value with no default', () => {
+    test('handleMaxAttemptChange set attempts to empty value with no default', () => {
       const value = '';
       output = hooks.scoringCardHooks(scoring, updateSettings, null);
       output.handleMaxAttemptChange({ target: { value } });
@@ -235,42 +235,42 @@ describe('Problem settings hooks', () => {
       expect(updateSettings)
         .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: null, unlimited: true } } });
     });
-    test('test handleOnChange', () => {
+    test('handleOnChange', () => {
       const value = 6;
       output.handleOnChange({ target: { value } });
       expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith(value);
     });
-    test('test handleOnChange set attempts to zero', () => {
+    test('handleOnChange set attempts to zero', () => {
       const value = 0;
       output.handleOnChange({ target: { value } });
       expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith(value);
     });
-    test('test handleOnChange set attempts to default value from empty string', () => {
+    test('handleOnChange set attempts to default value from empty string', () => {
       const value = '';
       output.handleOnChange({ target: { value } });
       expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith('');
     });
-    test('test handleOnChange set attempts to default value', () => {
+    test('handleOnChange set attempts to default value', () => {
       const value = 1;
       output.handleOnChange({ target: { value } });
       expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith('1 (Default)');
     });
-    test('test handleOnChange set attempts to non-numeric value', () => {
+    test('handleOnChange set attempts to non-numeric value', () => {
       const value = '';
       output.handleOnChange({ target: { value } });
       expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith(value);
     });
-    test('test handleOnChange set attempts to negative value', () => {
+    test('handleOnChange set attempts to negative value', () => {
       const value = -1;
       output.handleOnChange({ target: { value } });
       expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith(0);
     });
-    test('test handleWeightChange', () => {
+    test('handleWeightChange', () => {
       const value = 2;
       output.handleWeightChange({ target: { value } });
       expect(updateSettings).toHaveBeenCalledWith({ scoring: { ...scoring, weight: parseFloat(value) } });
     });
-    test('test handleGradingMethodChange', () => {
+    test('handleGradingMethodChange', () => {
       const value = 'first_score';
       output.handleGradingMethodChange({ target: { value } });
       expect(updateSettings).toHaveBeenCalledWith({ scoring: { ...scoring, gradingMethod: value } });
@@ -285,12 +285,12 @@ describe('Problem settings hooks', () => {
     beforeEach(() => {
       output = hooks.useAnswerSettings(showAnswer, updateSettings);
     });
-    test('test handleShowAnswerChange', () => {
+    test('handleShowAnswerChange', () => {
       const value = 'always';
       output.handleShowAnswerChange({ target: { value } });
       expect(updateSettings).toHaveBeenCalledWith({ showAnswer: { ...showAnswer, on: value } });
     });
-    test('test handleAttemptsChange', () => {
+    test('handleAttemptsChange', () => {
       const value = 3;
       output.handleAttemptsChange({ target: { value } });
       expect(updateSettings).toHaveBeenCalledWith({
@@ -300,7 +300,7 @@ describe('Problem settings hooks', () => {
   });
 
   describe('Timer card hooks', () => {
-    test('test handleChange', () => {
+    test('handleChange', () => {
       output = hooks.timerCardHooks(updateSettings);
       const value = 5;
       output.handleChange({ target: { value } });
@@ -335,7 +335,7 @@ describe('Problem settings hooks', () => {
       jest.spyOn(editHooks, moduleKeys.fetchEditorContent)
         .mockImplementationOnce(fetchEditorContent);
     });
-    test('test onClick Multi-select to Dropdown', () => {
+    test('onClick Multi-select to Dropdown', () => {
       output = hooks.typeRowHooks(typeRowProps);
       output.onClick();
       expect(typeRowProps.setBlockTitle).toHaveBeenCalledWith(ProblemTypes[ProblemTypeKeys.DROPDOWN].title);
@@ -357,7 +357,7 @@ describe('Problem settings hooks', () => {
       expect(typeRowProps.updateField).toHaveBeenCalledWith({ problemType: ProblemTypeKeys.DROPDOWN });
     });
 
-    test('test onClick Multi-select to Dropdown with one correct answer', () => {
+    test('onClick Multi-select to Dropdown with one correct answer', () => {
       const oneAnswerTypeRowProps = {
         ...typeRowProps,
         correctAnswerCount: 1,
@@ -384,7 +384,7 @@ describe('Problem settings hooks', () => {
       });
       expect(typeRowProps.updateField).toHaveBeenCalledWith({ problemType: ProblemTypeKeys.DROPDOWN });
     });
-    test('test onClick Multi-select to Numeric', () => {
+    test('onClick Multi-select to Numeric', () => {
       output = hooks.typeRowHooks({
         ...typeRowProps,
         typeKey: ProblemTypeKeys.NUMERIC,
@@ -409,7 +409,7 @@ describe('Problem settings hooks', () => {
       expect(typeRowProps.updateField).toHaveBeenCalledWith({ problemType: ProblemTypeKeys.NUMERIC });
     });
 
-    test('test onClick Multi-select to Text Input', () => {
+    test('onClick Multi-select to Text Input', () => {
       output = hooks.typeRowHooks({
         ...typeRowProps,
         typeKey: ProblemTypeKeys.TEXTINPUT,
@@ -422,7 +422,7 @@ describe('Problem settings hooks', () => {
       expect(typeRowProps.updateField).toHaveBeenCalledWith({ problemType: ProblemTypeKeys.TEXTINPUT });
     });
 
-    test('test typeRowHooks sets localized block title when formatMessage is provided', () => {
+    test('typeRowHooks sets localized block title when formatMessage is provided', () => {
       const mockSetBlockTitle = jest.fn();
       const mockUpdateField = jest.fn();
       const mockUpdateAnswer = jest.fn();
@@ -448,7 +448,7 @@ describe('Problem settings hooks', () => {
       expect(mockUpdateField).toHaveBeenCalledWith({ problemType: ProblemTypeKeys.MULTISELECT });
     });
   });
-  test('test handleConfirmEditorSwitch hook', () => {
+  test('handleConfirmEditorSwitch hook', () => {
     const switchEditor = jest.fn();
     const setConfirmOpen = jest.fn();
     window.scrollTo = jest.fn();

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GeneralFeedback/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GeneralFeedback/hooks.test.js
@@ -35,10 +35,10 @@ describe('Problem settings hooks', () => {
     beforeEach(() => {
       output = hooks.generalFeedbackHooks(generalFeedback, updateSettings);
     });
-    test('test default state is false', () => {
+    test('default state is false', () => {
       expect(output.summary.message).toEqual(messages.noGeneralFeedbackSummary);
     });
-    test('test showAdvancedCards sets state to true', () => {
+    test('showAdvancedCards sets state to true', () => {
       const mockEvent = { target: { value: 'sOmE_otheR_ValUe' } };
       output.handleChange(mockEvent);
       expect(updateSettings).toHaveBeenCalledWith({ generalFeedback: mockEvent.target.value });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/hooks.test.js
@@ -35,10 +35,10 @@ describe('groupFeedbackCardHooks', () => {
     beforeEach(() => {
       output = hooks.groupFeedbackCardHooks(groupFeedbacks, updateSettings);
     });
-    test('test default state is false', () => {
+    test('default state is false', () => {
       expect(output.summary.message).toEqual(messages.noGroupFeedbackSummary);
     });
-    test('test Event adds a new feedback ', () => {
+    test('Event adds a new feedback', () => {
       output.handleAdd();
       expect(updateSettings).toHaveBeenCalledWith({ groupFeedbackList: [{ id: 0, answers: [], feedback: '' }] });
     });
@@ -66,20 +66,20 @@ describe('groupFeedbackRowHooks', () => {
     beforeEach(() => {
       output = hooks.groupFeedbackRowHooks({ id: mockId, groupFeedbacks, updateSettings });
     });
-    test('test associate an answer with the feedback object', () => {
+    test('associate an answer with the feedback object', () => {
       const mockNewAnswer = 'nEw VAluE';
       output.handleAnswersSelectedChange({ target: { checked: true, value: mockNewAnswer } });
       expect(updateSettings).toHaveBeenCalledWith(
         { groupFeedbackList: [{ id: mockId, answers: [mockAnswer, mockNewAnswer], feedback: mockFeedback }] },
       );
     });
-    test('test unassociate an answer with the feedback object', () => {
+    test('unassociate an answer with the feedback object', () => {
       output.handleAnswersSelectedChange({ target: { checked: false, value: mockAnswer } });
       expect(updateSettings).toHaveBeenCalledWith(
         { groupFeedbackList: [{ id: mockId, answers: [], feedback: mockFeedback }] },
       );
     });
-    test('test update feedback text with a groupfeedback', () => {
+    test('update feedback text with a groupfeedback', () => {
       const mockNewFeedback = 'nEw fEedBack';
       output.handleFeedbackChange({ target: { checked: false, value: mockNewFeedback } });
       expect(updateSettings).toHaveBeenCalledWith(

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/index.test.tsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/index.test.tsx
@@ -40,7 +40,7 @@ describe('HintsCard', () => {
   beforeEach(() => initializeMocks());
 
   describe('behavior', () => {
-    it(' calls groupFeedbacksCardHooks when initialized', () => {
+    it('calls groupFeedbacksCardHooks when initialized', () => {
       const groupFeedbacksCardHooksProps = {
         summary: { message: messages.noGroupFeedbackSummary },
         handleAdd: jest.fn().mockName('groupFeedbacksCardHooks.handleAdd'),

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/hooks.test.js
@@ -35,10 +35,10 @@ describe('Problem settings hooks', () => {
     beforeEach(() => {
       output = hooks.useRandomizationSettingStatus({ randomization, updateSettings });
     });
-    test('test default state is false', () => {
+    test('default state is false', () => {
       expect(output.summary).toEqual({ message: RandomizationTypes[RandomizationTypesKeys.NEVER], values: {} });
     });
-    test('test showAdvancedCards sets state to true', () => {
+    test('showAdvancedCards sets state to true', () => {
       const mockEvent = { target: { value: 'sOmE_otheR_ValUe' } };
       output.handleChange(mockEvent);
       expect(updateSettings).toHaveBeenCalledWith({ randomization: mockEvent.target.value });

--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.test.js
@@ -72,7 +72,7 @@ describe('Check React State OLXParser problem', () => {
     });
   });
 
-  describe('with label and em tag wrapped in div: ', () => {
+  describe('with label and em tag wrapped in div:', () => {
     const olxparser = new OLXParser(multipleChoiceWithFeedbackAndHintsOLX.rawOLX);
     const problem = olxparser.getParsedOLXData();
     const stateParser = new ReactStateOLXParser({

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.test.tsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.test.tsx
@@ -76,7 +76,7 @@ describe('SocialShareWidget', () => {
 
   describe('rendered with videoSharingEnabled true', () => {
     describe('and allowVideoSharing value equals true', () => {
-      describe(' with level equal to course', () => {
+      describe('with level equal to course', () => {
         it('should have setting location message', () => {
           render(
             <SocialShareWidget
@@ -106,7 +106,7 @@ describe('SocialShareWidget', () => {
           expect(checkbox).toBeDisabled();
         });
       });
-      describe(' with level equal to block', () => {
+      describe('with level equal to block', () => {
         it('should not have setting location message', () => {
           render(
             <SocialShareWidget
@@ -216,7 +216,7 @@ describe('SocialShareWidget', () => {
     });
 
     describe('and allowVideoSharing value equals false', () => {
-      describe(' with level equal to course', () => {
+      describe('with level equal to course', () => {
         it('should have setting location message', () => {
           render(
             <SocialShareWidget
@@ -247,7 +247,7 @@ describe('SocialShareWidget', () => {
         });
       });
 
-      describe(' with level equal to block', () => {
+      describe('with level equal to block', () => {
         it('should not have setting location message', () => {
           render(
             <SocialShareWidget

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/index.test.tsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/index.test.tsx
@@ -68,7 +68,7 @@ describe('TranscriptWidget', () => {
 
   describe('hooks', () => {
     describe('transcriptLanguages', () => {
-      test('empty list of transcripts returns ', () => {
+      test('empty list of transcripts returns', () => {
         expect(hooks.transcriptLanguages([])).toEqual('None');
       });
       test('unset gives none', () => {
@@ -82,7 +82,7 @@ describe('TranscriptWidget', () => {
       });
     });
     describe('hasTranscripts', () => {
-      test('null returns false ', () => {
+      test('null returns false', () => {
         expect(hooks.hasTranscripts(null)).toEqual(false);
       });
       test('empty list returns false', () => {
@@ -94,11 +94,11 @@ describe('TranscriptWidget', () => {
     });
     describe('onAddNewTranscript', () => {
       const mockUpdateField = jest.fn();
-      test('null returns [empty string] ', () => {
+      test('null returns [empty string]', () => {
         hooks.onAddNewTranscript({ transcripts: null, updateField: mockUpdateField });
         expect(mockUpdateField).toHaveBeenCalledWith({ transcripts: [''] });
       });
-      test(' transcripts return list with blank added', () => {
+      test('transcripts return list with blank added', () => {
         const mocklist = ['en', 'fr', 3];
         hooks.onAddNewTranscript({ transcripts: mocklist, updateField: mockUpdateField });
 

--- a/src/editors/data/redux/app/reducer.test.js
+++ b/src/editors/data/redux/app/reducer.test.js
@@ -32,7 +32,7 @@ describe('app reducer', () => {
       });
     });
     const setterTest = (action, target) => {
-      describe(action, () => {
+      describe(`action ${action}`, () => {
         it(`load ${target} from payload`, () => {
           expect(reducer(testingState, actions[action](testValue))).toEqual({
             ...testingState,

--- a/src/editors/data/redux/problem/reducers.test.ts
+++ b/src/editors/data/redux/problem/reducers.test.ts
@@ -14,8 +14,8 @@ describe('problem reducer', () => {
   const testValue = 'roll for initiative';
 
   describe('handling actions', () => {
-    const setterTest = (action, target) => {
-      describe(action, () => {
+    const setterTest = (action: string, target: any) => {
+      describe(`action ${action}`, () => {
         it(`load ${target} from payload`, () => {
           expect(reducer(testingState, actions[action](testValue))).toEqual({
             ...testingState,
@@ -143,7 +143,7 @@ describe('problem reducer', () => {
       });
     });
     describe('updateAnswer', () => {
-      it('sets answers, as well as setting the correctAnswerCount ', () => {
+      it('sets answers, as well as setting the correctAnswerCount', () => {
         const answer = { id: 'A', correct: true };
         expect(reducer(
           {

--- a/src/editors/data/redux/requests/selectors.test.js
+++ b/src/editors/data/redux/requests/selectors.test.js
@@ -36,7 +36,7 @@ describe('request selectors', () => {
     });
     describe('state selectors', () => {
       const testStateSelector = (selector, expected) => {
-        describe(selector, () => {
+        describe(`selector ${selector}`, () => {
           it(`returns true iff the request status equals ${expected}`, () => {
             expect(selectors[selector]({ status: expected })).toEqual(true);
             expect(selectors[selector]({ status: 'other' })).toEqual(false);
@@ -104,7 +104,7 @@ describe('request selectors', () => {
         selectors.statusSelector = statusSelector;
       });
       const testStatusSelector = (name) => {
-        describe(name, () => {
+        describe(`${name} selector`, () => {
           it(`returns a status selector keyed to the ${name} selector`, () => {
             expect(connectedSelectors[name].statusSelector).toEqual(selectors[name]);
           });

--- a/src/editors/data/redux/thunkActions/requests.test.js
+++ b/src/editors/data/redux/thunkActions/requests.test.js
@@ -187,6 +187,7 @@ describe('requests thunkActions module', () => {
       expect(dispatchedAction.networkRequest.onSuccess).toEqual(onSuccess);
       expect(dispatchedAction.networkRequest.onFailure).toEqual(onFailure);
     });
+    // oxlint-disable-next-line jest/valid-title
     test(expectedString, () => {
       expect(dispatchedAction.networkRequest).toEqual({
         ...expectedData,

--- a/src/editors/sharedComponents/CodeEditor/index.test.tsx
+++ b/src/editors/sharedComponents/CodeEditor/index.test.tsx
@@ -116,7 +116,7 @@ describe('CodeEditor', () => {
         initializeMocks();
       });
       let useRefSpy;
-      test('Renders and calls Hooks ', () => {
+      test('Renders and calls Hooks', () => {
         const props = {
           intl: { formatMessage },
           innerRef: {

--- a/src/editors/sharedComponents/ImageUploadModal/SelectImageModal/hooks.test.js
+++ b/src/editors/sharedComponents/ImageUploadModal/SelectImageModal/hooks.test.js
@@ -222,7 +222,7 @@ describe('SelectImageModal hooks', () => {
     const selectedFileSuccess = { value: testValue, size: 2000 };
     const clearSelection = jest.fn();
     const onSizeFail = jest.fn();
-    it('returns false for valid file size ', () => {
+    it('returns false for valid file size', () => {
       hook = hooks.checkValidFileSize({ selectedFile: selectedFileFail, clearSelection, onSizeFail });
       expect(clearSelection).toHaveBeenCalled();
       expect(onSizeFail).toHaveBeenCalled();

--- a/src/export-page/CourseExportPage.test.tsx
+++ b/src/export-page/CourseExportPage.test.tsx
@@ -110,7 +110,7 @@ describe('<CourseExportPage />', () => {
       screen.getByText(
         /There has been a failure to export to XML at least one component. It is recommended that you go to the edit page and repair the error before attempting another export. Please check that all components on the page are valid and do not display any error messages. The raw error message is: test error/i,
       ),
-    );
+    ).toBeInTheDocument();
     const closeModalWindowButton = screen.getByText('Return to export');
     await user.click(closeModalWindowButton);
     expect(screen.queryByText(modalErrorMessages.errorCancelButtonUnit.defaultMessage)).not.toBeInTheDocument();

--- a/src/files-and-videos/videos-page/VideosPage.test.tsx
+++ b/src/files-and-videos/videos-page/VideosPage.test.tsx
@@ -119,7 +119,7 @@ describe('Videos page', () => {
 
     it('should not render transcript settings button', async () => {
       await emptyMockStore(RequestStatus.SUCCESSFUL);
-      expect(screen.queryByText(videoMessages.transcriptSettingsButtonLabel.defaultMessage));
+      expect(screen.queryByText(videoMessages.transcriptSettingsButtonLabel.defaultMessage)).not.toBeInTheDocument();
     });
 
     it('should have Video uploads title', async () => {

--- a/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
@@ -240,7 +240,7 @@ describe('TranscriptSettings', () => {
     });
 
     describe('api succeeds', () => {
-      it('should update cielo24 credentials ', async () => {
+      it('should update cielo24 credentials', async () => {
         const cielo24Button = screen.getAllByLabelText('Cielo24 radio')[0];
         await user.click(cielo24Button);
 

--- a/src/generic/hooks/tests/hooks.test.tsx
+++ b/src/generic/hooks/tests/hooks.test.tsx
@@ -233,6 +233,5 @@ describe('useLoadBearingHook', () => {
     rerender({ id: 'new-id' });
 
     expect(setValue).toHaveBeenCalledWith(expect.any(Function));
-    expect(setValue.mock.calls);
   });
 });

--- a/src/generic/tag-count/TagCount.test.tsx
+++ b/src/generic/tag-count/TagCount.test.tsx
@@ -17,6 +17,6 @@ describe('<TagCount>', () => {
     render(<TagCount count={17} onClick={() => {}} />);
     expect(screen.getByRole('button', {
       name: /17/i,
-    }));
+    })).toBeInTheDocument();
   });
 });

--- a/src/generic/toast-context/index.test.tsx
+++ b/src/generic/toast-context/index.test.tsx
@@ -5,7 +5,7 @@ import { AppProvider } from '@edx/frontend-platform/react';
 import { ToastContext, ToastProvider } from '.';
 import initializeStore from '../../store';
 
-export interface WraperProps {
+interface WraperProps {
   children: React.ReactNode;
 }
 

--- a/src/group-configurations/data/apiHooks.ts
+++ b/src/group-configurations/data/apiHooks.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { AxiosError } from 'axios';
 import {
   useQuery,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -156,6 +156,7 @@ subscribe(APP_INIT_ERROR, (error) => {
   );
 });
 
+// oxlint-disable-next-line typescript/no-floating-promises
 initialize({
   handlers: {
     config: () => {

--- a/src/library-authoring/create-library/data/api.test.ts
+++ b/src/library-authoring/create-library/data/api.test.ts
@@ -82,7 +82,7 @@ describe('create library api', () => {
 
     axiosMock.onPost().reply(400, 'Bad Request');
 
-    await expect(createLibraryV2(libraryData)).rejects.toThrow();
+    await expect(createLibraryV2(libraryData)).rejects.toThrow('Request failed with status code 400');
   });
 
   it('should throw error when createLibraryRestore fails', async () => {
@@ -90,7 +90,7 @@ describe('create library api', () => {
 
     axiosMock.onPost().reply(400, 'Bad Request');
 
-    await expect(createLibraryRestore(file)).rejects.toThrow();
+    await expect(createLibraryRestore(file)).rejects.toThrow('Request failed with status code 400');
   });
 
   it('should throw error when getLibraryRestoreStatus fails', async () => {
@@ -98,17 +98,17 @@ describe('create library api', () => {
 
     axiosMock.onGet().reply(404, 'Not Found');
 
-    await expect(getLibraryRestoreStatus(taskId)).rejects.toThrow();
+    await expect(getLibraryRestoreStatus(taskId)).rejects.toThrow('Request failed with status code 404');
   });
 
   it('should handle invalid parameters', async () => {
     // @ts-expect-error - testing invalid input
-    await expect(createLibraryV2(null)).rejects.toThrow();
+    await expect(createLibraryV2(null)).rejects.toThrow('Request failed with status code 404');
 
     // @ts-expect-error - testing invalid input
-    await expect(createLibraryRestore(null)).rejects.toThrow();
+    await expect(createLibraryRestore(null)).rejects.toThrow('Request failed with status code 404');
 
     // @ts-expect-error - testing invalid input
-    await expect(getLibraryRestoreStatus(null)).rejects.toThrow();
+    await expect(getLibraryRestoreStatus(null)).rejects.toThrow('Request failed with status code 404');
   });
 });

--- a/src/library-authoring/create-library/data/apiHooks.test.tsx
+++ b/src/library-authoring/create-library/data/apiHooks.test.tsx
@@ -92,7 +92,7 @@ describe('create library apiHooks', () => {
 
       const { result } = renderHook(() => useCreateLibraryRestore(), { wrapper });
 
-      await expect(result.current.mutateAsync(file)).rejects.toThrow();
+      await expect(result.current.mutateAsync(file)).rejects.toThrow('Request failed with status code 400');
     });
   });
 

--- a/src/library-authoring/import-course/ImportDetailsPage.test.tsx
+++ b/src/library-authoring/import-course/ImportDetailsPage.test.tsx
@@ -70,7 +70,7 @@ describe('<ImportDetailsPage />', () => {
 
   it('should render In Progress state', async () => {
     render(mockGetMigrationStatus.migrationIdInProgress);
-    expect(await screen.findByText(/test course is being imported/i));
+    expect(await screen.findByText(/test course is being imported/i)).toBeInTheDocument();
     expect(screen.getByRole('button', {
       name: /view imported content/i,
     })).toBeDisabled();
@@ -81,8 +81,8 @@ describe('<ImportDetailsPage />', () => {
     const url = bulkModulestoreMigrateUrl();
     axiosMock.onPost(url).reply(200);
     render(mockGetMigrationStatus.migrationIdFailed);
-    expect(await screen.findByText(/test course was not imported into your Library/i));
-    expect(screen.getByText(/import failed for the following reasons:/i));
+    expect(await screen.findByText(/test course was not imported into your Library/i)).toBeInTheDocument();
+    expect(screen.getByText(/import failed for the following reasons:/i)).toBeInTheDocument();
     const retryImport = screen.getByRole('button', {
       name: /re-try import/i,
     });
@@ -98,7 +98,7 @@ describe('<ImportDetailsPage />', () => {
       await screen.findByText(
         /test course has been imported to your library in a collection called test collection/i,
       ),
-    );
+    ).toBeInTheDocument();
     expect(await screen.findByText(/Total Blocks/i)).toBeInTheDocument();
     expect(await screen.findByText('4')).toBeInTheDocument();
 

--- a/src/library-authoring/section-subsections/LibrarySectionSubsectionPage.test.tsx
+++ b/src/library-authoring/section-subsections/LibrarySectionSubsectionPage.test.tsx
@@ -249,14 +249,14 @@ describe('<LibrarySectionPage / LibrarySubsectionPage />', () => {
 
       // Select the child
       fireEvent.click(child);
-      expect((await screen.findAllByText(`${childType} block 0`)).length === 2);
+      expect(await screen.findAllByText(`${childType} block 0`)).toHaveLength(1);
 
       // Because the Preview show/hide is dependent on the selected item
       // being in the URL, and because our test router doesn't change
       // paths, we have to explicitly navigate to the child page to check
       // the Preview tab is shown. Boo.
       renderLibrarySectionPage(undefined, undefined, cType, childId);
-      expect((await screen.findAllByText(`${childType} block 0`)).length === 2);
+      expect(await screen.findAllByText(`${childType} block 0`)).toHaveLength(2);
       expect(await screen.findByText('Preview')).toBeInTheDocument();
     });
 

--- a/src/optimizer-page/data/api.test.js
+++ b/src/optimizer-page/data/api.test.js
@@ -93,7 +93,7 @@ describe('Course Optimizer API', () => {
       const url = api.postLinkCheckCourseApiUrl(courseId);
       axiosMock.onPost(url).reply(500, { error: 'Internal Server Error' });
 
-      await expect(api.postLinkCheck(courseId)).rejects.toThrow();
+      await expect(api.postLinkCheck(courseId)).rejects.toThrow('Request failed with status code 500');
     });
 
     it('should handle 404 errors', async () => {
@@ -102,7 +102,7 @@ describe('Course Optimizer API', () => {
       const url = api.postLinkCheckCourseApiUrl(courseId);
       axiosMock.onPost(url).reply(404, { error: 'Not Found' });
 
-      await expect(api.postLinkCheck(courseId)).rejects.toThrow();
+      await expect(api.postLinkCheck(courseId)).rejects.toThrow('Request failed with status code 404');
     });
   });
 
@@ -123,7 +123,7 @@ describe('Course Optimizer API', () => {
       const url = api.getLinkCheckStatusApiUrl(courseId);
       axiosMock.onGet(url).reply(500, { error: 'Internal Server Error' });
 
-      await expect(api.getLinkCheckStatus(courseId)).rejects.toThrow();
+      await expect(api.getLinkCheckStatus(courseId)).rejects.toThrow('Request failed with status code 500');
     });
 
     it('should handle 403 errors', async () => {
@@ -132,7 +132,7 @@ describe('Course Optimizer API', () => {
       const url = api.getLinkCheckStatusApiUrl(courseId);
       axiosMock.onGet(url).reply(403, { error: 'Forbidden' });
 
-      await expect(api.getLinkCheckStatus(courseId)).rejects.toThrow();
+      await expect(api.getLinkCheckStatus(courseId)).rejects.toThrow('Request failed with status code 403');
     });
   });
 
@@ -153,7 +153,7 @@ describe('Course Optimizer API', () => {
       const url = api.postRerunLinkUpdateApiUrl(courseId);
       axiosMock.onPost(url).reply(500, { error: 'Update failed' });
 
-      await expect(api.postRerunLinkUpdateAll(courseId)).rejects.toThrow();
+      await expect(api.postRerunLinkUpdateAll(courseId)).rejects.toThrow('Request failed with status code 500');
     });
   });
 
@@ -176,7 +176,9 @@ describe('Course Optimizer API', () => {
       const url = api.postRerunLinkUpdateApiUrl(courseId);
       axiosMock.onPost(url).reply(500, { error: 'Update failed' });
 
-      await expect(api.postRerunLinkUpdateSingle(courseId, 'https://test.com', 'block-1')).rejects.toThrow();
+      await expect(api.postRerunLinkUpdateSingle(courseId, 'https://test.com', 'block-1')).rejects.toThrow(
+        'Request failed with status code 500',
+      );
     });
 
     it('should use default contentType when not provided', async () => {
@@ -237,7 +239,7 @@ describe('Course Optimizer API', () => {
       const url = api.getRerunLinkUpdateStatusApiUrl(courseId);
       axiosMock.onGet(url).reply(500, { error: 'Internal Server Error' });
 
-      await expect(api.getRerunLinkUpdateStatus(courseId)).rejects.toThrow();
+      await expect(api.getRerunLinkUpdateStatus(courseId)).rejects.toThrow('Request failed with status code 500');
     });
   });
 

--- a/src/optimizer-page/data/thunks.test.js
+++ b/src/optimizer-page/data/thunks.test.js
@@ -51,7 +51,7 @@ describe('startLinkCheck thunk', () => {
     });
   });
 
-  describe('failed request should set stage and request ', () => {
+  describe('failed request should set stage and request', () => {
     it('should set request status to failed', async () => {
       mockGetStartLinkCheck.mockRejectedValue(new Error('error'));
 

--- a/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
@@ -295,7 +295,7 @@ describe('DiscussionsSettings', () => {
       await user.click(getByRole(container, 'button', { name: 'Cancel' }));
 
       expect(queryByRole(container, 'dialog', { name: 'Confirm' })).not.toBeInTheDocument();
-      expect(queryByRole(container, 'dialog', { name: 'Configure discussion' }));
+      expect(queryByRole(container, 'dialog', { name: 'Configure discussion' })).not.toBeInTheDocument();
     });
   });
 

--- a/src/pages-and-resources/discussions/app-list/SupportedFeature.test.jsx
+++ b/src/pages-and-resources/discussions/app-list/SupportedFeature.test.jsx
@@ -17,7 +17,7 @@ describe('SupportedFeature', () => {
     container = wrapper.container;
   });
 
-  test('displays a check icon ', () => {
+  test('displays a check icon', () => {
     expect(container.querySelector('svg')).toHaveAttribute('id', 'check-icon');
   });
 

--- a/src/pages-and-resources/discussions/data/redux.test.js
+++ b/src/pages-and-resources/discussions/data/redux.test.js
@@ -270,7 +270,7 @@ describe('Data layer integration tests', () => {
   });
 
   describe('updateValidationStatus', () => {
-    test.each([true, false])('sets hasValidationError value to %s ', (hasError) => {
+    test.each([true, false])('sets hasValidationError value to %s', (hasError) => {
       store.dispatch(updateValidationStatus({ hasError }));
 
       expect(store.getState().discussions.hasValidationError).toEqual(hasError);

--- a/src/schedule-and-details/ScheduleAndDetails.test.tsx
+++ b/src/schedule-and-details/ScheduleAndDetails.test.tsx
@@ -130,7 +130,7 @@ describe('<ScheduleAndDetails />', () => {
     ).toBe(0);
   });
 
-  it('should show save alert onChange ', async () => {
+  it('should show save alert onChange', async () => {
     renderComponent();
     const inputs = await screen.findAllByPlaceholderText(DATE_FORMAT.toLocaleUpperCase());
     // @ts-ignore

--- a/src/schedule-and-details/details-section/DetailsSection.test.jsx
+++ b/src/schedule-and-details/details-section/DetailsSection.test.jsx
@@ -42,7 +42,7 @@ describe('<DetailsSection />', () => {
       name: courseSettingsMock.languageOptions[0][1],
     });
 
-    await waitFor(() => expect(anotherOption));
+    await waitFor(() => expect(anotherOption).toBeInTheDocument());
     fireEvent.click(anotherOption);
     expect(onChangeMock).toHaveBeenCalledWith(
       courseSettingsMock.languageOptions[0][0],

--- a/src/search-manager/data/apiHooks.test.tsx
+++ b/src/search-manager/data/apiHooks.test.tsx
@@ -38,7 +38,7 @@ describe('search manager api hooks', () => {
     fetchMock.reset();
   });
 
-  it('it should return block types facet', async () => {
+  it('should return block types facet', async () => {
     fetchMockResponse();
     const { result } = renderHook(() => useGetBlockTypes('filter'), { wrapper });
     await waitFor(() => {

--- a/src/studio-home/tabs-section/TabsSection.test.tsx
+++ b/src/studio-home/tabs-section/TabsSection.test.tsx
@@ -40,7 +40,7 @@ const tabSectionComponent = (overrideProps) => (
   />
 );
 
-export const LocationDisplay = () => {
+const LocationDisplay = () => {
   const location = useLocation();
 
   return <div data-testid="location-display">{location.pathname}</div>;

--- a/src/studio-home/tabs-section/courses-tab/courses-filters/courses-filter-menu/index.test.jsx
+++ b/src/studio-home/tabs-section/courses-tab/courses-filters/courses-filter-menu/index.test.jsx
@@ -87,7 +87,7 @@ describe('CoursesFilterMenu', () => {
     expect(screen.getByTestId('menu-item-icon')).toBeInTheDocument();
   });
 
-  it('should call onCourseTypeSelected function when a menu item is selected ', () => {
+  it('should call onCourseTypeSelected function when a menu item is selected', () => {
     renderComponent();
     const courseFilterMenuToggle = screen.getByTestId('course-filter-menu-toggle');
     expect(courseFilterMenuToggle).toBeInTheDocument();

--- a/src/studio-home/tabs-section/courses-tab/courses-filters/courses-order-filter-menu/index.test.jsx
+++ b/src/studio-home/tabs-section/courses-tab/courses-filters/courses-order-filter-menu/index.test.jsx
@@ -71,7 +71,7 @@ describe('CoursesTypesFilterMenu', () => {
     expect(oldestCoursesMenuItem).toBeInTheDocument();
   });
 
-  it('should show an icon when a menu item is selected ', () => {
+  it('should show an icon when a menu item is selected', () => {
     renderComponent();
     const courseOrderMenu = screen.getByTestId('dropdown-toggle-courses-order-menu');
     fireEvent.click(courseOrderMenu);
@@ -81,7 +81,7 @@ describe('CoursesTypesFilterMenu', () => {
     expect(screen.getByTestId('menu-item-icon')).toBeInTheDocument();
   });
 
-  it('should call onCourseTypeSelected function when a menu item is selected ', () => {
+  it('should call onCourseTypeSelected function when a menu item is selected', () => {
     renderComponent();
     const courseOrderMenu = screen.getByTestId('dropdown-toggle-courses-order-menu');
     fireEvent.click(courseOrderMenu);

--- a/src/studio-home/tabs-section/courses-tab/courses-filters/courses-types-filter-menu/index.test.jsx
+++ b/src/studio-home/tabs-section/courses-tab/courses-filters/courses-types-filter-menu/index.test.jsx
@@ -69,7 +69,7 @@ describe('CoursesTypesFilterMenu', () => {
     expect(archiveCoursesMenuItem).toBeInTheDocument();
   });
 
-  it('should show an icon when a menu item is selected ', () => {
+  it('should show an icon when a menu item is selected', () => {
     renderComponent();
     const courseTypesMenu = screen.getByTestId('dropdown-toggle-course-type-menu');
     fireEvent.click(courseTypesMenu);
@@ -79,7 +79,7 @@ describe('CoursesTypesFilterMenu', () => {
     expect(screen.getByTestId('menu-item-icon')).toBeInTheDocument();
   });
 
-  it('should call onCourseTypeSelected function when a menu item is selected ', () => {
+  it('should call onCourseTypeSelected function when a menu item is selected', () => {
     renderComponent();
     const courseTypesMenu = screen.getByTestId('dropdown-toggle-course-type-menu');
     fireEvent.click(courseTypesMenu);

--- a/src/taxonomy/tag-list/TagListTable.test.jsx
+++ b/src/taxonomy/tag-list/TagListTable.test.jsx
@@ -788,6 +788,7 @@ describe('<TagListTable />', () => {
   ];
 
   tagDepthScenarios.forEach(({ description, tagName }) => {
+    // oxlint-disable-next-line jest/valid-title
     describe(description, () => {
       beforeEach(async () => {
         axiosMock.resetHistory();
@@ -964,6 +965,7 @@ describe('<TagListTable />', () => {
     ];
 
     tagDepthScenarios.forEach(({ description, tagName }) => {
+      // oxlint-disable-next-line jest/valid-title
       describe(description, () => {
         beforeEach(async () => {
           axiosMock.resetHistory();

--- a/src/taxonomy/tag-list/hooks.test.tsx
+++ b/src/taxonomy/tag-list/hooks.test.tsx
@@ -191,7 +191,7 @@ describe('useEditActions', () => {
     } = buildActions();
     deleteTagMutation.mutateAsync.mockResolvedValue(undefined);
 
-    actions.handleDeleteRow({
+    await actions.handleDeleteRow({
       original: {
         id: 1,
         value: 'tag to delete',
@@ -226,7 +226,7 @@ describe('useEditActions', () => {
     } = buildActions();
     deleteTagMutation.mutateAsync.mockRejectedValue(new Error('server failed'));
 
-    actions.handleDeleteRow({
+    await actions.handleDeleteRow({
       original: {
         id: 1,
         value: 'tag to delete',

--- a/src/textbooks/textbook-form/TextbookForm.test.tsx
+++ b/src/textbooks/textbook-form/TextbookForm.test.tsx
@@ -57,9 +57,9 @@ describe('<TextbookForm />', () => {
     expect(screen.getByTestId('chapter-upload-button')).toBeInTheDocument();
     expect(screen.getByTestId('chapter-delete-button')).toBeInTheDocument();
 
-    expect(screen.getByRole('button', { name: messages.addChapterButton.defaultMessage }));
-    expect(screen.getByRole('button', { name: messages.cancelButton.defaultMessage }));
-    expect(screen.getByRole('button', { name: messages.saveButton.defaultMessage }));
+    expect(screen.getByRole('button', { name: messages.addChapterButton.defaultMessage })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: messages.cancelButton.defaultMessage })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: messages.saveButton.defaultMessage })).toBeInTheDocument();
   });
 
   it('calls onSubmit when the "Save" button is clicked with a valid form', async () => {


### PR DESCRIPTION
## Description

I noticed that our linter was no longer properly linting `await` and some other things. The problem is that in https://github.com/openedx/frontend-app-authoring/pull/2972 I added the `react` plugin but it accidentally disabled all the other plugins. This PR restores the defaults, adds a `jest` linting plugin, and fixes all the detected lint issues.

## Supporting information

Part of https://github.com/openedx/frontend-app-authoring/issues/2559

Private ref MNG-4670