### PR TITLE
feat: string displayNumber added to courses list

### DIFF
--- a/src/studio-home/tabs-section/courses-tab/index.test.tsx
+++ b/src/studio-home/tabs-section/courses-tab/index.test.tsx
@@ -191,4 +191,39 @@ describe('<CoursesTab />', () => {
     renderComponent({}, customStoreData);
     expect(screen.getByText(/\/ 123 \//)).toBeInTheDocument();
   });
+
+  it('should render displayOrg in the card subtitle when it is provided', () => {
+    const courseWithDisplayOrg = {
+      ...studioHomeMock.courses[0],
+      org: 'HarvardX',
+      displayOrg: 'Harvard University',
+    };
+    const customStoreData = {
+      studioHomeData: {
+        courses: [courseWithDisplayOrg],
+        numPages: 1,
+        coursesCount: 1,
+      },
+    };
+    renderComponent({}, customStoreData);
+    expect(screen.getByText(/Harvard University \//)).toBeInTheDocument();
+    expect(screen.queryByText(/HarvardX \//)).not.toBeInTheDocument();
+  });
+
+  it('should fall back to org in the card subtitle when displayOrg is empty', () => {
+    const courseWithEmptyDisplayOrg = {
+      ...studioHomeMock.courses[0],
+      org: 'HarvardX',
+      displayOrg: '',
+    };
+    const customStoreData = {
+      studioHomeData: {
+        courses: [courseWithEmptyDisplayOrg],
+        numPages: 1,
+        coursesCount: 1,
+      },
+    };
+    renderComponent({}, customStoreData);
+    expect(screen.getByText(/HarvardX \//)).toBeInTheDocument();
+  });
 });

--- a/src/studio-home/tabs-section/courses-tab/index.test.tsx
+++ b/src/studio-home/tabs-section/courses-tab/index.test.tsx
@@ -156,4 +156,39 @@ describe('<CoursesTab />', () => {
     const state = store.getState();
     expect(state.studioHome.studioHomeCoursesRequestParams).toStrictEqual(studioHomeCoursesRequestParamsDefault);
   });
+
+  it('should render displayNumber in the card subtitle when it is provided', () => {
+    const courseWithDisplayNumber = {
+      ...studioHomeMock.courses[0],
+      number: '123',
+      displayNumber: 'DISP-999',
+    };
+    const customStoreData = {
+      studioHomeData: {
+        courses: [courseWithDisplayNumber],
+        numPages: 1,
+        coursesCount: 1,
+      },
+    };
+    renderComponent({}, customStoreData);
+    expect(screen.getByText(/DISP-999/)).toBeInTheDocument();
+    expect(screen.queryByText(/\/ 123 \//)).not.toBeInTheDocument();
+  });
+
+  it('should fall back to number in the card subtitle when displayNumber is empty', () => {
+    const courseWithEmptyDisplayNumber = {
+      ...studioHomeMock.courses[0],
+      number: '123',
+      displayNumber: '',
+    };
+    const customStoreData = {
+      studioHomeData: {
+        courses: [courseWithEmptyDisplayNumber],
+        numPages: 1,
+        coursesCount: 1,
+      },
+    };
+    renderComponent({}, customStoreData);
+    expect(screen.getByText(/\/ 123 \//)).toBeInTheDocument();
+  });
 });

--- a/src/studio-home/tabs-section/courses-tab/index.tsx
+++ b/src/studio-home/tabs-section/courses-tab/index.tsx
@@ -85,6 +85,7 @@ const CardList = ({
                 org,
                 rerunLink,
                 number,
+                displayNumber,
                 run,
                 url,
               }) => (
@@ -97,7 +98,7 @@ const CardList = ({
                   lmsLink={lmsLink}
                   rerunLink={rerunLink}
                   org={org}
-                  number={number}
+                  number={displayNumber || number}
                   run={run}
                   url={url}
                   selectMode={inSelectMode ? 'single' : undefined}

--- a/src/studio-home/tabs-section/courses-tab/index.tsx
+++ b/src/studio-home/tabs-section/courses-tab/index.tsx
@@ -83,6 +83,7 @@ const CardList = ({
                 displayName,
                 lmsLink,
                 org,
+                displayOrg,
                 rerunLink,
                 number,
                 displayNumber,
@@ -97,7 +98,7 @@ const CardList = ({
                   displayName={displayName}
                   lmsLink={lmsLink}
                   rerunLink={rerunLink}
-                  org={org}
+                  org={displayOrg || org}
                   number={displayNumber || number}
                   run={run}
                   url={url}


### PR DESCRIPTION
## Description

this is part of this PR
https://github.com/openedx/openedx-platform/pull/38851

now Authoring shows correctly the string display number if exists.

## Testing instructions

add "course number display string" to a course in advance settings 
this will show the course number string in courses list in authoring home
<img width="1846" height="420" alt="Screenshot 2026-07-16 at 12 00 43 p m" src="https://github.com/user-attachments/assets/d1c66d62-2a7a-4484-83ce-e15a711ec579" />

if there's no Course number display string it will show the course number
<img width="1898" height="471" alt="Screenshot 2026-07-16 at 12 01 17 p m" src="https://github.com/user-attachments/assets/c76f5d49-f055-4e53-9c1e-cc79f0152a86" />

