### PR TITLE
feat(authz): add permission validation for advanced settings and certificate pages

### DIFF
--- a/src/advanced-settings/AdvancedSettings.test.tsx
+++ b/src/advanced-settings/AdvancedSettings.test.tsx
@@ -53,6 +53,7 @@ describe('<AdvancedSettings />', () => {
       isLoading: false,
       isAuthzEnabled: false,
       canViewAdvancedSettings: true,
+      canManageAdvancedSettings: true,
     } as ReturnType<typeof useCourseUserPermissions>);
   });
 
@@ -176,6 +177,7 @@ describe('<AdvancedSettings />', () => {
       isLoading: false,
       isAuthzEnabled: true,
       canViewAdvancedSettings: true,
+      canManageAdvancedSettings: true,
     } as ReturnType<typeof useCourseUserPermissions>);
     render();
     expect(await screen.findByText(messages.headingSubtitle.defaultMessage)).toBeInTheDocument();
@@ -211,5 +213,22 @@ describe('<AdvancedSettings />', () => {
     render();
     expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
     expect(screen.queryByText(/Under Construction/i)).not.toBeInTheDocument();
+  });
+
+  it('should show view-only alert and disable editing when user has view but not manage permission', async () => {
+    mockWaffleFlags({ enableAuthzCourseAuthoring: true });
+    jest.mocked(useCourseUserPermissions).mockReturnValue({
+      isLoading: false,
+      isAuthzEnabled: true,
+      canViewAdvancedSettings: true,
+      canManageAdvancedSettings: false,
+    } as ReturnType<typeof useCourseUserPermissions>);
+    render();
+    expect(await screen.findByTestId('viewOnlyPermissionsAlert')).toBeInTheDocument();
+    expect(await screen.findByText(messages.headingSubtitle.defaultMessage)).toBeInTheDocument();
+    const textarea = screen.getByLabelText(/Advanced Module List/i);
+    expect(textarea).toBeDisabled();
+    expect(screen.queryByText(messages.buttonSaveText.defaultMessage)).not.toBeInTheDocument();
+    expect(screen.queryByText(messages.buttonCancelText.defaultMessage)).not.toBeInTheDocument();
   });
 });

--- a/src/advanced-settings/AdvancedSettings.test.tsx
+++ b/src/advanced-settings/AdvancedSettings.test.tsx
@@ -52,7 +52,7 @@ describe('<AdvancedSettings />', () => {
     jest.mocked(useCourseUserPermissions).mockReturnValue({
       isLoading: false,
       isAuthzEnabled: false,
-      canManageAdvancedSettings: true,
+      canViewAdvancedSettings: true,
     } as ReturnType<typeof useCourseUserPermissions>);
   });
 
