### PR TITLE
feat: string displayNumber added to courses list (#3141) Backport

### DIFF
--- a/src/studio-home/tabs-section/courses-tab/index.test.tsx
+++ b/src/studio-home/tabs-section/courses-tab/index.test.tsx
@@ -138,14 +138,7 @@ describe('<CoursesTab />', () => {
       number: '123',
       displayNumber: 'DISP-999',
     };
-    const customStoreData = {
-      studioHomeData: {
-        courses: [courseWithDisplayNumber],
-        numPages: 1,
-        coursesCount: 1,
-      },
-    };
-    renderComponent({}, customStoreData);
+    renderComponent({ coursesDataItems: [courseWithDisplayNumber] });
     expect(screen.getByText(/DISP-999/)).toBeInTheDocument();
     expect(screen.queryByText(/\/ 123 \//)).not.toBeInTheDocument();
   });
@@ -156,14 +149,7 @@ describe('<CoursesTab />', () => {
       number: '123',
       displayNumber: '',
     };
-    const customStoreData = {
-      studioHomeData: {
-        courses: [courseWithEmptyDisplayNumber],
-        numPages: 1,
-        coursesCount: 1,
-      },
-    };
-    renderComponent({}, customStoreData);
+    renderComponent({ coursesDataItems: [courseWithEmptyDisplayNumber] });
     expect(screen.getByText(/\/ 123 \//)).toBeInTheDocument();
   });
 
@@ -173,14 +159,7 @@ describe('<CoursesTab />', () => {
       org: 'HarvardX',
       displayOrg: 'Harvard University',
     };
-    const customStoreData = {
-      studioHomeData: {
-        courses: [courseWithDisplayOrg],
-        numPages: 1,
-        coursesCount: 1,
-      },
-    };
-    renderComponent({}, customStoreData);
+    renderComponent({ coursesDataItems: [courseWithDisplayOrg] });
     expect(screen.getByText(/Harvard University \//)).toBeInTheDocument();
     expect(screen.queryByText(/HarvardX \//)).not.toBeInTheDocument();
   });
@@ -191,14 +170,7 @@ describe('<CoursesTab />', () => {
       org: 'HarvardX',
       displayOrg: '',
     };
-    const customStoreData = {
-      studioHomeData: {
-        courses: [courseWithEmptyDisplayOrg],
-        numPages: 1,
-        coursesCount: 1,
-      },
-    };
-    renderComponent({}, customStoreData);
+    renderComponent({ coursesDataItems: [courseWithEmptyDisplayOrg] });
     expect(screen.getByText(/HarvardX \//)).toBeInTheDocument();
   });
 });

--- a/src/studio-home/tabs-section/courses-tab/index.test.tsx
+++ b/src/studio-home/tabs-section/courses-tab/index.test.tsx
@@ -131,4 +131,74 @@ describe('<CoursesTab />', () => {
     const state = store.getState();
     expect(state.studioHome.studioHomeCoursesRequestParams).toStrictEqual(studioHomeCoursesRequestParamsDefault);
   });
+
+  it('should render displayNumber in the card subtitle when it is provided', () => {
+    const courseWithDisplayNumber = {
+      ...studioHomeMock.courses[0],
+      number: '123',
+      displayNumber: 'DISP-999',
+    };
+    const customStoreData = {
+      studioHomeData: {
+        courses: [courseWithDisplayNumber],
+        numPages: 1,
+        coursesCount: 1,
+      },
+    };
+    renderComponent({}, customStoreData);
+    expect(screen.getByText(/DISP-999/)).toBeInTheDocument();
+    expect(screen.queryByText(/\/ 123 \//)).not.toBeInTheDocument();
+  });
+
+  it('should fall back to number in the card subtitle when displayNumber is empty', () => {
+    const courseWithEmptyDisplayNumber = {
+      ...studioHomeMock.courses[0],
+      number: '123',
+      displayNumber: '',
+    };
+    const customStoreData = {
+      studioHomeData: {
+        courses: [courseWithEmptyDisplayNumber],
+        numPages: 1,
+        coursesCount: 1,
+      },
+    };
+    renderComponent({}, customStoreData);
+    expect(screen.getByText(/\/ 123 \//)).toBeInTheDocument();
+  });
+
+  it('should render displayOrg in the card subtitle when it is provided', () => {
+    const courseWithDisplayOrg = {
+      ...studioHomeMock.courses[0],
+      org: 'HarvardX',
+      displayOrg: 'Harvard University',
+    };
+    const customStoreData = {
+      studioHomeData: {
+        courses: [courseWithDisplayOrg],
+        numPages: 1,
+        coursesCount: 1,
+      },
+    };
+    renderComponent({}, customStoreData);
+    expect(screen.getByText(/Harvard University \//)).toBeInTheDocument();
+    expect(screen.queryByText(/HarvardX \//)).not.toBeInTheDocument();
+  });
+
+  it('should fall back to org in the card subtitle when displayOrg is empty', () => {
+    const courseWithEmptyDisplayOrg = {
+      ...studioHomeMock.courses[0],
+      org: 'HarvardX',
+      displayOrg: '',
+    };
+    const customStoreData = {
+      studioHomeData: {
+        courses: [courseWithEmptyDisplayOrg],
+        numPages: 1,
+        coursesCount: 1,
+      },
+    };
+    renderComponent({}, customStoreData);
+    expect(screen.getByText(/HarvardX \//)).toBeInTheDocument();
+  });
 });

--- a/src/studio-home/tabs-section/courses-tab/index.tsx
+++ b/src/studio-home/tabs-section/courses-tab/index.tsx
@@ -138,8 +138,10 @@ const CoursesTab: React.FC<Props> = ({
                 displayName,
                 lmsLink,
                 org,
+                displayOrg,
                 rerunLink,
                 number,
+                displayNumber,
                 run,
                 url,
               }) => (
@@ -149,8 +151,8 @@ const CoursesTab: React.FC<Props> = ({
                   displayName={displayName}
                   lmsLink={lmsLink}
                   rerunLink={rerunLink}
-                  org={org}
-                  number={number}
+                  org={displayOrg || org}
+                  number={displayNumber || number}
                   run={run}
                   url={url}
                 />

--- a/src/studio-home/tabs-section/courses-tab/index.tsx
+++ b/src/studio-home/tabs-section/courses-tab/index.tsx
@@ -31,7 +31,9 @@ interface Props {
     displayName: string;
     lmsLink: string | null;
     number: string;
+    displayNumber?: string | null;
     org: string;
+    displayOrg?: string | null;
     rerunLink: string | null;
     run: string;
     url: string;


### PR DESCRIPTION
## Description
Backport of #3141 
this is part of this PR
https://github.com/openedx/openedx-platform/pull/38851

now Authoring shows correctly the string display number if exists.

## Testing instructions
add "course number display string" to a course in advance settings 
this will show the course number string in courses list in authoring home
<img width="1846" height="420" alt="Screenshot 2026-07-16 at 12 00 43 p m" src="https://github.com/user-attachments/assets/d1c66d62-2a7a-4484-83ce-e15a711ec579" />

if there's no Course number display string it will show the course number
<img width="1898" height="471" alt="Screenshot 2026-07-16 at 12 01 17 p m" src="https://github.com/user-attachments/assets/c76f5d49-f055-4e53-9c1e-cc79f0152a86" />

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
