### PR TITLE
fix: add skipUrlUpdate prop to SearchContextProvider in SearchUI

### DIFF
--- a/src/search-manager/FilterByBlockType.tsx
+++ b/src/search-manager/FilterByBlockType.tsx
@@ -15,6 +15,7 @@ import SearchFilterWidget from './SearchFilterWidget';
 import messages from './messages';
 import BlockTypeLabel from './BlockTypeLabel';
 import { useSearchContext } from './SearchManager';
+import { TypesFilterData } from './hooks';
 
 interface ProblemFilterItemProps {
   count: number;
@@ -53,21 +54,22 @@ const ProblemFilterItem = ({ count, handleCheckboxChange }: ProblemFilterItemPro
 
   const handleProblemCheckboxChange = React.useCallback((e) => {
     setTypesFilter((types) => {
+      const next = new TypesFilterData(types.toString());
       if (e.target.checked) {
-        types.problems.add(e.target.value);
+        next.problems.add(e.target.value);
       } else {
-        types.problems.delete(e.target.value);
+        next.problems.delete(e.target.value);
       }
 
-      if (types.problems.size === problemTypesLength) {
+      if (next.problems.size === problemTypesLength) {
         // Add 'problem' to block type filter if all problem types are selected.
-        types.blocks.add(blockType);
+        next.blocks.add(blockType);
       } else {
         // Delete 'problem' filter if its selected.
-        types.blocks.delete(blockType);
+        next.blocks.delete(blockType);
       }
 
-      return types;
+      return next;
     });
   }, [setTypesFilter, problemTypesLength]);
 
@@ -150,20 +152,21 @@ const FilterItem = ({ blockType, count }: FilterItemProps) => {
 
   const handleCheckboxChange = React.useCallback((e) => {
     setTypesFilter((types) => {
+      const next = new TypesFilterData(types.toString());
       if (e.target.checked) {
-        types.blocks.add(e.target.value);
+        next.blocks.add(e.target.value);
       } else {
-        types.blocks.delete(e.target.value);
+        next.blocks.delete(e.target.value);
       }
       // The "problem" block type also selects/clears all the problem types
       if (blockType === 'problem') {
         if (e.target.checked) {
-          types.union({ problems: Object.keys(problemTypes) });
+          next.union({ problems: Object.keys(problemTypes) });
         } else {
-          types.problems.clear();
+          next.problems.clear();
         }
       }
-      return types;
+      return next;
     });
   }, [setTypesFilter]);
 

--- a/src/search-manager/SearchManager.ts
+++ b/src/search-manager/SearchManager.ts
@@ -164,7 +164,7 @@ export const SearchContextProvider: React.FC<{
     || !!usageKey;
   const isFiltered = canClearFilters || (searchKeywords !== '');
   const clearFilters = React.useCallback(() => {
-    setTypesFilter((types) => types.clear());
+    setTypesFilter(new TypesFilterData());
     setTagsFilter([]);
     setPublishStatusFilter([]);
     if (usageKey !== '') {

--- a/src/search-modal/SearchUI.test.tsx
+++ b/src/search-modal/SearchUI.test.tsx
@@ -196,9 +196,12 @@ describe('<SearchUI />', () => {
     });
     // Enter a keyword - search for 'giraffe':
     fireEvent.change(getByRole('searchbox'), { target: { value: 'giraffe' } });
-    // Wait for the new search request to load all the results:
+    // Wait for the keyword search request. SearchUI uses skipUrlUpdate, so search state is
+    // managed by React.useState and updated asynchronously via a 400ms debounce.
+    // We wait for the 2nd fetch (initial render = 1st, keyword search = 2nd) to ensure
+    // the debounce has fired and the results are from the 'giraffe' query, not the initial render.
     await waitFor(() => {
-      expect(fetchMock).toHaveFetchedTimes(1, searchEndpoint, 'post');
+      expect(fetchMock).toHaveFetchedTimes(2, searchEndpoint, 'post');
     });
     // And make sure the request was limited to this course:
     expect(fetchMock).toHaveLastFetched((_url, req) => {
@@ -393,23 +396,28 @@ describe('<SearchUI />', () => {
           <SearchUI {...defaults} />
         </Wrap>,
       );
-      const { getByRole, getByText } = rendered;
       // Wait for the initial search request that loads all the filter options:
       await waitFor(() => {
         expect(fetchMock).toHaveFetchedTimes(1, searchEndpoint, 'post');
       });
+    });
+
+    it('can do a keyword search and see results', async () => {
+      const { getByRole, getByText } = rendered;
       // Enter a keyword - search for 'giraffe':
       fireEvent.change(getByRole('searchbox'), { target: { value: 'giraffe' } });
-      // Wait for the new search request to load all the results and the filter options, based on the search so far:
+      // Wait for the keyword search request. SearchUI uses skipUrlUpdate, so search state is
+      // managed by React.useState and updated asynchronously via a 400ms debounce.
+      // We wait for the 2nd fetch (initial render = 1st, keyword search = 2nd) to ensure
+      // the debounce has fired and results reflect the 'giraffe' query.
       await waitFor(() => {
-        expect(fetchMock).toHaveFetchedTimes(1, searchEndpoint, 'post');
+        expect(fetchMock).toHaveFetchedTimes(2, searchEndpoint, 'post');
       });
       // And make sure the request was limited to this course:
       expect(fetchMock).toHaveLastFetched((_url, req) => {
         const requestData = JSON.parse((req.body ?? '') as string);
         const requestedFilter = requestData?.queries[0].filter;
-        // the filter is:
-        // ['', 'type = "course_block"', 'context_key = "course-v1:org+test+123"']
+        // the filter is: ['', 'type = "course_block"', 'context_key = "course-v1:org+test+123"']
         return (requestedFilter?.length === 3);
       });
       // Now we should see the results:
@@ -418,8 +426,7 @@ describe('<SearchUI />', () => {
     });
 
     afterEach(async () => {
-      // Clear any search filters applied by the previous test.
-      // We need to do this because search filters are stored in the URL, and so they can leak between tests.
+      // Clear any search filters applied by the previous test so they don't leak into the next one.
       const { queryByRole } = rendered;
       const clearFilters = queryByRole('button', { name: /clear filters/i });
       if (clearFilters) {
@@ -444,7 +451,7 @@ describe('<SearchUI />', () => {
       await waitFor(() => {
         expect(fetchMock).toHaveFetchedTimes(2, searchEndpoint, 'post');
       });
-      // Because we're mocking the results, there's no actual changes to the mock results,
+      // Because we're mocking the results, there are no actual changes to the mock results,
       // but we can verify that the filter was sent in the request
       expect(fetchMock).toHaveLastFetched((_url, req) => {
         const requestData = JSON.parse((req.body ?? '') as string);
@@ -461,6 +468,48 @@ describe('<SearchUI />', () => {
           'type = "course_block"',
           'context_key = "course-v1:org+test+123"',
         ]);
+      });
+    });
+
+    it('adds the problem block type filter when all problem subtypes are selected', async () => {
+      const { getByRole, getByTestId } = rendered;
+
+      // Open the Type filter dropdown:
+      fireEvent.click(getByRole('button', { name: 'Type' }), {});
+      await waitFor(() => {
+        expect(getByRole('group')).toBeInTheDocument();
+      });
+
+      // Open the Problem subtypes submenu via the arrow button:
+      fireEvent.click(getByTestId('open-problem-item-button'), {});
+
+      // Click every individual problem subtype. The mock result has exactly these 5 types.
+      // When the last one is clicked, problems.size === problemTypesLength and
+      // 'problem' is auto-added to the blocks filter (the branch under test).
+      const problemTypes = [
+        'choiceresponse',
+        'multiplechoiceresponse',
+        'numericalresponse',
+        'optionresponse',
+        'stringresponse',
+      ];
+      for (const problemType of problemTypes) {
+        // eslint-disable-next-line no-await-in-loop
+        const checkbox = await waitFor(
+          () => document.querySelector(`input[value="${problemType}"]`) as HTMLInputElement,
+        );
+        fireEvent.click(checkbox);
+      }
+
+      // After all subtypes are selected, the search should include block_type = problem:
+      await waitFor(() => {
+        expect(fetchMock).toHaveLastFetched((_url, req) => {
+          const requestData = JSON.parse((req.body ?? '') as string);
+          const filter = requestData?.queries[0]?.filter;
+          return Array.isArray(filter) && filter.some(
+            (f: unknown) => Array.isArray(f) && f.includes('block_type = problem'),
+          );
+        });
       });
     });
 

--- a/src/search-modal/SearchUI.tsx
+++ b/src/search-modal/SearchUI.tsx
@@ -37,6 +37,7 @@ const SearchUI: React.FC<{
         ...(searchThisCourse ? [`context_key = "${props.courseId}"`] : []),
       ]}
       closeSearchModal={props.closeSearchModal}
+      skipUrlUpdate
     >
       {
         /* We need to override z-index here or the <Dropdown.Menu> appears behind the <ModalDialog.Body>


### PR DESCRIPTION
When opening the global search modal (magnifying glass in the header) from a Content Library page and typing a search term, the library page's own search bar was mirroring the same input in the background.

**Root cause:** both the search modal and the library page use `SearchContextProvider`, which by default syncs all search state to URL query params (`?q=...`). Since they share the same URL, typing in the modal updated `?q=` which the library page's search bar also reads and reflects.

The fix adds `skipUrlUpdate` to the `SearchContextProvider` inside `SearchUI` (the modal's inner content), making the modal use isolated `React.useState` instead of URL params. The modal's search state is now fully decoupled from the page's search state.

**Secondary bug exposed by the fix:** before adding `skipUrlUpdate`, `setTypesFilter` used `useStateWithUrlSearchParam` which serializes the value via `toString()` on every call; it never compares references. So mutating `TypesFilterData` in place and returning the same object worked fine: the setter only cared about the serialized string. After `skipUrlUpdate`, `setTypesFilter` became a raw `React.useState` setter, which uses `Object.is(prev, next)` for change detection. Since the mutation happened on the same object and the same reference was returned, `Object.is` returned `true` → no re-render → block type filter chips never appeared.

Fixed by returning a new `TypesFilterData` instance on every update in `FilterByBlockType` and `SearchManager`. The mutation bug always existed but was invisible until `skipUrlUpdate` removed the serialization layer that was masking it.

## Supporting information

- Fixes [openedx/frontend-app-authoring#3099](https://github.com/openedx/frontend-app-authoring/issues/3099) — Course search modal updates the Content Library search input in the background

## Testing instructions

1. Open Studio and navigate to a Content Library.
2. Open a Collection so the collection search bar is visible.
3. Click the magnifying glass icon in the header to open the global search modal.
4. Type a search term in the modal (e.g. `rich`).
5. Verify the collection page's search bar in the background does **not** change.
6. Close the modal and confirm the collection search bar is still empty/unchanged.
7. Confirm the modal still searches correctly (results update as you type).
8. Confirm block type filters (Type dropdown) still work correctly inside the modal.

## Evidence

<img width="1873" height="1011" alt="image" src="https://github.com/user-attachments/assets/aa3bc98d-0d17-4dba-88a6-e88e4a22babb" />
