### PR TITLE
build: Default the dev MFE config API URL to local.openedx.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "dprint fmt && dprint --config dprint.messages.json fmt --excludes-override none && oxlint --type-aware --fix",
     "start": "fedx-scripts webpack-dev-server --progress",
     "start:with-theme": "paragon install-theme && npm start && npm install",
-    "dev": "PUBLIC_PATH=/authoring/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
+    "dev": "PUBLIC_PATH=/authoring/ MFE_CONFIG_API_URL='http://local.openedx.io:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
     "test": "TZ=UTC fedx-scripts jest --coverage --passWithNoTests",
     "test:dev": "TZ=UTC fedx-scripts jest --coverage --watch --passWithNoTests",
     "test:ci": "TZ=UTC fedx-scripts jest --silent --coverage --passWithNoTests",


### PR DESCRIPTION
Defaults the `dev` npm script's `MFE_CONFIG_API_URL` to `http://local.openedx.io:8000/api/mfe_config/v1` instead of `http://localhost:8000/...`.

Fetching MFE config from `local.openedx.io` keeps the LMS, Studio, and MFEs under one `*.local.openedx.io` domain, which avoids localhost-specific CORS/cookie carve-outs and better matches a production setup. It works with Tutor dev (whose default LMS host is `local.openedx.io`) and with the upcoming openedx-platform bare-metal `development.py` config.

Motivated by openedx/openedx-platform#37444.