@@ -175,7 +175,7 @@ describe('<AdvancedSettings />', () => {
     jest.mocked(useCourseUserPermissions).mockReturnValue({
       isLoading: false,
       isAuthzEnabled: true,
-      canManageAdvancedSettings: true,
+      canViewAdvancedSettings: true,
     } as ReturnType<typeof useCourseUserPermissions>);
     render();
     expect(await screen.findByText(messages.headingSubtitle.defaultMessage)).toBeInTheDocument();
@@ -192,7 +192,7 @@ describe('<AdvancedSettings />', () => {
     jest.mocked(useCourseUserPermissions).mockReturnValue({
       isLoading: false,
       isAuthzEnabled: true,
-      canManageAdvancedSettings: false,
+      canViewAdvancedSettings: false,
     } as ReturnType<typeof useCourseUserPermissions>);
     render();
     expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
@@ -203,7 +203,7 @@ describe('<AdvancedSettings />', () => {
     jest.mocked(useCourseUserPermissions).mockReturnValue({
       isLoading: false,
       isAuthzEnabled: true,
-      canManageAdvancedSettings: false,
+      canViewAdvancedSettings: false,
     } as ReturnType<typeof useCourseUserPermissions>);
     axiosMock
       .onGet(`${getCourseAdvancedSettingsApiUrl(courseId)}?fetch_all=0`)

--- a/src/advanced-settings/AdvancedSettings.tsx
+++ b/src/advanced-settings/AdvancedSettings.tsx
@@ -13,6 +13,7 @@ import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
 import { useCourseUserPermissions } from '@src/authz/hooks';
 import { getAdvancedSettingsPermissions } from '@src/authz/permissionHelpers';
 import PermissionDeniedAlert from 'CourseAuthoring/generic/PermissionDeniedAlert';
+import ViewOnlyPermissionsAlert from '@src/generic/ViewOnlyPermissionsAlert';
 import AlertProctoringError from '@src/generic/AlertProctoringError';
 import { LoadingSpinner } from '@src/generic/Loading';
 import InternetConnectionAlert from '@src/generic/internet-connection-alert';
@@ -46,6 +47,7 @@ const AdvancedSettings = () => {
   const {
     isLoading: isLoadingUserPermissions,
     canViewAdvancedSettings,
+    canManageAdvancedSettings,
   } = useCourseUserPermissions(courseId, getAdvancedSettingsPermissions(courseId));
 
   const {
@@ -201,6 +203,7 @@ const AdvancedSettings = () => {
                 subtitle={intl.formatMessage(messages.headingSubtitle)}
                 title={intl.formatMessage(messages.headingTitle)}
                 contentTitle={intl.formatMessage(messages.policy)}
+                banner={!canManageAdvancedSettings ? <ViewOnlyPermissionsAlert /> : null}
               />
               <article>
                 <div>
@@ -246,6 +249,7 @@ const AdvancedSettings = () => {
                             handleBlur={handleSettingBlur}
                             isEditableState={isEditableState}
                             setIsEditableState={setIsEditableState}
+                            disabled={!canManageAdvancedSettings}
                           />
                         );
                       })}

--- a/src/advanced-settings/AdvancedSettings.tsx
+++ b/src/advanced-settings/AdvancedSettings.tsx
@@ -45,7 +45,7 @@ const AdvancedSettings = () => {
 
   const {
     isLoading: isLoadingUserPermissions,
-    canManageAdvancedSettings,
+    canViewAdvancedSettings,
   } = useCourseUserPermissions(courseId, getAdvancedSettingsPermissions(courseId));
 
   const {
@@ -102,7 +102,7 @@ const AdvancedSettings = () => {
     );
   }
 
-  if (!canManageAdvancedSettings) {
+  if (!canViewAdvancedSettings) {
     return <PermissionDeniedAlert />;
   }
 

--- a/src/advanced-settings/setting-card/SettingCard.test.tsx
+++ b/src/advanced-settings/setting-card/SettingCard.test.tsx
@@ -1,8 +1,13 @@
-import { fireEvent, render, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { IntlProvider } from '@edx/frontend-platform/i18n';
+import {
+  fireEvent,
+  initializeMocks,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from '@src/testUtils';
 
-import SettingCard from './SettingCard';
+import SettingCard, { type SettingCardProps } from './SettingCard';
 import messages from './messages';
 
 const setEdited = jest.fn();
@@ -25,10 +30,9 @@ jest.mock('react-textarea-autosize', () =>
     />
   )));
 
-const RootWrapper = () => (
-  <IntlProvider locale="en">
+const renderComponent = (props: Partial<SettingCardProps> = {}) =>
+  render(
     <SettingCard
-      isOn
       name="settingName"
       setEdited={setEdited}
       setIsEditableState={setIsEditableState}
@@ -37,48 +41,42 @@ const RootWrapper = () => (
       handleBlur={handleBlur}
       isEditableState
       saveSettingsPrompt={false}
-    />
-  </IntlProvider>
-);
+      {...props}
+    />,
+  );
 
 describe('<SettingCard />', () => {
-  afterEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    initializeMocks();
+  });
+
   it('renders the setting card with the provided data', () => {
-    const { getByText, getByLabelText } = render(<RootWrapper />);
-    const cardTitle = getByText(/Setting Name/i);
-    const input = getByLabelText(/Setting Name/i);
+    renderComponent();
+    const cardTitle = screen.getByText(/Setting Name/i);
+    const input = screen.getByLabelText(/Setting Name/i);
     expect(cardTitle).toBeInTheDocument();
     expect(input).toBeInTheDocument();
-    expect(input.value).toBe(JSON.stringify(settingData.value, null, 4));
+    expect(input).toHaveValue(JSON.stringify(settingData.value, null, 4));
   });
+
   it('displays the deprecated status when the setting is deprecated', () => {
-    const deprecatedSettingData = { ...settingData, deprecated: true };
-    const { getByText } = render(
-      <IntlProvider locale="en">
-        <SettingCard
-          isOn
-          name="settingName"
-          setEdited={setEdited}
-          setIsEditableState={setIsEditableState}
-          showSaveSettingsPrompt={showSaveSettingsPrompt}
-          settingData={deprecatedSettingData}
-          handleBlur={handleBlur}
-          isEditable={false}
-          saveSettingsPrompt
-        />
-      </IntlProvider>,
-    );
-    const deprecatedStatus = getByText(messages.deprecated.defaultMessage);
-    expect(deprecatedStatus).toBeInTheDocument();
+    renderComponent({
+      settingData: { ...settingData, deprecated: true },
+      isEditableState: false,
+      saveSettingsPrompt: true,
+    });
+    expect(screen.getByText(messages.deprecated.defaultMessage)).toBeInTheDocument();
   });
+
   it('does not display the deprecated status when the setting is not deprecated', () => {
-    const { queryByText } = render(<RootWrapper />);
-    expect(queryByText(messages.deprecated.defaultMessage)).toBeNull();
+    renderComponent();
+    expect(screen.queryByText(messages.deprecated.defaultMessage)).toBeNull();
   });
+
   it('calls setEdited on blur', async () => {
     const user = userEvent.setup();
-    const { getByLabelText } = render(<RootWrapper />);
-    const inputBox = getByLabelText(/Setting Name/i);
+    renderComponent();
+    const inputBox = screen.getByLabelText(/Setting Name/i);
     fireEvent.focus(inputBox);
     await user.clear(inputBox);
     await user.type(inputBox, '3, 2, 1');
@@ -90,5 +88,10 @@ describe('<SettingCard />', () => {
       expect(setEdited).toHaveBeenCalled();
       expect(handleBlur).toHaveBeenCalled();
     });
+  });
+
+  it('disables the setting input when `disabled` is true', () => {
+    renderComponent({ disabled: true });
+    expect(screen.getByLabelText(/Setting Name/i)).toBeDisabled();
   });
 });

--- a/src/advanced-settings/setting-card/SettingCard.tsx
+++ b/src/advanced-settings/setting-card/SettingCard.tsx
@@ -25,6 +25,7 @@ const SettingCard = ({
   saveSettingsPrompt,
   isEditableState,
   setIsEditableState,
+  disabled = false,
 }) => {
   const intl = useIntl();
   const { deprecated, help, displayName } = settingData;
@@ -99,6 +100,7 @@ const SettingCard = ({
                 onChange={handleSettingChange}
                 aria-label={displayName}
                 onBlur={handleCardBlur}
+                disabled={disabled}
               />
             </Form.Group>
           </Card.Section>
@@ -133,6 +135,7 @@ SettingCard.propTypes = {
   saveSettingsPrompt: PropTypes.bool.isRequired,
   isEditableState: PropTypes.bool.isRequired,
   setIsEditableState: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
 };
 
 export default SettingCard;

--- a/src/advanced-settings/setting-card/SettingCard.tsx
+++ b/src/advanced-settings/setting-card/SettingCard.tsx
@@ -9,12 +9,28 @@ import {
   useToggle,
 } from '@openedx/paragon';
 import { InfoOutline, Warning } from '@openedx/paragon/icons';
-import PropTypes from 'prop-types';
 import { capitalize } from 'lodash';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import TextareaAutosize from 'react-textarea-autosize';
 
 import messages from './messages';
+
+export interface SettingCardProps {
+  name: string;
+  settingData: {
+    deprecated?: boolean;
+    help?: string;
+    displayName?: string;
+    value?: unknown;
+  };
+  handleBlur: () => void;
+  setEdited: React.Dispatch<React.SetStateAction<Record<string, unknown>>>;
+  showSaveSettingsPrompt: (show: boolean) => void;
+  saveSettingsPrompt: boolean;
+  isEditableState: boolean;
+  setIsEditableState: (isEditable: boolean) => void;
+  disabled?: boolean;
+}
 
 const SettingCard = ({
   name,
@@ -26,7 +42,7 @@ const SettingCard = ({
   isEditableState,
   setIsEditableState,
   disabled = false,
-}) => {
+}: SettingCardProps) => {
   const intl = useIntl();
   const { deprecated, help, displayName } = settingData;
   const initialValue = JSON.stringify(settingData.value, null, 4);
@@ -84,7 +100,7 @@ const SettingCard = ({
                   <div
                     className="p-2 x-small rounded modal-popup-content"
                     // eslint-disable-next-line react/no-danger
-                    dangerouslySetInnerHTML={{ __html: help }}
+                    dangerouslySetInnerHTML={{ __html: help ?? '' }}
                   />
                 </ModalPopup>
                 <ActionRow.Spacer />
@@ -113,29 +129,6 @@ const SettingCard = ({
       </Card>
     </li>
   );
-};
-
-SettingCard.propTypes = {
-  settingData: PropTypes.shape({
-    deprecated: PropTypes.bool,
-    help: PropTypes.string,
-    displayName: PropTypes.string,
-    value: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.bool,
-      PropTypes.number,
-      PropTypes.object,
-      PropTypes.array,
-    ]),
-  }).isRequired,
-  setEdited: PropTypes.func.isRequired,
-  showSaveSettingsPrompt: PropTypes.func.isRequired,
-  name: PropTypes.string.isRequired,
-  handleBlur: PropTypes.func.isRequired,
-  saveSettingsPrompt: PropTypes.bool.isRequired,
-  isEditableState: PropTypes.bool.isRequired,
-  setIsEditableState: PropTypes.func.isRequired,
-  disabled: PropTypes.bool,
 };
 
 export default SettingCard;

--- a/src/authz/constants.ts
+++ b/src/authz/constants.ts
@@ -19,6 +19,7 @@ export const COURSE_PERMISSIONS = {
   VIEW_COURSE: 'courses.view_course',
   EDIT_COURSE_CONTENT: 'courses.edit_course_content',
 
+  VIEW_ADVANCED_SETTINGS: 'courses.view_advanced_settings',
   MANAGE_ADVANCED_SETTINGS: 'courses.manage_advanced_settings',
 
   VIEW_GRADING_SETTINGS: 'courses.view_grading_settings',
@@ -42,6 +43,8 @@ export const COURSE_PERMISSIONS = {
   VIEW_COURSE_TEAM: 'courses.view_course_team',
 
   MANAGE_GROUP_CONFIGURATIONS: 'courses.manage_group_configurations',
+
+  VIEW_CERTIFICATES: 'courses.view_certificates',
   MANAGE_CERTIFICATES: 'courses.manage_certificates',
 
   VIEW_CHECKLISTS: 'courses.view_checklists',

--- a/src/authz/permissionHelpers.test.ts
+++ b/src/authz/permissionHelpers.test.ts
@@ -93,17 +93,26 @@ describe('permissionHelpers', () => {
     });
 
     describe('getAdvancedSettingsPermissions', () => {
-      it('returns MANAGE permission with the correct action and scope', () => {
+      it('returns VIEW and MANAGE permissions with the correct actions and scope', () => {
         const result = getAdvancedSettingsPermissions(courseId);
 
-        expect(result.canManageAdvancedSettings.action).toBe(COURSE_PERMISSIONS.MANAGE_ADVANCED_SETTINGS);
-        expect(result.canManageAdvancedSettings.scope).toBe(courseId);
+        expect(result).toEqual({
+          canViewAdvancedSettings: {
+            action: COURSE_PERMISSIONS.VIEW_ADVANCED_SETTINGS,
+            scope: courseId,
+          },
+          canManageAdvancedSettings: {
+            action: COURSE_PERMISSIONS.MANAGE_ADVANCED_SETTINGS,
+            scope: courseId,
+          },
+        });
       });
 
       it('uses the provided courseId as scope', () => {
         const otherId = 'course-v1:another+test+run';
         const result = getAdvancedSettingsPermissions(otherId);
 
+        expect(result.canViewAdvancedSettings.scope).toBe(otherId);
         expect(result.canManageAdvancedSettings.scope).toBe(otherId);
       });
     });
@@ -208,10 +217,14 @@ describe('permissionHelpers', () => {
   });
 
   describe('getCertificatesPermissions', () => {
-    it('returns MANAGE_CERTIFICATES permission with the correct action and scope', () => {
+    it('returns VIEW and MANAGE permissions with the correct actions and scope', () => {
       const result = getCertificatesPermissions(courseId);
 
       expect(result).toEqual({
+        canViewCertificates: {
+          action: COURSE_PERMISSIONS.VIEW_CERTIFICATES,
+          scope: courseId,
+        },
         canManageCertificates: {
           action: COURSE_PERMISSIONS.MANAGE_CERTIFICATES,
           scope: courseId,

--- a/src/authz/permissionHelpers.ts
+++ b/src/authz/permissionHelpers.ts
@@ -61,6 +61,10 @@ export const getPagesAndResourcesPermissions = (courseId: string) => ({
 });
 
 export const getAdvancedSettingsPermissions = (courseId: string) => ({
+  canViewAdvancedSettings: {
+    action: COURSE_PERMISSIONS.VIEW_ADVANCED_SETTINGS,
+    scope: courseId,
+  },
   canManageAdvancedSettings: {
     action: COURSE_PERMISSIONS.MANAGE_ADVANCED_SETTINGS,
     scope: courseId,
@@ -99,6 +103,10 @@ export const getGroupConfigurationsPermissions = (courseId: string) => ({
 });
 
 export const getCertificatesPermissions = (courseId: string) => ({
+  canViewCertificates: {
+    action: COURSE_PERMISSIONS.VIEW_CERTIFICATES,
+    scope: courseId,
+  },
   canManageCertificates: {
     action: COURSE_PERMISSIONS.MANAGE_CERTIFICATES,
     scope: courseId,

--- a/src/certificates/Certificates.test.tsx
+++ b/src/certificates/Certificates.test.tsx
@@ -18,7 +18,7 @@ const mockPermissions = (overrides = {}) =>
   jest.mocked(useCourseUserPermissions).mockReturnValue({
     isLoading: false,
     isAuthzEnabled: true,
-    canManageCertificates: true,
+    canViewCertificates: true,
     ...overrides,
   } as ReturnType<typeof useCourseUserPermissions>);
 
@@ -38,7 +38,7 @@ describe('Certificates', () => {
   });
 
   it('shows PermissionDeniedAlert when user lacks manage certificates permission', async () => {
-    mockPermissions({ canManageCertificates: false });
+    mockPermissions({ canViewCertificates: false });
     axiosMock
       .onGet(getCertificatesApiUrl(courseId))
       .reply(200, certificatesDataMock);

--- a/src/certificates/Certificates.test.tsx
+++ b/src/certificates/Certificates.test.tsx
@@ -19,6 +19,7 @@ const mockPermissions = (overrides = {}) =>
     isLoading: false,
     isAuthzEnabled: true,
     canViewCertificates: true,
+    canManageCertificates: true,
     ...overrides,
   } as ReturnType<typeof useCourseUserPermissions>);
 
@@ -45,6 +46,16 @@ describe('Certificates', () => {
     renderComponent();
     expect(await screen.findByTestId('permissionDeniedAlert')).toBeInTheDocument();
     expect(screen.queryByText(messages.withoutModesText.defaultMessage)).not.toBeInTheDocument();
+  });
+
+  it('renders content in view-only mode when user can view but not manage', async () => {
+    mockPermissions({ canViewCertificates: true, canManageCertificates: false });
+    axiosMock
+      .onGet(getCertificatesApiUrl(courseId))
+      .reply(200, certificatesDataMock);
+    renderComponent();
+    expect(await screen.findByTestId('certificates-list')).toBeInTheDocument();
+    expect(screen.getByTestId('viewOnlyPermissionsAlert')).toBeInTheDocument();
   });
 
   it('renders WithoutModes when there are certificates but no certificate modes', async () => {

--- a/src/certificates/Certificates.tsx
+++ b/src/certificates/Certificates.tsx
@@ -36,10 +36,10 @@ const Certificates = () => {
 
   const {
     isLoading: isLoadingUserPermissions,
-    canManageCertificates,
+    canViewCertificates,
   } = useCourseUserPermissions(courseId, getCertificatesPermissions(courseId));
 
-  if (!isLoadingUserPermissions && !canManageCertificates) {
+  if (!isLoadingUserPermissions && !canViewCertificates) {
     return <PermissionDeniedAlert />;
   }
 

--- a/src/certificates/Certificates.tsx
+++ b/src/certificates/Certificates.tsx
@@ -1,8 +1,5 @@
 import { Helmet } from 'react-helmet';
 
-import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
-import { useCourseUserPermissions } from '@src/authz/hooks';
-import { getCertificatesPermissions } from '@src/authz/permissionHelpers';
 import PermissionDeniedAlert from '@src/generic/PermissionDeniedAlert';
 import Placeholder from '../editors/Placeholder';
 import Loading from '../generic/Loading';
@@ -14,6 +11,7 @@ import CertificateCreateForm from './certificate-create-form/CertificateCreateFo
 import CertificateEditForm from './certificate-edit-form/CertificateEditForm';
 import { MODE_STATES } from './data/constants';
 import MainLayout from './layout/MainLayout';
+import { useCertificatesContext } from './context';
 
 const MODE_COMPONENTS = {
   [MODE_STATES.noModes]: CertificateWithoutModes,
@@ -24,7 +22,6 @@ const MODE_COMPONENTS = {
 };
 
 const Certificates = () => {
-  const { courseId } = useCourseAuthoringContext();
   const {
     certificates,
     componentMode,
@@ -34,12 +31,9 @@ const Certificates = () => {
     hasCertificateModes,
   } = useCertificatesData();
 
-  const {
-    isLoading: isLoadingUserPermissions,
-    canViewCertificates,
-  } = useCourseUserPermissions(courseId, getCertificatesPermissions(courseId));
+  const { canViewCertificates } = useCertificatesContext();
 
-  if (!isLoadingUserPermissions && !canViewCertificates) {
+  if (!canViewCertificates) {
     return <PermissionDeniedAlert />;
   }
 

--- a/src/certificates/certificate-details/CertificateDetails.test.tsx
+++ b/src/certificates/certificate-details/CertificateDetails.test.tsx
@@ -8,6 +8,8 @@ import {
 } from '@src/testUtils';
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
 import { CertificatesProvider } from '@src/certificates/context';
+import { mockWaffleFlags } from '@src/data/apiHooks.mock';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 
 import { getCertificatesApiUrl, getUpdateCertificateApiUrl } from '../data/api';
 import { certificatesDataMock } from '../__mocks__';
@@ -25,6 +27,19 @@ const defaultProps: CertificateDetialsProps = {
   detailsCourseNumber: certificatesDataMock.courseNumber,
 };
 
+jest.mock('@src/authz/hooks', () => ({
+  useCourseUserPermissions: jest.fn(),
+}));
+
+const mockPermissions = (overrides = {}) =>
+  jest.mocked(useCourseUserPermissions).mockReturnValue({
+    isLoading: false,
+    isAuthzEnabled: true,
+    canViewCertificates: true,
+    canManageCertificates: true,
+    ...overrides,
+  } as ReturnType<typeof useCourseUserPermissions>);
+
 const renderComponent = (props = defaultProps) =>
   render(
     <CourseAuthoringProvider courseId={courseId}>
@@ -37,6 +52,8 @@ const renderComponent = (props = defaultProps) =>
 describe('CertificateDetails', () => {
   beforeEach(() => {
     ({ axiosMock } = initializeMocks());
+    mockWaffleFlags({ enableAuthzCourseAuthoring: false });
+    mockPermissions();
     axiosMock
       .onGet(getCertificatesApiUrl(courseId))
       .reply(200, certificatesDataMock);
@@ -87,5 +104,16 @@ describe('CertificateDetails', () => {
 
     await screen.findByText(messages.detailsSectionTitle.defaultMessage);
     expect(screen.getByText(courseTitleOverride)).toBeInTheDocument();
+  });
+
+  it('hides edit and delete buttons in view-only mode', async () => {
+    mockPermissions({ canManageCertificates: false });
+    renderComponent();
+
+    await screen.findByText(messages.detailsSectionTitle.defaultMessage);
+    expect(screen.queryByRole('button', { name: commonMessages.editTooltip.defaultMessage })).not
+      .toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: commonMessages.deleteTooltip.defaultMessage })).not
+      .toBeInTheDocument();
   });
 });

--- a/src/certificates/certificate-details/CertificateDetails.tsx
+++ b/src/certificates/certificate-details/CertificateDetails.tsx
@@ -14,6 +14,7 @@ import ModalNotification from '../../generic/modal-notification';
 import commonMessages from '../messages';
 import messages from './messages';
 import useCertificateDetails from './hooks/useCertificateDetails';
+import { useCertificatesContext } from '@src/certificates/context';
 
 export interface CertificateDetialsProps {
   certificateId: number;
@@ -31,6 +32,7 @@ const CertificateDetails = ({
   courseNumberOverride,
 }: CertificateDetialsProps) => {
   const intl = useIntl();
+  const { canManageCertificates } = useCertificatesContext();
   const {
     isConfirmOpen,
     confirmOpen,
@@ -48,24 +50,26 @@ const CertificateDetails = ({
       title={intl.formatMessage(messages.detailsSectionTitle)}
       className="certificate-details"
       data-testid="certificate-details"
-      actions={
-        <Stack direction="horizontal" gap={2}>
-          <IconButtonWithTooltip
-            src={EditOutlineIcon}
-            iconAs={Icon}
-            tooltipContent={<div>{intl.formatMessage(commonMessages.editTooltip)}</div>}
-            alt={intl.formatMessage(commonMessages.editTooltip)}
-            onClick={isCertificateActive ? editModalOpen : handleEditAll}
-          />
-          <IconButtonWithTooltip
-            src={DeleteOutlineIcon}
-            iconAs={Icon}
-            tooltipContent={<div>{intl.formatMessage(commonMessages.deleteTooltip)}</div>}
-            alt={intl.formatMessage(commonMessages.deleteTooltip)}
-            onClick={confirmOpen}
-          />
-        </Stack>
-      }
+      actions={canManageCertificates ?
+        (
+          <Stack direction="horizontal" gap={2}>
+            <IconButtonWithTooltip
+              src={EditOutlineIcon}
+              iconAs={Icon}
+              tooltipContent={<div>{intl.formatMessage(commonMessages.editTooltip)}</div>}
+              alt={intl.formatMessage(commonMessages.editTooltip)}
+              onClick={isCertificateActive ? editModalOpen : handleEditAll}
+            />
+            <IconButtonWithTooltip
+              src={DeleteOutlineIcon}
+              iconAs={Icon}
+              tooltipContent={<div>{intl.formatMessage(commonMessages.deleteTooltip)}</div>}
+              alt={intl.formatMessage(commonMessages.deleteTooltip)}
+              onClick={confirmOpen}
+            />
+          </Stack>
+        ) :
+        undefined}
     >
       <Stack>
         <Stack direction="horizontal" gap={1.5} className="certificate-details__info">

--- a/src/certificates/certificate-signatories/CertificateSignatories.test.tsx
+++ b/src/certificates/certificate-signatories/CertificateSignatories.test.tsx
@@ -1,4 +1,7 @@
 import { initializeMocks, render, screen, within, userEvent } from '@src/testUtils';
+import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
+import { CertificatesProvider } from '@src/certificates/context';
+import { mockWaffleFlags } from '@src/data/apiHooks.mock';
 
 import { signatoriesMock } from '../__mocks__';
 import commonMessages from '../messages';
@@ -20,7 +23,11 @@ const mockArrayHelpers = {
 
 const renderComponent = (props) =>
   render(
-    <CertificateSignatories {...props} />,
+    <CourseAuthoringProvider courseId="course-123">
+      <CertificatesProvider>
+        <CertificateSignatories {...props} />
+      </CertificatesProvider>
+    </CourseAuthoringProvider>,
   );
 
 const defaultProps = {
@@ -38,6 +45,7 @@ const defaultProps = {
 describe('CertificateSignatories', () => {
   beforeEach(() => {
     initializeMocks();
+    mockWaffleFlags({ enableAuthzCourseAuthoring: false });
 
     mockUseEditSignatory.mockReturnValue({
       toggleEditSignatory: jest.fn(),
@@ -72,6 +80,7 @@ describe('CertificateSignatories', () => {
 describe('CertificateSignatories - real useEditSignatory', () => {
   beforeEach(() => {
     initializeMocks();
+    mockWaffleFlags({ enableAuthzCourseAuthoring: false });
 
     // Use the real implementation so handleDeleteSignatory actually calls arrayHelpers.remove
     const realUseEditSignatory = jest.requireActual('./hooks/useEditSignatory').default;

--- a/src/certificates/certificate-signatories/signatory/Signatory.test.tsx
+++ b/src/certificates/certificate-signatories/signatory/Signatory.test.tsx
@@ -1,4 +1,8 @@
 import { initializeMocks, render, screen, userEvent } from '@src/testUtils';
+import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
+import { CertificatesProvider } from '@src/certificates/context';
+import { mockWaffleFlags } from '@src/data/apiHooks.mock';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 
 import { signatoriesMock } from '../../__mocks__';
 import commonMessages from '../../messages';
@@ -7,9 +11,26 @@ import Signatory from './Signatory';
 
 const mockHandleEdit = jest.fn();
 
+jest.mock('@src/authz/hooks', () => ({
+  useCourseUserPermissions: jest.fn(),
+}));
+
+const mockPermissions = (overrides = {}) =>
+  jest.mocked(useCourseUserPermissions).mockReturnValue({
+    isLoading: false,
+    isAuthzEnabled: true,
+    canViewCertificates: true,
+    canManageCertificates: true,
+    ...overrides,
+  } as ReturnType<typeof useCourseUserPermissions>);
+
 const renderSignatory = (props) =>
   render(
-    <Signatory {...props} />,
+    <CourseAuthoringProvider courseId="course-123">
+      <CertificatesProvider>
+        <Signatory {...props} />
+      </CertificatesProvider>
+    </CourseAuthoringProvider>,
   );
 
 const defaultProps = { ...signatoriesMock[0], handleEdit: mockHandleEdit, index: 0 };
@@ -17,6 +38,8 @@ const defaultProps = { ...signatoriesMock[0], handleEdit: mockHandleEdit, index:
 describe('Signatory Component', () => {
   beforeEach(() => {
     initializeMocks();
+    mockWaffleFlags({ enableAuthzCourseAuthoring: false });
+    mockPermissions();
   });
 
   it('renders signatory data in view mode', () => {
@@ -44,5 +67,13 @@ describe('Signatory Component', () => {
     await user.click(editButton);
 
     expect(mockHandleEdit).toHaveBeenCalled();
+  });
+
+  it('hides edit button in view-only mode', () => {
+    mockPermissions({ canManageCertificates: false });
+    renderSignatory(defaultProps);
+
+    expect(screen.queryByRole('button', { name: commonMessages.editTooltip.defaultMessage })).not
+      .toBeInTheDocument();
   });
 });

--- a/src/certificates/certificate-signatories/signatory/Signatory.tsx
+++ b/src/certificates/certificate-signatories/signatory/Signatory.tsx
@@ -12,6 +12,7 @@ import { getConfig } from '@edx/frontend-platform';
 
 import commonMessages from '../../messages';
 import messages from '../messages';
+import { useCertificatesContext } from '@src/certificates/context';
 
 interface SignatoryProps {
   name: string;
@@ -31,6 +32,7 @@ const Signatory = ({
   handleEdit,
 }: SignatoryProps) => {
   const intl = useIntl();
+  const { canManageCertificates } = useCertificatesContext();
 
   return (
     <div className="bg-light-200 p-2.5 signatory" data-testid="signatory">
@@ -49,14 +51,16 @@ const Signatory = ({
         </Stack>
       </Stack>
 
-      <IconButtonWithTooltip
-        className="signatory__action-button"
-        src={EditOutlineIcon}
-        iconAs={Icon}
-        alt={intl.formatMessage(commonMessages.editTooltip)}
-        tooltipContent={<div>{intl.formatMessage(commonMessages.editTooltip)}</div>}
-        onClick={handleEdit}
-      />
+      {canManageCertificates && (
+        <IconButtonWithTooltip
+          className="signatory__action-button"
+          src={EditOutlineIcon}
+          iconAs={Icon}
+          alt={intl.formatMessage(commonMessages.editTooltip)}
+          tooltipContent={<div>{intl.formatMessage(commonMessages.editTooltip)}</div>}
+          onClick={handleEdit}
+        />
+      )}
       <div className="signatory__image-container">
         {signatureImagePath && (
           <Image

--- a/src/certificates/context.tsx
+++ b/src/certificates/context.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, useMemo, useState } from 'react';
 import { MODE_STATES } from './data/constants';
 import { useCourseAuthoringContext } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
+import { getCertificatesPermissions } from '@src/authz/permissionHelpers';
 import {
   useCreateCertificate,
   useDeleteCertificate,
@@ -16,6 +18,8 @@ export type CertificatesContextData = {
   setComponentMode: (mode: ModeState) => void;
   savingIsSuccess: boolean;
   savingErrorMessage?: string;
+  canViewCertificates: boolean;
+  canManageCertificates: boolean;
   activationStatusMutation: UseMutationResult;
   updateCertificateMutation: UseMutationResult;
   deleteCertificateMutation: UseMutationResult;
@@ -30,6 +34,12 @@ const CertificatesContext = createContext<CertificatesContextData | undefined>(u
 export const CertificatesProvider = ({ children }) => {
   const { courseId } = useCourseAuthoringContext();
   const [componentMode, setComponentMode] = useState<ModeState>(MODE_STATES.noModes);
+
+  const {
+    canViewCertificates,
+    canManageCertificates,
+  } = useCourseUserPermissions(courseId, getCertificatesPermissions(courseId));
+
   const activationStatusMutation = useUpdateCertificateActiveStatus(courseId);
   const updateCertificateMutation = useUpdateCertificate(courseId);
   const deleteCertificateMutation = useDeleteCertificate(courseId);
@@ -49,6 +59,8 @@ export const CertificatesProvider = ({ children }) => {
     const contextValue = {
       componentMode,
       setComponentMode,
+      canViewCertificates,
+      canManageCertificates,
       activationStatusMutation,
       updateCertificateMutation,
       deleteCertificateMutation,
@@ -61,6 +73,8 @@ export const CertificatesProvider = ({ children }) => {
   }, [
     componentMode,
     setComponentMode,
+    canViewCertificates,
+    canManageCertificates,
     activationStatusMutation,
     updateCertificateMutation,
   ]);

--- a/src/certificates/empty-certificates-with-modes/EmptyCertificatesWithModes.test.tsx
+++ b/src/certificates/empty-certificates-with-modes/EmptyCertificatesWithModes.test.tsx
@@ -5,6 +5,8 @@ import {
   userEvent,
 } from '@src/testUtils';
 import { CertificatesProvider, useCertificatesContext } from '@src/certificates/context';
+import { mockWaffleFlags } from '@src/data/apiHooks.mock';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 import { MODE_STATES } from '../data/constants';
 import messages from '../messages';
 import EmptyCertificatesWithModes from './EmptyCertificatesWithModes';
@@ -14,6 +16,19 @@ const ComponentModeDisplay = () => {
   const { componentMode } = useCertificatesContext();
   return <div data-testid="component-mode">{componentMode}</div>;
 };
+
+jest.mock('@src/authz/hooks', () => ({
+  useCourseUserPermissions: jest.fn(),
+}));
+
+const mockPermissions = (overrides = {}) =>
+  jest.mocked(useCourseUserPermissions).mockReturnValue({
+    isLoading: false,
+    isAuthzEnabled: true,
+    canViewCertificates: true,
+    canManageCertificates: true,
+    ...overrides,
+  } as ReturnType<typeof useCourseUserPermissions>);
 
 const renderComponent = () =>
   render(
@@ -28,6 +43,8 @@ const renderComponent = () =>
 describe('EmptyCertificatesWithModes', () => {
   beforeEach(() => {
     initializeMocks();
+    mockWaffleFlags({ enableAuthzCourseAuthoring: false });
+    mockPermissions();
   });
 
   it('renders correctly', () => {
@@ -46,5 +63,14 @@ describe('EmptyCertificatesWithModes', () => {
     await user.click(screen.getByRole('button', { name: messages.setupCertificateBtn.defaultMessage }));
 
     expect(screen.getByTestId('component-mode')).toHaveTextContent(MODE_STATES.create);
+  });
+
+  it('hides add button in view-only mode', () => {
+    mockPermissions({ canManageCertificates: false });
+    renderComponent();
+
+    expect(screen.getByText(messages.noCertificatesText.defaultMessage)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: messages.setupCertificateBtn.defaultMessage })).not
+      .toBeInTheDocument();
   });
 });

--- a/src/certificates/empty-certificates-with-modes/EmptyCertificatesWithModes.tsx
+++ b/src/certificates/empty-certificates-with-modes/EmptyCertificatesWithModes.tsx
@@ -8,7 +8,7 @@ import { useCertificatesContext } from '../context';
 
 const EmptyCertificatesWithModes = () => {
   const intl = useIntl();
-  const { setComponentMode } = useCertificatesContext();
+  const { setComponentMode, canManageCertificates } = useCertificatesContext();
   const handleCreateMode = () => {
     setComponentMode(MODE_STATES.create);
   };
@@ -19,12 +19,14 @@ const EmptyCertificatesWithModes = () => {
         <ActionRow>
           <span className="small">{intl.formatMessage(messages.noCertificatesText)}</span>
           <ActionRow.Spacer />
-          <Button
-            iconBefore={AddIcon}
-            onClick={handleCreateMode}
-          >
-            {intl.formatMessage(messages.setupCertificateBtn)}
-          </Button>
+          {canManageCertificates && (
+            <Button
+              iconBefore={AddIcon}
+              onClick={handleCreateMode}
+            >
+              {intl.formatMessage(messages.setupCertificateBtn)}
+            </Button>
+          )}
         </ActionRow>
       </Card.Section>
     </Card>

--- a/src/certificates/layout/MainLayout.tsx
+++ b/src/certificates/layout/MainLayout.tsx
@@ -4,6 +4,7 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { SavingErrorAlert } from '@src/generic/saving-error-alert';
 import SubHeader from '@src/generic/sub-header/SubHeader';
+import ViewOnlyPermissionsAlert from '@src/generic/ViewOnlyPermissionsAlert';
 import messages from '../messages';
 import CertificatesSidebar from './certificates-sidebar/CertificatesSidebar';
 import HeaderButtons from './header-buttons/HeaderButtons';
@@ -20,6 +21,7 @@ const MainLayout = ({ showHeaderButtons = false, children }: MainLayoutProps) =>
   const {
     savingIsSuccess,
     savingErrorMessage,
+    canManageCertificates,
   } = useCertificatesContext();
 
   useEffect(() => {
@@ -39,6 +41,7 @@ const MainLayout = ({ showHeaderButtons = false, children }: MainLayoutProps) =>
           headerActions={showHeaderButtons ?
             <HeaderButtons /> :
             null}
+          banner={!canManageCertificates ? <ViewOnlyPermissionsAlert className="mb-3" /> : null}
         />
         <section>
           <Layout

--- a/src/certificates/layout/header-buttons/HeaderButtons.test.tsx
+++ b/src/certificates/layout/header-buttons/HeaderButtons.test.tsx
@@ -1,4 +1,5 @@
 import { CourseAuthoringProvider } from '@src/CourseAuthoringContext';
+import { useCourseUserPermissions } from '@src/authz/hooks';
 
 import {
   render,
@@ -7,6 +8,7 @@ import {
   screen,
   userEvent,
 } from '@src/testUtils';
+import { mockWaffleFlags } from '@src/data/apiHooks.mock';
 import { getCertificatesApiUrl, getUpdateCertificateActiveStatusApiUrl } from '../../data/api';
 import { certificatesDataMock } from '../../__mocks__';
 import messages from '../../messages';
@@ -15,6 +17,19 @@ import { CertificatesProvider } from '@src/certificates/context';
 
 let axiosMock;
 const courseId = 'course-123';
+
+jest.mock('@src/authz/hooks', () => ({
+  useCourseUserPermissions: jest.fn(),
+}));
+
+const mockPermissions = (overrides = {}) =>
+  jest.mocked(useCourseUserPermissions).mockReturnValue({
+    isLoading: false,
+    isAuthzEnabled: true,
+    canViewCertificates: true,
+    canManageCertificates: true,
+    ...overrides,
+  } as ReturnType<typeof useCourseUserPermissions>);
 
 const renderComponent = () =>
   render(
@@ -29,6 +44,8 @@ describe('HeaderButtons Component', () => {
   beforeEach(() => {
     const mocks = initializeMocks();
     axiosMock = mocks.axiosMock;
+    mockWaffleFlags({ enableAuthzCourseAuthoring: false });
+    mockPermissions();
     axiosMock
       .onGet(getCertificatesApiUrl(courseId))
       .reply(200, certificatesDataMock);
@@ -103,6 +120,18 @@ describe('HeaderButtons Component', () => {
     await user.click(deactivateButton);
 
     expect(screen.getByRole('button', { name: messages.headingActionsActivate.defaultMessage })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: messages.headingActionsDeactivate.defaultMessage })).not
+      .toBeInTheDocument();
+  });
+
+  it('hides activate button in view-only mode', async () => {
+    mockPermissions({ canManageCertificates: false });
+    renderComponent();
+
+    await waitFor(() => screen.getByRole('link', { name: messages.headingActionsPreview.defaultMessage }));
+
+    expect(screen.queryByRole('button', { name: messages.headingActionsActivate.defaultMessage })).not
+      .toBeInTheDocument();
     expect(screen.queryByRole('button', { name: messages.headingActionsDeactivate.defaultMessage })).not
       .toBeInTheDocument();
   });

--- a/src/certificates/layout/header-buttons/HeaderButtons.tsx
+++ b/src/certificates/layout/header-buttons/HeaderButtons.tsx
@@ -8,16 +8,18 @@ import {
 
 import messages from '../../messages';
 import useHeaderButtons from './hooks/useHeaderButtons';
+import { useCertificatesContext } from '@src/certificates/context';
 
 const HeaderButtons = () => {
   const intl = useIntl();
+  const { canManageCertificates } = useCertificatesContext();
   const {
     previewUrl,
     courseModes,
     dropdowmItem,
-    isCertificateActive,
     setDropdowmItem,
     handleActivationStatus,
+    isCertificateActive,
   } = useHeaderButtons();
 
   return (
@@ -34,14 +36,16 @@ const HeaderButtons = () => {
       >
         {intl.formatMessage(messages.headingActionsPreview)}
       </Button>
-      <Button
-        variant="outline-primary"
-        onClick={handleActivationStatus}
-      >
-        {isCertificateActive
-          ? intl.formatMessage(messages.headingActionsDeactivate)
-          : intl.formatMessage(messages.headingActionsActivate)}
-      </Button>
+      {canManageCertificates && (
+        <Button
+          variant="outline-primary"
+          onClick={handleActivationStatus}
+        >
+          {isCertificateActive
+            ? intl.formatMessage(messages.headingActionsDeactivate)
+            : intl.formatMessage(messages.headingActionsActivate)}
+        </Button>
+      )}
     </>
   );
 };

--- a/src/course-outline/outline-sidebar/info-sidebar/CourseInfoSidebar.tsx
+++ b/src/course-outline/outline-sidebar/info-sidebar/CourseInfoSidebar.tsx
@@ -141,7 +141,7 @@ const SettingsTab = () => {
           isNewPage
         />
       )}
-      {perms.canManageAdvancedSettings && (
+      {perms.canViewAdvancedSettings && (
         <HelpSidebarLink
           as="span"
           pathToPage={`/course/${courseId}/${advancedSettings}`}

--- a/src/generic/help-sidebar/HelpSidebar.test.tsx
+++ b/src/generic/help-sidebar/HelpSidebar.test.tsx
@@ -42,7 +42,7 @@ const mockCoursePermissions = (
     canViewGradingSettings: true,
     canViewCourseTeam: true,
     canManageGroupConfigurations: true,
-    canManageAdvancedSettings: true,
+    canViewAdvancedSettings: true,
     ...permissions,
   } as unknown as ReturnType<typeof useCourseUserPermissions>);
 };
@@ -91,7 +91,7 @@ describe('HelpSidebar', () => {
       ['canViewScheduleAndDetails', messages.sidebarLinkToScheduleAndDetails],
       ['canViewGradingSettings', messages.sidebarLinkToGrading],
       ['canManageGroupConfigurations', messages.sidebarLinkToGroupConfigurations],
-      ['canManageAdvancedSettings', messages.sidebarLinkToAdvancedSettings],
+      ['canViewAdvancedSettings', messages.sidebarLinkToAdvancedSettings],
     ])('renders the %s link only when the permission is granted', async (permission, message) => {
       mockCoursePermissions({ [permission]: true });
       const { queryByText, unmount } = renderHelpSidebar(props);
@@ -130,7 +130,7 @@ describe('HelpSidebar', () => {
         canViewGradingSettings: false,
         canViewCourseTeam: false,
         canManageGroupConfigurations: false,
-        canManageAdvancedSettings: false,
+        canViewAdvancedSettings: false,
       }, { isLoading: true });
       const { queryByText } = renderHelpSidebar(props);
 

--- a/src/generic/help-sidebar/HelpSidebar.tsx
+++ b/src/generic/help-sidebar/HelpSidebar.tsx
@@ -109,7 +109,7 @@ const HelpSidebar = ({
                     isNewPage
                   />
                 )}
-                {showOtherLink(advancedSettings) && perms.canManageAdvancedSettings && (
+                {showOtherLink(advancedSettings) && perms.canViewAdvancedSettings && (
                   <HelpSidebarLink
                     pathToPage={`/course/${courseId}/${advancedSettings}`}
                     title={intl.formatMessage(messages.sidebarLinkToAdvancedSettings)}

--- a/src/header/hooks.test.tsx
+++ b/src/header/hooks.test.tsx
@@ -279,12 +279,12 @@ describe('header utils', () => {
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
         isAuthzEnabled: false,
-        canManageAdvancedSettings: true,
+        canViewAdvancedSettings: true,
         canViewGradingSettings: true,
         canViewScheduleAndDetails: true,
         canViewCourseTeam: true,
         canManageGroupConfigurations: true,
-        canManageCertificates: true,
+        canViewCertificates: true,
       } as ReturnType<typeof useCourseUserPermissions>);
     });
 
@@ -314,7 +314,7 @@ describe('header utils', () => {
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
         isAuthzEnabled: true,
-        canManageAdvancedSettings: true,
+        canViewAdvancedSettings: true,
         canViewGradingSettings: true,
         canViewScheduleAndDetails: true,
       } as ReturnType<typeof useCourseUserPermissions>);
@@ -329,7 +329,7 @@ describe('header utils', () => {
       mockWaffleFlags({ enableAuthzCourseAuthoring: false });
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
-        canManageAdvancedSettings: true,
+        canViewAdvancedSettings: true,
         canViewCourseTeam: true,
       } as any);
       const actualItems =
@@ -352,7 +352,7 @@ describe('header utils', () => {
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
         isAuthzEnabled: true,
-        canManageAdvancedSettings: true,
+        canViewAdvancedSettings: true,
         canViewCourseTeam: true,
       } as any);
       const courseIdWithSpecialChars = 'course-v1:org+course+run';
@@ -369,7 +369,7 @@ describe('header utils', () => {
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
         isAuthzEnabled: true,
-        canManageAdvancedSettings: false,
+        canViewAdvancedSettings: false,
         canViewGradingSettings: true,
         canViewScheduleAndDetails: true,
       } as ReturnType<typeof useCourseUserPermissions>);
@@ -399,7 +399,7 @@ describe('header utils', () => {
         isLoading: false,
         isAuthzEnabled: true,
         canViewScheduleAndDetails: true,
-        canManageAdvancedSettings: true,
+        canViewAdvancedSettings: true,
         canViewGradingSettings: true,
       } as ReturnType<typeof useCourseUserPermissions>);
       const { result } = renderHook(() => useSettingMenuItems('course-123'), { wrapper: createWrapper() });
@@ -415,7 +415,7 @@ describe('header utils', () => {
         isLoading: false,
         isAuthzEnabled: true,
         canViewScheduleAndDetails: false,
-        canManageAdvancedSettings: true,
+        canViewAdvancedSettings: true,
         canViewGradingSettings: true,
       } as ReturnType<typeof useCourseUserPermissions>);
       const { result } = renderHook(() => useSettingMenuItems('course-123'), { wrapper: createWrapper() });
@@ -431,7 +431,7 @@ describe('header utils', () => {
         isLoading: false,
         isAuthzEnabled: true,
         canViewGradingSettings: true,
-        canManageAdvancedSettings: true,
+        canViewAdvancedSettings: true,
         canViewScheduleAndDetails: true,
       } as ReturnType<typeof useCourseUserPermissions>);
       const { result } = renderHook(() => useSettingMenuItems('course-123'), { wrapper: createWrapper() });
@@ -447,7 +447,7 @@ describe('header utils', () => {
         isLoading: false,
         isAuthzEnabled: true,
         canViewGradingSettings: false,
-        canManageAdvancedSettings: true,
+        canViewAdvancedSettings: true,
         canViewScheduleAndDetails: true,
       } as ReturnType<typeof useCourseUserPermissions>);
       const { result } = renderHook(() => useSettingMenuItems('course-123'), { wrapper: createWrapper() });
@@ -462,7 +462,7 @@ describe('header utils', () => {
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
         isAuthzEnabled: true,
-        canManageAdvancedSettings: true,
+        canViewAdvancedSettings: true,
         canViewGradingSettings: true,
         canViewScheduleAndDetails: true,
         canViewCourseTeam: true,
@@ -504,7 +504,7 @@ describe('header utils', () => {
       expect(actualItemsTitle).not.toContain('Group Configurations');
     });
 
-    it('when authz flag is enabled and user lacks canManageCertificates should not include certificates option', () => {
+    it('when authz flag is enabled and user lacks canViewCertificates should not include certificates option', () => {
       mockWaffleFlags({ enableAuthzCourseAuthoring: true });
       setConfig({
         ...getConfig(),
@@ -513,7 +513,7 @@ describe('header utils', () => {
       jest.mocked(useCourseUserPermissions).mockReturnValue({
         isLoading: false,
         isAuthzEnabled: true,
-        canManageCertificates: false,
+        canViewCertificates: false,
       } as any);
       const actualItemsTitle = renderHook(() => useSettingMenuItems('course-123'), { wrapper: createWrapper() }).result
         .current.map((item) => item.title);

--- a/src/header/hooks.tsx
+++ b/src/header/hooks.tsx
@@ -96,7 +96,7 @@ export const useSettingMenuItems = (courseId: string) => {
   // legacy value: it would briefly show the link (and the Settings dropdown) to users
   // that authz then denies.
   const canAccessAdvancedSettings = perms.isAuthzEnabled
-    ? perms.canManageAdvancedSettings
+    ? perms.canViewAdvancedSettings
     : !perms.isLoading && legacyCanAccessAdvancedSettings;
 
   const items = [
@@ -138,7 +138,7 @@ export const useSettingMenuItems = (courseId: string) => {
       }] :
       []),
   ];
-  if (getConfig().ENABLE_CERTIFICATE_PAGE === 'true' && perms.canManageCertificates) {
+  if (getConfig().ENABLE_CERTIFICATE_PAGE === 'true' && perms.canViewCertificates) {
     items.push({
       href: `/course/${courseId}/certificates`,
       title: intl.formatMessage(messages['header.links.certificates']),


### PR DESCRIPTION
## Description

This PR is the continuation of the effort to implement the new Authz system into Course Authoring. The PR is focused on hiding actions according to user permissions.

Specifically, it splits the **Advanced Settings** and **Certificates** pages into a *view* level and a *manage* level:

- Adds the new `courses.view_advanced_settings` and `courses.view_certificates` permissions to `src/authz/constants.ts`, and exposes them through `getAdvancedSettingsPermissions()` / `getCertificatesPermissions()`.
- **Access points** (Settings dropdown in the header, `HelpSidebar`, and the course outline `CourseInfoSidebar`) now gate the *Advanced Settings* and *Certificates* links on the `view_*` permission instead of `manage_*`, so users with read-only access can still reach the pages.
- **Advanced Settings**: page access is now gated by `canViewAdvancedSettings` (`PermissionDeniedAlert` otherwise). Without `manage_advanced_settings` the page renders a `ViewOnlyPermissionsAlert` banner and every `SettingCard` field is `disabled`.
- **Certificates**: permissions moved into `CertificatesProvider` (`src/certificates/context.tsx`) so they're resolved once and consumed anywhere in the tree. Page access is gated by `canViewCertificates`; without `manage_certificates` the page shows the `ViewOnlyPermissionsAlert` banner and hides the write actions: the *Activate/Deactivate* button, the *Set up certificate* button on the empty state, the edit/delete actions on the certificate details card, and the edit action on each signatory. The *Preview* button stays available to read-only users.


**Impacted user roles:** Course Auditor / Course Editor — i.e. anyone whose role grants `view_advanced_settings` or `view_certificates` without the matching `manage_*`. Users with the `manage_*` permissions ( Course Staff / Course Admin) are unaffected. This only takes effect when the `enable_authz_course_authoring` waffle flag is on; with the flag off, the legacy behavior is preserved.

## Additional information
It closes https://github.com/openedx/openedx-authz/issues/316
[Design link](https://www.figma.com/design/onU2END2OXaF7RRLWEHsZI/AuthZ---v2?node-id=9145-5928&t=e306FFuID4UFajek-4)


## Testing instructions

1. Check out this branch and run the MFE against a devstack/tutor instance with both backend PRs above applied.
2. Enable the `enable_authz_course_authoring` waffle flag.
3. Assign a user a role that grants `courses.view_advanced_settings` and `courses.view_certificates` but **not** the corresponding `manage_*` permissions, and log in as that user.
   - Use the API http://local.openedx.io:8000/api/authz/v1/roles/users/
   - Assign `course_auditor` as role
5. Open the  course and verify:
   - **Header → Settings** dropdown shows *Advanced Settings* and *Certificates*.
   - The *Advanced Settings* link is also visible in the Help sidebar and in the course outline info sidebar (Settings tab).
6. Go to **Advanced Settings** and verify:
   - The page loads (no "permission denied" alert).
   - A "view only" alert is shown under the page header.
   - All setting fields are disabled and cannot be edited.
7. Go to **Certificates** (with `ENABLE_CERTIFICATE_PAGE=true`) and verify:
   - The page loads and shows the "view only" alert.
   - The *Preview* button is present, but *Activate*/*Deactivate* is not.
   - The certificate details card shows no edit or delete icon buttons.
   - Signatories show no edit icon button.
   - On a course with modes but no certificate yet, the *Set up certificate* button is hidden.
8. Now log in as a user **with** `manage_advanced_settings` / `manage_certificates` and repeat steps 5–6: no "view only" alert, all fields editable, and every action button present and working as before.
9. Finally, log in as a user with **neither** permission and confirm the pages return the permission-denied alert and the links are hidden from the menus/sidebars.
10. Turn the waffle flag off and confirm the legacy behavior is unchanged for all users.



**Advanced Settings**

<img width="1797" height="951" alt="image" src="https://github.com/user-attachments/assets/8fc609b5-e45d-4317-98fe-4c17743989ef" />


** Certificates**

<img width="1797" height="951" alt="image" src="https://github.com/user-attachments/assets/638c46d6-a1ab-406c-87d5-2c1653510f50" />


## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
