### PR TITLE
fix: gate studio home roles button on manage-team permission

### DIFF
--- a/src/authz/constants.ts
+++ b/src/authz/constants.ts
@@ -40,6 +40,7 @@ export const COURSE_PERMISSIONS = {
   MANAGE_LIBRARY_UPDATES: 'courses.manage_library_updates',
 
   VIEW_COURSE_TEAM: 'courses.view_course_team',
+  MANAGE_COURSE_TEAM: 'courses.manage_course_team',
 
   MANAGE_GROUP_CONFIGURATIONS: 'courses.manage_group_configurations',
   MANAGE_CERTIFICATES: 'courses.manage_certificates',

--- a/src/authz/permissionHelpers.test.ts
+++ b/src/authz/permissionHelpers.test.ts
@@ -11,7 +11,7 @@ import {
   getCertificatesPermissions,
   getChecklistsPermissions,
   getImportExportPermissions,
-  getViewTeamPermissions,
+  getManageTeamPermissions,
 } from './permissionHelpers';
 import { CONTENT_LIBRARY_PERMISSIONS, COURSE_PERMISSIONS } from './constants';
 
@@ -254,22 +254,22 @@ describe('permissionHelpers', () => {
     });
   });
 
-  describe('getViewTeamPermissions', () => {
-    it('returns course and library view-team permissions with the correct actions', () => {
-      const result = getViewTeamPermissions();
+  describe('getManageTeamPermissions', () => {
+    it('returns course and library manage-team permissions with the correct actions', () => {
+      const result = getManageTeamPermissions();
 
       expect(result).toEqual({
-        canViewCourseTeam: {
-          action: COURSE_PERMISSIONS.VIEW_COURSE_TEAM,
+        canManageCourseTeam: {
+          action: COURSE_PERMISSIONS.MANAGE_COURSE_TEAM,
         },
-        canViewLibraryTeam: {
-          action: CONTENT_LIBRARY_PERMISSIONS.VIEW_LIBRARY_TEAM,
+        canManageLibraryTeam: {
+          action: CONTENT_LIBRARY_PERMISSIONS.MANAGE_LIBRARY_TEAM,
         },
       });
     });
 
     it('is scope-less so it validates the permissions across any course or library', () => {
-      const result = getViewTeamPermissions();
+      const result = getManageTeamPermissions();
 
       // A scope of '' would be rejected by the AuthZ API as a bad request; the scope key
       // must be absent entirely so the check applies to any object.

--- a/src/authz/permissionHelpers.ts
+++ b/src/authz/permissionHelpers.ts
@@ -1,14 +1,18 @@
 import { CONTENT_LIBRARY_PERMISSIONS, COURSE_PERMISSIONS } from './constants';
 
-// It validates whether the user can view a team on *any* course or
+// It validates whether the user can manage a team on *any* course or
 // library, to decide if the "Roles & Permissions" button (which links to the admin
 // console in Studio Home) should be shown.
-export const getViewTeamPermissions = () => ({
-  canViewCourseTeam: {
-    action: COURSE_PERMISSIONS.VIEW_COURSE_TEAM,
+// The check is on *manage* rather than *view* on purpose: the admin console's role
+// assignment flow requires manage_course_team / manage_library_team, so users who can
+// only view a team (e.g. Course Staff) would otherwise reach the button, walk the whole
+// assignment wizard and only fail on the final step.
+export const getManageTeamPermissions = () => ({
+  canManageCourseTeam: {
+    action: COURSE_PERMISSIONS.MANAGE_COURSE_TEAM,
   },
-  canViewLibraryTeam: {
-    action: CONTENT_LIBRARY_PERMISSIONS.VIEW_LIBRARY_TEAM,
+  canManageLibraryTeam: {
+    action: CONTENT_LIBRARY_PERMISSIONS.MANAGE_LIBRARY_TEAM,
   },
 });
 

--- a/src/studio-home/StudioHome.test.tsx
+++ b/src/studio-home/StudioHome.test.tsx
@@ -31,8 +31,8 @@ jest.mock('@src/authz/data/apiHooks', () => ({
   useUserPermissions: jest.fn(),
 }));
 
-/** Set the result of the scope-less "can view any team" permission check. */
-const mockViewTeamPermissions = (data: Record<string, boolean>) => {
+/** Set the result of the scope-less "can manage any team" permission check. */
+const mockManageTeamPermissions = (data: Record<string, boolean>) => {
   // Mirror production: the query is skipped (data undefined) unless it is enabled,
   // which happens only when authz is on and the admin console URL is configured.
   jest.mocked(useUserPermissions).mockImplementation((_permissions, enabled = true) => ({
@@ -54,7 +54,7 @@ describe('<StudioHome />', () => {
       const mocks = initializeMocks();
       mocks.axiosMock.onGet(getStudioHomeApiUrl()).reply(404);
       mockUseSelector.mockReturnValue({ studioHomeLoadingStatus: RequestStatus.FAILED });
-      mockViewTeamPermissions({});
+      mockManageTeamPermissions({});
     });
 
     it('should render fetch error', async () => {
@@ -75,7 +75,7 @@ describe('<StudioHome />', () => {
       const mocks = initializeMocks();
       mocks.axiosMock.onGet(getStudioHomeApiUrl()).reply(200, studioHomeMock);
       mockUseSelector.mockReturnValue(studioHomeMock);
-      mockViewTeamPermissions({});
+      mockManageTeamPermissions({});
     });
 
     it('should render page and page title correctly', async () => {
@@ -108,9 +108,9 @@ describe('<StudioHome />', () => {
     });
 
     it.each([
-      ['course', { canViewCourseTeam: true, canViewLibraryTeam: false }],
-      ['library', { canViewCourseTeam: false, canViewLibraryTeam: true }],
-    ])('should render roles and permissions button when authz is enabled and the user can view a %s team', async (
+      ['course', { canManageCourseTeam: true, canManageLibraryTeam: false }],
+      ['library', { canManageCourseTeam: false, canManageLibraryTeam: true }],
+    ])('should render roles and permissions button when authz is enabled and the user can manage a %s team', async (
       _team,
       permissions,
     ) => {
@@ -119,7 +119,7 @@ describe('<StudioHome />', () => {
         ADMIN_CONSOLE_URL: 'https://admin-console.example.com',
       });
       mockWaffleFlags({ enableAuthzCourseAuthoring: true });
-      mockViewTeamPermissions(permissions);
+      mockManageTeamPermissions(permissions);
 
       render(<StudioHome />, { path: '/home' });
       const header = getHeaderElement();
@@ -133,7 +133,23 @@ describe('<StudioHome />', () => {
         ADMIN_CONSOLE_URL: 'https://admin-console.example.com',
       });
       mockWaffleFlags({ enableAuthzCourseAuthoring: true });
-      mockViewTeamPermissions({ canViewCourseTeam: false, canViewLibraryTeam: false });
+      mockManageTeamPermissions({ canManageCourseTeam: false, canManageLibraryTeam: false });
+
+      render(<StudioHome />, { path: '/home' });
+      const header = getHeaderElement();
+      expect(within(header).queryByRole('link', { name: 'Roles and permissions' })).not.toBeInTheDocument();
+    });
+
+    it('should not render roles and permissions button for users who can only view a team', async () => {
+      // Course Staff / Editor / Auditor hold view_course_team but not manage_course_team. They must
+      // not reach the admin console: the role assignment flow there requires manage_course_team, so
+      // they could complete the whole wizard and only fail on the final step.
+      setConfig({
+        ...getConfig(),
+        ADMIN_CONSOLE_URL: 'https://admin-console.example.com',
+      });
+      mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+      mockManageTeamPermissions({ canManageCourseTeam: false, canManageLibraryTeam: false });
 
       render(<StudioHome />, { path: '/home' });
       const header = getHeaderElement();
@@ -146,7 +162,7 @@ describe('<StudioHome />', () => {
         ADMIN_CONSOLE_URL: 'https://admin-console.example.com',
       });
       mockWaffleFlags({ enableAuthzCourseAuthoring: false });
-      mockViewTeamPermissions({ canViewCourseTeam: true, canViewLibraryTeam: true });
+      mockManageTeamPermissions({ canManageCourseTeam: true, canManageLibraryTeam: true });
 
       render(<StudioHome />, { path: '/home' });
       const header = getHeaderElement();

--- a/src/studio-home/StudioHome.tsx
+++ b/src/studio-home/StudioHome.tsx
@@ -14,7 +14,7 @@ import { Link, useLocation } from 'react-router-dom';
 
 import { useWaffleFlags } from '@src/data/apiHooks';
 import { useUserPermissions } from '@src/authz/data/apiHooks';
-import { getViewTeamPermissions } from '@src/authz/permissionHelpers';
+import { getManageTeamPermissions } from '@src/authz/permissionHelpers';
 import { getAdminConsoleUrl, isAdminConsoleEnabled } from '@src/authz/urls';
 import Loading from '../generic/Loading';
 import InternetConnectionAlert from '../generic/internet-connection-alert';
@@ -54,14 +54,14 @@ const StudioHome = () => {
   const adminConsoleUrl = getAdminConsoleUrl();
 
   // The "Roles & Permissions" button links to the admin console, so only show it to users
-  // who can view a team somewhere: on any course (view_course_team) or any library
-  // (view_library_team).
-  const { data: viewTeamPermissions } = useUserPermissions(
-    getViewTeamPermissions(),
+  // who can manage a team somewhere: on any course (manage_course_team) or any library
+  // (manage_library_team).
+  const { data: manageTeamPermissions } = useUserPermissions(
+    getManageTeamPermissions(),
     isAuthzEnabled && isAdminConsoleEnabled(),
   );
-  const canViewConsoleTeams = Boolean(
-    viewTeamPermissions?.canViewCourseTeam || viewTeamPermissions?.canViewLibraryTeam,
+  const canManageConsoleTeams = Boolean(
+    manageTeamPermissions?.canManageCourseTeam || manageTeamPermissions?.canManageLibraryTeam,
   );
 
   const {
@@ -83,7 +83,7 @@ const StudioHome = () => {
       );
     }
 
-    if (canViewConsoleTeams) {
+    if (canManageConsoleTeams) {
       headerButtons.push(
         <div className="border-right mr-3 pr-4 py-2">
           <Button
@@ -129,7 +129,7 @@ const StudioHome = () => {
     }
 
     return headerButtons;
-  }, [location, userIsActive, isFailedLoadingPage, canViewConsoleTeams]);
+  }, [location, userIsActive, isFailedLoadingPage, canManageConsoleTeams]);
 
   const headerButtons = userIsActive ? getHeaderButtons() : [];
   if (isLoadingPage && !isFiltered) {


### PR DESCRIPTION
## Description

The "Roles and permissions" button on the Studio Home page is gated on whether the user can *view* a team on any course or library (`courses.view_course_team` / `content_libraries.view_library_team`). However, the admin console's role assignment flow requires the corresponding *manage* permissions: `RoleUserAPIView.put`/`delete` in `openedx-authz` are decorated with `@authz_permissions([MANAGE_LIBRARY_TEAM, COURSES_MANAGE_COURSE_TEAM])`.

Of the four course roles, only `course_admin` holds `courses.manage_course_team`; `course_staff`, `course_editor` and `course_auditor` hold `courses.view_course_team` only. Those three therefore see the button, can walk the entire role assignment wizard, and only fail on the final step with a `403 permission_denied`. The same applies on the library side, where only `library_admin` holds `content_libraries.manage_library_team`.

This changes the gate to the two `manage_*_team` permissions, so the button is only shown to users who can actually complete the action. The waffle flag and `ADMIN_CONSOLE_URL` conditions are unchanged.

Useful information to include:

- Which user roles will this change impact? Course Author (specifically: Course Staff, Course Editor and Course Auditor no longer see the button; Course Admin is unaffected)
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).

Before

_Studio Home as a user holding `course_staff` — the "Roles and permissions" button is rendered, and completing the assignment wizard from it fails with a 403._

<img width="3024" height="1656" alt="before-staff" src="https://github.com/user-attachments/assets/58294cdf-04f0-4b50-bc6b-1b45e460fb9f" />


After

_Same user, same page — the button is no longer rendered._

<img width="3024" height="1656" alt="after-staff" src="https://github.com/user-attachments/assets/17e9b491-862a-4575-bf52-3c81951d919d" />

_A user holding `course_admin` still sees it._

<img width="3024" height="1656" alt="after-admin" src="https://github.com/user-attachments/assets/005cdbbd-788d-4062-910a-2396d935cc31" />

## Supporting information

Upstream issue: https://github.com/openedx/wg-build-test-release/issues/590

The original report was raised internally at MIT and is not publicly readable, so repeating it here:

> **To Reproduce**
> 1. Log in to Studio as a user with the Course Staff role or no role
> 2. Navigate to the Studio home page
> 3. Observe that the "Roles and Permissions" button is visible
>
> **Expected behavior:** Users with the Course Staff role or no organization access should not see the "Roles and Permissions" button on the Studio home page.
>
> **Actual behavior:** The button is visible to Course Staff users. The user can click through and complete the entire assignment process, but an error appears when finalizing (the action itself does not complete).

The "no role" half of that report was fixed by #3072 and #3151; this PR covers the Course Staff / Editor / Auditor half.

## Testing instructions

You need a devstack/tutor with Studio and this MFE running. Total time: ~5 minutes.

### Step 1 — Set up the flag, two users, and their roles

Open a Studio (CMS) Python shell:

- **Tutor:** `tutor dev exec cms ./manage.py cms shell`
- **Devstack:** `make studio-shell`, then `./manage.py cms shell`

Change `COURSE` to any course that exists in your environment, then paste the whole block:

```python
from django.contrib.auth import get_user_model
from common.djangoapps.student.models import UserProfile
from openedx_authz.api.data import RoleData, ScopeData, UserData
from openedx_authz.api.roles import assign_role_to_subject_in_scope
from waffle.models import Flag

COURSE = 'course-v1:OpenedX+DemoX+DemoCourse'   # <-- change me

Flag.objects.update_or_create(name='authz.enable_course_authoring', defaults={'everyone': True})

U = get_user_model()
for username, role in [('team_admin', 'course_admin'), ('team_staff', 'course_staff')]:
    user, _ = U.objects.get_or_create(username=username, defaults={'email': f'{username}@example.com'})
    user.is_active = True
    user.set_password(username)
    user.save()
    UserProfile.objects.get_or_create(user=user, defaults={'name': username})
    assign_role_to_subject_in_scope(
        UserData(external_key=username), RoleData(external_key=role), ScopeData(external_key=COURSE),
    )
    print('READY', username, '/', username, '->', role)
```

That turns on the `authz.enable_course_authoring` waffle flag and creates two users, each with the password equal to their username:

| Sign in with | Password | Role |
| --- | --- | --- |
| `team_admin@example.com` | `team_admin` | Course Admin |
| `team_staff@example.com` | `team_staff` | Course Staff |

### Step 2 — Make sure `ADMIN_CONSOLE_URL` is set

In your MFE config (e.g. `.env.development`):

```
ADMIN_CONSOLE_URL='http://localhost:2025/admin-console'
```

The admin console MFE does **not** need to be running — this test is only about whether the button appears. Restart the dev server if you changed this value.

### Step 3 — Sign in as the Course Admin

Go to Studio home (e.g. `http://localhost:2001/home`) and sign in as `team_admin@example.com` / `team_admin`.

✅ **Expected:** the "Roles and permissions" button **is** in the top-right of the header.

### Step 4 — Sign in as the Course Staff

Open a **new incognito window** (so you don't have to log out), go to Studio home, and sign in as `team_staff@example.com` / `team_staff`.

✅ **Expected:** the "Roles and permissions" button is **not** there. The rest of the page is unchanged — same courses, same tabs.

### Step 5 — Confirm the permission check is what hid it (optional but recommended)

With the Course Staff window open, DevTools → Network → filter for `validate`. You should see a `POST` to `<STUDIO_BASE_URL>/api/authz/v1/permissions/validate/me` with this request body:

```json
[{"action": "courses.manage_course_team"}, {"action": "content_libraries.manage_library_team"}]
```

and this response:

```json
[{"action": "courses.manage_course_team", "allowed": false},
 {"action": "content_libraries.manage_library_team", "allowed": false}]
```

For `team_admin`, `courses.manage_course_team` comes back `true`.

If that request is **missing entirely**, then the button was hidden by the waffle flag or by `ADMIN_CONSOLE_URL` instead of by permissions — re-check steps 1 and 2.

### Step 6 — See the old, broken behaviour (optional)

Temporarily put the gate back on the `view` permissions:

```bash
# macOS; on Linux use: sed -i 's/.../.../' ...
sed -i '' 's/MANAGE_COURSE_TEAM/VIEW_COURSE_TEAM/; s/MANAGE_LIBRARY_TEAM/VIEW_LIBRARY_TEAM/' src/authz/permissionHelpers.ts
```

Reload Studio home as `team_staff`: the button reappears, and clicking through the role assignment wizard ends in `403 permission_denied` from `PUT /api/authz/v1/roles/users/` — the bug this PR fixes.

Restore the fix with:

```bash
git checkout src/authz/permissionHelpers.ts
```

### Automated tests

```bash
npm run test -- src/studio-home/StudioHome.test.tsx src/authz/permissionHelpers.test.ts
```

## Other information

- This does not depend on any other change. `courses.manage_course_team` already exists in `openedx-authz` (verified against 1.21.1) and is the permission its role assignment endpoints enforce; this PR only adds the constant to this repo's `COURSE_PERMISSIONS` map.
- `getManageTeamPermissions` (renamed from `getViewTeamPermissions`) has a single consumer, `StudioHome`. The separate course-scoped `getCourseTeamPermissions` helper is untouched and still checks `view_course_team`, so the course-level "Roles and permissions" nav item and the help/info sidebar links are unaffected — reaching a read-only team list with view access is intended there.
- `validateUserPermissions` fills any missing response key with `false`, so if a deployment's backend does not recognise the action the button hides rather than appearing without permission — the safe direction.
- Security: this narrows who is shown a link into the admin console. It is a UI-level gate only; the underlying `openedx-authz` endpoints already enforced these permissions, which is why the previous behaviour surfaced as a late 403 rather than an actual privilege escalation.
- Not in scope, noted for follow-up: the role assignment wizard in `frontend-app-admin-console` lists candidate scopes via `useScopes()` without the `management_permission_only` parameter, so it can still offer scopes the user may only view. That is a separate fix in that repo.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
