### PR TITLE
fix: fill the fullscreen component editor with the editor [backport to verawood]

### DIFF
--- a/src/editors/AdvancedEditor.test.tsx
+++ b/src/editors/AdvancedEditor.test.tsx
@@ -8,10 +8,14 @@ import {
   act,
   fireEvent,
 } from '../testUtils';
+import { LibraryBlock } from '../library-authoring/LibraryBlock';
 import AdvancedEditor from './AdvancedEditor';
 
 jest.mock('./containers/EditorContainer', () => ({
-  EditorModalWrapper: jest.fn(() => <div>Advanced Editor Iframe</div>),
+  EditorModalWrapper: jest.fn(({ children }) => <div>Advanced Editor Iframe{children}</div>),
+}));
+jest.mock('../library-authoring/LibraryBlock', () => ({
+  LibraryBlock: jest.fn(() => <div>Library Block</div>),
 }));
 const onCloseMock = jest.fn();
 
@@ -98,5 +102,21 @@ describe('AdvancedEditor', () => {
     window.dispatchEvent(messageEvent);
 
     expect(onCloseMock).not.toHaveBeenCalled();
+  });
+
+  it('lets the block fill the modal only in fullscreen', async () => {
+    render(<AdvancedEditor usageKey="test" onClose={onCloseMock} />);
+
+    expect(LibraryBlock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ fillContainer: false }),
+      expect.anything(),
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Toggle Fullscreen' }));
+
+    expect(LibraryBlock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ fillContainer: true }),
+      expect.anything(),
+    );
   });
 });

--- a/src/editors/AdvancedEditor.tsx
+++ b/src/editors/AdvancedEditor.tsx
@@ -89,6 +89,7 @@ const AdvancedEditor = ({ usageKey, onClose }: AdvancedEditorProps) => {
             view="studio_view"
             scrolling="yes"
             minHeight="70vh"
+            fillContainer={isFullscreen}
           />
         </IframeProvider>
       </EditorModalWrapper>

--- a/src/editors/containers/EditorContainer/index.scss
+++ b/src/editors/containers/EditorContainer/index.scss
@@ -4,3 +4,24 @@
     overflow: visible;
   }
 }
