### PR TITLE
Fix pb-message boilerplate templates ignored by generic container

### DIFF
--- a/src/course-unit/add-component/AddComponent.test.tsx
+++ b/src/course-unit/add-component/AddComponent.test.tsx
@@ -745,6 +745,37 @@ describe('<AddComponent />', () => {
     expect(screen.getByRole('button')).not.toBeDisabled();
   });
 
+  it('passes boilerplate name when clicking a generic container block button', async () => {
+    axiosMock
+      .onGet(getCourseSectionVerticalApiUrl(blockId))
+      .reply(200, {
+        ...courseSectionVerticalMock,
+        component_templates: [
+          {
+            type: 'pb-message',
+            display_name: 'Message (complete)',
+            templates: [{ display_name: 'Message (complete)', category: 'pb-message', boilerplate_name: 'pb-message-complete' }],
+            support_legend: { show_legend: false },
+          },
+        ],
+      });
+    await executeThunk(fetchCourseSectionVerticalData(blockId), store.dispatch);
+
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.click(screen.getByRole('button', {
+      name: new RegExp(`${messages.buttonText.defaultMessage} Message \\(complete\\)`, 'i'),
+    }));
+
+    expect(handleCreateNewCourseXBlockMock).toHaveBeenCalledWith({
+      type: 'pb-message',
+      category: 'pb-message',
+      boilerplate: 'pb-message-complete',
+      parentLocator: blockId,
+    });
+  });
+
   describe('component support label', () => {
     it('component support label is hidden if component support legend is disabled', async () => {
       const supportLevels = ['fs', 'ps'];

--- a/src/course-unit/add-component/AddComponent.test.tsx
+++ b/src/course-unit/add-component/AddComponent.test.tsx
@@ -754,7 +754,11 @@ describe('<AddComponent />', () => {
           {
             type: 'pb-message',
             display_name: 'Message (complete)',
-            templates: [{ display_name: 'Message (complete)', category: 'pb-message', boilerplate_name: 'pb-message-complete' }],
+            templates: [{
+              display_name: 'Message (complete)',
+              category: 'pb-message',
+              boilerplate_name: 'pb-message-complete',
+            }],
             support_legend: { show_legend: false },
           },
         ],

--- a/src/course-unit/add-component/AddComponent.tsx
+++ b/src/course-unit/add-component/AddComponent.tsx
@@ -234,7 +234,10 @@ const AddComponent = ({
         // Pass boilerplate so that blocks with multiple templates (e.g. pb-message)
         // get initialised with the correct template content instead of the default.
         handleCreateNewCourseXBlock({
-          type, category: type, boilerplate: moduleName, parentLocator: blockId,
+          type,
+          category: type,
+          boilerplate: moduleName,
+          parentLocator: blockId,
         });
     }
   };

--- a/src/course-unit/add-component/AddComponent.tsx
+++ b/src/course-unit/add-component/AddComponent.tsx
@@ -231,7 +231,11 @@ const AddComponent = ({
         // Generic handler for container-specific block types declared via
         // StudioContainerWithNestedXBlocksMixin.allowed_nested_blocks that are
         // not one of the MFE's built-in component types (html, video, problem…).
-        handleCreateNewCourseXBlock({ type, category: type, parentLocator: blockId });
+        // Pass boilerplate so that blocks with multiple templates (e.g. pb-message)
+        // get initialised with the correct template content instead of the default.
+        handleCreateNewCourseXBlock({
+          type, category: type, boilerplate: moduleName, parentLocator: blockId,
+        });
     }
   };
 
@@ -283,7 +287,7 @@ const AddComponent = ({
                       return (
                         <li key={type}>
                           <AddComponentButton
-                            onClick={() => handleCreateNewXBlock(type)}
+                            onClick={() => handleCreateNewXBlock(type, firstTemplate?.boilerplateName)}
                             displayName={displayName}
                             type={type}
                             beta={beta}

--- a/src/course-unit/add-component/AddComponent.tsx
+++ b/src/course-unit/add-component/AddComponent.tsx
@@ -18,6 +18,7 @@ import { useEventListener } from '@src/generic/hooks';
 import VideoSelectorPage from '@src/editors/VideoSelectorPage';
 import EditorPage from '@src/editors/EditorPage';
 import { SelectedComponent } from '@src/library-authoring';
+import { type CreateCourseXBlockParams } from '@src/course-unit/hooks';
 import { fetchCourseSectionVerticalData } from '../data/thunk';
 import { messageTypes } from '../constants';
 import messages from './messages';
@@ -31,7 +32,7 @@ type ComponentTemplateData = {
   type: string;
   beta?: boolean;
   templates: Array<{
-    boilerplateName?: string;
+    boilerplateName?: string | null;
     category?: string;
     displayName: string;
     supportLevel?: string | boolean;
@@ -57,7 +58,7 @@ export interface AddComponentProps {
   isGenericContainerType?: boolean;
   parentLocator: string;
   handleCreateNewCourseXBlock: (
-    args: object,
+    args: CreateCourseXBlockParams,
     callback?: (args: { courseKey: string; locator: string; }) => void,
   ) => void;
   isProblemBankType?: boolean;
@@ -148,7 +149,7 @@ const AddComponent = ({
     closeAddLibraryContentModal();
   }, [usageId]);
 
-  const handleCreateNewXBlock = (type: string, moduleName?: string) => {
+  const handleCreateNewXBlock = (type: string, moduleName?: string | null) => {
     switch (type) {
       case COMPONENT_TYPES.discussion:
       case COMPONENT_TYPES.dragAndDrop:
@@ -209,7 +210,7 @@ const AddComponent = ({
             },
           );
         } else {
-          handleCreateNewCourseXBlock({ type: moduleName, category: moduleName, parentLocator: blockId });
+          handleCreateNewCourseXBlock({ type: moduleName!, category: moduleName!, parentLocator: blockId });
         }
         break;
       case COMPONENT_TYPES.openassessment:

--- a/src/course-unit/add-component/add-component-modals/ComponentModalView.tsx
+++ b/src/course-unit/add-component/add-component-modals/ComponentModalView.tsx
@@ -10,7 +10,7 @@ import messages from '../messages';
 import ModalContainer from './ModalContainer';
 
 interface ComponentTemplate {
-  boilerplateName?: string;
+  boilerplateName?: string | null;
   category?: string;
   displayName: string;
   supportLevel?: string | boolean;

--- a/src/course-unit/hooks.tsx
+++ b/src/course-unit/hooks.tsx
@@ -301,8 +301,8 @@ export interface CreateCourseXBlockParams {
   /** If we're linking in a block from a library, this is the upstream usage key in that library */
   libraryContentKey?: string;
   /** Specify this to paste from clipboard rather than creating a blank component. */
-  stagedContent?: "clipboard";
-};
+  stagedContent?: 'clipboard';
+}
 
 export const useHandleCreateNewCourseXBlock = ({ blockId }: { blockId: string; }) => {
   const dispatch = useDispatch();

--- a/src/course-unit/hooks.tsx
+++ b/src/course-unit/hooks.tsx
@@ -285,12 +285,31 @@ export const useCourseUnit = ({
   };
 };
 
+export interface CreateCourseXBlockParams {
+  /** The usage key string of the parent that will contain this new block */
+  parentLocator: string;
+  /** The XBlock type to create. Note: a "type" field is ignored - don't add that here. */
+  category?: string;
+  /**
+   * The XBlock type to create. Ignored on the backend, but our frontend code accepts it instead of `category` and
+   * sets `category` to this value.
+   * @deprecated
+   */
+  type?: string;
+  /** Template to use for the XBlock's initial content */
+  boilerplate?: string | null;
+  /** If we're linking in a block from a library, this is the upstream usage key in that library */
+  libraryContentKey?: string;
+  /** Specify this to paste from clipboard rather than creating a blank component. */
+  stagedContent?: "clipboard";
+};
+
 export const useHandleCreateNewCourseXBlock = ({ blockId }: { blockId: string; }) => {
   const dispatch = useDispatch();
   const { sendMessageToIframe } = useIframe();
 
   // oxlint-disable typescript-eslint(await-thenable)
-  return async (body: object, callback?: (args: { courseKey: string; locator: string; }) => void) => (
+  return async (body: CreateCourseXBlockParams, callback?: (args: { courseKey: string; locator: string; }) => void) => (
     // eslint-disable-next-line @typescript-eslint/return-await
     await dispatch(createNewCourseXBlock(body, callback, blockId, sendMessageToIframe))
   );


### PR DESCRIPTION
## Summary

**Bug:**
When inside a Problem Builder (or other `StudioContainerWithNestedXBlocksMixin`) container block, the "Add Component" buttons for **pb-message** variants (Message complete / incomplete / Max attempts) all create the same default block, ignoring the selected boilerplate template.
For detail look at this comment: https://github.com/openedx/frontend-app-authoring/pull/3058#issuecomment-5028801762

Ticket: https://github.com/openedx/frontend-app-authoring/issues/3156

**What we fixed in this PR:**

- Buttons for blocks declared via `StudioContainerWithNestedXBlocksMixin` (e.g. pb-message complete/incomplete/max-attempts) were ignoring the `boilerplate_name` from their template spec, so every variant always created the default block.
- Fixed by passing `firstTemplate?.boilerplateName` from the button `onClick` through to the `handleCreateNewCourseXBlock` API call as `boilerplate`.

## Test Results:

<img width="1909" height="744" alt="Screenshot 2026-07-24 at 10 27 27 PM" src="https://github.com/user-attachments/assets/09a3cc03-89b9-4a70-af06-d92eb52e32ac" />
<img width="1893" height="621" alt="Screenshot 2026-07-24 at 10 28 08 PM" src="https://github.com/user-attachments/assets/2a64c329-cc62-4881-aa29-3d619268ec83" />

