### PR TITLE
Adding permission checks on course outline page for course content edition part 1

### DIFF
--- a/plugins/course-apps/proctoring/Settings.test.jsx
+++ b/plugins/course-apps/proctoring/Settings.test.jsx
@@ -472,7 +472,8 @@ describe('ProctoredExamSettings', () => {
       });
       // (1) for studio settings
       // (2) for course details
-      expect(axiosMock.history.get.length).toBe(2);
+      // (3) for user course permissions
+      expect(axiosMock.history.get.length).toBe(3);
       expect(axiosMock.history.get[0].url.includes('proctored_exam_settings')).toEqual(true);
     });
 

--- a/src/CourseAuthoringContext.tsx
+++ b/src/CourseAuthoringContext.tsx
@@ -10,6 +10,8 @@ import { type UnitXBlock, type XBlock } from '@src/data/types';
 import { CourseDetailsData } from './data/api';
 import { useCourseDetails } from './data/apiHooks';
 import { RequestStatusType } from './data/constants';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import { getCourseOutlinePermissions } from '@src/authz/permissionHelpers';
 
 export type ModalState = {
   value?: XBlock | UnitXBlock;
@@ -29,6 +31,9 @@ export type CourseAuthoringContextData = {
   currentUnlinkModalData?: ModalState;
   openUnlinkModal: (value: ModalState) => void;
   closeUnlinkModal: () => void;
+  isLoading: boolean;
+  canEditCourseContent: boolean;
+  canPublishCourseContent: boolean;
 };
 
 /**
@@ -58,7 +63,14 @@ export const CourseAuthoringProvider = ({
     closeUnlinkModal,
   ] = useToggleWithValue<ModalState>();
 
+  const {
+    canEditCourseContent,
+    canPublishCourseContent,
+    isLoading: isUserPermissionsLoading,
+  } = useCourseUserPermissions(courseId, getCourseOutlinePermissions(courseId));
+
   const getUnitUrl = (locator: string) => `/course/${courseId}/container/${locator}`;
+  const isLoading = isUserPermissionsLoading;
 
   /**
    * Open the unit page for a given locator.
@@ -78,6 +90,9 @@ export const CourseAuthoringProvider = ({
     openUnlinkModal,
     closeUnlinkModal,
     currentUnlinkModalData,
+    isLoading,
+    canEditCourseContent,
+    canPublishCourseContent,
   }), [
     courseId,
     courseDetails,
@@ -89,6 +104,9 @@ export const CourseAuthoringProvider = ({
     openUnlinkModal,
     closeUnlinkModal,
     currentUnlinkModalData,
+    canEditCourseContent,
+    canPublishCourseContent,
+    isLoading,
   ]);
 
   return (

--- a/src/CourseAuthoringContext.tsx
+++ b/src/CourseAuthoringContext.tsx
@@ -31,7 +31,7 @@ export type CourseAuthoringContextData = {
   currentUnlinkModalData?: ModalState;
   openUnlinkModal: (value: ModalState) => void;
   closeUnlinkModal: () => void;
-  isLoading: boolean;
+  isLoadingPermissions: boolean;
   canEditCourseContent: boolean;
   canPublishCourseContent: boolean;
 };
@@ -66,11 +66,10 @@ export const CourseAuthoringProvider = ({
   const {
     canEditCourseContent,
     canPublishCourseContent,
-    isLoading: isUserPermissionsLoading,
+    isLoading: isLoadingUserPermissions,
   } = useCourseUserPermissions(courseId, getCourseOutlinePermissions(courseId));
 
   const getUnitUrl = (locator: string) => `/course/${courseId}/container/${locator}`;
-  const isLoading = isUserPermissionsLoading;
 
   /**
    * Open the unit page for a given locator.
@@ -90,7 +89,7 @@ export const CourseAuthoringProvider = ({
     openUnlinkModal,
     closeUnlinkModal,
     currentUnlinkModalData,
-    isLoading,
+    isLoadingPermissions: isLoadingUserPermissions,
     canEditCourseContent,
     canPublishCourseContent,
   }), [
@@ -106,7 +105,7 @@ export const CourseAuthoringProvider = ({
     currentUnlinkModalData,
     canEditCourseContent,
     canPublishCourseContent,
-    isLoading,
+    isLoadingUserPermissions,
   ]);
 
   return (

--- a/src/authz/constants.ts
+++ b/src/authz/constants.ts
@@ -17,7 +17,9 @@ export const CONTENT_LIBRARY_PERMISSIONS = {
 
 export const COURSE_PERMISSIONS = {
   VIEW_COURSE: 'courses.view_course',
+  CREATE_COURSE: 'courses.create_course',
   EDIT_COURSE_CONTENT: 'courses.edit_course_content',
+  PUBLISH_COURSE_CONTENT: 'courses.publish_course_content',
 
   MANAGE_ADVANCED_SETTINGS: 'courses.manage_advanced_settings',
 

--- a/src/authz/permissionHelpers.test.ts
+++ b/src/authz/permissionHelpers.test.ts
@@ -164,6 +164,10 @@ describe('permissionHelpers', () => {
           action: COURSE_PERMISSIONS.EDIT_COURSE_CONTENT,
           scope: courseId,
         },
+        canPublishCourseContent: {
+          action: COURSE_PERMISSIONS.PUBLISH_COURSE_CONTENT,
+          scope: courseId,
+        },
       });
     });
   });

--- a/src/authz/permissionHelpers.ts
+++ b/src/authz/permissionHelpers.ts
@@ -75,6 +75,10 @@ export const getCourseOutlinePermissions = (courseId: string) => ({
     action: COURSE_PERMISSIONS.EDIT_COURSE_CONTENT,
     scope: courseId,
   },
+  canPublishCourseContent: {
+    action: COURSE_PERMISSIONS.PUBLISH_COURSE_CONTENT,
+    scope: courseId,
+  },
 });
 
 export const getLibraryUpdatesPermissions = (courseId: string) => ({

--- a/src/course-outline/CourseOutline.test.tsx
+++ b/src/course-outline/CourseOutline.test.tsx
@@ -9,6 +9,7 @@ import { getClipboardUrl } from '@src/generic/data/api';
 import { ContainerType } from '@src/generic/key-utils';
 import { getDownstreamApiUrl } from '@src/generic/unlink-modal/data/api';
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
+import { mockWaffleFlags } from '@src/data/apiHooks.mock';
 import {
   act,
   fireEvent,
@@ -186,16 +187,6 @@ jest.mock('@src/help-urls/hooks', () => ({
 jest.mock('./data/api', () => ({
   ...jest.requireActual('./data/api'),
   getTagsCount: () => jest.fn().mockResolvedValue({}),
-}));
-
-jest.mock('@src/authz/hooks', () => ({
-  ...jest.requireActual('@src/authz/hooks'),
-  useCourseUserPermissions: jest.fn().mockReturnValue({
-    isLoading: false,
-    isAuthzEnabled: false,
-    canEditCourseContent: true,
-    canPublishCourseContent: true,
-  }),
 }));
 
 jest.mock('@edx/frontend-platform/logging', () => ({
@@ -562,6 +553,11 @@ const renderComponent = () =>
 describe('<CourseOutline />', () => {
   beforeEach(async () => {
     const mocks = initializeMocks();
+    mockWaffleFlags({ enableAuthzCourseAuthoring: false });
+    mocks.validateUserPermissionsMock.mockResolvedValue({
+      canEditCourseContent: true,
+      canPublishCourseContent: true,
+    });
     selectedContainerId = undefined;
     // restore index mock — use reorder outline spec (section[0] has 2 subsections for configure/drag tests)
     courseOutlineIndexMock = buildTestOutline({

--- a/src/course-outline/CourseOutline.test.tsx
+++ b/src/course-outline/CourseOutline.test.tsx
@@ -188,6 +188,16 @@ jest.mock('./data/api', () => ({
   getTagsCount: () => jest.fn().mockResolvedValue({}),
 }));
 
+jest.mock('@src/authz/hooks', () => ({
+  ...jest.requireActual('@src/authz/hooks'),
+  useCourseUserPermissions: jest.fn().mockReturnValue({
+    isLoading: false,
+    isAuthzEnabled: false,
+    canEditCourseContent: true,
+    canPublishCourseContent: true,
+  }),
+}));
+
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
 }));

--- a/src/course-outline/CourseOutline.tsx
+++ b/src/course-outline/CourseOutline.tsx
@@ -51,6 +51,8 @@ const CourseOutline = () => {
   const location = useLocation();
   const {
     courseId,
+    canEditCourseContent,
+    isLoading: isLoadingAuthoringContext,
   } = useCourseAuthoringContext();
   const {
     courseUsageKey,
@@ -94,7 +96,14 @@ const CourseOutline = () => {
   const [showSuccessAlert, setShowSuccessAlert] = useState(false);
 
   const isInternetConnectionAlertFailed = savingStatus === RequestStatus.FAILED;
-  const isReIndexShow = Boolean(reindexLink);
+  const isReIndexShow = canEditCourseContent && Boolean(reindexLink);
+
+  // The header's "+ Add" button creates course content, so gate its visibility behind the
+  // edit permission. This is scoped to the header actions and leaves the outline tree unaffected.
+  const headerCourseActions = useMemo(
+    () => ({ ...courseActions, childAddable: canEditCourseContent && courseActions.childAddable }),
+    [courseActions, canEditCourseContent],
+  );
 
   const handleAddBlock = useCreateCourseBlock(courseId);
   const pasteMutation = usePasteItem(courseId);
@@ -169,7 +178,7 @@ const CourseOutline = () => {
     }
   }, [location, courseId, courseName]);
 
-  if (isLoading) {
+  if (isLoading || isLoadingAuthoringContext) {
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return (
       <Row className="m-0 mt-4 justify-content-center">
@@ -249,7 +258,7 @@ const CourseOutline = () => {
                 headerNavigationsActions={headerNavigationsActions}
                 isDisabledReindexButton={isDisabledReindexButton}
                 hasSections={Boolean(sections.length)}
-                courseActions={courseActions}
+                courseActions={headerCourseActions}
                 errors={errors}
                 sections={sections}
               />

--- a/src/course-outline/CourseOutline.tsx
+++ b/src/course-outline/CourseOutline.tsx
@@ -52,7 +52,7 @@ const CourseOutline = () => {
   const {
     courseId,
     canEditCourseContent,
-    isLoading: isLoadingAuthoringContext,
+    isLoadingPermissions,
   } = useCourseAuthoringContext();
   const {
     courseUsageKey,
@@ -178,7 +178,7 @@ const CourseOutline = () => {
     }
   }, [location, courseId, courseName]);
 
-  if (isLoading || isLoadingAuthoringContext) {
+  if (isLoading || isLoadingPermissions) {
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return (
       <Row className="m-0 mt-4 justify-content-center">

--- a/src/course-outline/OutlineNode.tsx
+++ b/src/course-outline/OutlineNode.tsx
@@ -105,7 +105,7 @@ const OutlineNode = ({
 
   const { activeId, overId } = useContext(DragContext);
   const { selectedContainerState, openContainerSidebar, setSelectedContainerState } = useOutlineSidebarContext();
-  const { courseId, openUnlinkModal, getUnitUrl } = useCourseAuthoringContext();
+  const { courseId, openUnlinkModal, getUnitUrl, canEditCourseContent } = useCourseAuthoringContext();
   const duplicateMutation = useDuplicateItem(courseId);
   const { openPublishModal } = useCourseOutlineContext();
   const queryClient = useQueryClient();
@@ -236,7 +236,7 @@ const OutlineNode = ({
     else { onOrderChange(effectiveSection, getPossibleMoves!(index, 1)); }
   };
 
-  const isDraggable = model.isDraggable(actions, isHeaderVisible);
+  const isDraggable = canEditCourseContent && model.isDraggable(actions, isHeaderVisible);
 
   const titleComponent = depth < 2 ?
     (
@@ -352,7 +352,7 @@ const OutlineNode = ({
                 data-testid={levelConfig.contentTestId}
                 onClick={(e) => onClickCard(e, false)}
               >
-                {depth === 0 && onOpenHighlightsModal && (
+                {canEditCourseContent && depth === 0 && onOpenHighlightsModal && (
                   <div className="outline-section__status mb-1">
                     <Button
                       className="p-0 bg-transparent"
@@ -381,14 +381,14 @@ const OutlineNode = ({
               })}
             >
               {children}
-              {actions.childAddable && (
+              {canEditCourseContent && actions.childAddable && (
                 <OutlineAddChildButtons
                   childType={levelConfig.containerType!}
                   parentLocator={blk.id}
                   grandParentLocator={depth === 1 ? parentSection?.id : undefined}
                 />
               )}
-              {showPaste && (
+              {canEditCourseContent && showPaste && (
                 <PasteComponent
                   className="mt-4 border-gray-500 rounded-0"
                   text={intl.formatMessage(outlineNodeMessages.pasteButton)}

--- a/src/course-outline/OutlineNode.tsx
+++ b/src/course-outline/OutlineNode.tsx
@@ -335,7 +335,6 @@ const OutlineNode = ({
                 {...(depth === 2 ?
                   {
                     isVertical: true,
-                    enableCopyPasteUnits: blk.enableCopyPasteUnits ?? false,
                     onClickCopy: () => copyToClipboard(blk.id),
                     discussionEnabled: blk.discussionEnabled,
                     discussionsSettings,

--- a/src/course-outline/OutlineTree.tsx
+++ b/src/course-outline/OutlineTree.tsx
@@ -17,6 +17,7 @@ import {
 } from './drag-helper/utils';
 import { applyReorderMove } from './drag-helper/utils';
 import { type Depth, LEVEL_NAMES } from './outline-level';
+import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
 
 export interface OutlineTreeProps {
   sections: XBlock[];
@@ -80,6 +81,8 @@ const OutlineTree = ({
     previewSections(nextSections);
     await commitSectionReorder(sectionListIds);
   }, [sections, previewSections, commitSectionReorder]);
+
+  const { canEditCourseContent } = useCourseAuthoringContext();
 
   const handleSubsectionOrderChange = useCallback(
     async (section: XBlock, moveDetails: SubsectionMoveDetails | null) => {
@@ -180,7 +183,7 @@ const OutlineTree = ({
                     )}
                   </SortableContext>
                 </DraggableList>
-                {courseActions.childAddable && (
+                {canEditCourseContent && courseActions.childAddable && (
                   <OutlineAddChildButtons
                     childType={ContainerType.Section}
                     parentLocator={courseUsageKey}
@@ -190,7 +193,7 @@ const OutlineTree = ({
             ) :
             (
               <EmptyPlaceholder>
-                {courseActions.childAddable ?
+                {canEditCourseContent && courseActions.childAddable ?
                   (
                     <OutlineAddChildButtons
                       childType={ContainerType.Section}

--- a/src/course-outline/card-header/CardHeader.test.tsx
+++ b/src/course-outline/card-header/CardHeader.test.tsx
@@ -9,7 +9,6 @@ import {
 } from '@src/testUtils';
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
 import { mockWaffleFlags } from '@src/data/apiHooks.mock';
-import { useCourseUserPermissions } from '@src/authz/hooks';
 import { courseId } from '@src/schedule-and-details/__mocks__/courseDetails';
 import { userEvent } from '@testing-library/user-event';
 import { renderCard, setupCardTestMocks } from '../__mocks__/testSetup';
@@ -41,14 +40,6 @@ jest.mock('@src/course-outline/data/apiHooks', () => ({
   useUpdateCourseBlockName: () => useUpdateCourseBlockNameMock,
 }));
 
-jest.mock('@src/authz/hooks', () => ({
-  useCourseUserPermissions: jest.fn().mockReturnValue({
-    isLoading: false,
-    canEditCourseContent: true,
-    canPublishCourseContent: true,
-  }),
-}));
-
 const cardHeaderProps = {
   title: 'Some title',
   status: ITEM_BADGE_STATUS.live,
@@ -76,9 +67,11 @@ const cardHeaderProps = {
   },
 };
 
-const mockPermissions = (mockedPermissions) => {
-  mockWaffleFlags({ enableAuthzCourseAuthoring: !!mockedPermissions });
-  jest.mocked(useCourseUserPermissions).mockReturnValue(mockedPermissions);
+let validateUserPermissionsMock;
+
+const mockPermissions = (canEditCourseContent = true) => {
+  mockWaffleFlags({ enableAuthzCourseAuthoring: !canEditCourseContent });
+  validateUserPermissionsMock.mockResolvedValue({ canEditCourseContent });
 };
 
 const renderComponent = (props?: object, entry = '/') => {
@@ -114,7 +107,9 @@ const renderComponent = (props?: object, entry = '/') => {
 
 describe('<CardHeader />', () => {
   beforeEach(() => {
-    setupCardTestMocks();
+    const mocks = setupCardTestMocks();
+    validateUserPermissionsMock = mocks.validateUserPermissionsMock;
+    mockPermissions(true);
     useUpdateCourseBlockNameMock.isPending = false;
     useUpdateCourseBlockNameMock.mutate.mockClear();
     useUpdateCourseBlockNameMock.mutateAsync.mockClear();
@@ -597,14 +592,15 @@ describe('<CardHeader />', () => {
 
   describe('canEditCourseContent permission', () => {
     it('renders the rename button and actions menu when canEditCourseContent is true', async () => {
-      renderComponent({ canEditCourseContent: true });
+      mockPermissions(true);
+      renderComponent();
 
       expect(await screen.findByTestId('subsection-edit-button')).toBeInTheDocument();
       expect(await screen.findByTestId('subsection-card-header__menu')).toBeInTheDocument();
     });
 
     it('does not render the rename button when canEditCourseContent is false', async () => {
-      mockPermissions({ canEditCourseContent: false });
+      mockPermissions(false);
       renderComponent();
 
       expect(await screen.findByText(cardHeaderProps.title)).toBeInTheDocument();
@@ -612,7 +608,7 @@ describe('<CardHeader />', () => {
     });
 
     it('does not render the actions menu when canEditCourseContent is false', async () => {
-      mockPermissions({ canEditCourseContent: false });
+      mockPermissions(false);
       renderComponent();
 
       expect(await screen.findByText(cardHeaderProps.title)).toBeInTheDocument();

--- a/src/course-outline/card-header/CardHeader.test.tsx
+++ b/src/course-outline/card-header/CardHeader.test.tsx
@@ -8,6 +8,8 @@ import {
   waitFor,
 } from '@src/testUtils';
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
+import { mockWaffleFlags } from '@src/data/apiHooks.mock';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 import { courseId } from '@src/schedule-and-details/__mocks__/courseDetails';
 import { userEvent } from '@testing-library/user-event';
 import { renderCard, setupCardTestMocks } from '../__mocks__/testSetup';
@@ -39,6 +41,14 @@ jest.mock('@src/course-outline/data/apiHooks', () => ({
   useUpdateCourseBlockName: () => useUpdateCourseBlockNameMock,
 }));
 
+jest.mock('@src/authz/hooks', () => ({
+  useCourseUserPermissions: jest.fn().mockReturnValue({
+    isLoading: false,
+    canEditCourseContent: true,
+    canPublishCourseContent: true,
+  }),
+}));
+
 const cardHeaderProps = {
   title: 'Some title',
   status: ITEM_BADGE_STATUS.live,
@@ -64,6 +74,11 @@ const cardHeaderProps = {
     duplicable: true,
     unlinkable: true,
   },
+};
+
+const mockPermissions = (mockedPermissions) => {
+  mockWaffleFlags({ enableAuthzCourseAuthoring: !!mockedPermissions });
+  jest.mocked(useCourseUserPermissions).mockReturnValue(mockedPermissions);
 };
 
 const renderComponent = (props?: object, entry = '/') => {
@@ -578,5 +593,31 @@ describe('<CardHeader />', () => {
     fireEvent.click(unlinkMenuItem);
     await act(async () => fireEvent.click(unlinkMenuItem));
     expect(onClickUnlinkMock).toHaveBeenCalled();
+  });
+
+  describe('canEditCourseContent permission', () => {
+    it('renders the rename button and actions menu when canEditCourseContent is true', async () => {
+      renderComponent({ canEditCourseContent: true });
+
+      expect(await screen.findByTestId('subsection-edit-button')).toBeInTheDocument();
+      expect(await screen.findByTestId('subsection-card-header__menu')).toBeInTheDocument();
+    });
+
+    it('does not render the rename button when canEditCourseContent is false', async () => {
+      mockPermissions({ canEditCourseContent: false });
+      renderComponent();
+
+      expect(await screen.findByText(cardHeaderProps.title)).toBeInTheDocument();
+      expect(screen.queryByTestId('subsection-edit-button')).not.toBeInTheDocument();
+    });
+
+    it('does not render the actions menu when canEditCourseContent is false', async () => {
+      mockPermissions({ canEditCourseContent: false });
+      renderComponent();
+
+      expect(await screen.findByText(cardHeaderProps.title)).toBeInTheDocument();
+      expect(screen.queryByTestId('subsection-card-header__menu')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('subsection-card-header__menu-button')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/course-outline/card-header/CardHeader.tsx
+++ b/src/course-outline/card-header/CardHeader.tsx
@@ -6,7 +6,7 @@ import {
   useState,
 } from 'react';
 import { getConfig } from '@edx/frontend-platform';
-import { useIntl } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { useSearchParams } from 'react-router-dom';
 import {
   Dropdown,
@@ -57,7 +57,6 @@ interface CardHeaderProps {
   namePrefix: string;
   proctoringExamConfigurationLink?: string;
   actions: XBlockActions;
-  enableCopyPasteUnits?: boolean;
   isVertical?: boolean;
   isSequential?: boolean;
   discussionEnabled?: boolean;
@@ -96,7 +95,6 @@ const CardHeader = ({
   titleComponent,
   namePrefix,
   actions,
-  enableCopyPasteUnits,
   isVertical,
   isSequential,
   proctoringExamConfigurationLink,
@@ -117,7 +115,7 @@ const CardHeader = ({
     setCurrentPageKey('align');
     onClickManageTags?.();
   }, [setCurrentPageKey, cardId]);
-  const { courseId } = useCourseAuthoringContext();
+  const { courseId, canEditCourseContent, canPublishCourseContent } = useCourseAuthoringContext();
   const [isFormOpen, openForm, closeForm] = useToggle(false);
   // Set true by any Escape keydown handler; checked in handleEditSubmit
   // to prevent blur-after-Escape from saving the dirty titleValue.
@@ -285,15 +283,18 @@ const CardHeader = ({
           (
             <Stack direction="horizontal" gap={2}>
               {titleComponent}
-              <IconButtonWithTooltip
-                className="item-card-button-icon"
-                data-testid={`${namePrefix}-edit-button`}
-                alt={intl.formatMessage(messages.altButtonRename)}
-                tooltipContent={<div>{intl.formatMessage(messages.altButtonRename)}</div>}
-                iconAs={EditIcon}
-                onClick={onEditClick}
-                disabled={editMutation.isPending}
-              />
+              {canEditCourseContent &&
+                (
+                  <IconButtonWithTooltip
+                    className="item-card-button-icon"
+                    data-testid={`${namePrefix}-edit-button`}
+                    alt={intl.formatMessage(messages.altButtonRename)}
+                    tooltipContent={<div>{intl.formatMessage(messages.altButtonRename)}</div>}
+                    iconAs={EditIcon}
+                    onClick={onEditClick}
+                    disabled={editMutation.isPending}
+                  />
+                )}
             </Stack>
           )}
         <div className="ml-auto d-flex">
@@ -313,105 +314,110 @@ const CardHeader = ({
               onClick={onClickSync}
             />
           )}
-          <Dropdown data-testid={`${namePrefix}-card-header__menu`}>
-            <Dropdown.Toggle
-              className="item-card-header__menu"
-              id={`${namePrefix}-card-header__menu`}
-              data-testid={`${namePrefix}-card-header__menu-button`}
-              as={IconButton}
-              src={MoveVertIcon}
-              alt={`${namePrefix}-card-header__menu`}
-              iconAs={Icon}
-            />
-            <Dropdown.Menu>
-              {isSequential && proctoringExamConfigurationLink && (
+          {canEditCourseContent && (
+            <Dropdown data-testid={`${namePrefix}-card-header__menu`}>
+              <Dropdown.Toggle
+                className="item-card-header__menu"
+                id={`${namePrefix}-card-header__menu`}
+                data-testid={`${namePrefix}-card-header__menu-button`}
+                as={IconButton}
+                src={MoveVertIcon}
+                alt={`${namePrefix}-card-header__menu`}
+                iconAs={Icon}
+              />
+              <Dropdown.Menu>
+                {isSequential && proctoringExamConfigurationLink && (
+                  <Dropdown.Item
+                    as={Hyperlink}
+                    target="_blank"
+                    destination={fullProctoringExamConfigurationLink()}
+                    href={fullProctoringExamConfigurationLink()}
+                    externalLinkTitle={intl.formatMessage(messages.proctoringLinkTooltip)}
+                  >
+                    {intl.formatMessage(messages.menuProctoringLinkText)}
+                  </Dropdown.Item>
+                )}
+                {canPublishCourseContent &&
+                  (
+                    <Dropdown.Item
+                      data-testid={`${namePrefix}-card-header__menu-publish-button`}
+                      disabled={isDisabledPublish}
+                      onClick={onClickPublish}
+                    >
+                      {intl.formatMessage(messages.menuPublish)}
+                    </Dropdown.Item>
+                  )}
                 <Dropdown.Item
-                  as={Hyperlink}
-                  target="_blank"
-                  destination={fullProctoringExamConfigurationLink()}
-                  href={fullProctoringExamConfigurationLink()}
-                  externalLinkTitle={intl.formatMessage(messages.proctoringLinkTooltip)}
-                >
-                  {intl.formatMessage(messages.menuProctoringLinkText)}
-                </Dropdown.Item>
-              )}
-              <Dropdown.Item
-                data-testid={`${namePrefix}-card-header__menu-publish-button`}
-                disabled={isDisabledPublish}
-                onClick={onClickPublish}
-              >
-                {intl.formatMessage(messages.menuPublish)}
-              </Dropdown.Item>
-              <Dropdown.Item
-                data-testid={`${namePrefix}-card-header__menu-configure-button`}
-                disabled={editMutation.isPending}
-                onClick={onConfigureClick}
-              >
-                {intl.formatMessage(messages.menuConfigure)}
-              </Dropdown.Item>
-              {getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true' && (
-                <Dropdown.Item
-                  data-testid={`${namePrefix}-card-header__menu-manage-tags-button`}
+                  data-testid={`${namePrefix}-card-header__menu-configure-button`}
                   disabled={editMutation.isPending}
-                  onClick={openManageTagsDrawer}
+                  onClick={onConfigureClick}
                 >
-                  {intl.formatMessage(messages.menuManageTags)}
+                  {intl.formatMessage(messages.menuConfigure)}
                 </Dropdown.Item>
-              )}
+                {getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true' && (
+                  <Dropdown.Item
+                    data-testid={`${namePrefix}-card-header__menu-manage-tags-button`}
+                    disabled={editMutation.isPending}
+                    onClick={openManageTagsDrawer}
+                  >
+                    {intl.formatMessage(messages.menuManageTags)}
+                  </Dropdown.Item>
+                )}
 
-              {isVertical && enableCopyPasteUnits && (
-                <Dropdown.Item onClick={onClickCopy}>
-                  {intl.formatMessage(messages.menuCopy)}
-                </Dropdown.Item>
-              )}
-              {actions.duplicable && (
-                <Dropdown.Item
-                  data-testid={`${namePrefix}-card-header__menu-duplicate-button`}
-                  onClick={onClickDuplicate}
-                >
-                  {intl.formatMessage(messages.menuDuplicate)}
-                </Dropdown.Item>
-              )}
-              {actions.draggable && (
-                <>
-                  <Dropdown.Item
-                    data-testid={`${namePrefix}-card-header__menu-move-up-button`}
-                    onClick={onClickMoveUp}
-                    disabled={!actions.allowMoveUp}
-                  >
-                    {intl.formatMessage(messages.menuMoveUp)}
+                {isVertical && (
+                  <Dropdown.Item onClick={onClickCopy}>
+                    {intl.formatMessage(messages.menuCopy)}
                   </Dropdown.Item>
+                )}
+                {actions.duplicable && (
                   <Dropdown.Item
-                    data-testid={`${namePrefix}-card-header__menu-move-down-button`}
-                    onClick={onClickMoveDown}
-                    disabled={!actions.allowMoveDown}
+                    data-testid={`${namePrefix}-card-header__menu-duplicate-button`}
+                    onClick={onClickDuplicate}
                   >
-                    {intl.formatMessage(messages.menuMoveDown)}
+                    {intl.formatMessage(messages.menuDuplicate)}
                   </Dropdown.Item>
-                </>
-              )}
-              {((actions.unlinkable ?? null) !== null || actions.deletable) && <Dropdown.Divider />}
-              {(actions.unlinkable ?? null) !== null && (
-                <Dropdown.Item
-                  data-testid={`${namePrefix}-card-header__menu-unlink-button`}
-                  onClick={onClickUnlink}
-                  disabled={!actions.unlinkable}
-                  className="allow-hover-on-disabled"
-                  title={!actions.unlinkable ? intl.formatMessage(messages.menuUnlinkDisabledTooltip) : undefined}
-                >
-                  {intl.formatMessage(messages.menuUnlink)}
-                </Dropdown.Item>
-              )}
-              {actions.deletable && (
-                <Dropdown.Item
-                  data-testid={`${namePrefix}-card-header__menu-delete-button`}
-                  onClick={onClickDelete}
-                >
-                  {intl.formatMessage(messages.menuDelete)}
-                </Dropdown.Item>
-              )}
-            </Dropdown.Menu>
-          </Dropdown>
+                )}
+                {actions.draggable && (
+                  <>
+                    <Dropdown.Item
+                      data-testid={`${namePrefix}-card-header__menu-move-up-button`}
+                      onClick={onClickMoveUp}
+                      disabled={!actions.allowMoveUp}
+                    >
+                      {intl.formatMessage(messages.menuMoveUp)}
+                    </Dropdown.Item>
+                    <Dropdown.Item
+                      data-testid={`${namePrefix}-card-header__menu-move-down-button`}
+                      onClick={onClickMoveDown}
+                      disabled={!actions.allowMoveDown}
+                    >
+                      {intl.formatMessage(messages.menuMoveDown)}
+                    </Dropdown.Item>
+                  </>
+                )}
+                {((actions.unlinkable ?? null) !== null || actions.deletable) && <Dropdown.Divider />}
+                {(actions.unlinkable ?? null) !== null && (
+                  <Dropdown.Item
+                    data-testid={`${namePrefix}-card-header__menu-unlink-button`}
+                    onClick={onClickUnlink}
+                    disabled={!actions.unlinkable}
+                    className="allow-hover-on-disabled"
+                    title={!actions.unlinkable ? intl.formatMessage(messages.menuUnlinkDisabledTooltip) : undefined}
+                  >
+                    {intl.formatMessage(messages.menuUnlink)}
+                  </Dropdown.Item>
+                )}
+                {actions.deletable && (
+                  <Dropdown.Item
+                    data-testid={`${namePrefix}-card-header__menu-delete-button`}
+                    onClick={onClickDelete}
+                  >
+                    <FormattedMessage {...messages.menuDelete} />
+                  </Dropdown.Item>
+                )}
+              </Dropdown.Menu>
+            </Dropdown>
+          )}
         </div>
       </div>
     </>

--- a/src/course-outline/outline-sidebar/OutlineSidebarPagesContext.tsx
+++ b/src/course-outline/outline-sidebar/OutlineSidebarPagesContext.tsx
@@ -14,25 +14,28 @@ import { OutlineAlignSidebar } from './OutlineAlignSidebar';
 import OutlineHelpSidebar from './OutlineHelpSidebar';
 import { InfoSidebar } from './info-sidebar/InfoSidebar';
 import messages from './messages';
+import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
 
 export type OutlineSidebarPages = {
   info: SidebarPage;
   help: SidebarPage;
-  add: SidebarPage;
+  add?: SidebarPage;
   align?: SidebarPage;
 };
 
-const getOutlineSidebarPages = () => ({
+const getOutlineSidebarPages = (canEditCourseContent: boolean = false) => ({
   info: {
     component: InfoSidebar,
     icon: Info,
     title: messages.sidebarButtonInfo,
   },
-  add: {
-    component: AddSidebar,
-    icon: Plus,
-    title: messages.sidebarButtonAdd,
-  },
+  ...(canEditCourseContent && {
+    add: {
+      component: AddSidebar,
+      icon: Plus,
+      title: messages.sidebarButtonAdd,
+    },
+  }),
   ...(getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true' && {
     align: {
       component: OutlineAlignSidebar,
@@ -84,9 +87,11 @@ type OutlineSidebarPagesProviderProps = {
 };
 
 export const OutlineSidebarPagesProvider = ({ children }: OutlineSidebarPagesProviderProps) => {
+  const { canEditCourseContent } = useCourseAuthoringContext();
+
   // align page is sometimes not added when getOutlineSidebarPages() is called at the top level.
   // So if we call it inside the hook, getConfig has updated values and align page is added.
-  const sidebarPages = useMemo(getOutlineSidebarPages, []);
+  const sidebarPages = useMemo(() => getOutlineSidebarPages(canEditCourseContent), [canEditCourseContent]);
 
   return (
     <OutlineSidebarPagesContext.Provider value={sidebarPages}>

--- a/src/course-outline/status-bar/StatusBar.test.tsx
+++ b/src/course-outline/status-bar/StatusBar.test.tsx
@@ -1,7 +1,7 @@
 import { VIDEO_SHARING_OPTIONS } from '@src/course-outline/constants';
 import { CourseOutlineStatusBar } from '@src/course-outline/data/types';
 import { initializeMocks, render, screen } from '@src/testUtils';
-import { useCourseUserPermissions } from '@src/authz/hooks';
+import { mockWaffleFlags } from '@src/data/apiHooks.mock';
 import { StatusBar, StatusBarProps } from './StatusBar';
 import messages from './messages';
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
@@ -39,19 +39,10 @@ jest.mock('@src/course-outline/data/apiHooks', () => ({
   }),
 }));
 
-// StatusBar reads canEditCourseContent from useCourseUserPermissions to gate edit affordances.
-jest.mock('@src/authz/hooks', () => ({
-  ...jest.requireActual('@src/authz/hooks'),
-  useCourseUserPermissions: jest.fn(),
-}));
-
-/** Set the resolved course-scoped edit permission used to gate edit affordances in the status bar. */
+let validateUserPermissionsMock;
 const mockPermissions = (canEditCourseContent = true) => {
-  jest.mocked(useCourseUserPermissions).mockReturnValue({
-    isLoading: false,
-    isAuthzEnabled: false,
-    canEditCourseContent,
-  } as unknown as ReturnType<typeof useCourseUserPermissions>);
+  mockWaffleFlags({ enableAuthzCourseAuthoring: !canEditCourseContent });
+  validateUserPermissionsMock.mockResolvedValue({ canEditCourseContent });
 };
 
 const mockOpenEnableHighlightsModal = jest.fn();
@@ -74,7 +65,8 @@ const renderComponent = (props?: Partial<StatusBarProps>) =>
 
 describe('<StatusBar />', () => {
   beforeEach(() => {
-    initializeMocks();
+    const mocks = initializeMocks();
+    validateUserPermissionsMock = mocks.validateUserPermissionsMock;
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2013-03-05'));
     mockPermissions(true);

--- a/src/course-outline/status-bar/StatusBar.test.tsx
+++ b/src/course-outline/status-bar/StatusBar.test.tsx
@@ -1,8 +1,10 @@
 import { VIDEO_SHARING_OPTIONS } from '@src/course-outline/constants';
 import { CourseOutlineStatusBar } from '@src/course-outline/data/types';
 import { initializeMocks, render, screen } from '@src/testUtils';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 import { StatusBar, StatusBarProps } from './StatusBar';
 import messages from './messages';
+import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
 
 const courseId = 'course-v1:123';
 const isLoading = false;
@@ -36,6 +38,22 @@ jest.mock('@src/course-outline/data/apiHooks', () => ({
     isLoading: false,
   }),
 }));
+
+// StatusBar reads canEditCourseContent from useCourseUserPermissions to gate edit affordances.
+jest.mock('@src/authz/hooks', () => ({
+  ...jest.requireActual('@src/authz/hooks'),
+  useCourseUserPermissions: jest.fn(),
+}));
+
+/** Set the resolved course-scoped edit permission used to gate edit affordances in the status bar. */
+const mockPermissions = (canEditCourseContent = true) => {
+  jest.mocked(useCourseUserPermissions).mockReturnValue({
+    isLoading: false,
+    isAuthzEnabled: false,
+    canEditCourseContent,
+  } as unknown as ReturnType<typeof useCourseUserPermissions>);
+};
+
 const mockOpenEnableHighlightsModal = jest.fn();
 const mockHandleVideoSharingOptionChange = jest.fn();
 
@@ -49,6 +67,9 @@ const renderComponent = (props?: Partial<StatusBarProps>) =>
       handleVideoSharingOptionChange={mockHandleVideoSharingOptionChange}
       {...props}
     />,
+    {
+      extraWrapper: ({ children }) => <CourseAuthoringProvider courseId={courseId}>{children}</CourseAuthoringProvider>,
+    },
   );
 
 describe('<StatusBar />', () => {
@@ -56,6 +77,7 @@ describe('<StatusBar />', () => {
     initializeMocks();
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2013-03-05'));
+    mockPermissions(true);
   });
 
   it('renders StatusBar component correctly', async () => {
@@ -143,6 +165,29 @@ describe('<StatusBar />', () => {
       },
     });
     expect(await screen.findByText(messages.highlightEmailsEnabled.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('does not render the enable highlights button when canEditCourseContent is false', async () => {
+    mockPermissions(false);
+    renderComponent();
+
+    // Wait for the status bar to render, then confirm the enable button is absent.
+    expect(await screen.findByText('Feb 05, 2013 - Apr 09, 2013')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Enable highlights emails' })).not.toBeInTheDocument();
+  });
+
+  it('still shows the enabled highlights message when canEditCourseContent is false', async () => {
+    mockPermissions(false);
+    renderComponent({
+      statusBarData: {
+        ...statusBarData,
+        highlightsEnabledForMessaging: true,
+      },
+    });
+
+    // The "enabled" message is informational (not an edit action), so it renders regardless of permission.
+    expect(await screen.findByText(messages.highlightEmailsEnabled.defaultMessage)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Enable highlights emails' })).not.toBeInTheDocument();
   });
 
   it('does render video sharing dropdown if enabled', async () => {

--- a/src/course-outline/status-bar/StatusBar.tsx
+++ b/src/course-outline/status-bar/StatusBar.tsx
@@ -29,6 +29,7 @@ import { useHelpUrls } from '@src/help-urls/hooks';
 
 import messages from './messages';
 import { NotificationStatusIcon } from './NotificationStatusIcon';
+import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
 
 const CourseBadge = ({ startDate, endDate }: { startDate: Moment; endDate: Moment; }) => {
   const now = moment().utc();
@@ -192,19 +193,23 @@ const Highlights = ({ highlightsEnabledForMessaging, openEnableHighlightsModal }
 }) => {
   const intl = useIntl();
 
+  const { canEditCourseContent } = useCourseAuthoringContext();
+
   if (highlightsEnabledForMessaging) {
     return (
       <span data-testid="highlights-enabled-span" className="small">
         {intl.formatMessage(messages.highlightEmailsEnabled)}
       </span>
     );
-  } else {
-    return (
-      <Button data-testid="highlights-enable-button" size="sm" onClick={openEnableHighlightsModal}>
-        {intl.formatMessage(messages.highlightEmailsButton)}
-      </Button>
-    );
   }
+  if (!canEditCourseContent) {
+    return null;
+  }
+  return (
+    <Button data-testid="highlights-enable-button" size="sm" onClick={openEnableHighlightsModal}>
+      {intl.formatMessage(messages.highlightEmailsButton)}
+    </Button>
+  );
 };
 
 const VideoSharingDropdown = ({ handleVideoSharingOptionChange, videoSharingOptions }: {

--- a/src/generic/sidebar/Sidebar.tsx
+++ b/src/generic/sidebar/Sidebar.tsx
@@ -88,12 +88,17 @@ export function Sidebar<T extends SidebarPages>({
 }: SidebarProps<T>) {
   const intl = useIntl();
 
+  // currentPageKey may point to a page that isn't currently available (e.g. one hidden by
+  // permissions or a stale value coming from the URL). Fall back to the first available page
+  // so the sidebar renders instead of crashing on an undefined page.
+  const [fallbackPageKey] = Object.keys(pages) as (keyof T)[];
+  const effectivePageKey = pages[currentPageKey] ? currentPageKey : fallbackPageKey;
   const {
     component: SidebarComponent,
     icon: SidebarIcon,
     title,
-  } = pages[currentPageKey];
-  const activeKey = isOpen ? currentPageKey : undefined;
+  } = pages[effectivePageKey];
+  const activeKey = isOpen ? effectivePageKey : undefined;
 
   return (
     <Stack direction="horizontal" className="align-items-baseline flex-fill overflow-hidden" gap={2}>

--- a/src/studio-home/StudioHome.tsx
+++ b/src/studio-home/StudioHome.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import classNames from 'classnames';
 import {
   Button,
   Container,
@@ -85,7 +86,11 @@ const StudioHome = () => {
 
     if (canViewConsoleTeams) {
       headerButtons.push(
-        <div className="border-right mr-3 pr-4 py-2">
+        <div
+          className={classNames('mr-3 pr-4 py-2', {
+            'border-right': hasAbilityToCreateNewCourse || canCreateNewLibrary,
+          })}
+        >
           <Button
             as="a"
             href={adminConsoleUrl}
@@ -129,7 +134,14 @@ const StudioHome = () => {
     }
 
     return headerButtons;
-  }, [location, userIsActive, isFailedLoadingPage, canViewConsoleTeams]);
+  }, [
+    location,
+    userIsActive,
+    isFailedLoadingPage,
+    canViewConsoleTeams,
+    hasAbilityToCreateNewCourse,
+    canCreateNewLibrary,
+  ]);
 
   const headerButtons = userIsActive ? getHeaderButtons() : [];
   if (isLoadingPage && !isFiltered) {


### PR DESCRIPTION
## Description

Conditionally renders or hides the editable and publishable course content sections on the course outline home page.
The goal is to ensure that users with these roles interact only with the permitted elements, by applying “read-only” states or disabling modification actions as defined by the design.
This first pr focus on the course outline page, there will be future prs for section/unit specific internal page.

### Permission Matrix
| Category | Permission | Course Editor | Course Auditor |
|--------|--------|--------|--------|
| **Course Access & Content** | `courses.view_course` | ✅ | ✅ |
|  | `courses.create_course` | ❌ | ❌ |
|  | `courses.publish_course_content` | ❌ | ❌ |
|  | `courses.edit_course_content` | ✅ | ❌ |

The elements covered on this pr are the ones highlighted by the red squares.
<img width="1984" height="1528" alt="image" src="https://github.com/user-attachments/assets/fd34f503-8174-4d24-8bad-24bc4296825c" />

## Supporting information
Partially closes https://github.com/openedx/openedx-authz/issues/383
[Figma](https://www.figma.com/design/onU2END2OXaF7RRLWEHsZI/AuthZ---v2?node-id=9124-58252&t=TQ1vgMaA4yD32S2i-4)

## Testing instructions
#### Requirements
Enable the `authz.enable_course_authoring` waffle flag.
You can set _course_auditor_  or _course_editor_ role to a user using the API `<lms_url>/api-docs/#/authz/authz_v1_roles_users_update`
Payload example:
```typescript
{
  "role": "course_auditor", // role
  "scope": "course-v1:OpenedX+DemoX+DemoCourse", //courseId
  // use scopes instead of scope if you need to set more than 1 resource
  "users": [
    "my_username" // username or email
  ]
}
``` 

##### Test case 1
Log in with a user with course_auditor role.
Go to studio home page and select the course on which the user is course_auditor to get into the course outline page.
Make sure you are allowed to see the course content info but not allowed to add/update course content nor publish the course. 
The sections highlighted on red must not be visible for course audit role:
<img width="1792" height="1390" alt="image" src="https://github.com/user-attachments/assets/44689970-6a26-4aa4-ae82-07b54d7ba89c" />
NOTE: The permission related to Tags are handled on a different ticket https://github.com/openedx/openedx-authz/issues/314

##### Test case 2
Log in with a user with course_editor role.
Go to studio home page and select the course on which the user is course_editor to get into the course outline page.
Make sure you are allowed to see the course content info, add/update course content but not allowed publish the course. 
Publish buttons/items must not be visible:
<img width="2880" height="1826" alt="image" src="https://github.com/user-attachments/assets/bbf793ad-df27-4e9e-812b-c487febac1fb" />


##### Test case 3
Log in with a user with role different than course_editor or course_auditor, (can be staff, superuser, course_admin or course_staff).
Go to studio home page and select the course on which the user has the prev permission set to go into the course outline page.
Make sure all the sections related to add, update and publish course content are visible and remain functional.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
