### PR TITLE
fix: stop the course outline scrolling back while you work in it [backport to verawood]

### DIFF
--- a/src/data/apiHooks.test.tsx
+++ b/src/data/apiHooks.test.tsx
@@ -1,3 +1,6 @@
+import { useRef } from 'react';
+import userEvent from '@testing-library/user-event';
+
 import {
   initializeMocks,
   cleanup,
@@ -5,7 +8,7 @@ import {
   render,
   waitFor,
 } from '../testUtils';
-import { useWaffleFlags } from './apiHooks';
+import { createGlobalState, useWaffleFlags } from './apiHooks';
 import { getApiWaffleFlagsUrl } from './api';
 
 // A little component for testing our waffle flag hooks.
@@ -108,5 +111,62 @@ describe('useWaffleFlags', () => {
     });
     expect(await screen.findByLabelText('isError')).toHaveTextContent('false');
     expect(await screen.findByLabelText('useNewCourseOutlinePage')).toHaveTextContent('enabled');
+  });
+});
+
+// A little component for testing the global state hooks.
+const useCounter = createGlobalState<{ count: number; }>(() => ['test', 'counter'], { count: 0 });
+
+const CounterComponent = () => {
+  const { data, setData, resetData } = useCounter();
+  const firstSetData = useRef(setData);
+  const firstResetData = useRef(resetData);
+  const callbacksKeptIdentity = setData === firstSetData.current && resetData === firstResetData.current;
+
+  return (
+    <ul>
+      <li aria-label="count">{data?.count ?? 'none'}</li>
+      <li aria-label="callbacks">{callbacksKeptIdentity ? 'same' : 'recreated'}</li>
+      <li>
+        <button type="button" onClick={() => setData({ count: (data?.count ?? 0) + 1 })}>increment</button>
+      </li>
+      <li>
+        <button
+          type="button"
+          onClick={() => {
+            void resetData();
+          }}
+        >
+          reset
+        </button>
+      </li>
+    </ul>
+  );
+};
+
+describe('createGlobalState', () => {
+  it('keeps its callbacks across renders, so effects depending on them do not re-run', async () => {
+    const user = userEvent.setup();
+    initializeMocks();
+    render(<CounterComponent />);
+    await waitFor(() => expect(screen.getByLabelText('count')).toHaveTextContent('0'));
+
+    await user.click(screen.getByRole('button', { name: 'increment' }));
+    await waitFor(() => expect(screen.getByLabelText('count')).toHaveTextContent('1'));
+
+    expect(screen.getByLabelText('callbacks')).toHaveTextContent('same');
+  });
+
+  it('resets the value it stores', async () => {
+    const user = userEvent.setup();
+    initializeMocks();
+    render(<CounterComponent />);
+    await waitFor(() => expect(screen.getByLabelText('count')).toHaveTextContent('0'));
+
+    await user.click(screen.getByRole('button', { name: 'increment' }));
+    await waitFor(() => expect(screen.getByLabelText('count')).toHaveTextContent('1'));
+
+    await user.click(screen.getByRole('button', { name: 'reset' }));
+    await waitFor(() => expect(screen.getByLabelText('count')).toHaveTextContent('0'));
   });
 });

--- a/src/data/apiHooks.ts
+++ b/src/data/apiHooks.ts
@@ -1,3 +1,5 @@
+import { useCallback, useMemo } from 'react';
+
 import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { UserAgreement, UserAgreementRecord } from '@src/data/types';
@@ -154,7 +156,7 @@ export function createGlobalState<T>(
 ) {
   return (queryKeyArgs?: any) => {
     const queryClient = useQueryClient();
-    const queryKey = queryKeyFn(queryKeyArgs);
+    const queryKey = useMemo(() => queryKeyFn(queryKeyArgs), [queryKeyArgs]);
 
     const { data } = useQuery({
       queryKey,
@@ -166,15 +168,13 @@ export function createGlobalState<T>(
       refetchIntervalInBackground: false,
     });
 
-    function setData(x: Partial<T>) {
+    const setData = useCallback((x: Partial<T>) => {
       queryClient.setQueryData(queryKey, x);
-    }
+    }, [queryClient, queryKey]);
 
-    async function resetData() {
-      await queryClient.invalidateQueries({
-        queryKey,
-      });
-    }
+    const resetData = useCallback(async () => {
+      await queryClient.invalidateQueries({ queryKey });
+    }, [queryClient, queryKey]);
 
     return { data, setData, resetData };
   };


### PR DESCRIPTION
## Description

Backport of #3213 to `release/verawood`.

Open a course outline through a link that points at one of its blocks — the kind Studio search and "view in outline" produce, with `?show=<block>` in the address — and the page starts snapping back to that block. Opening the menu on any section is enough to be thrown back to it, which makes the outline hard to work in at all. The block stays highlighted for as long as the link is in the address bar, and the outline reads that as "scroll to it" every time it re-renders.

The outline now scrolls to the highlighted block when you arrive and then leaves the page alone.

<details><summary>Implementation notes</summary>

- `createGlobalState` in `src/data/apiHooks.ts` returned `setData` and `resetData` as plain functions declared in the hook body, so both got a new identity on every render.
- `SectionCard`, `SubsectionCard` and `UnitCard` list `resetScrollState` among the dependencies of the effect that calls `scrollToElement`, so that effect ran on every render. While `?show=` names the card, its guard `isScrolledToElement` stays true, so every render scrolled. The effect also calls `resetScrollState()`, which invalidates the query and causes another render — hence repeated jumps rather than one.
- The fix is in the hook rather than in the three cards: a hook whose callbacks are read as dependencies has to keep their identity, the way `useQuery`'s `refetch` does. `queryKey` is memoised on `queryKeyArgs` so the callbacks can depend on it honestly, without a ref.
- Fixing the three dependency arrays instead would also work, but it leaves the same trap in place for every other caller of `createGlobalState`.

</details>

## Screenshot/Video

### Before
https://github.com/user-attachments/assets/3c0fddbe-0e5b-4967-b36c-9762613f3edf

### After
https://github.com/user-attachments/assets/2a47cbeb-6631-4653-b70b-50c9c7808226

## Testing

Preconditions: a course with several sections, a staff user.

1. Open the course outline with a block in the address, for example `<AUTHORING>/course/<courseId>?show=<sectionId>`.
2. Expected: the page scrolls to that section and highlights it — unchanged.
3. Scroll away from the highlighted section.
4. Open the menu on any other section.
5. Expected: the menu opens and the page stays where you left it. Before this change it scrolled back to the highlighted section.
6. Rename a section, then open and close a few menus.
7. Expected: the page stays put throughout.
8. Open the outline without `?show=` and repeat.
9. Expected: unchanged.

## Verified locally

| Check | Result |
|---|---|
| Outline with `?show=<section>`, scrolled to 6000px, section menu opened | page stays at 6000px; before the fix it scrolled to 3654px, a jump of 2346px |
| Arrival behaviour | still scrolls to the block and highlights it — one highlighted card, page settles at its top |
| Section menu | opens as before: `aria-expanded` flips and the dropdown renders |
| `jest src/course-outline` | 32 suites, 357 tests |
| `jest src/data/apiHooks.test.tsx` | 5 tests, including two new ones for the hook |
| Red/green | restoring the plain functions fails the new identity test |
| `tsc`, `dprint`, `oxlint` | clean |
| **Not verified** | One browser at 1440×863. The three card effects were left as they are, so the fix rests on the hook keeping its callbacks stable. |
