### PR TITLE
feat: add export button for legacy libraries in migration wizard

### DIFF
--- a/src/studio-home/card-item/CardItem.test.tsx
+++ b/src/studio-home/card-item/CardItem.test.tsx
@@ -73,6 +73,20 @@ describe('<CardItem />', () => {
     expect(screen.queryByText(messages.viewLiveBtnText.defaultMessage)).not.toBeInTheDocument();
   });
 
+  it('should render export button for library card when exportUrl is provided', async () => {
+    const props = { ...studioHomeMock.archivedCourses[0], isLibraries: true };
+    const exportUrl = 'http://localhost:18010/export/library-v1:LSE+123';
+    render(<CardItem {...props} exportUrl={exportUrl} />);
+    const exportBtn = screen.getByRole('link', { name: messages.exportLibraryBtnText.defaultMessage });
+    expect(exportBtn).toHaveAttribute('href', exportUrl);
+  });
+
+  it('should not render export button when exportUrl is not provided', () => {
+    const props = { ...studioHomeMock.archivedCourses[0], isLibraries: true };
+    render(<CardItem {...props} />);
+    expect(screen.queryByRole('link', { name: messages.exportLibraryBtnText.defaultMessage })).not.toBeInTheDocument();
+  });
+
   it('should render course key if displayname is empty', () => {
     const props = studioHomeMock.courses[1];
     const courseKeyTest = 'course-key';

--- a/src/studio-home/card-item/index.tsx
+++ b/src/studio-home/card-item/index.tsx
@@ -121,7 +121,7 @@ const CardTitle: React.FC<CardTitleProps> = ({
   return getTitle();
 };
 
-const ExportButton = ({ exportUrl, itemId }: { exportUrl: string; itemId?: string }) => {
+const ExportButton = ({ exportUrl, itemId }: { exportUrl: string; itemId?: string; }) => {
   const intl = useIntl();
   const label = intl.formatMessage(messages.exportLibraryBtnText);
   return (
@@ -339,9 +339,7 @@ export const CardItem: React.FC<Props> = ({
               />
             ) :
             exportUrl ?
-            (
-              <ExportButton exportUrl={exportUrl} itemId={itemId} />
-            ) :
+            <ExportButton exportUrl={exportUrl} itemId={itemId} /> :
             (
               <CardMenu
                 showMenu={showActionsMenu}

--- a/src/studio-home/card-item/index.tsx
+++ b/src/studio-home/card-item/index.tsx
@@ -6,14 +6,17 @@ import React, {
 } from 'react';
 import { useSelector } from 'react-redux';
 import {
+  Button,
   Card,
   Dropdown,
   Icon,
   Form,
   IconButton,
+  OverlayTrigger,
   Stack,
+  Tooltip,
 } from '@openedx/paragon';
-import { ArrowForward, MoreHoriz } from '@openedx/paragon/icons';
+import { ArrowForward, Download, MoreHoriz } from '@openedx/paragon/icons';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
 import { Link } from 'react-router-dom';
@@ -118,6 +121,26 @@ const CardTitle: React.FC<CardTitleProps> = ({
   return getTitle();
 };
 
+const ExportButton = ({ exportUrl, itemId }: { exportUrl: string; itemId?: string }) => {
+  const intl = useIntl();
+  const label = intl.formatMessage(messages.exportLibraryBtnText);
+  return (
+    <OverlayTrigger
+      placement="top"
+      overlay={<Tooltip id={`export-${itemId}`}>{label}</Tooltip>}
+    >
+      <Button
+        variant="tertiary"
+        size="sm"
+        href={exportUrl}
+        aria-label={label}
+      >
+        <Icon src={Download} />
+      </Button>
+    </OverlayTrigger>
+  );
+};
+
 interface CardMenuProps {
   showMenu: boolean;
   isShowRerunLink?: boolean;
@@ -204,6 +227,7 @@ interface BaseProps {
   isSelected?: boolean;
   itemId?: string;
   scrollIntoView?: boolean;
+  exportUrl?: string;
 }
 
 type Props =
@@ -241,6 +265,7 @@ export const CardItem: React.FC<Props> = ({
   titleSecondaryLink,
   cardStatusWidget,
   scrollIntoView = false,
+  exportUrl,
 }) => {
   const {
     allowCourseReruns,
@@ -312,6 +337,10 @@ export const CardItem: React.FC<Props> = ({
                 selectMode={selectMode}
                 title={title}
               />
+            ) :
+            exportUrl ?
+            (
+              <ExportButton exportUrl={exportUrl} itemId={itemId} />
             ) :
             (
               <CardMenu

--- a/src/studio-home/data/api.ts
+++ b/src/studio-home/data/api.ts
@@ -59,8 +59,7 @@ export async function getStudioHomeLibraries(): Promise<LibrariesV1ListData> {
   return camelCaseObject(data);
 }
 
-export const getLibraryV1ExportUrl = (libraryKey: string) =>
-  new URL(`export/${libraryKey}`, getApiBaseUrl()).href;
+export const getLibraryV1ExportUrl = (libraryKey: string) => new URL(`export/${libraryKey}`, getApiBaseUrl()).href;
 
 /**
  * Handle course notification requests.

--- a/src/studio-home/data/api.ts
+++ b/src/studio-home/data/api.ts
@@ -59,6 +59,9 @@ export async function getStudioHomeLibraries(): Promise<LibrariesV1ListData> {
   return camelCaseObject(data);
 }
 
+export const getLibraryV1ExportUrl = (libraryKey: string) =>
+  new URL(`export/${libraryKey}`, getApiBaseUrl()).href;
+
 /**
  * Handle course notification requests.
  */

--- a/src/studio-home/messages.ts
+++ b/src/studio-home/messages.ts
@@ -58,6 +58,11 @@ const messages = defineMessages({
     id: 'course-authoring.studio-home.btn.view-live.text',
     defaultMessage: 'View live',
   },
+  exportLibraryBtnText: {
+    id: 'course-authoring.studio-home.btn.export-library.text',
+    defaultMessage: 'Export',
+    description: 'Aria-label and tooltip text for the export button on legacy library cards.',
+  },
   organizationTitle: {
     id: 'course-authoring.studio-home.organization.title',
     defaultMessage: 'Organization and library settings',

--- a/src/studio-home/tabs-section/libraries-tab/index.tsx
+++ b/src/studio-home/tabs-section/libraries-tab/index.tsx
@@ -19,6 +19,7 @@ import { useLibrariesV1Data } from '@src/studio-home/data/apiHooks';
 import { CardItem, MakeLinkOrSpan, PrevToNextName } from '@src/studio-home/card-item';
 import SearchFilterWidget from '@src/search-manager/SearchFilterWidget';
 import type { LibraryV1Data } from '@src/studio-home/data/api';
+import { getLibraryV1ExportUrl } from '@src/studio-home/data/api';
 import { parseLibraryKey } from '@src/generic/key-utils';
 
 import messages from '../messages';
@@ -75,6 +76,7 @@ const CardList = ({
           selectMode={inSelectMode ? 'multiple' : undefined}
           selectPosition={inSelectMode ? 'title' : undefined}
           isSelected={selectedIds?.includes(libraryKey)}
+          exportUrl={getLibraryV1ExportUrl(libraryKey)}
           subtitleWrapper={isMigrated ? subtitleWrapper : null}
           titleSecondaryLink={(isMigrated && migratedToTitle) ?
             (


### PR DESCRIPTION
## Description:
In this PR we added the option to allow exports of legacy libraries.
Details can be found on the ticket.

Ticket: https://github.com/openedx/frontend-app-authoring/issues/2911#issuecomment-5027611624

## How to test this PR:
- Go to studio home page
- Go in Libraries tab, if you have legacy library available the "Review Legacy Library" option will appear on top message block.
- Go in "Review Legacy Library Library" will show "Migrate Legacy Libraries" page, each library option will show export button on right hand side.


## Testing Results:

<img width="1480" height="708" alt="Screenshot 2026-07-23 at 8 35 54 PM" src="https://github.com/user-attachments/assets/db49c6c4-5990-4121-a043-fb1d3d92e097" />

<img width="1496" height="734" alt="Screenshot 2026-07-23 at 8 21 22 PM" src="https://github.com/user-attachments/assets/b5e749e9-d141-4e45-935a-aa1b6167c642" />
<img width="1504" height="728" alt="Screenshot 2026-07-23 at 8 21 34 PM" src="https://github.com/user-attachments/assets/78f70bdc-acd5-4db4-9ade-f4e2d7abeab6" />
<img width="1493" height="816" alt="Screenshot 2026-07-23 at 8 22 02 PM" src="https://github.com/user-attachments/assets/92c4645c-21cd-40f4-8953-dd9eaedeee6b" />