+
+// Pass the fullscreen height down: flex-basis outranks h-75 and TinyMCE's inline height.
+.editor-modal.pgn__modal-fullscreen {
+  .pgn__modal-body,
+  .pgn__modal-body-content,
+  .editor-body {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .pgn__modal-body-content,
+  .editor-body,
+  .tox-tinymce {
+    flex: 1 1 0;
+    min-height: 0;
+  }
+
+  .pgn__modal-body-content {
+    overflow-y: auto;
+  }
+}

--- a/src/editors/containers/EditorContainer/index.tsx
+++ b/src/editors/containers/EditorContainer/index.tsx
@@ -46,6 +46,7 @@ export const EditorModalWrapper: React.FC<WrapperProps & { onClose: () => void; 
       isOpen
       onClose={onClose}
       title={title}
+      className="editor-modal"
       size={fullscreen ? 'fullscreen' : 'xl'}
       isOverflowVisible={false}
       hasCloseButton={false}

--- a/src/library-authoring/LibraryBlock/LibraryBlock.tsx
+++ b/src/library-authoring/LibraryBlock/LibraryBlock.tsx
@@ -19,6 +19,7 @@ interface LibraryBlockProps {
   view?: string;
   scrolling?: string;
   minHeight?: string;
+  fillContainer?: boolean;
   scrollIntoView?: boolean;
   showTitle?: boolean;
 }
@@ -37,6 +38,7 @@ export const LibraryBlock = ({
   version,
   view,
   minHeight,
+  fillContainer = false,
   scrolling = 'no',
   scrollIntoView = false,
   showTitle = false,
@@ -92,9 +94,10 @@ export const LibraryBlock = ({
       referrerPolicy="origin"
       style={{
         width: '100%',
-        height: iframeHeight,
         pointerEvents: 'auto',
-        minHeight,
+        ...(fillContainer
+          ? { flex: '1 1 auto', height: 'auto', minHeight: 0 }
+          : { height: iframeHeight, minHeight }),
       }}
       allow={IFRAME_FEATURE_POLICY}
       allowFullScreen


### PR DESCRIPTION
## Description

Backport of #3209 to `release/verawood`.

Two component editors do not use the space they are given when expanded to fullscreen. The text and game editors leave a band of empty page between the writing area and the footer. The editor for blocks without a dedicated editor — anything advanced, reached from a direct editor link — shows the block in the top 70% of the modal with empty space beneath it, and a block taller than the modal cannot be reached at all.

Both now fill the modal in fullscreen: the writing area grows with the page, and a block taller than the modal scrolls inside its frame. Neither editor changes at its normal size.

<details><summary>Implementation notes</summary>

- Two independent causes, hence two commits.
- `LibraryBlock` sizes its IFrame to the height the block reports, with a `70vh` floor. In a fullscreen modal that is a fixed height inside a fixed-height flex column, so it neither grows into the space nor overflows into a scroll — flexbox shrinks it instead and the modal itself does not scroll. The new `fillContainer` prop swaps that for a growing flex item, and `AdvancedEditor` sets it only in fullscreen. It is opt-in because outside a flex parent the item would collapse to the IFrame default of 150px.
- The text editor stack holds two heights of its own: `.editor-body` carries an `h-75` utility, and TinyMCE resolves its `height: '100%'` once when it is built and keeps that pixel value in an inline style. A definite `flex-basis` outranks both, which is why the stylesheet needs no `!important`.
- `EditorContainer/index.scss` existed but was never imported; it is imported now, and the modal carries an `editor-modal` class so the rules do not reach every fullscreen Paragon modal in the app.
- `.pgn__modal-body-content` gets `overflow-y: auto` because bounding it takes scrolling away from the modal body, and the problem editor is routinely taller than the modal.

</details>

## Screenshot/Video

| # | View | What to check | Before | After |
|:-:|:-----|:--------------|:-------|:------|
| 1 | **Text editor, fullscreen** (an HTML component) | The writing area reaches the footer instead of stopping short of it | `03-text-editor-before.png` | `03-text-editor-after.png` |
| 2 | **Advanced editor, fullscreen** (a poll component) | The block fills the modal instead of leaving a band of empty space below it | `04-paragon-advanced-before.png` | `04-paragon-advanced-after.png` |

## Testing

Preconditions: a course with an HTML component, a problem, and any advanced component such as a poll.

1. Open a unit, edit the HTML component, and click the expand icon.
2. Expected: the writing area runs from the toolbar down to the footer, with no empty band above the buttons.
3. Type enough to overflow the area.
4. Expected: it scrolls inside the editor; the footer stays put.
5. Leave fullscreen.
6. Expected: the editor is the size it always was.
7. Edit the problem component and expand it.
8. Expected: the editor still scrolls as a whole and the footer stays visible.
9. Open an advanced component through its editor link, e.g. `/authoring/course/<courseId>/editor/poll/<blockId>`, and expand it.
10. Expected: the block fills the modal; a block taller than the modal scrolls inside its frame.

## Verified locally

| Check | Result |
|---|---|
| Advanced editor, fullscreen | frame grew from 604px to the full 791px available on all four block types from the ticket — scorm, feedback, poll and survey; the gap below it went from 187px to 0 |
| Advanced editor, tall block | at a 450px viewport the frame takes the whole 378px available and the block scrolls inside it; before, flexbox shrank the frame and the modal did not scroll |
| Text editor, fullscreen | writing area 500px → 697px, empty space below it 206px → 9px, which is the body's own padding |
| Text editor, normal size | 500px, unchanged |
| Problem editor, fullscreen | content bounded by the body and scrolling inside it, 1954px of content in 697px; footer visible |
| `jest` on the editor suites | 8 suites, 51 tests |
| Red/green | reverting the `fillContainer` line fails exactly the new test |
| `tsc`, `dprint`, `oxlint`, `stylelint` | clean |
| **Not verified** | One browser at 1440×863. The stylesheet has no test coverage; only the prop is covered by a test. |
