### PR TITLE
refactor(authz): validate Studio button view access and use useCourseUserPermissions in course-scoped contexts

### DIFF
--- a/src/advanced-settings/AdvancedSettings.test.tsx
+++ b/src/advanced-settings/AdvancedSettings.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event';
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
-import { useUserPermissions } from '@src/authz/data/apiHooks';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 import { mockWaffleFlags } from '@src/data/apiHooks.mock';
 import {
   render as baseRender,
@@ -26,8 +26,9 @@ jest.mock('react-textarea-autosize', () =>
     />
   )));
 
-jest.mock('@src/authz/data/apiHooks', () => ({
-  useUserPermissions: jest.fn(),
+jest.mock('@src/authz/hooks', () => ({
+  ...jest.requireActual('@src/authz/hooks'),
+  useCourseUserPermissions: jest.fn(),
 }));
 
 const render = () =>
@@ -46,10 +47,13 @@ describe('<AdvancedSettings />', () => {
       .onGet(`${getCourseAdvancedSettingsApiUrl(courseId)}?fetch_all=0`)
       .reply(200, advancedSettingsMock);
 
-    jest.mocked(useUserPermissions).mockReturnValue({
+    mockWaffleFlags({ enableAuthzCourseAuthoring: false });
+
+    jest.mocked(useCourseUserPermissions).mockReturnValue({
       isLoading: false,
-      data: { canManageAdvancedSettings: true },
-    } as unknown as ReturnType<typeof useUserPermissions>);
+      isAuthzEnabled: false,
+      canManageAdvancedSettings: true,
+    } as ReturnType<typeof useCourseUserPermissions>);
   });
 
   it('should render placeholder when settings fetch returns 403', async () => {
@@ -168,10 +172,11 @@ describe('<AdvancedSettings />', () => {
 
   it('should render without errors when authz.enable_course_authoring flag is enabled and the user is authorized', async () => {
     mockWaffleFlags({ enableAuthzCourseAuthoring: true });
-    jest.mocked(useUserPermissions).mockReturnValue({
+    jest.mocked(useCourseUserPermissions).mockReturnValue({
       isLoading: false,
-      data: { canManageAdvancedSettings: true },
-    } as unknown as ReturnType<typeof useUserPermissions>);
+      isAuthzEnabled: true,
+      canManageAdvancedSettings: true,
+    } as ReturnType<typeof useCourseUserPermissions>);
     render();
     expect(await screen.findByText(messages.headingSubtitle.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(messages.headingTitle.defaultMessage, {
@@ -184,20 +189,22 @@ describe('<AdvancedSettings />', () => {
 
   it('should show permission alert when authz.enable_course_authoring flag is enabled and the user is not authorized', async () => {
     mockWaffleFlags({ enableAuthzCourseAuthoring: true });
-    jest.mocked(useUserPermissions).mockReturnValue({
+    jest.mocked(useCourseUserPermissions).mockReturnValue({
       isLoading: false,
-      data: { canManageAdvancedSettings: false },
-    } as unknown as ReturnType<typeof useUserPermissions>);
+      isAuthzEnabled: true,
+      canManageAdvancedSettings: false,
+    } as ReturnType<typeof useCourseUserPermissions>);
     render();
     expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
   });
 
   it('should show permission denied alert when the user is not authorized', async () => {
     mockWaffleFlags({ enableAuthzCourseAuthoring: true });
-    jest.mocked(useUserPermissions).mockReturnValue({
+    jest.mocked(useCourseUserPermissions).mockReturnValue({
       isLoading: false,
-      data: { canManageAdvancedSettings: false },
-    } as unknown as ReturnType<typeof useUserPermissions>);
+      isAuthzEnabled: true,
+      canManageAdvancedSettings: false,
+    } as ReturnType<typeof useCourseUserPermissions>);
     axiosMock
       .onGet(`${getCourseAdvancedSettingsApiUrl(courseId)}?fetch_all=0`)
       .reply(403);

--- a/src/advanced-settings/AdvancedSettings.tsx
+++ b/src/advanced-settings/AdvancedSettings.tsx
@@ -10,9 +10,8 @@ import {
 import { CheckCircle, Info, Warning } from '@openedx/paragon/icons';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
-import { useWaffleFlags } from '@src/data/apiHooks';
-import { useUserPermissions } from '@src/authz/data/apiHooks';
-import { COURSE_PERMISSIONS } from '@src/authz/constants';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import { getAdvancedSettingsPermissions } from '@src/authz/permissionHelpers';
 import PermissionDeniedAlert from 'CourseAuthoring/generic/PermissionDeniedAlert';
 import AlertProctoringError from '@src/generic/AlertProctoringError';
 import { LoadingSpinner } from '@src/generic/Loading';
@@ -44,14 +43,11 @@ const AdvancedSettings = () => {
 
   const { courseId, courseDetails } = useCourseAuthoringContext();
 
-  const waffleFlags = useWaffleFlags(courseId);
-  const isAuthzEnabled = waffleFlags.enableAuthzCourseAuthoring;
-  const { isLoading: isLoadingUserPermissions, data: userPermissions } = useUserPermissions({
-    canManageAdvancedSettings: {
-      action: COURSE_PERMISSIONS.MANAGE_ADVANCED_SETTINGS,
-      scope: courseId,
-    },
-  }, isAuthzEnabled);
+  const {
+    isLoading: isLoadingUserPermissions,
+    isAuthzEnabled,
+    canManageAdvancedSettings,
+  } = useCourseUserPermissions(courseId, getAdvancedSettingsPermissions(courseId));
 
   const {
     data: advancedSettingsData = {},
@@ -71,7 +67,7 @@ const AdvancedSettings = () => {
     error: queryError,
   } = updateMutation;
 
-  const isLoading = isPendingSettingsStatus || (isAuthzEnabled && isLoadingUserPermissions);
+  const isLoading = isPendingSettingsStatus || isLoadingUserPermissions;
   const updateSettingsButtonState = {
     labels: {
       default: intl.formatMessage(messages.buttonSaveText),
@@ -108,9 +104,7 @@ const AdvancedSettings = () => {
   }
 
   // Show permission denied alert when authz is enabled and user doesn't have permission
-  const authzIsEnabledAndNoPermission = isAuthzEnabled
-    && !isLoadingUserPermissions
-    && !userPermissions?.canManageAdvancedSettings;
+  const authzIsEnabledAndNoPermission = isAuthzEnabled && !canManageAdvancedSettings;
 
   if (authzIsEnabledAndNoPermission) {
     return <PermissionDeniedAlert />;

--- a/src/advanced-settings/AdvancedSettings.tsx
+++ b/src/advanced-settings/AdvancedSettings.tsx
@@ -45,7 +45,6 @@ const AdvancedSettings = () => {
 
   const {
     isLoading: isLoadingUserPermissions,
-    isAuthzEnabled,
     canManageAdvancedSettings,
   } = useCourseUserPermissions(courseId, getAdvancedSettingsPermissions(courseId));
 
@@ -103,10 +102,7 @@ const AdvancedSettings = () => {
     );
   }
 
-  // Show permission denied alert when authz is enabled and user doesn't have permission
-  const authzIsEnabledAndNoPermission = isAuthzEnabled && !canManageAdvancedSettings;
-
-  if (authzIsEnabledAndNoPermission) {
+  if (!canManageAdvancedSettings) {
     return <PermissionDeniedAlert />;
   }
 

--- a/src/authz/hooks.test.ts
+++ b/src/authz/hooks.test.ts
@@ -76,4 +76,15 @@ describe('useCourseUserPermissions', () => {
     expect(result.current.canView).toBe(false);
     expect(result.current.canEdit).toBe(false);
   });
+
+  it('does not validate permissions when courseId is empty, even if authz is enabled', () => {
+    mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+
+    const { result } = renderHook(() => useCourseUserPermissions('', permissions));
+
+    // The validation query must be disabled when there is no course context.
+    expect(useUserPermissions).toHaveBeenCalledWith(permissions, false);
+    expect(result.current.canView).toBe(false);
+    expect(result.current.canEdit).toBe(false);
+  });
 });

--- a/src/authz/hooks.ts
+++ b/src/authz/hooks.ts
@@ -44,11 +44,12 @@ export const useCourseUserPermissions = <Query extends PermissionValidationQuery
   const waffleFlags = useWaffleFlags(courseId);
   const isWaffleFlagsLoading: boolean = waffleFlags?.isLoading ?? true;
   const isAuthzEnabled: boolean = waffleFlags?.enableAuthzCourseAuthoring ?? false;
+  const shouldValidatePermissions = isAuthzEnabled && !!courseId;
 
   const {
     isLoading: isLoadingUserPermissions,
     data: userPermissions,
-  } = useUserPermissions(permissions, isAuthzEnabled);
+  } = useUserPermissions(permissions, shouldValidatePermissions);
 
   const isLoading = isWaffleFlagsLoading || (isAuthzEnabled && isLoadingUserPermissions);
 

--- a/src/authz/permissionHelpers.test.ts
+++ b/src/authz/permissionHelpers.test.ts
@@ -11,8 +11,9 @@ import {
   getCertificatesPermissions,
   getChecklistsPermissions,
   getImportExportPermissions,
+  getViewTeamPermissions,
 } from './permissionHelpers';
-import { COURSE_PERMISSIONS } from './constants';
+import { CONTENT_LIBRARY_PERMISSIONS, COURSE_PERMISSIONS } from './constants';
 
 const courseId = 'course-v1:org+course+run';
 
@@ -249,6 +250,31 @@ describe('permissionHelpers', () => {
           action: COURSE_PERMISSIONS.EXPORT_TAGS,
           scope: courseId,
         },
+      });
+    });
+  });
+
+  describe('getViewTeamPermissions', () => {
+    it('returns course and library view-team permissions with the correct actions', () => {
+      const result = getViewTeamPermissions();
+
+      expect(result).toEqual({
+        canViewCourseTeam: {
+          action: COURSE_PERMISSIONS.VIEW_COURSE_TEAM,
+        },
+        canViewLibraryTeam: {
+          action: CONTENT_LIBRARY_PERMISSIONS.VIEW_LIBRARY_TEAM,
+        },
+      });
+    });
+
+    it('is scope-less so it validates the permissions across any course or library', () => {
+      const result = getViewTeamPermissions();
+
+      // A scope of '' would be rejected by the AuthZ API as a bad request; the scope key
+      // must be absent entirely so the check applies to any object.
+      Object.values(result).forEach((permission) => {
+        expect(permission).not.toHaveProperty('scope');
       });
     });
   });

--- a/src/authz/permissionHelpers.ts
+++ b/src/authz/permissionHelpers.ts
@@ -1,4 +1,16 @@
-import { COURSE_PERMISSIONS } from './constants';
+import { CONTENT_LIBRARY_PERMISSIONS, COURSE_PERMISSIONS } from './constants';
+
+// It validates whether the user can view a team on *any* course or
+// library, to decide if the "Roles & Permissions" button (which links to the admin
+// console in Studio Home) should be shown.
+export const getViewTeamPermissions = () => ({
+  canViewCourseTeam: {
+    action: COURSE_PERMISSIONS.VIEW_COURSE_TEAM,
+  },
+  canViewLibraryTeam: {
+    action: CONTENT_LIBRARY_PERMISSIONS.VIEW_LIBRARY_TEAM,
+  },
+});
 
 export const getScheduleAndDetailsPermissions = (courseId: string) => ({
   canViewScheduleAndDetails: {

--- a/src/authz/urls.ts
+++ b/src/authz/urls.ts
@@ -1,0 +1,21 @@
+import { getConfig } from '@edx/frontend-platform';
+
+/**
+ * URLs of the admin console MFE, where roles and permissions are managed when authz is enabled.
+ *
+ * ADMIN_CONSOLE_URL is null when the MFE isn't deployed; the callers that offer a legacy in-Studio
+ * team UI as an alternative check `isAdminConsoleEnabled()` before building any of these links.
+ */
+
+const getAdminConsoleBaseUrl = (): string => getConfig().ADMIN_CONSOLE_URL ?? '';
+
+/** Whether the admin console MFE is deployed. */
+export const isAdminConsoleEnabled = (): boolean => !!getConfig().ADMIN_CONSOLE_URL;
+
+/** "Roles & permissions" home, covering every scope the user can manage. */
+export const getAdminConsoleUrl = (): string => `${getAdminConsoleBaseUrl()}/authz`;
+
+/** "Roles & permissions" of a single scope: a course or a library. */
+export const getAdminConsoleScopeUrl = (scope: string): string => (
+  `${getAdminConsoleUrl()}?scope=${encodeURIComponent(scope)}`
+);

--- a/src/course-outline/outline-sidebar/info-sidebar/CourseInfoSidebar.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/CourseInfoSidebar.tsx
@@ -1,3 +1,4 @@
+import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Tab,
@@ -6,10 +7,10 @@ import {
 } from '@openedx/paragon';
 import { SchoolOutline, Tag } from '@openedx/paragon/icons';
 
-import { useUserPermissions } from '@src/authz/data/apiHooks';
-import { COURSE_PERMISSIONS } from '@src/authz/constants';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import * as permissionHelpers from '@src/authz/permissionHelpers';
 import { ContentTagsDrawerSheet, ContentTagsSnippet } from '@src/content-tags-drawer';
-import { useCourseSettings, useWaffleFlags } from '@src/data/apiHooks';
+import { useCourseSettings } from '@src/data/apiHooks';
 import { ComponentCountSnippet } from '@src/generic/block-type-utils';
 import { HelpSidebarLink, otherLinkURLParams, messages as helpSidebarMessages } from '@src/generic/help-sidebar';
 import { SidebarContent, SidebarSection, SidebarTitle } from '@src/generic/sidebar';
@@ -73,60 +74,76 @@ const SettingsTab = () => {
     scheduleAndDetails,
     groupConfigurations,
   } = otherLinkURLParams;
-  const waffleFlags = useWaffleFlags(courseId);
-
   const proctoredExamSettingsUrl = courseSettingsData?.mfeProctoredExamSettingsUrl;
 
   /*
     AuthZ for Course Authoring
     If authz.enable_course_authoring flag is enabled, validate permissions using AuthZ API.
   */
-  const isAuthzEnabled = waffleFlags.enableAuthzCourseAuthoring;
-  const { isLoading: isLoadingUserPermissions, data: userPermissions } = useUserPermissions({
-    canManageAdvancedSettings: {
-      action: COURSE_PERMISSIONS.MANAGE_ADVANCED_SETTINGS,
-      scope: courseId,
-    },
-  }, isAuthzEnabled);
-
-  // If it's still loading, don't show the Advanced Settings link, otherwise, use the permission to decide
-  const authzCanManageAdvancedSettings = isLoadingUserPermissions
-    ? false
-    : !!userPermissions?.canManageAdvancedSettings;
-
-  // When authz is enabled, use permission, otherwise it's always allowed (legacy behavior)
-  const canManageAdvancedSettings = isAuthzEnabled ? authzCanManageAdvancedSettings : true;
+  const {
+    isAuthzEnabled,
+    canViewScheduleAndDetails,
+    canViewGradingSettings,
+    canViewCourseTeam,
+    canManageGroupConfigurations,
+    canManageAdvancedSettings,
+  } = useCourseUserPermissions(courseId, {
+    ...permissionHelpers.getScheduleAndDetailsPermissions(courseId),
+    ...permissionHelpers.getGradingPermissions(courseId),
+    ...permissionHelpers.getCourseTeamPermissions(courseId),
+    ...permissionHelpers.getGroupConfigurationsPermissions(courseId),
+    ...permissionHelpers.getAdvancedSettingsPermissions(courseId),
+  });
 
   return (
     <SidebarSection
       title={intl.formatMessage(messages.settingsTabText)}
     >
-      <HelpSidebarLink
-        as="span"
-        pathToPage={`/course/${courseId}/${scheduleAndDetails}`}
-        title={intl.formatMessage(
-          helpSidebarMessages.sidebarLinkToScheduleAndDetails,
-        )}
-        isNewPage
-      />
-      <HelpSidebarLink
-        as="span"
-        pathToPage={`/course/${courseId}/${grading}`}
-        title={intl.formatMessage(helpSidebarMessages.sidebarLinkToGrading)}
-        isNewPage
-      />
-      <HelpSidebarLink
-        as="span"
-        pathToPage={`/course/${courseId}/${courseTeam}`}
-        title={intl.formatMessage(helpSidebarMessages.sidebarLinkToCourseTeam)}
-        isNewPage
-      />
-      <HelpSidebarLink
-        as="span"
-        pathToPage={`/course/${courseId}/${groupConfigurations}`}
-        title={intl.formatMessage(helpSidebarMessages.sidebarLinkToGroupConfigurations)}
-        isNewPage
-      />
+      {canViewScheduleAndDetails && (
+        <HelpSidebarLink
+          as="span"
+          pathToPage={`/course/${courseId}/${scheduleAndDetails}`}
+          title={intl.formatMessage(
+            helpSidebarMessages.sidebarLinkToScheduleAndDetails,
+          )}
+          isNewPage
+        />
+      )}
+      {canViewGradingSettings && (
+        <HelpSidebarLink
+          as="span"
+          pathToPage={`/course/${courseId}/${grading}`}
+          title={intl.formatMessage(helpSidebarMessages.sidebarLinkToGrading)}
+          isNewPage
+        />
+      )}
+      {canViewCourseTeam && (
+        isAuthzEnabled ?
+          (
+            <HelpSidebarLink
+              as="span"
+              pathToPage={`${getConfig().ADMIN_CONSOLE_URL}/authz?scope=${encodeURIComponent(courseId)}`}
+              title={intl.formatMessage(helpSidebarMessages.sidebarLinkToRolesAndPermissions)}
+              isNewPage={false}
+            />
+          ) :
+          (
+            <HelpSidebarLink
+              as="span"
+              pathToPage={`/course/${courseId}/${courseTeam}`}
+              title={intl.formatMessage(helpSidebarMessages.sidebarLinkToCourseTeam)}
+              isNewPage
+            />
+          )
+      )}
+      {canManageGroupConfigurations && (
+        <HelpSidebarLink
+          as="span"
+          pathToPage={`/course/${courseId}/${groupConfigurations}`}
+          title={intl.formatMessage(helpSidebarMessages.sidebarLinkToGroupConfigurations)}
+          isNewPage
+        />
+      )}
       {canManageAdvancedSettings && (
         <HelpSidebarLink
           as="span"

--- a/src/course-outline/outline-sidebar/info-sidebar/CourseInfoSidebar.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/CourseInfoSidebar.tsx
@@ -80,14 +80,7 @@ const SettingsTab = () => {
     AuthZ for Course Authoring
     If authz.enable_course_authoring flag is enabled, validate permissions using AuthZ API.
   */
-  const {
-    isAuthzEnabled,
-    canViewScheduleAndDetails,
-    canViewGradingSettings,
-    canViewCourseTeam,
-    canManageGroupConfigurations,
-    canManageAdvancedSettings,
-  } = useCourseUserPermissions(courseId, {
+  const perms = useCourseUserPermissions(courseId, {
     ...permissionHelpers.getScheduleAndDetailsPermissions(courseId),
     ...permissionHelpers.getGradingPermissions(courseId),
     ...permissionHelpers.getCourseTeamPermissions(courseId),
@@ -99,7 +92,7 @@ const SettingsTab = () => {
     <SidebarSection
       title={intl.formatMessage(messages.settingsTabText)}
     >
-      {canViewScheduleAndDetails && (
+      {perms.canViewScheduleAndDetails && (
         <HelpSidebarLink
           as="span"
           pathToPage={`/course/${courseId}/${scheduleAndDetails}`}
@@ -109,7 +102,7 @@ const SettingsTab = () => {
           isNewPage
         />
       )}
-      {canViewGradingSettings && (
+      {perms.canViewGradingSettings && (
         <HelpSidebarLink
           as="span"
           pathToPage={`/course/${courseId}/${grading}`}
@@ -117,12 +110,12 @@ const SettingsTab = () => {
           isNewPage
         />
       )}
-      {canViewCourseTeam && (
+      {perms.canViewCourseTeam && (
         /*
           canViewCourseTeam is true both with the AuthZ permission and with the flag off (permissions
           fall back to true), so isAuthzEnabled picks the destination: Admin Console or legacy Course Team.
         */
-        isAuthzEnabled ?
+        perms.isAuthzEnabled ?
           (
             <HelpSidebarLink
               as="span"
@@ -140,7 +133,7 @@ const SettingsTab = () => {
             />
           )
       )}
-      {canManageGroupConfigurations && (
+      {perms.canManageGroupConfigurations && (
         <HelpSidebarLink
           as="span"
           pathToPage={`/course/${courseId}/${groupConfigurations}`}
@@ -148,7 +141,7 @@ const SettingsTab = () => {
           isNewPage
         />
       )}
-      {canManageAdvancedSettings && (
+      {perms.canManageAdvancedSettings && (
         <HelpSidebarLink
           as="span"
           pathToPage={`/course/${courseId}/${advancedSettings}`}

--- a/src/course-outline/outline-sidebar/info-sidebar/CourseInfoSidebar.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/CourseInfoSidebar.tsx
@@ -1,4 +1,3 @@
-import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Tab,
@@ -9,6 +8,7 @@ import { SchoolOutline, Tag } from '@openedx/paragon/icons';
 
 import { useCourseUserPermissions } from '@src/authz/hooks';
 import * as permissionHelpers from '@src/authz/permissionHelpers';
+import { getAdminConsoleScopeUrl } from '@src/authz/urls';
 import { ContentTagsDrawerSheet, ContentTagsSnippet } from '@src/content-tags-drawer';
 import { useCourseSettings } from '@src/data/apiHooks';
 import { ComponentCountSnippet } from '@src/generic/block-type-utils';
@@ -119,7 +119,7 @@ const SettingsTab = () => {
           (
             <HelpSidebarLink
               as="span"
-              pathToPage={`${getConfig().ADMIN_CONSOLE_URL}/authz?scope=${encodeURIComponent(courseId)}`}
+              pathToPage={getAdminConsoleScopeUrl(courseId)}
               title={intl.formatMessage(helpSidebarMessages.sidebarLinkToRolesAndPermissions)}
               isNewPage
             />

--- a/src/course-outline/outline-sidebar/info-sidebar/CourseInfoSidebar.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/CourseInfoSidebar.tsx
@@ -118,13 +118,17 @@ const SettingsTab = () => {
         />
       )}
       {canViewCourseTeam && (
+        /*
+          canViewCourseTeam is true both with the AuthZ permission and with the flag off (permissions
+          fall back to true), so isAuthzEnabled picks the destination: Admin Console or legacy Course Team.
+        */
         isAuthzEnabled ?
           (
             <HelpSidebarLink
               as="span"
               pathToPage={`${getConfig().ADMIN_CONSOLE_URL}/authz?scope=${encodeURIComponent(courseId)}`}
               title={intl.formatMessage(helpSidebarMessages.sidebarLinkToRolesAndPermissions)}
-              isNewPage={false}
+              isNewPage
             />
           ) :
           (

--- a/src/course-team/CourseTeam.test.tsx
+++ b/src/course-team/CourseTeam.test.tsx
@@ -1,4 +1,5 @@
 import userEvent from '@testing-library/user-event';
+import { getConfig, setConfig } from '@edx/frontend-platform';
 import {
   screen,
   initializeMocks,
@@ -7,6 +8,7 @@ import {
 } from '@src/testUtils';
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
 import { USER_ROLES } from '@src/constants';
+import { mockWaffleFlags } from '@src/data/apiHooks.mock';
 
 import { courseTeamMock, courseTeamWithOneUser, courseTeamWithoutUsers } from './__mocks__';
 import { getCourseTeamApiUrl, updateCourseTeamUserApiUrl } from './data/api';
@@ -15,8 +17,10 @@ import messages from './messages';
 import addUserFormMessages from './add-user-form/messages';
 
 let axiosMock;
+let validateUserPermissionsMock;
 const mockPathname = '/foo-bar';
 const courseId = '123';
+const adminConsoleUrl = 'https://admin-console.example.com';
 
 const render = () =>
   baseRender(
@@ -27,9 +31,28 @@ const render = () =>
   );
 
 describe('<CourseTeam />', () => {
+  const originalLocation = window.location;
+  const mockLocationReplace = jest.fn();
+
+  beforeAll(() => {
+    // jsdom's window.location is read-only, so swap it for one whose replace() we can assert on.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: Object.assign(Object.create(Object.getPrototypeOf(originalLocation)), originalLocation, {
+        replace: mockLocationReplace,
+      }),
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+  });
+
   beforeEach(() => {
     const mocks = initializeMocks();
     axiosMock = mocks.axiosMock;
+    validateUserPermissionsMock = mocks.validateUserPermissionsMock;
+    mockWaffleFlags();
   });
 
   it('render CourseTeam component with 3 team members correctly', async () => {
@@ -239,5 +262,53 @@ describe('<CourseTeam />', () => {
     render();
 
     expect(await screen.findByRole('alert')).toBeInTheDocument();
+  });
+
+  describe('when authz is enabled for the course', () => {
+    beforeEach(() => {
+      setConfig({ ...getConfig(), ADMIN_CONSOLE_URL: adminConsoleUrl });
+      mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+      axiosMock
+        .onGet(getCourseTeamApiUrl(courseId))
+        .reply(200, courseTeamMock);
+    });
+
+    it('redirects to the admin console instead of rendering the course team page', async () => {
+      validateUserPermissionsMock.mockResolvedValue({ canViewCourseTeam: true });
+
+      render();
+
+      await waitFor(() => {
+        expect(window.location.replace).toHaveBeenCalledWith(
+          `${adminConsoleUrl}/authz?scope=${encodeURIComponent(courseId)}`,
+        );
+      });
+      expect(screen.queryByText(messages.headingTitle.defaultMessage)).not.toBeInTheDocument();
+    });
+
+    it('denies access without redirecting when the user cannot view the course team', async () => {
+      // The CMS denies the legacy API too, so the permission check must win over the 403 alert.
+      axiosMock
+        .onGet(getCourseTeamApiUrl(courseId))
+        .reply(403);
+      validateUserPermissionsMock.mockResolvedValue({ canViewCourseTeam: false });
+
+      render();
+
+      expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
+      expect(window.location.replace).not.toHaveBeenCalled();
+    });
+  });
+
+  it('renders the course team page when authz is disabled', async () => {
+    setConfig({ ...getConfig(), ADMIN_CONSOLE_URL: adminConsoleUrl });
+    axiosMock
+      .onGet(getCourseTeamApiUrl(courseId))
+      .reply(200, courseTeamMock);
+
+    render();
+
+    expect(await screen.findByText(messages.headingTitle.defaultMessage)).toBeInTheDocument();
+    expect(window.location.replace).not.toHaveBeenCalled();
   });
 });

--- a/src/course-team/CourseTeam.tsx
+++ b/src/course-team/CourseTeam.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Button,
@@ -7,11 +9,15 @@ import {
 import { Add as IconAdd } from '@openedx/paragon/icons';
 
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import { getCourseTeamPermissions } from '@src/authz/permissionHelpers';
 import InternetConnectionAlert from '@src/generic/internet-connection-alert';
 import SubHeader from '@src/generic/sub-header/SubHeader';
 import { USER_ROLES } from '@src/constants';
 import getPageHeadTitle from '@src/generic/utils';
 import ConnectionErrorAlert from '@src/generic/ConnectionErrorAlert';
+import PermissionDeniedAlert from '@src/generic/PermissionDeniedAlert';
+import Loading from '@src/generic/Loading';
 
 import messages from './messages';
 import CourseTeamSideBar from './course-team-sidebar/CourseTeamSidebar';
@@ -52,7 +58,35 @@ const CourseTeam = () => {
     handleChangeRoleUserSubmit,
   } = useCourseTeam();
 
+  /*
+  With authz enabled the team is managed in the admin console. Reaching
+  this page by direct URL redirects there for users with view team permissions.
+  */
+  const {
+    isLoading: isLoadingPermissions,
+    isAuthzEnabled,
+    canViewCourseTeam,
+  } = useCourseUserPermissions(courseId, getCourseTeamPermissions(courseId));
+
+  const shouldRedirectToAdminConsole = isAuthzEnabled && canViewCourseTeam;
+
+  useEffect(() => {
+    if (shouldRedirectToAdminConsole) {
+      const adminConsoleBaseUrl = getConfig().ADMIN_CONSOLE_URL;
+      window.location.replace(`${adminConsoleBaseUrl}/authz?scope=${encodeURIComponent(courseId)}`);
+    }
+  }, [shouldRedirectToAdminConsole, courseId]);
+
   document.title = getPageHeadTitle(courseName, intl.formatMessage(messages.headingTitle));
+
+  // The redirect is fired from the effect above, so keep the spinner up while the browser leaves.
+  if (isLoadingPermissions || shouldRedirectToAdminConsole) {
+    return <Loading />;
+  }
+
+  if (!canViewCourseTeam) {
+    return <PermissionDeniedAlert />;
+  }
 
   if (isLoadingDenied) {
     return (

--- a/src/course-team/CourseTeam.tsx
+++ b/src/course-team/CourseTeam.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Button,
@@ -11,6 +10,7 @@ import { Add as IconAdd } from '@openedx/paragon/icons';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
 import { useCourseUserPermissions } from '@src/authz/hooks';
 import { getCourseTeamPermissions } from '@src/authz/permissionHelpers';
+import { getAdminConsoleScopeUrl } from '@src/authz/urls';
 import InternetConnectionAlert from '@src/generic/internet-connection-alert';
 import SubHeader from '@src/generic/sub-header/SubHeader';
 import { USER_ROLES } from '@src/constants';
@@ -72,8 +72,7 @@ const CourseTeam = () => {
 
   useEffect(() => {
     if (shouldRedirectToAdminConsole) {
-      const adminConsoleBaseUrl = getConfig().ADMIN_CONSOLE_URL;
-      window.location.replace(`${adminConsoleBaseUrl}/authz?scope=${encodeURIComponent(courseId)}`);
+      window.location.replace(getAdminConsoleScopeUrl(courseId));
     }
   }, [shouldRedirectToAdminConsole, courseId]);
 

--- a/src/generic/help-sidebar/HelpSidebar.test.tsx
+++ b/src/generic/help-sidebar/HelpSidebar.test.tsx
@@ -1,14 +1,13 @@
 import { waitFor } from '@testing-library/react';
 
-import { mockWaffleFlags } from '@src/data/apiHooks.mock';
-import { useUserPermissions } from '@src/authz/data/apiHooks';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 import { initializeMocks, render } from '@src/testUtils';
 
 import messages from './messages';
 import { HelpSidebar } from '.';
 
-jest.mock('@src/authz/data/apiHooks', () => ({
-  useUserPermissions: jest.fn(),
+jest.mock('@src/authz/hooks', () => ({
+  useCourseUserPermissions: jest.fn(),
 }));
 
 const mockPathname = '/foo-bar';
@@ -27,14 +26,23 @@ const props = {
   proctoredExamSettingsUrl: '',
 };
 
+/**
+ * Set the result of the course-scoped Advanced Settings permission check.
+ * HelpSidebar only reads `canManageAdvancedSettings`; the loading / authz-disabled
+ * fallbacks are owned (and tested) by useCourseUserPermissions itself.
+ */
+const mockAdvancedSettingsPermission = (canManageAdvancedSettings: boolean, isLoading = false) => {
+  jest.mocked(useCourseUserPermissions).mockReturnValue({
+    isLoading,
+    isAuthzEnabled: true,
+    canManageAdvancedSettings,
+  } as unknown as ReturnType<typeof useCourseUserPermissions>);
+};
+
 describe('HelpSidebar', () => {
   beforeEach(() => {
     initializeMocks();
-    // @ts-ignore
-    jest.mocked(useUserPermissions).mockReturnValue({
-      isLoading: false,
-      data: undefined,
-    });
+    mockAdvancedSettingsPermission(true);
   });
 
   it('renders children correctly', () => {
@@ -70,39 +78,20 @@ describe('HelpSidebar', () => {
     expect(getByText(messages.sidebarLinkToProctoredExamSettings.defaultMessage)).toBeTruthy();
   });
 
-  it('should render the advanced settings sidebar link when authz.enable_course_authoring flag is enabled and the user is authorized', async () => {
-    // Mock feature flag
-    mockWaffleFlags({ enableAuthzCourseAuthoring: true });
-    // Mock the useUserPermissions hook to return true for the authz.enable_course_authoring permission
-    // @ts-ignore
-    jest.mocked(useUserPermissions).mockReturnValue({
-      isLoading: false,
-      data: { canManageAdvancedSettings: true },
-    });
+  it('should render the advanced settings sidebar link when the user can manage advanced settings', async () => {
+    mockAdvancedSettingsPermission(true);
     const { queryByText } = renderHelpSidebar(props);
     await waitFor(() => expect(queryByText(messages.sidebarLinkToAdvancedSettings.defaultMessage)).toBeTruthy());
   });
-  it('should not render the advanced settings sidebar link when authz.enable_course_authoring flag is enabled and the user is not authorized', async () => {
-    // Mock feature flag
-    mockWaffleFlags({ enableAuthzCourseAuthoring: true });
-    // Mock the useUserPermissions hook to return true for the authz.enable_course_authoring permission
-    // @ts-ignore
-    jest.mocked(useUserPermissions).mockReturnValue({
-      isLoading: false,
-      data: { canManageAdvancedSettings: false },
-    });
+
+  it('should not render the advanced settings sidebar link when the user cannot manage advanced settings', async () => {
+    mockAdvancedSettingsPermission(false);
     const { queryByText } = renderHelpSidebar(props);
     await waitFor(() => expect(queryByText(messages.sidebarLinkToAdvancedSettings.defaultMessage)).toBeFalsy());
   });
-  it('should not render the advanced settings sidebar link when authz.enable_course_authoring flag is enabled and the permissions are still loading', async () => {
-    // Mock feature flag
-    mockWaffleFlags({ enableAuthzCourseAuthoring: true });
-    // Mock the useUserPermissions hook to return true for the authz.enable_course_authoring permission
-    // @ts-ignore
-    jest.mocked(useUserPermissions).mockReturnValue({
-      isLoading: true,
-      data: undefined,
-    });
+
+  it('should not render the advanced settings sidebar link while the permission check is loading', async () => {
+    mockAdvancedSettingsPermission(false, true);
     const { queryByText } = renderHelpSidebar(props);
     await waitFor(() => expect(queryByText(messages.sidebarLinkToAdvancedSettings.defaultMessage)).toBeFalsy());
   });

--- a/src/generic/help-sidebar/HelpSidebar.test.tsx
+++ b/src/generic/help-sidebar/HelpSidebar.test.tsx
@@ -27,22 +27,30 @@ const props = {
 };
 
 /**
- * Set the result of the course-scoped Advanced Settings permission check.
- * HelpSidebar only reads `canManageAdvancedSettings`; the loading / authz-disabled
- * fallbacks are owned (and tested) by useCourseUserPermissions itself.
+ * Set the result of the course-scoped permission checks used by the "Other course settings" links.
+ * The loading / authz-disabled fallbacks are owned (and tested) by useCourseUserPermissions itself,
+ * so tests state the resolved answers directly.
  */
-const mockAdvancedSettingsPermission = (canManageAdvancedSettings: boolean, isLoading = false) => {
+const mockCoursePermissions = (
+  permissions: Record<string, boolean> = {},
+  { isLoading = false, isAuthzEnabled = true } = {},
+) => {
   jest.mocked(useCourseUserPermissions).mockReturnValue({
     isLoading,
-    isAuthzEnabled: true,
-    canManageAdvancedSettings,
+    isAuthzEnabled,
+    canViewScheduleAndDetails: true,
+    canViewGradingSettings: true,
+    canViewCourseTeam: true,
+    canManageGroupConfigurations: true,
+    canManageAdvancedSettings: true,
+    ...permissions,
   } as unknown as ReturnType<typeof useCourseUserPermissions>);
 };
 
 describe('HelpSidebar', () => {
   beforeEach(() => {
     initializeMocks();
-    mockAdvancedSettingsPermission(true);
+    mockCoursePermissions({}, { isAuthzEnabled: false });
   });
 
   it('renders children correctly', () => {
@@ -78,21 +86,61 @@ describe('HelpSidebar', () => {
     expect(getByText(messages.sidebarLinkToProctoredExamSettings.defaultMessage)).toBeTruthy();
   });
 
-  it('should render the advanced settings sidebar link when the user can manage advanced settings', async () => {
-    mockAdvancedSettingsPermission(true);
-    const { queryByText } = renderHelpSidebar(props);
-    await waitFor(() => expect(queryByText(messages.sidebarLinkToAdvancedSettings.defaultMessage)).toBeTruthy());
-  });
+  describe('authz validation', () => {
+    it.each([
+      ['canViewScheduleAndDetails', messages.sidebarLinkToScheduleAndDetails],
+      ['canViewGradingSettings', messages.sidebarLinkToGrading],
+      ['canManageGroupConfigurations', messages.sidebarLinkToGroupConfigurations],
+      ['canManageAdvancedSettings', messages.sidebarLinkToAdvancedSettings],
+    ])('renders the %s link only when the permission is granted', async (permission, message) => {
+      mockCoursePermissions({ [permission]: true });
+      const { queryByText, unmount } = renderHelpSidebar(props);
+      await waitFor(() => expect(queryByText(message.defaultMessage)).toBeTruthy());
+      unmount();
 
-  it('should not render the advanced settings sidebar link when the user cannot manage advanced settings', async () => {
-    mockAdvancedSettingsPermission(false);
-    const { queryByText } = renderHelpSidebar(props);
-    await waitFor(() => expect(queryByText(messages.sidebarLinkToAdvancedSettings.defaultMessage)).toBeFalsy());
-  });
+      mockCoursePermissions({ [permission]: false });
+      const { queryByText: queryWithoutPermission } = renderHelpSidebar(props);
+      await waitFor(() => expect(queryWithoutPermission(message.defaultMessage)).toBeFalsy());
+    });
 
-  it('should not render the advanced settings sidebar link while the permission check is loading', async () => {
-    mockAdvancedSettingsPermission(false, true);
-    const { queryByText } = renderHelpSidebar(props);
-    await waitFor(() => expect(queryByText(messages.sidebarLinkToAdvancedSettings.defaultMessage)).toBeFalsy());
+    it('should render the roles and permissions link instead of course team when authz is enabled', async () => {
+      mockCoursePermissions({ canViewCourseTeam: true });
+      const { queryByText } = renderHelpSidebar(props);
+      await waitFor(() => expect(queryByText(messages.sidebarLinkToRolesAndPermissions.defaultMessage)).toBeTruthy());
+      expect(queryByText(messages.sidebarLinkToCourseTeam.defaultMessage)).toBeFalsy();
+    });
+
+    it('should render the course team link when authz is disabled', async () => {
+      mockCoursePermissions({}, { isAuthzEnabled: false });
+      const { queryByText } = renderHelpSidebar(props);
+      await waitFor(() => expect(queryByText(messages.sidebarLinkToCourseTeam.defaultMessage)).toBeTruthy());
+      expect(queryByText(messages.sidebarLinkToRolesAndPermissions.defaultMessage)).toBeFalsy();
+    });
+
+    it('should not render the team link when the user cannot view the course team', async () => {
+      mockCoursePermissions({ canViewCourseTeam: false });
+      const { queryByText } = renderHelpSidebar(props);
+      await waitFor(() => expect(queryByText(messages.sidebarLinkToRolesAndPermissions.defaultMessage)).toBeFalsy());
+      expect(queryByText(messages.sidebarLinkToCourseTeam.defaultMessage)).toBeFalsy();
+    });
+
+    it('should not render any of the gated links while the permission check is loading', async () => {
+      mockCoursePermissions({
+        canViewScheduleAndDetails: false,
+        canViewGradingSettings: false,
+        canViewCourseTeam: false,
+        canManageGroupConfigurations: false,
+        canManageAdvancedSettings: false,
+      }, { isLoading: true });
+      const { queryByText } = renderHelpSidebar(props);
+
+      await waitFor(() => {
+        expect(queryByText(messages.sidebarLinkToScheduleAndDetails.defaultMessage)).toBeFalsy();
+      });
+      expect(queryByText(messages.sidebarLinkToGrading.defaultMessage)).toBeFalsy();
+      expect(queryByText(messages.sidebarLinkToRolesAndPermissions.defaultMessage)).toBeFalsy();
+      expect(queryByText(messages.sidebarLinkToGroupConfigurations.defaultMessage)).toBeFalsy();
+      expect(queryByText(messages.sidebarLinkToAdvancedSettings.defaultMessage)).toBeFalsy();
+    });
   });
 });

--- a/src/generic/help-sidebar/HelpSidebar.tsx
+++ b/src/generic/help-sidebar/HelpSidebar.tsx
@@ -3,9 +3,8 @@ import { useLocation } from 'react-router-dom';
 import classNames from 'classnames';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
-import { useUserPermissions } from '@src/authz/data/apiHooks';
-import { COURSE_PERMISSIONS } from '@src/authz/constants';
-import { useWaffleFlags } from '../../data/apiHooks';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import { getAdvancedSettingsPermissions } from '@src/authz/permissionHelpers';
 import { otherLinkURLParams } from './constants';
 import messages from './messages';
 import HelpSidebarLink from './HelpSidebarLink';
@@ -34,29 +33,15 @@ const HelpSidebar = ({
     scheduleAndDetails,
     groupConfigurations,
   } = otherLinkURLParams;
-  const waffleFlags = useWaffleFlags(courseId);
-
   const showOtherLink = (params) => !pathname.includes(params);
 
   /*
     AuthZ for Course Authoring
-    If authz.enable_course_authoring flag is enabled, validate permissions using AuthZ API.
   */
-  const isAuthzEnabled = waffleFlags.enableAuthzCourseAuthoring;
-  const { isLoading: isLoadingUserPermissions, data: userPermissions } = useUserPermissions({
-    canManageAdvancedSettings: {
-      action: COURSE_PERMISSIONS.MANAGE_ADVANCED_SETTINGS,
-      scope: courseId,
-    },
-  }, isAuthzEnabled);
-
-  // If it's still loading, don't show the Advanced Settings link, otherwise, use the permission to decide
-  const authzCanManageAdvancedSettings = isLoadingUserPermissions
-    ? false
-    : !!userPermissions?.canManageAdvancedSettings;
-
-  // When authz is enabled, use permission, otherwise it's always allowed (legacy behavior)
-  const canManageAdvancedSettings = isAuthzEnabled ? authzCanManageAdvancedSettings : true;
+  const { canManageAdvancedSettings } = useCourseUserPermissions(
+    courseId,
+    getAdvancedSettingsPermissions(courseId),
+  );
 
   return (
     <aside className={classNames('help-sidebar', className)}>

--- a/src/generic/help-sidebar/HelpSidebar.tsx
+++ b/src/generic/help-sidebar/HelpSidebar.tsx
@@ -1,10 +1,11 @@
 import { type ReactNode } from 'react';
 import { useLocation } from 'react-router-dom';
 import classNames from 'classnames';
+import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { useCourseUserPermissions } from '@src/authz/hooks';
-import { getAdvancedSettingsPermissions } from '@src/authz/permissionHelpers';
+import * as permissionHelpers from '@src/authz/permissionHelpers';
 import { otherLinkURLParams } from './constants';
 import messages from './messages';
 import HelpSidebarLink from './HelpSidebarLink';
@@ -37,11 +38,15 @@ const HelpSidebar = ({
 
   /*
     AuthZ for Course Authoring
+    If authz.enable_course_authoring flag is enabled, validate permissions using AuthZ API.
   */
-  const { canManageAdvancedSettings } = useCourseUserPermissions(
-    courseId,
-    getAdvancedSettingsPermissions(courseId),
-  );
+  const perms = useCourseUserPermissions(courseId, {
+    ...permissionHelpers.getScheduleAndDetailsPermissions(courseId),
+    ...permissionHelpers.getGradingPermissions(courseId),
+    ...permissionHelpers.getCourseTeamPermissions(courseId),
+    ...permissionHelpers.getGroupConfigurationsPermissions(courseId),
+    ...permissionHelpers.getAdvancedSettingsPermissions(courseId),
+  });
 
   return (
     <aside className={classNames('help-sidebar', className)}>
@@ -58,7 +63,7 @@ const HelpSidebar = ({
               aria-label={intl.formatMessage(messages.sidebarTitleOther)}
             >
               <ul className="p-0 mb-0">
-                {showOtherLink(scheduleAndDetails) && (
+                {showOtherLink(scheduleAndDetails) && perms.canViewScheduleAndDetails && (
                   <HelpSidebarLink
                     pathToPage={`/course/${courseId}/${scheduleAndDetails}`}
                     title={intl.formatMessage(
@@ -67,21 +72,35 @@ const HelpSidebar = ({
                     isNewPage
                   />
                 )}
-                {showOtherLink(grading) && (
+                {showOtherLink(grading) && perms.canViewGradingSettings && (
                   <HelpSidebarLink
                     pathToPage={`/course/${courseId}/${grading}`}
                     title={intl.formatMessage(messages.sidebarLinkToGrading)}
                     isNewPage
                   />
                 )}
-                {showOtherLink(courseTeam) && (
-                  <HelpSidebarLink
-                    pathToPage={`/course/${courseId}/${courseTeam}`}
-                    title={intl.formatMessage(messages.sidebarLinkToCourseTeam)}
-                    isNewPage
-                  />
+                {showOtherLink(courseTeam) && perms.canViewCourseTeam && (
+                  /*
+                    canViewCourseTeam is true both with the AuthZ permission and with the flag off (permissions
+                    fall back to true), so isAuthzEnabled picks the destination: Admin Console or legacy Course Team.
+                  */
+                  perms.isAuthzEnabled ?
+                    (
+                      <HelpSidebarLink
+                        pathToPage={`${getConfig().ADMIN_CONSOLE_URL}/authz?scope=${encodeURIComponent(courseId)}`}
+                        title={intl.formatMessage(messages.sidebarLinkToRolesAndPermissions)}
+                        isNewPage
+                      />
+                    ) :
+                    (
+                      <HelpSidebarLink
+                        pathToPage={`/course/${courseId}/${courseTeam}`}
+                        title={intl.formatMessage(messages.sidebarLinkToCourseTeam)}
+                        isNewPage
+                      />
+                    )
                 )}
-                {showOtherLink(groupConfigurations) && (
+                {showOtherLink(groupConfigurations) && perms.canManageGroupConfigurations && (
                   <HelpSidebarLink
                     pathToPage={`/course/${courseId}/${groupConfigurations}`}
                     title={intl.formatMessage(
@@ -90,7 +109,7 @@ const HelpSidebar = ({
                     isNewPage
                   />
                 )}
-                {showOtherLink(advancedSettings) && canManageAdvancedSettings && (
+                {showOtherLink(advancedSettings) && perms.canManageAdvancedSettings && (
                   <HelpSidebarLink
                     pathToPage={`/course/${courseId}/${advancedSettings}`}
                     title={intl.formatMessage(messages.sidebarLinkToAdvancedSettings)}

--- a/src/generic/help-sidebar/HelpSidebar.tsx
+++ b/src/generic/help-sidebar/HelpSidebar.tsx
@@ -1,11 +1,11 @@
 import { type ReactNode } from 'react';
 import { useLocation } from 'react-router-dom';
 import classNames from 'classnames';
-import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { useCourseUserPermissions } from '@src/authz/hooks';
 import * as permissionHelpers from '@src/authz/permissionHelpers';
+import { getAdminConsoleScopeUrl } from '@src/authz/urls';
 import { otherLinkURLParams } from './constants';
 import messages from './messages';
 import HelpSidebarLink from './HelpSidebarLink';
@@ -87,7 +87,7 @@ const HelpSidebar = ({
                   perms.isAuthzEnabled ?
                     (
                       <HelpSidebarLink
-                        pathToPage={`${getConfig().ADMIN_CONSOLE_URL}/authz?scope=${encodeURIComponent(courseId)}`}
+                        pathToPage={getAdminConsoleScopeUrl(courseId)}
                         title={intl.formatMessage(messages.sidebarLinkToRolesAndPermissions)}
                         isNewPage
                       />

--- a/src/generic/help-sidebar/messages.ts
+++ b/src/generic/help-sidebar/messages.ts
@@ -20,6 +20,11 @@ const messages = defineMessages({
     defaultMessage: 'Course team',
     description: 'Link to Studio Course Team page',
   },
+  sidebarLinkToRolesAndPermissions: {
+    id: 'course-authoring.help-sidebar.links.roles-and-permissions',
+    defaultMessage: 'Roles and Permissions',
+    description: 'Link to Studio Roles and Permissions page',
+  },
   sidebarLinkToGroupConfigurations: {
     id: 'course-authoring.help-sidebar.links.group-configurations',
     defaultMessage: 'Group configurations',

--- a/src/header/hooks.test.tsx
+++ b/src/header/hooks.test.tsx
@@ -637,7 +637,7 @@ describe('header utils', () => {
           .current;
       expect(items).toContainEqual({
         title: 'Library Team',
-        href: 'http://admin-console.com/authz/libraries/library-123',
+        href: 'http://admin-console.com/authz?scope=library-123',
       });
     });
     it('should contain admin console url if set and readOnly is true', () => {
@@ -649,7 +649,7 @@ describe('header utils', () => {
         renderHook(() => useLibrarySettingsMenuItems('library-123', true), { wrapper: createWrapper() }).result.current;
       expect(items).toContainEqual({
         title: 'Library Team',
-        href: 'http://admin-console.com/authz/libraries/library-123',
+        href: 'http://admin-console.com/authz?scope=library-123',
       });
     });
   });

--- a/src/header/hooks.tsx
+++ b/src/header/hooks.tsx
@@ -12,6 +12,7 @@ import { LibQueryParamKeys } from '@src/library-authoring/routes';
 
 import { useCourseUserPermissions } from '@src/authz/hooks';
 import * as permissionHelpers from '@src/authz/permissionHelpers';
+import { getAdminConsoleScopeUrl, isAdminConsoleEnabled } from '@src/authz/urls';
 import messages from './messages';
 
 export const useContentMenuItems = (courseId: string) => {
@@ -115,7 +116,7 @@ export const useSettingMenuItems = (courseId: string) => {
       ? [
         perms.isAuthzEnabled
           ? {
-            href: `${getConfig().ADMIN_CONSOLE_URL}/authz?scope=${encodeURIComponent(courseId)}`,
+            href: getAdminConsoleScopeUrl(courseId),
             title: intl.formatMessage(messages['header.links.roles.permissions']),
           }
           : {
@@ -219,12 +220,11 @@ export const useLibrarySettingsMenuItems = (itemId: string, readOnly: boolean) =
   const intl = useIntl();
 
   const openTeamAccessModalUrl = () => {
-    const adminConsoleUrl = getConfig().ADMIN_CONSOLE_URL;
     // always show link to admin console MFE if it is being used
-    const shouldShowAdminConsoleLink = !!adminConsoleUrl;
+    const shouldShowAdminConsoleLink = isAdminConsoleEnabled();
 
     // if the admin console MFE isn't being used, show team modal button for non–read-only users
-    const shouldShowTeamModalButton = !adminConsoleUrl && !readOnly;
+    const shouldShowTeamModalButton = !shouldShowAdminConsoleLink && !readOnly;
     if (shouldShowTeamModalButton) {
       if (!window.location.href) {
         return null;
@@ -235,7 +235,7 @@ export const useLibrarySettingsMenuItems = (itemId: string, readOnly: boolean) =
       return url.toString();
     }
     if (shouldShowAdminConsoleLink) {
-      return `${adminConsoleUrl}/authz/libraries/${itemId}`;
+      return getAdminConsoleScopeUrl(itemId);
     }
     return null;
   };

--- a/src/library-authoring/library-info/LibraryInfo.test.tsx
+++ b/src/library-authoring/library-info/LibraryInfo.test.tsx
@@ -284,7 +284,10 @@ describe('<LibraryInfo />', () => {
     render();
     const manageTeam = await screen.findByText('Manage Access');
     expect(manageTeam).toBeInTheDocument();
-    expect(manageTeam).toHaveAttribute('href', `${ADMIN_CONSOLE_URL}/authz?scope=${libraryData.id}`);
+    expect(manageTeam).toHaveAttribute(
+      'href',
+      `${ADMIN_CONSOLE_URL}/authz?scope=${encodeURIComponent(libraryData.id)}`,
+    );
   });
 
   it('renders settings section title', () => {

--- a/src/library-authoring/library-info/LibraryInfo.tsx
+++ b/src/library-authoring/library-info/LibraryInfo.tsx
@@ -1,10 +1,10 @@
 import { useCallback } from 'react';
 import { Button, Hyperlink, Stack } from '@openedx/paragon';
-import { getConfig } from '@edx/frontend-platform';
 import { FormattedDate, useIntl } from '@edx/frontend-platform/i18n';
 
 import { CONTENT_LIBRARY_PERMISSIONS } from '@src/authz/constants';
 import { useUserPermissions } from '@src/authz/data/apiHooks';
+import { getAdminConsoleScopeUrl, isAdminConsoleEnabled } from '@src/authz/urls';
 import messages from './messages';
 import LibraryPublishStatus from './LibraryPublishStatus';
 import { useLibraryContext } from '../common/context/LibraryContext';
@@ -21,13 +21,11 @@ const LibraryInfo = () => {
       scope: libraryId,
     },
   }, typeof libraryId !== 'undefined');
-  const adminConsoleUrl = getConfig().ADMIN_CONSOLE_URL;
-
   // always show link to admin console MFE if it is being used
-  const shouldShowAdminConsoleLink = !!adminConsoleUrl;
+  const shouldShowAdminConsoleLink = isAdminConsoleEnabled();
 
   // if the admin console MFE isn't being used, show team modal button for non–read-only users
-  const shouldShowTeamModalButton = !adminConsoleUrl && !readOnly;
+  const shouldShowTeamModalButton = !shouldShowAdminConsoleLink && !readOnly;
 
   const openLibraryTeamModal = useCallback(() => {
     setSidebarAction(SidebarActions.ManageTeam);
@@ -49,7 +47,7 @@ const LibraryInfo = () => {
             as={Hyperlink}
             variant="outline-primary"
             className="my-3"
-            destination={`${adminConsoleUrl}/authz?scope=${libraryId}`}
+            destination={getAdminConsoleScopeUrl(libraryId)}
             target="_blank"
           >
             {intl.formatMessage(messages.libraryTeamButtonTitle)}

--- a/src/studio-home/StudioHome.test.tsx
+++ b/src/studio-home/StudioHome.test.tsx
@@ -1,6 +1,7 @@
 import * as reactRedux from 'react-redux';
 import { getConfig, setConfig } from '@edx/frontend-platform';
 import { mockWaffleFlags } from '@src/data/apiHooks.mock';
+import { useUserPermissions } from '@src/authz/data/apiHooks';
 
 import {
   fireEvent,
@@ -26,6 +27,18 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
 }));
 
+jest.mock('@src/authz/data/apiHooks', () => ({
+  useUserPermissions: jest.fn(),
+}));
+
+/** Set the result of the scope-less "can view any team" permission check. */
+const mockViewTeamPermissions = (data: Record<string, boolean>) => {
+  jest.mocked(useUserPermissions).mockReturnValue({
+    isLoading: false,
+    data,
+  } as unknown as ReturnType<typeof useUserPermissions>);
+};
+
 /** Helper function to get the Studio header in the rendered HTML */
 function getHeaderElement(): HTMLElement {
   const header = screen.getByRole('banner');
@@ -39,6 +52,7 @@ describe('<StudioHome />', () => {
       const mocks = initializeMocks();
       mocks.axiosMock.onGet(getStudioHomeApiUrl()).reply(404);
       mockUseSelector.mockReturnValue({ studioHomeLoadingStatus: RequestStatus.FAILED });
+      mockViewTeamPermissions({});
     });
 
     it('should render fetch error', async () => {
@@ -59,6 +73,7 @@ describe('<StudioHome />', () => {
       const mocks = initializeMocks();
       mocks.axiosMock.onGet(getStudioHomeApiUrl()).reply(200, studioHomeMock);
       mockUseSelector.mockReturnValue(studioHomeMock);
+      mockViewTeamPermissions({});
     });
 
     it('should render page and page title correctly', async () => {
@@ -90,17 +105,37 @@ describe('<StudioHome />', () => {
       within(header).getByRole('button', { name: 'New course' }); // will error if not found
     });
 
-    it('should render roles and permissions button when authz is enabled', async () => {
+    it.each([
+      ['course', { canViewCourseTeam: true, canViewLibraryTeam: false }],
+      ['library', { canViewCourseTeam: false, canViewLibraryTeam: true }],
+    ])('should render roles and permissions button when authz is enabled and the user can view a %s team', async (
+      _team,
+      permissions,
+    ) => {
       setConfig({
         ...getConfig(),
         ADMIN_CONSOLE_URL: 'https://admin-console.example.com',
       });
       mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+      mockViewTeamPermissions(permissions);
 
       render(<StudioHome />, { path: '/home' });
       const header = getHeaderElement();
       const rolesButton = within(header).getByRole('link', { name: 'Roles and permissions' });
       expect(rolesButton).toHaveAttribute('href', 'https://admin-console.example.com/authz');
+    });
+
+    it('should not render roles and permissions button when authz is enabled but the user cannot manage any team', async () => {
+      setConfig({
+        ...getConfig(),
+        ADMIN_CONSOLE_URL: 'https://admin-console.example.com',
+      });
+      mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+      mockViewTeamPermissions({ canViewCourseTeam: false, canViewLibraryTeam: false });
+
+      render(<StudioHome />, { path: '/home' });
+      const header = getHeaderElement();
+      expect(within(header).queryByRole('link', { name: 'Roles and permissions' })).not.toBeInTheDocument();
     });
 
     it('should not render roles and permissions button when authz is disabled', async () => {
@@ -109,6 +144,7 @@ describe('<StudioHome />', () => {
         ADMIN_CONSOLE_URL: 'https://admin-console.example.com',
       });
       mockWaffleFlags({ enableAuthzCourseAuthoring: false });
+      mockViewTeamPermissions({ canViewCourseTeam: true, canViewLibraryTeam: true });
 
       render(<StudioHome />, { path: '/home' });
       const header = getHeaderElement();

--- a/src/studio-home/StudioHome.test.tsx
+++ b/src/studio-home/StudioHome.test.tsx
@@ -33,10 +33,12 @@ jest.mock('@src/authz/data/apiHooks', () => ({
 
 /** Set the result of the scope-less "can view any team" permission check. */
 const mockViewTeamPermissions = (data: Record<string, boolean>) => {
-  jest.mocked(useUserPermissions).mockReturnValue({
+  // Mirror production: the query is skipped (data undefined) unless it is enabled,
+  // which happens only when authz is on and the admin console URL is configured.
+  jest.mocked(useUserPermissions).mockImplementation((_permissions, enabled = true) => ({
     isLoading: false,
-    data,
-  } as unknown as ReturnType<typeof useUserPermissions>);
+    data: enabled ? data : undefined,
+  } as unknown as ReturnType<typeof useUserPermissions>));
 };
 
 /** Helper function to get the Studio header in the rendered HTML */

--- a/src/studio-home/StudioHome.tsx
+++ b/src/studio-home/StudioHome.tsx
@@ -14,6 +14,8 @@ import { StudioFooterSlot } from '@edx/frontend-component-footer';
 import { Link, useLocation } from 'react-router-dom';
 
 import { useWaffleFlags } from '@src/data/apiHooks';
+import { useUserPermissions } from '@src/authz/data/apiHooks';
+import { getViewTeamPermissions } from '@src/authz/permissionHelpers';
 import Loading from '../generic/Loading';
 import InternetConnectionAlert from '../generic/internet-connection-alert';
 import Header from '../header';
@@ -49,7 +51,19 @@ const StudioHome = () => {
 
   const waffleFlags = useWaffleFlags();
   const isAuthzEnabled = waffleFlags?.enableAuthzCourseAuthoring ?? false;
-  const adminConsoleUrl = `${getConfig().ADMIN_CONSOLE_URL}/authz`;
+  const adminConsoleBaseUrl = getConfig().ADMIN_CONSOLE_URL;
+  const adminConsoleUrl = `${adminConsoleBaseUrl}/authz`;
+
+  // The "Roles & Permissions" button links to the admin console, so only show it to users
+  // who can view a team somewhere: on any course (view_course_team) or any library
+  // (view_library_team).
+  const { data: viewTeamPermissions } = useUserPermissions(
+    getViewTeamPermissions(),
+    isAuthzEnabled && !!adminConsoleBaseUrl,
+  );
+  const canViewConsoleTeams = Boolean(
+    viewTeamPermissions?.canViewCourseTeam || viewTeamPermissions?.canViewLibraryTeam,
+  );
 
   const {
     userIsActive,
@@ -70,7 +84,7 @@ const StudioHome = () => {
       );
     }
 
-    if (isAuthzEnabled && getConfig().ADMIN_CONSOLE_URL) {
+    if (isAuthzEnabled && adminConsoleBaseUrl && canViewConsoleTeams) {
       headerButtons.push(
         <div className="border-right mr-3 pr-4 py-2">
           <Button
@@ -116,7 +130,7 @@ const StudioHome = () => {
     }
 
     return headerButtons;
-  }, [location, userIsActive, isFailedLoadingPage, isAuthzEnabled]);
+  }, [location, userIsActive, isFailedLoadingPage, isAuthzEnabled, adminConsoleBaseUrl, canViewConsoleTeams]);
 
   const headerButtons = userIsActive ? getHeaderButtons() : [];
   if (isLoadingPage && !isFiltered) {

--- a/src/studio-home/StudioHome.tsx
+++ b/src/studio-home/StudioHome.tsx
@@ -84,7 +84,7 @@ const StudioHome = () => {
       );
     }
 
-    if (isAuthzEnabled && adminConsoleBaseUrl && canViewConsoleTeams) {
+    if (canViewConsoleTeams) {
       headerButtons.push(
         <div className="border-right mr-3 pr-4 py-2">
           <Button
@@ -130,7 +130,7 @@ const StudioHome = () => {
     }
 
     return headerButtons;
-  }, [location, userIsActive, isFailedLoadingPage, isAuthzEnabled, adminConsoleBaseUrl, canViewConsoleTeams]);
+  }, [location, userIsActive, isFailedLoadingPage, canViewConsoleTeams]);
 
   const headerButtons = userIsActive ? getHeaderButtons() : [];
   if (isLoadingPage && !isFiltered) {

--- a/src/studio-home/StudioHome.tsx
+++ b/src/studio-home/StudioHome.tsx
@@ -9,13 +9,13 @@ import {
 } from '@openedx/paragon';
 import { Add as AddIcon, Error, ManageAccounts } from '@openedx/paragon/icons';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
-import { getConfig } from '@edx/frontend-platform';
 import { StudioFooterSlot } from '@edx/frontend-component-footer';
 import { Link, useLocation } from 'react-router-dom';
 
 import { useWaffleFlags } from '@src/data/apiHooks';
 import { useUserPermissions } from '@src/authz/data/apiHooks';
 import { getViewTeamPermissions } from '@src/authz/permissionHelpers';
+import { getAdminConsoleUrl, isAdminConsoleEnabled } from '@src/authz/urls';
 import Loading from '../generic/Loading';
 import InternetConnectionAlert from '../generic/internet-connection-alert';
 import Header from '../header';
@@ -51,15 +51,14 @@ const StudioHome = () => {
 
   const waffleFlags = useWaffleFlags();
   const isAuthzEnabled = waffleFlags?.enableAuthzCourseAuthoring ?? false;
-  const adminConsoleBaseUrl = getConfig().ADMIN_CONSOLE_URL;
-  const adminConsoleUrl = `${adminConsoleBaseUrl}/authz`;
+  const adminConsoleUrl = getAdminConsoleUrl();
 
   // The "Roles & Permissions" button links to the admin console, so only show it to users
   // who can view a team somewhere: on any course (view_course_team) or any library
   // (view_library_team).
   const { data: viewTeamPermissions } = useUserPermissions(
     getViewTeamPermissions(),
-    isAuthzEnabled && !!adminConsoleBaseUrl,
+    isAuthzEnabled && isAdminConsoleEnabled(),
   );
   const canViewConsoleTeams = Boolean(
     viewTeamPermissions?.canViewCourseTeam || viewTeamPermissions?.canViewLibraryTeam,


### PR DESCRIPTION
## Description

This PR updates all course-scoped permission checks to use `useCourseUserPermissions`, ensuring a consistent permissions model across course-specific areas.

Additionally, it guards the **Roles & Permissions** button on the Home page so it is only rendered for users with permission to view team members in at least one course or library.

**Implemented changes**
- Centralized course-scoped permission checks on `useCourseUserPermissions`. Replaced the repeated `useUserPermissions + useWaffleFlags + manual isAuthzEnabled/loading/fallback` boilerplate in course-scoped contexts with the `useCourseUserPermissions` hook, which folds the waffle-flag gate, loading state, and "authz-disabled ⇒ allow (legacy behavior)" fallback into one place. Applied to:
  - HelpSidebar
  - AdvancedSettings
  - CourseInfoSidebar (course outline Settings tab)
- Validated per-link access in the course Settings sidebar. CourseInfoSidebar's Settings tab previously only gated the Advanced settings link. It now validates each link against its own permission — Schedule & details, Grading, Course team, Group configurations, and Advanced settings — mirroring the header navigation.
- Fixed the Studio Home "Roles & Permissions" button visibility. The button previously appeared for any user whenever AuthZ + ADMIN_CONSOLE_URL were configured. It now only shows to users who can actually view a team somewhere with `view_course_team` on any course or `view_library_team` on any library.
- Hardened the hook against unscoped queries. `useCourseUserPermissions` now only issues the permission query when both AuthZ is enabled and a courseId is present (shouldValidatePermissions), avoiding unscoped permission lookups.

## Supporting information

- Closes https://github.com/openedx/frontend-app-authoring/issues/3131
- Closes https://github.com/openedx/frontend-app-authoring/issues/3148

## Testing instructions

- Enter to Studio with a user without permissions, Roles and Permissions button should not be visible. Only 1 request should be launch to `validate/me`, no scope in there.

**No permissions**
<img width="1767" height="1066" alt="image" src="https://github.com/user-attachments/assets/7cf664c6-f948-4e22-a5ed-8c65b8f3b4c2" />

**Allowed view team**
<img width="1767" height="1066" alt="image" src="https://github.com/user-attachments/assets/fd03101f-3bbf-4758-849e-0bac682f5dd6" />


- Enter a course with the flag off and open settings in the sidebar, you should see Course Team link.
<img width="530" height="723" alt="image" src="https://github.com/user-attachments/assets/ba0c791b-1461-43d9-b534-2c363af82fc0" />
<img width="1149" height="81" alt="image" src="https://github.com/user-attachments/assets/25388f60-3eda-43a7-a3bf-4115ebeec774" />

- Enter a course with flag on and open settings in the sidebar, you should see Roles and Permissions link.
<img width="530" height="723" alt="image" src="https://github.com/user-attachments/assets/4828033f-78b7-4e76-89d0-aea0695a5724" />

- Validations in Advance Setting should behave as the original PR https://github.com/openedx/frontend-app-authoring/pull/2869


## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
