### PR TITLE
refactor: migrate course_details + grading callers to standardized v3 APIs (FC-0118)

### DIFF
--- a/src/course-outline/data/api.ts
+++ b/src/course-outline/data/api.ts
@@ -19,7 +19,10 @@ export const getCourseOutlineIndexApiUrl = (
   courseId: string,
 ) => `${getApiBaseUrl()}/api/contentstore/v1/course_index/${courseId}`;
 
-export const getCourseDetailsApiUrl = (courseId) => `${getApiBaseUrl()}/api/contentstore/v1/course_details/${courseId}`;
+// FC-0118 (ADR 0037): standardized v3 endpoint. The trailing slash is required
+// by the DRF DefaultRouter that serves the v3 ViewSet (unlike the v1 APIView).
+export const getCourseDetailsApiUrl = (courseId) =>
+  `${getApiBaseUrl()}/api/contentstore/v3/course_details/${courseId}/`;
 
 export const getCourseBestPracticesApiUrl = ({
   courseId,

--- a/src/course-outline/data/api.ts
+++ b/src/course-outline/data/api.ts
@@ -19,7 +19,8 @@ export const getCourseOutlineIndexApiUrl = (
   courseId: string,
 ) => `${getApiBaseUrl()}/api/contentstore/v1/course_index/${courseId}`;
 
-export const getCourseDetailsApiUrl = (courseId) => `${getApiBaseUrl()}/api/contentstore/v1/course_details/${courseId}`;
+export const getCourseDetailsApiUrl = (courseId) =>
+  `${getApiBaseUrl()}/api/contentstore/v3/course_details/${courseId}/`;
 
 export const getCourseBestPracticesApiUrl = ({
   courseId,

--- a/src/grading-settings/GradingSettings.test.jsx
+++ b/src/grading-settings/GradingSettings.test.jsx
@@ -11,7 +11,7 @@ import { mockWaffleFlags } from '@src/data/apiHooks.mock';
 import { useCourseUserPermissions } from '@src/authz/hooks';
 
 import gradingSettings from './__mocks__/gradingSettings';
-import { getGradingSettingsApiUrl } from './data/api';
+import { getGradingSettingsApiUrl, getAuthoringGradingApiUrl } from './data/api';
 import * as apiHooks from './data/apiHooks';
 import GradingSettings from './GradingSettings';
 import messages from './messages';
@@ -45,7 +45,7 @@ describe('<GradingSettings />', () => {
       .onGet(getGradingSettingsApiUrl(courseId))
       .reply(200, gradingSettings);
     axiosMock
-      .onPost(getGradingSettingsApiUrl(courseId))
+      .onPatch(getAuthoringGradingApiUrl(courseId))
       .reply(200, {});
     axiosMock.onGet(getCourseSettingsApiUrl(courseId))
       .reply(200, {});
@@ -147,7 +147,7 @@ describe('<GradingSettings /> permissions', () => {
     Object.defineProperty(window, 'scrollTo', { value: jest.fn(), writable: true });
     const { axiosMock: mock } = mocks;
     mock.onGet(getGradingSettingsApiUrl(courseId)).reply(200, gradingSettings);
-    mock.onPost(getGradingSettingsApiUrl(courseId)).reply(200, {});
+    mock.onPatch(getAuthoringGradingApiUrl(courseId)).reply(200, {});
     mock.onGet(getCourseSettingsApiUrl(courseId)).reply(200, {});
     jest.mocked(useCourseUserPermissions).mockReturnValue({
       isLoading: false,

--- a/src/grading-settings/data/api.js
+++ b/src/grading-settings/data/api.js
@@ -4,8 +4,20 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { deepConvertingKeysToCamelCase, deepConvertingKeysToSnakeCase } from '../../utils';
 
 const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
+
+// FC-0118 (ADR 0037): the read stays on the v1 `course_grading` endpoint.
+// The standardized v3 `authoring_grading` ViewSet only exposes a write
+// (PATCH partial_update) and has no GET, so grading settings are still
+// fetched from v1 until a v3 read endpoint exists.
 export const getGradingSettingsApiUrl = (courseId) =>
   `${getApiBaseUrl()}/api/contentstore/v1/course_grading/${courseId}`;
+
+// FC-0118 (ADR 0031/0037): the write is migrated to the standardized v3
+// `authoring_grading` endpoint, which collapses the old GET+POST pair into a
+// single PATCH (partial_update). The trailing slash is required by the DRF
+// DefaultRouter that serves the v3 ViewSet.
+export const getAuthoringGradingApiUrl = (courseId) =>
+  `${getApiBaseUrl()}/api/contentstore/v3/authoring_grading/${courseId}/`;
 
 /**
  * Get's grading setting for a course.
@@ -26,6 +38,6 @@ export async function getGradingSettings(courseId) {
  */
 export async function sendGradingSettings(courseId, settings) {
   const { data } = await getAuthenticatedHttpClient()
-    .post(getGradingSettingsApiUrl(courseId), deepConvertingKeysToSnakeCase(settings));
+    .patch(getAuthoringGradingApiUrl(courseId), deepConvertingKeysToSnakeCase(settings));
   return camelCaseObject(data);
 }

--- a/src/grading-settings/data/api.js
+++ b/src/grading-settings/data/api.js
@@ -4,8 +4,13 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { deepConvertingKeysToCamelCase, deepConvertingKeysToSnakeCase } from '../../utils';
 
 const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
+
 export const getGradingSettingsApiUrl = (courseId) =>
   `${getApiBaseUrl()}/api/contentstore/v1/course_grading/${courseId}`;
+
+// v3 authoring_grading exposes only PATCH and has no GET, so the read stays on v1.
+export const getAuthoringGradingApiUrl = (courseId) =>
+  `${getApiBaseUrl()}/api/contentstore/v3/authoring_grading/${courseId}/`;
 
 /**
  * Get's grading setting for a course.
@@ -26,6 +31,6 @@ export async function getGradingSettings(courseId) {
  */
 export async function sendGradingSettings(courseId, settings) {
   const { data } = await getAuthenticatedHttpClient()
-    .post(getGradingSettingsApiUrl(courseId), deepConvertingKeysToSnakeCase(settings));
+    .patch(getAuthoringGradingApiUrl(courseId), deepConvertingKeysToSnakeCase(settings));
   return camelCaseObject(data);
 }

--- a/src/schedule-and-details/data/api.ts
+++ b/src/schedule-and-details/data/api.ts
@@ -3,7 +3,10 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { convertObjectToSnakeCase } from '@src/utils';
 
 const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
-export const getCourseDetailsApiUrl = (courseId) => `${getApiBaseUrl()}/api/contentstore/v1/course_details/${courseId}`;
+// FC-0118 (ADR 0037): standardized v3 endpoint. The trailing slash is required
+// by the DRF DefaultRouter that serves the v3 ViewSet (unlike the v1 APIView).
+export const getCourseDetailsApiUrl = (courseId) =>
+  `${getApiBaseUrl()}/api/contentstore/v3/course_details/${courseId}/`;
 export const getUploadAssetsUrl = (courseId) => `${getApiBaseUrl()}/assets/${courseId}/`;
 
 // TODO: This interface has only basic data, all the rest needs to be added.

--- a/src/schedule-and-details/data/api.ts
+++ b/src/schedule-and-details/data/api.ts
@@ -3,7 +3,8 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { convertObjectToSnakeCase } from '@src/utils';
 
 const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
-export const getCourseDetailsApiUrl = (courseId) => `${getApiBaseUrl()}/api/contentstore/v1/course_details/${courseId}`;
+export const getCourseDetailsApiUrl = (courseId) =>
+  `${getApiBaseUrl()}/api/contentstore/v3/course_details/${courseId}/`;
 export const getUploadAssetsUrl = (courseId) => `${getApiBaseUrl()}/assets/${courseId}/`;
 
 // TODO: This interface has only basic data, all the rest needs to be added.


### PR DESCRIPTION
## Description

Part of the FC-0118 downstream migration tracked in #3127. Points two of the
**Ready** Studio API callers at their standardized v3 endpoints. Pure
URL/verb version bumps — no UI or behaviour change for Course Authors.

**Commits (one per API, so each can be reviewed / rolled back independently):**

1. **`course_details` → v3** — `getCourseDetails` (GET) and `updateCourseDetails`
   (PUT) now target `/api/contentstore/v3/course_details/{course_id}/`. The v3
   ViewSet supports the same GET+PUT and returns the same `CourseDetailsSerializer`
   shape. Both call sites are migrated (`schedule-and-details` and the duplicate
   in `course-outline`) so all course-details reads land on v3.
2. **`course_grading` write → v3 `authoring_grading`** — the save
   (`sendGradingSettings`) moves from `POST v1/course_grading` to
   `PATCH v3/authoring_grading/{course_id}/`, which collapses the old GET+POST
   pair into a single `partial_update`. Same serializer payload is returned.

> **Note — grading read stays on v1 (intentional).** The v3 `authoring_grading`
> ViewSet only exposes the write (`partial_update`); it has no GET. So
> `getGradingSettings` remains on `v1/course_grading` until a v3 read endpoint
> exists. This is called out in a code comment.

The **trailing slash** on both v3 URLs is required — v3 is served by a DRF
`DefaultRouter` (the v1 APIViews had none). Omitting it would 301-redirect and
drop the request body on PUT/PATCH.

**User roles impacted:** Course Author (Studio Schedule & Details, Grading
Settings pages). No visible change expected.

## Supporting information

- Tracking issue: #3127
- Backend ADRs / PRs (on `openedx/edx-platform`, branch `feat/axim-api_improvements`):
  Course Details v3 (#38708), Author Grading v3 (#38726), ADR 0031 (merge
  endpoints), ADR 0037 (versioning).
- **Out of scope here (deferred):** Xblock legacy→v1 REST (own PR — it needs
  per-call-site verb changes, not a URL swap), the ADR 0029 error-handling
  wrapper (own PR), and Course Home #2 / Home Courses #3 (on hold pending #2540).

## Testing instructions

1. Open a course in Studio → **Settings → Schedule & Details**. Confirm the page
   loads and saving changes persists (network calls hit `.../v3/course_details/<id>/`).
2. Open **Settings → Grading**. Confirm current grading loads (GET
   `.../v1/course_grading/<id>`) and that saving persists (PATCH
   `.../v3/authoring_grading/<id>/`).
3. `npm test` — updated suites: `ScheduleAndDetails.test.tsx` (13 passing),
   `GradingSettings.test.jsx` (12 passing), `course-outline` spot-check green.

## Other information

- Depends on the v3 endpoints landing on `edx-platform` (feat/axim-api_improvements).
  The old versions remain live, so this is safe to merge once v3 is deployed.
- No migrations, no accessibility impact.

## Best Practices Checklist

- [ ] Any _new_ files are using TypeScript — N/A (no new files)
- [x] Avoid `propTypes`/`defaultProps` in new/modified code
- [x] Tests use `initializeMocks` from `src/testUtils`
- [x] No new Redux state
- [x] Data loaded via React Query (`apiHooks`)
- [ ] New i18n messages have `description` — N/A (no new messages)
- [x] No `../` added to import paths
