### PR TITLE
refactor: migrate Studio Home courses caller to standardized v4 API (FC-0118)

### DIFF
--- a/src/studio-home/data/api.test.js
+++ b/src/studio-home/data/api.test.js
@@ -10,7 +10,6 @@ import {
   handleCourseNotification,
   sendRequestForCourseCreator,
   getApiBaseUrl,
-  getStudioHomeCourses,
   getStudioHomeCoursesV2,
   getStudioHomeLibraries,
 } from './api';
@@ -48,18 +47,8 @@ describe('studio-home api calls', () => {
     expect(result).toEqual(expected);
   });
 
-  it('should get studio courses data', async () => {
-    const apiLink = `${getApiBaseUrl()}/api/contentstore/v1/home/courses`;
-    axiosMock.onGet(apiLink).reply(200, generateGetStudioCoursesApiResponseV2());
-    const result = await getStudioHomeCourses('');
-    const expected = generateGetStudioCoursesApiResponseV2();
-
-    expect(axiosMock.history.get[0].url).toEqual(apiLink);
-    expect(result).toEqual(expected);
-  });
-
   it('should get studio courses data v2', async () => {
-    const apiLink = `${getApiBaseUrl()}/api/contentstore/v2/home/courses`;
+    const apiLink = `${getApiBaseUrl()}/api/contentstore/v4/home/courses/`;
     axiosMock.onGet(apiLink).reply(200, generateGetStudioCoursesApiResponseV2());
     const result = await getStudioHomeCoursesV2('');
     const expected = generateGetStudioCoursesApiResponseV2();

--- a/src/studio-home/data/api.ts
+++ b/src/studio-home/data/api.ts
@@ -14,23 +14,18 @@ export async function getStudioHomeData(): Promise<object> {
   return camelCaseObject(data);
 }
 
-/** Get list of courses from the deprecated non-paginated API */
-export async function getStudioHomeCourses(search: string) {
-  const { data } = await getAuthenticatedHttpClient().get(
-    `${getApiBaseUrl()}/api/contentstore/v1/home/courses${search}`,
-  );
-  return camelCaseObject(data);
-}
 /**
  * Get's studio home courses.
- * Note: We are changing /api/contentstore/v1 to /api/contentstore/v2 due to upcoming breaking changes.
- * Features such as pagination, filtering, and ordering are better handled in the new version.
- * Please refer to this PR for further details: https://github.com/openedx/edx-platform/pull/34173
+ *
+ * FC-0118 (ADR 0028/0037): migrated to the standardized v4 `home/courses`
+ * endpoint. The trailing slash is required by the DRF DefaultRouter that serves
+ * the v4 ViewSet. The deprecated non-paginated v1 `home/courses` fallback has
+ * been dropped; pagination, filtering, and ordering are handled natively by v4.
  */
 export async function getStudioHomeCoursesV2(search: string, customParams: object): Promise<object> {
   const customParamsFormat = snakeCaseObject(customParams);
   const { data } = await getAuthenticatedHttpClient().get(
-    `${getApiBaseUrl()}/api/contentstore/v2/home/courses${search}`,
+    `${getApiBaseUrl()}/api/contentstore/v4/home/courses/${search}`,
     { params: customParamsFormat },
   );
   return camelCaseObject(data);

--- a/src/studio-home/data/thunks.test.js
+++ b/src/studio-home/data/thunks.test.js
@@ -26,7 +26,7 @@ describe('fetchStudioHomeData thunk', () => {
     dispatch = jest.fn();
 
     axiosMock.onGet(getStudioHomeApiUrl()).reply(200, generateGetStudioHomeDataApiResponse());
-    axiosMock.onGet(new RegExp(`${getApiBaseUrl()}/api/contentstore/v2/home/courses.*`))
+    axiosMock.onGet(new RegExp(`${getApiBaseUrl()}/api/contentstore/v4/home/courses.*`))
       .reply(200, generateGetStudioCoursesApiResponseV2());
   });
 

--- a/src/studio-home/tabs-section/TabsSection.test.tsx
+++ b/src/studio-home/tabs-section/TabsSection.test.tsx
@@ -28,7 +28,7 @@ const { studioShortName } = studioHomeMock;
 
 let axiosMock;
 let store;
-const courseApiLinkV2 = `${getApiBaseUrl()}/api/contentstore/v2/home/courses`;
+const courseApiLinkV2 = `${getApiBaseUrl()}/api/contentstore/v4/home/courses/`;
 
 const tabSectionComponent = (overrideProps) => (
   <TabsSection


### PR DESCRIPTION
## ⛔ Draft — blocked by #2540 (do not merge yet)

This PR is intentionally opened as a **draft**. It is item **#3** of the FC-0118
Studio-API caller migration tracked in **openedx/frontend-app-authoring#3127**,
and it is **on hold pending #2540** (the "Studio Home" Redux → React Query +
Context refactor). #2540 intends to break the kitchen-sink Studio Home state
(course list, library list, permissions, feature flags, branding) into smaller,
purpose-specific queries; versioning the courses endpoint as-is would entrench a
payload shape we plan to remove. **Do not merge until #2540's direction is settled.**

### Merge order / dependencies
- **Blocked by:** #2540 — resolve first.
- **Sibling PR (same file):** the Course Home `v1 → v3` PR (item #2 of #3127) also
  edits `src/studio-home/data/api.ts`. These two should be reviewed together;
  whichever merges first, the other must rebase. Suggested order: **Course Home
  (#2) first, then this one.**
- **Independent of** the Xblock PR (item #1 of #3127).

## Description

Migrates the Studio Home **course list** caller from the deprecated v2 endpoint
to the standardized **v4** endpoint (FC-0118, ADR 0028/0037):

- `getStudioHomeCoursesV2` now targets `GET /api/contentstore/v4/home/courses/`
  instead of `…/v2/home/courses`. The v4 `HomeCoursesViewSet` is served by a DRF
  `DefaultRouter`, so the URL now carries the **required trailing slash**.
- The deprecated non-paginated **v1** `home/courses` fallback
  (`getStudioHomeCourses`) had **no remaining callers** and is removed.
  Pagination, filtering, and ordering are handled natively by v4.

The default (full) response shape is unchanged between v2 and v4 (ADR 0036
`?view=` presets are opt-in and default to the full payload), so this is a
behaviour-preserving swap for the paginated caller.

## Supporting information

- Tracking issue: openedx/frontend-app-authoring#3127 (item #3, "Home Courses v2 → v4").
- Backend v4 endpoint: `HomeCoursesViewSet` registered at `home/courses` via
  `DefaultRouter` in `cms/djangoapps/contentstore/rest_api/v4/urls.py`.

## Testing instructions

1. `npm ci`
2. `npx jest src/studio-home`
3. Manual: open Studio Home, confirm the course list loads, paginates, filters,
   and orders correctly, and that the network tab shows requests to
   `/api/contentstore/v4/home/courses/`.

## Other information

- Files changed:
  - `src/studio-home/data/api.ts` — v4 URL + trailing slash; drop v1 fallback.
  - `src/studio-home/data/api.test.js` — drop the v1-fallback test; bump the
    caller test to v4.
  - `src/studio-home/data/thunks.test.js` — bump the courses mock regex to v4.
  - `src/studio-home/tabs-section/TabsSection.test.tsx` — bump the courses mock URL to v4.
- All 112 `src/studio-home` tests pass; `dprint check` is clean.
