### PR TITLE
Adding validation to display/hide edit button on pages and resources

### DIFF
--- a/src/pages-and-resources/pages/PageCard.test.jsx
+++ b/src/pages-and-resources/pages/PageCard.test.jsx
@@ -69,17 +69,17 @@ describe('LiveSettings', () => {
     });
   });
 
-  it('disables legacy-link arrow buttons in readOnly mode, but keeps settings gear accessible', async () => {
+  it('disables legacy-link arrow buttons in readOnly mode,', async () => {
     render(
       <PagesAndResourcesProvider courseId={courseId} isEditable={false}>
         <PageGrid pages={mockPageConfig} />
       </PagesAndResourcesProvider>,
     );
     await waitFor(() => {
-      // Arrow buttons for legacy-link pages must be disabled so auditors
+      // Arrow buttons for legacy-link pages must be hidden so auditors
       // can't navigate to external Studio pages that bypass isEditable.
       const disabledButtons = screen.queryAllByRole('button').filter((btn) => btn.disabled);
-      expect(disabledButtons.length).toBeGreaterThan(0);
+      expect(disabledButtons.length).toBe(0);
     });
   });
 

--- a/src/pages-and-resources/pages/PageSettingButton.jsx
+++ b/src/pages-and-resources/pages/PageSettingButton.jsx
@@ -30,17 +30,8 @@ const PageSettingButton = ({
 
   const canConfigureOrEnable = allowedOperations?.configure || allowedOperations?.enable;
 
-  if (determineLinkDestination && !isEditable) {
-    return (
-      <IconButton
-        src={ArrowForward}
-        iconAs={Icon}
-        size="inline"
-        alt={formatMessage(messages.settings)}
-        className="text-muted"
-        disabled
-      />
-    );
+  if (!isEditable) {
+    return null;
   }
 
   if (determineLinkDestination) {

--- a/src/pages-and-resources/pages/PageSettingButton.test.jsx
+++ b/src/pages-and-resources/pages/PageSettingButton.test.jsx
@@ -54,7 +54,7 @@ describe('PageSettingButton', () => {
     expect(linkElement).toHaveAttribute('href', `/course/${defaultProps.courseId}/page-id`);
   });
 
-  it('renders no icon button when is not editable', () => {
+  it('does not render an icon button when not editable', () => {
     renderComponent({ legacyLink: null }, { isEditable: false });
 
     const button = screen.queryByRole('button');

--- a/src/pages-and-resources/pages/PageSettingButton.test.jsx
+++ b/src/pages-and-resources/pages/PageSettingButton.test.jsx
@@ -54,11 +54,18 @@ describe('PageSettingButton', () => {
     expect(linkElement).toHaveAttribute('href', `/course/${defaultProps.courseId}/page-id`);
   });
 
-  it('renders disabled icon button in read-only mode with legacy link', () => {
-    renderComponent({ legacyLink: 'http://legacylink.com/textbooks' }, { isEditable: false });
+  it('renders no icon button when is not editable', () => {
+    renderComponent({ legacyLink: null }, { isEditable: false });
+
+    const button = screen.queryByRole('button');
+    expect(button).not.toBeInTheDocument();
+  });
+
+  it('renders icon button when is editable', () => {
+    renderComponent({ legacyLink: null }, { isEditable: true });
 
     const button = screen.getByRole('button');
-    expect(button).toBeDisabled();
+    expect(button).toBeInTheDocument();
   });
 
   it('renders arrow link when user is editable', () => {


### PR DESCRIPTION
## Description
Conditionally renders/hide the edit button on the pages and resources cards according to the user permissions.

Category | Permission | Course Editor | Course Auditor
-- | -- | -- | --
Pages & Resources | courses.view_pages_and_resources | ✅ | ✅
  | courses.manage_pages_and_resources | ✅ | ❌

The edit button is hidden for Course Auditors and it is visible for Course Editor (and the other roles with `courses.manage_pages_and_resources` permission assigned.

## Supporting information

Closes https://github.com/openedx/openedx-authz/issues/321
https://www.figma.com/design/onU2END2OXaF7RRLWEHsZI/AuthZ---v2?node-id=9133-59237
## Testing instructions

#### Requirements
Enable the `authz.enable_course_authoring` waffle flag.

#### Test case 1

1. Set course_auditor permission to a user using the API `<lms_url>/api-docs/#/authz/authz_v1_roles_users_update`
2. Login with the user an navigate to studio
3. Go to the course which the permission was set
4. Go to Content -> Pages and resources
5. You must see the page with all the cards having the edit button hidden
<img width="2630" height="1832" alt="image" src="https://github.com/user-attachments/assets/680ea5fa-071d-47e1-9dd8-55e33ddad0a4" />


#### Test case 2
1. Set course_editor permission to a user using the API <lms_url>/api-docs/#/authz/authz_v1_roles_users_update
2. Login with the user an navigate to studio
3. Go to the course which the permission was set
4. Go to Content -> Pages and resources
5. You must see the Pages and resources page with all the cards having the edit button visible
<img width="2630" height="1826" alt="image" src="https://github.com/user-attachments/assets/1015ba50-eeb9-4187-9d20-7c1711863c41" />


## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
