### PR TITLE
feat: remove legacy library content block creation button

### DIFF
--- a/src/course-unit/__mocks__/courseSectionVertical.ts
+++ b/src/course-unit/__mocks__/courseSectionVertical.ts
@@ -128,26 +128,6 @@ export default {
       beta: false,
     },
     {
-      type: 'library',
-      templates: [
-        {
-          display_name: 'Randomized Content Block',
-          category: 'library_content',
-          boilerplate_name: null,
-          hinted: false,
-          tab: 'common',
-          support_level: true,
-        },
-      ],
-      display_name: 'Legacy Library Content',
-      support_legend: {
-        show_legend: false,
-        allow_unsupported_xblocks: false,
-        documentation_label: 'Your Platform Name Here Support Levels:',
-      },
-      beta: false,
-    },
-    {
       type: 'html',
       templates: [
         {

--- a/src/course-unit/add-component/AddComponent.test.tsx
+++ b/src/course-unit/add-component/AddComponent.test.tsx
@@ -89,11 +89,6 @@ describe('<AddComponent />', () => {
 
     expect(getByRole('heading', { name: messages.title.defaultMessage })).toBeInTheDocument();
     Object.keys(componentTemplates).forEach((component) => {
-      // TODO: Remove this skip once edx-platform stops returning the 'library'
-      // template in the component templates response.
-      if (componentTemplates[component].type === COMPONENT_TYPES.library) {
-        return;
-      }
       const btn = getByRole('button', {
         name: new RegExp(
           `${componentTemplates[component].type} ${messages.buttonText.defaultMessage} ${
@@ -148,14 +143,6 @@ describe('<AddComponent />', () => {
 
     Object.keys(componentTemplates).map((component) => {
       if (componentTemplates[component].type === COMPONENT_TYPES.discussion) {
-        return expect(queryByRole('button', {
-          name: new RegExp(`${messages.buttonText.defaultMessage} ${componentTemplates[component].display_name}`, 'i'),
-        })).not.toBeInTheDocument();
-      }
-
-      // TODO: Remove this skip once edx-platform stops returning the 'library'
-      // template in the component templates response.
-      if (componentTemplates[component].type === COMPONENT_TYPES.library) {
         return expect(queryByRole('button', {
           name: new RegExp(`${messages.buttonText.defaultMessage} ${componentTemplates[component].display_name}`, 'i'),
         })).not.toBeInTheDocument();
@@ -281,14 +268,6 @@ describe('<AddComponent />', () => {
       parentLocator: '123',
       type: COMPONENT_TYPES.video,
     }, expect.any(Function));
-  });
-
-  it('does not render the legacy Library button', () => {
-    const { queryByRole } = renderComponent();
-    const libraryButton = queryByRole('button', {
-      name: new RegExp(`${messages.buttonText.defaultMessage} Legacy Library Content`, 'i'),
-    });
-    expect(libraryButton).not.toBeInTheDocument();
   });
 
   it('verifies modal behavior on button click', async () => {

--- a/src/course-unit/add-component/AddComponent.test.tsx
+++ b/src/course-unit/add-component/AddComponent.test.tsx
@@ -270,21 +270,12 @@ describe('<AddComponent />', () => {
     }, expect.any(Function));
   });
 
-  it('creates new "Library" xblock on click', async () => {
-    const user = userEvent.setup();
-    const { getByRole } = renderComponent();
-
-    const libraryButton = getByRole('button', {
+  it('does not render the legacy Library button', () => {
+    const { queryByRole } = renderComponent();
+    const libraryButton = queryByRole('button', {
       name: new RegExp(`${messages.buttonText.defaultMessage} Legacy Library Content`, 'i'),
     });
-
-    await user.click(libraryButton);
-    expect(handleCreateNewCourseXBlockMock).toHaveBeenCalled();
-    expect(handleCreateNewCourseXBlockMock).toHaveBeenCalledWith({
-      parentLocator: '123',
-      category: 'library_content',
-      type: COMPONENT_TYPES.library,
-    });
+    expect(libraryButton).not.toBeInTheDocument();
   });
 
   it('verifies modal behavior on button click', async () => {

--- a/src/course-unit/add-component/AddComponent.test.tsx
+++ b/src/course-unit/add-component/AddComponent.test.tsx
@@ -89,6 +89,11 @@ describe('<AddComponent />', () => {
 
     expect(getByRole('heading', { name: messages.title.defaultMessage })).toBeInTheDocument();
     Object.keys(componentTemplates).forEach((component) => {
+      // TODO: Remove this skip once edx-platform stops returning the 'library'
+      // template in the component templates response.
+      if (componentTemplates[component].type === COMPONENT_TYPES.library) {
+        return;
+      }
       const btn = getByRole('button', {
         name: new RegExp(
           `${componentTemplates[component].type} ${messages.buttonText.defaultMessage} ${
@@ -143,6 +148,14 @@ describe('<AddComponent />', () => {
 
     Object.keys(componentTemplates).map((component) => {
       if (componentTemplates[component].type === COMPONENT_TYPES.discussion) {
+        return expect(queryByRole('button', {
+          name: new RegExp(`${messages.buttonText.defaultMessage} ${componentTemplates[component].display_name}`, 'i'),
+        })).not.toBeInTheDocument();
+      }
+
+      // TODO: Remove this skip once edx-platform stops returning the 'library'
+      // template in the component templates response.
+      if (componentTemplates[component].type === COMPONENT_TYPES.library) {
         return expect(queryByRole('button', {
           name: new RegExp(`${messages.buttonText.defaultMessage} ${componentTemplates[component].display_name}`, 'i'),
         })).not.toBeInTheDocument();

--- a/src/course-unit/add-component/AddComponent.tsx
+++ b/src/course-unit/add-component/AddComponent.tsx
@@ -247,11 +247,6 @@ const AddComponent = ({
                   }
 
                   switch (type) {
-                    case COMPONENT_TYPES.library:
-                      // Suppress the legacy library button on the frontend.
-                      // TODO: Remove this case once edx-platform stops returning
-                      //  the 'library' template in the component templates response.
-                      return null;
                     case COMPONENT_TYPES.advanced:
                       modalParams = {
                         open: openAdvanced,

--- a/src/course-unit/add-component/AddComponent.tsx
+++ b/src/course-unit/add-component/AddComponent.tsx
@@ -177,11 +177,6 @@ const AddComponent = ({
           },
         );
         break;
-        // TODO: The library functional will be a bit different of current legacy (CMS)
-        //  behaviour and this ticket is on hold (blocked by other development team).
-      case COMPONENT_TYPES.library:
-        handleCreateNewCourseXBlock({ type, category: 'library_content', parentLocator: blockId });
-        break;
       case COMPONENT_TYPES.itembank:
         handleCreateNewCourseXBlock({ type, category: 'itembank', parentLocator: blockId });
         break;
@@ -252,6 +247,11 @@ const AddComponent = ({
                   }
 
                   switch (type) {
+                    case COMPONENT_TYPES.library:
+                      // Suppress the legacy library button on the frontend.
+                      // TODO: Remove this case once edx-platform stops returning
+                      //  the 'library' template in the component templates response.
+                      return null;
                     case COMPONENT_TYPES.advanced:
                       modalParams = {
                         open: openAdvanced,


### PR DESCRIPTION
## Summary

- Removes the **Add Legacy Library** button from the add-component strip, preventing creation of new `LegacyLibraryContentBlock` instances via the UI
- Existing usages remain fully functional — the container view, randomized settings editor, and "View all" navigation are unaffected
- A frontend suppression case is left in place with a TODO to remove it once edx-platform stops returning the `library` template in the component templates response

Ticket: https://github.com/openedx/openedx-platform/issues/38058

## Test plan

- [x] Verify the "Legacy Library Content" button no longer appears in the add-component strip on a course unit
- [x] Verify existing legacy library content blocks still render correctly when navigated to
- [x] Verify the randomized settings editor still works on existing legacy library content blocks
- [x] Verify "View all" still navigates to the MFE-based children view

## Testing Results
Before removing the legacy library button:

<img width="1492" height="731" alt="Screenshot 2026-07-28 at 12 03 35 AM" src="https://github.com/user-attachments/assets/d400f46b-107d-42d7-be8f-4fd3691e1941" />

_____________________________
After removing the legacy library button:


<img width="1494" height="740" alt="Screenshot 2026-07-28 at 12 08 36 AM" src="https://github.com/user-attachments/assets/2794469c-3069-48af-8d4c-f7456161b35d" />
<img width="1502" height="738" alt="Screenshot 2026-07-28 at 12 08 57 AM" src="https://github.com/user-attachments/assets/50d4fcd2-b3fd-4096-8809-cdc2adab0418" />
<img width="1495" height="740" alt="Screenshot 2026-07-28 at 12 09 17 AM" src="https://github.com/user-attachments/assets/62354a94-d0bb-43e1-8275-76e2e23ac2c1" />
<img width="1499" height="729" alt="Screenshot 2026-07-28 at 12 09 38 AM" src="https://github.com/user-attachments/assets/988ffd54-0362-491d-966f-aa9b29637c77" />

