### PR TITLE
refactor: migrate Studio Home caller to standardized v3 API (FC-0118)

### DIFF
--- a/src/studio-home/data/api.test.js
+++ b/src/studio-home/data/api.test.js
@@ -69,7 +69,7 @@ describe('studio-home api calls', () => {
   });
 
   it('should get studio v1 libraries data', async () => {
-    const apiLink = `${getApiBaseUrl()}/api/contentstore/v1/home/libraries`;
+    const apiLink = `${getApiBaseUrl()}/api/contentstore/v3/home/libraries/`;
     axiosMock.onGet(apiLink).reply(200, generateGetStudioHomeLibrariesApiResponse());
     const result = await getStudioHomeLibraries();
     const expected = generateGetStudioHomeLibrariesApiResponse();

--- a/src/studio-home/data/api.ts
+++ b/src/studio-home/data/api.ts
@@ -2,7 +2,11 @@ import { camelCaseObject, snakeCaseObject, getConfig } from '@edx/frontend-platf
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 export const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
-export const getStudioHomeApiUrl = () => new URL('api/contentstore/v1/home', getApiBaseUrl()).href;
+// FC-0118 (ADR 0028/0037): standardized v3 Studio Home endpoint. The trailing
+// slash is required by the DRF DefaultRouter that serves the v3 `HomeViewSet`
+// (the v1 route was a plain APIView). The aggregated home context lives at the
+// `list` action `…/v3/home/`, and the library list at `…/v3/home/libraries/`.
+export const getStudioHomeApiUrl = () => new URL('api/contentstore/v3/home/', getApiBaseUrl()).href;
 export const getRequestCourseCreatorUrl = () => new URL('request_course_creator', getApiBaseUrl()).href;
 export const getCourseNotificationUrl = (url) => new URL(url, getApiBaseUrl()).href;
 
@@ -55,7 +59,9 @@ export interface LibrariesV1ListData {
 }
 
 export async function getStudioHomeLibraries(): Promise<LibrariesV1ListData> {
-  const { data } = await getAuthenticatedHttpClient().get(`${getStudioHomeApiUrl()}/libraries`);
+  // `getStudioHomeApiUrl()` already ends in a slash (`…/v3/home/`); the v3
+  // library list is the `libraries` action at `…/v3/home/libraries/`.
+  const { data } = await getAuthenticatedHttpClient().get(`${getStudioHomeApiUrl()}libraries/`);
   return camelCaseObject(data);
 }
 


### PR DESCRIPTION
## ⛔ Draft — blocked by #2540 (do not merge yet)

This PR is intentionally opened as a **draft**. It is item **#2** of the FC-0118
Studio-API caller migration tracked in **openedx/frontend-app-authoring#3127**,
and it is **on hold pending #2540** (the "Studio Home" Redux → React Query +
Context refactor). #2540 intends to break the kitchen-sink Studio Home state
(course list, library list, permissions, feature flags, branding) into smaller,
purpose-specific queries; versioning this endpoint as-is would entrench a payload
shape we plan to remove. **Do not merge until #2540's direction is settled.**

### Merge order / dependencies
- **Blocked by:** #2540 — resolve first.
- **Merge this before its sibling:** the Home Courses `v2 → v4` PR (item #3 of
  #3127) also edits `src/studio-home/data/api.ts`. Suggested order: **this PR
  (Course Home #2) first, then Home Courses #3 rebases** on top.
- **Independent of** the Xblock PR (item #1 of #3127).

## Description

Migrates the Studio Home **landing page** and **libraries tab** reads from the
v1 endpoint to the standardized **v3** endpoint (FC-0118, ADR 0028/0037):

- `getStudioHomeApiUrl()` now targets `…/api/contentstore/v3/home/` instead of
  `…/v1/home`. The v3 `HomeViewSet` is served by a DRF `DefaultRouter`, so the
  URL now carries the **required trailing slash**.
- `getStudioHomeData` → `GET …/v3/home/` (the aggregated `list` action).
- `getStudioHomeLibraries` → `GET …/v3/home/libraries/` (the `libraries`
  action). The helper builds `home/libraries/` off the trailing-slash base.

The default (full) response shape is unchanged between v1 and v3 (ADR 0036
`?fields=` presets are opt-in and default to the full payload), so this is a
behaviour-preserving swap.

## Supporting information

- Tracking issue: openedx/frontend-app-authoring#3127 (item #2, "Course Home v1 → v3").
- Backend v3 endpoint: `HomeViewSet` registered at `home` via `DefaultRouter`
  in `cms/djangoapps/contentstore/rest_api/v3/urls.py`; exposes
  `GET /home/` (list), `/home/courses/`, and `/home/libraries/`.

## Testing instructions

1. `npm ci`
2. `npx jest src/studio-home`
3. Manual: open Studio Home, confirm the landing page and the Libraries tab load,
   and that the network tab shows requests to `/api/contentstore/v3/home/` and
   `/api/contentstore/v3/home/libraries/`.

## Other information

- Files changed:
  - `src/studio-home/data/api.ts` — v3 base URL + trailing slash; `libraries/`
    concatenation fixed for the trailing-slash base.
  - `src/studio-home/data/api.test.js` — bump the hardcoded libraries mock to v3.
- The ~15 other test files that mock `getStudioHomeApiUrl()` reference it **by
  function**, so they track the new URL automatically.
- `src/studio-home` (113 tests) passes; `dprint check` is clean. The only
  library-authoring failures in a broad run are **pre-existing, date-dependent
  flakes on `master`** (identical failure set with and without this change).
