### PR TITLE
feat: add in-platform transcript editor to the videos page

### DIFF
--- a/src/files-and-videos/generic/FileMenu.test.tsx
+++ b/src/files-and-videos/generic/FileMenu.test.tsx
@@ -132,7 +132,7 @@ describe('FileMenu', () => {
 
       expect(screen.queryByText('Copy video ID')).not.toBeInTheDocument();
       expect(screen.queryByText('Download')).not.toBeInTheDocument();
-      expect(screen.getByText('Info')).toBeInTheDocument();
+      expect(screen.getByText('Info and transcripts')).toBeInTheDocument();
     });
   });
 });

--- a/src/files-and-videos/generic/FileMenu.tsx
+++ b/src/files-and-videos/generic/FileMenu.tsx
@@ -70,7 +70,7 @@ const FileMenu = ({
           </>
         )}
         <Dropdown.Item onClick={openAssetInfo}>
-          <FormattedMessage {...messages.infoTitle} />
+          <FormattedMessage {...(fileType === 'video' ? messages.infoAndTranscriptsTitle : messages.infoTitle)} />
         </Dropdown.Item>
         {permissions.canDeleteFiles && (
           <>

--- a/src/files-and-videos/generic/FileTable.jsx
+++ b/src/files-and-videos/generic/FileTable.jsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
@@ -43,7 +49,7 @@ const FileTable = ({
   maxFileSize,
   thumbnailPreview,
   infoModalSidebar,
-  infoModalContentUnderPreview,
+  infoModalContentUnderPreview = /** @type {(file: any) => React.ReactNode} */ (() => null),
   permissions = {
     canCreateFiles: true,
     canDeleteFiles: true,
@@ -205,16 +211,31 @@ const FileTable = ({
       }),
   };
 
-  const hasMoreInfoColumn = tableColumns.filter(col => col.id === 'moreInfo').length === 1;
-  if (!hasMoreInfoColumn) {
-    tableColumns.push({ ...moreInfoColumn }); // eslint-disable-line no-param-reassign
-  }
+  const handleOpenFileInfoRef = useRef(handleOpenFileInfo);
+  handleOpenFileInfoRef.current = handleOpenFileInfo;
 
-  const transcriptColIndex = tableColumns.findIndex(col => col.id === 'transcriptStatus');
-  if (transcriptColIndex !== -1) {
-    // eslint-disable-next-line no-param-reassign, react/prop-types
-    tableColumns[transcriptColIndex].Cell = ({ row }) => TranscriptColumn({ row, handleOpenFileInfo });
-  }
+  // Copy the caller's columns instead of mutating them. Memoized (with the ref above)
+  // so the columns identity stays stable across re-renders: a new identity makes
+  // DataTable reset its internal state.
+  const columns = useMemo(() => {
+    const cols = [...tableColumns];
+    if (cols.filter(col => col.id === 'moreInfo').length !== 1) {
+      cols.push({ ...moreInfoColumn });
+    }
+    const transcriptColIndex = cols.findIndex(col => col.id === 'transcriptStatus');
+    if (transcriptColIndex !== -1) {
+      cols[transcriptColIndex] = {
+        ...cols[transcriptColIndex],
+        Cell: ({ row }) => (
+          <TranscriptColumn
+            row={row}
+            handleOpenFileInfo={(file) => handleOpenFileInfoRef.current(file)}
+          />
+        ),
+      };
+    }
+    return cols;
+  }, [tableColumns]);
 
   return (
     <div className="files-table">
@@ -243,7 +264,7 @@ const FileTable = ({
         initialState={initialState}
         tableActions={headerActions}
         bulkActions={headerActions}
-        columns={tableColumns}
+        columns={columns}
         itemCount={files.length}
         pageCount={pageCount}
         data={files}
@@ -363,6 +384,7 @@ FileTable.propTypes = {
   maxFileSize: PropTypes.number.isRequired,
   thumbnailPreview: PropTypes.func.isRequired,
   infoModalSidebar: PropTypes.func.isRequired,
+  // Render function `(file) => ReactNode` shown in the info modal under the file preview.
   infoModalContentUnderPreview: PropTypes.func,
   permissions: PropTypes.shape({
     canCreateFiles: PropTypes.bool,
@@ -374,7 +396,6 @@ FileTable.propTypes = {
 FileTable.defaultProps = {
   files: null,
   handleLockFile: () => {},
-  infoModalContentUnderPreview: () => null,
 };
 
 export default FileTable;

--- a/src/files-and-videos/generic/FileTable.jsx
+++ b/src/files-and-videos/generic/FileTable.jsx
@@ -24,6 +24,7 @@ import {
   MoreInfoColumn,
   FilterStatus,
   Footer,
+  TranscriptColumn,
 } from './table-components';
 import ApiStatusToast from './ApiStatusToast';
 import DeleteConfirmationModal from './DeleteConfirmationModal';
@@ -42,6 +43,7 @@ const FileTable = ({
   maxFileSize,
   thumbnailPreview,
   infoModalSidebar,
+  infoModalContentUnderPreview,
   permissions = {
     canCreateFiles: true,
     canDeleteFiles: true,
@@ -205,7 +207,13 @@ const FileTable = ({
 
   const hasMoreInfoColumn = tableColumns.filter(col => col.id === 'moreInfo').length === 1;
   if (!hasMoreInfoColumn) {
-    tableColumns.push({ ...moreInfoColumn });
+    tableColumns.push({ ...moreInfoColumn }); // eslint-disable-line no-param-reassign
+  }
+
+  const transcriptColIndex = tableColumns.findIndex(col => col.id === 'transcriptStatus');
+  if (transcriptColIndex !== -1) {
+    // eslint-disable-next-line no-param-reassign, react/prop-types
+    tableColumns[transcriptColIndex].Cell = ({ row }) => TranscriptColumn({ row, handleOpenFileInfo });
   }
 
   return (
@@ -322,6 +330,7 @@ const FileTable = ({
           usagePathStatus={usagePathStatus}
           error={usageErrorMessages}
           sidebar={infoModalSidebar}
+          contentUnderPreview={infoModalContentUnderPreview(selectedRows[0].original)}
         />
       )}
     </div>
@@ -354,6 +363,7 @@ FileTable.propTypes = {
   maxFileSize: PropTypes.number.isRequired,
   thumbnailPreview: PropTypes.func.isRequired,
   infoModalSidebar: PropTypes.func.isRequired,
+  infoModalContentUnderPreview: PropTypes.func,
   permissions: PropTypes.shape({
     canCreateFiles: PropTypes.bool,
     canDeleteFiles: PropTypes.bool,
@@ -364,6 +374,7 @@ FileTable.propTypes = {
 FileTable.defaultProps = {
   files: null,
   handleLockFile: () => {},
+  infoModalContentUnderPreview: () => null,
 };
 
 export default FileTable;

--- a/src/files-and-videos/generic/FileTable.jsx
+++ b/src/files-and-videos/generic/FileTable.jsx
@@ -49,7 +49,7 @@ const FileTable = ({
   maxFileSize,
   thumbnailPreview,
   infoModalSidebar,
-  infoModalContentUnderPreview = /** @type {(file: any) => React.ReactNode} */ (() => null),
+  infoModalContentUnderPreview = /** @type {(file: any) => React.ReactNode} */ (/* istanbul ignore next */ () => null),
   permissions = {
     canCreateFiles: true,
     canDeleteFiles: true,

--- a/src/files-and-videos/generic/InfoModal.jsx
+++ b/src/files-and-videos/generic/InfoModal.jsx
@@ -24,6 +24,7 @@ const InfoModal = ({
   usagePathStatus,
   error,
   sidebar,
+  contentUnderPreview,
 }) => {
   const intl = useIntl();
   const [activeTab, setActiveTab] = useState('fileInfo');
@@ -75,6 +76,7 @@ const InfoModal = ({
                 thumbnailPreview={thumbnailPreview}
                 imageSize={{ width: '503px', height: '281px' }}
               />
+              {contentUnderPreview}
               <div>
                 <div className="row m-0 font-weight-bold">
                   <FormattedMessage {...messages.usageTitle} />
@@ -114,10 +116,12 @@ InfoModal.propTypes = {
   error: PropTypes.arrayOf(PropTypes.string).isRequired,
   thumbnailPreview: PropTypes.func.isRequired,
   sidebar: PropTypes.func.isRequired,
+  contentUnderPreview: PropTypes.node,
 };
 
 InfoModal.defaultProps = {
   file: null,
+  contentUnderPreview: null,
 };
 
 export default InfoModal;

--- a/src/files-and-videos/generic/InfoModal.jsx
+++ b/src/files-and-videos/generic/InfoModal.jsx
@@ -24,7 +24,7 @@ const InfoModal = ({
   usagePathStatus,
   error,
   sidebar,
-  contentUnderPreview,
+  contentUnderPreview = null,
 }) => {
   const intl = useIntl();
   const [activeTab, setActiveTab] = useState('fileInfo');
@@ -121,7 +121,6 @@ InfoModal.propTypes = {
 
 InfoModal.defaultProps = {
   file: null,
-  contentUnderPreview: null,
 };
 
 export default InfoModal;

--- a/src/files-and-videos/generic/InfoModal.jsx
+++ b/src/files-and-videos/generic/InfoModal.jsx
@@ -24,7 +24,7 @@ const InfoModal = ({
   usagePathStatus,
   error,
   sidebar,
-  contentUnderPreview = null,
+  contentUnderPreview = /* istanbul ignore next */ null,
 }) => {
   const intl = useIntl();
   const [activeTab, setActiveTab] = useState('fileInfo');

--- a/src/files-and-videos/generic/messages.ts
+++ b/src/files-and-videos/generic/messages.ts
@@ -115,6 +115,11 @@ const messages = defineMessages({
     defaultMessage: 'Info',
     description: 'Label for info button in card menu dropdown',
   },
+  infoAndTranscriptsTitle: {
+    id: 'course-authoring.files-and-uploads.cardMenu.infoAndTranscriptsTitle',
+    defaultMessage: 'Info and transcripts',
+    description: 'Label for video info button in card menu dropdown',
+  },
   downloadEncodingsTitle: {
     id: 'course-authoring.files-and-uploads.cardMenu.downloadEncodingsTitle',
     defaultMessage: 'Download video list (.csv)',

--- a/src/files-and-videos/generic/messages.ts
+++ b/src/files-and-videos/generic/messages.ts
@@ -219,6 +219,11 @@ const messages = defineMessages({
     defaultMessage: 'Upload a file',
     description: 'Accessible (screen reader) label for file input',
   },
+  transcriptCountLabel: {
+    id: 'course-authoring.videos-page.table.transcriptColumn.message',
+    defaultMessage: '{numOfTranscripts, plural, =0 {No transcripts available} one {{numOfTranscripts} transcript available} other {{numOfTranscripts} transcripts available}}',
+    description: 'Message with the number of transcripts available for a video',
+  },
 });
 
 export default messages;

--- a/src/files-and-videos/generic/table-components/table-custom-columns/MoreInfoColumn.jsx
+++ b/src/files-and-videos/generic/table-components/table-custom-columns/MoreInfoColumn.jsx
@@ -122,7 +122,7 @@ const MoreInfoColumn = ({
             variant="tertiary"
             onClick={() => handleOpenFileInfo(row.original)}
           >
-            <FormattedMessage {...messages.infoTitle} />
+            <FormattedMessage {...(fileType === 'video' ? messages.infoAndTranscriptsTitle : messages.infoTitle)} />
           </MenuItem>
 
           {permissions.canDeleteFiles && (

--- a/src/files-and-videos/generic/table-components/table-custom-columns/MoreInfoColumn.test.jsx
+++ b/src/files-and-videos/generic/table-components/table-custom-columns/MoreInfoColumn.test.jsx
@@ -159,7 +159,7 @@ describe('MoreInfoColumn', () => {
 
       expect(screen.queryByText('Copy video ID')).not.toBeInTheDocument();
       expect(screen.queryByText('Download')).not.toBeInTheDocument();
-      expect(screen.getByText('Info')).toBeInTheDocument();
+      expect(screen.getByText('Info and transcripts')).toBeInTheDocument();
     });
 
     it('calls handleBulkDownload when Download is clicked', async () => {

--- a/src/files-and-videos/generic/table-components/table-custom-columns/TranscriptColumn.jsx
+++ b/src/files-and-videos/generic/table-components/table-custom-columns/TranscriptColumn.jsx
@@ -4,18 +4,19 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { Button, Icon } from '@openedx/paragon';
 import { Info } from '@openedx/paragon/icons';
 import { TRANSCRIPT_FAILURE_STATUSES } from '../../../videos-page/data/constants';
+import messages from '../../messages';
 
-const TranscriptColumn = ({ row, handleOpenFileInfo }) => {
+const TranscriptColumn = ({ row, handleOpenFileInfo = /** @type {((file: any) => void) | null} */ (null) }) => {
   const { transcripts, transcriptionStatus } = row.original;
-  const numOfTranscripts = transcripts?.length;
-  const transcriptMessage = numOfTranscripts > 0 ? `(${numOfTranscripts}) available` : null;
+  const numOfTranscripts = transcripts?.length ?? 0;
+  const label = <FormattedMessage {...messages.transcriptCountLabel} values={{ numOfTranscripts }} />;
 
   return (
     <div className="row m-0 align-items-center">
       {TRANSCRIPT_FAILURE_STATUSES.includes(transcriptionStatus) && (
         <Icon src={Info} size="sm" className="mr-2 text-danger-500" />
       )}
-      {numOfTranscripts > 0 && handleOpenFileInfo ?
+      {handleOpenFileInfo ?
         (
           <Button
             variant="link"
@@ -25,17 +26,10 @@ const TranscriptColumn = ({ row, handleOpenFileInfo }) => {
               handleOpenFileInfo(row.original);
             }}
           >
-            {transcriptMessage}
+            {label}
           </Button>
         ) :
-        (
-          <FormattedMessage
-            id="course-authoring.videos-page.table.transcriptColumn.message"
-            description="Message with the number of transcripts available"
-            defaultMessage="{message}"
-            values={{ message: transcriptMessage }}
-          />
-        )}
+        label}
     </div>
   );
 };
@@ -48,10 +42,6 @@ TranscriptColumn.propTypes = {
     }.isRequired,
   }.isRequired,
   handleOpenFileInfo: PropTypes.func,
-};
-
-TranscriptColumn.defaultProps = {
-  handleOpenFileInfo: null,
 };
 
 export default TranscriptColumn;

--- a/src/files-and-videos/generic/table-components/table-custom-columns/TranscriptColumn.jsx
+++ b/src/files-and-videos/generic/table-components/table-custom-columns/TranscriptColumn.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { Icon } from '@openedx/paragon';
+import { Button, Icon } from '@openedx/paragon';
 import { Info } from '@openedx/paragon/icons';
 import { TRANSCRIPT_FAILURE_STATUSES } from '../../../videos-page/data/constants';
 
-const TranscriptColumn = ({ row }) => {
+const TranscriptColumn = ({ row, handleOpenFileInfo }) => {
   const { transcripts, transcriptionStatus } = row.original;
   const numOfTranscripts = transcripts?.length;
   const transcriptMessage = numOfTranscripts > 0 ? `(${numOfTranscripts}) available` : null;
@@ -15,12 +15,27 @@ const TranscriptColumn = ({ row }) => {
       {TRANSCRIPT_FAILURE_STATUSES.includes(transcriptionStatus) && (
         <Icon src={Info} size="sm" className="mr-2 text-danger-500" />
       )}
-      <FormattedMessage
-        id="course-authoring.videos-page.table.transcriptColumn.message"
-        description="Message with the number of transcripts available"
-        defaultMessage="{message}"
-        values={{ message: transcriptMessage }}
-      />
+      {numOfTranscripts > 0 && handleOpenFileInfo ?
+        (
+          <Button
+            variant="link"
+            size="inline"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleOpenFileInfo(row.original);
+            }}
+          >
+            {transcriptMessage}
+          </Button>
+        ) :
+        (
+          <FormattedMessage
+            id="course-authoring.videos-page.table.transcriptColumn.message"
+            description="Message with the number of transcripts available"
+            defaultMessage="{message}"
+            values={{ message: transcriptMessage }}
+          />
+        )}
     </div>
   );
 };
@@ -32,6 +47,11 @@ TranscriptColumn.propTypes = {
       transcriptionStatus: PropTypes.string.isRequired,
     }.isRequired,
   }.isRequired,
+  handleOpenFileInfo: PropTypes.func,
+};
+
+TranscriptColumn.defaultProps = {
+  handleOpenFileInfo: null,
 };
 
 export default TranscriptColumn;

--- a/src/files-and-videos/generic/table-components/table-custom-columns/TranscriptColumn.test.tsx
+++ b/src/files-and-videos/generic/table-components/table-custom-columns/TranscriptColumn.test.tsx
@@ -1,0 +1,42 @@
+import {
+  fireEvent,
+  initializeMocks,
+  render,
+  screen,
+} from '@src/testUtils';
+import TranscriptColumn from './TranscriptColumn';
+
+const rowWith = (transcripts: string[], transcriptionStatus = '') => ({
+  original: { transcripts, transcriptionStatus },
+});
+
+describe('TranscriptColumn', () => {
+  beforeEach(() => {
+    initializeMocks();
+  });
+
+  it('pluralizes the transcript count', () => {
+    const { rerender } = render(<TranscriptColumn row={rowWith(['en'])} />);
+    expect(screen.getByText('1 transcript available')).toBeInTheDocument();
+
+    rerender(<TranscriptColumn row={rowWith(['en', 'es', 'fr'])} />);
+    expect(screen.getByText('3 transcripts available')).toBeInTheDocument();
+
+    rerender(<TranscriptColumn row={rowWith([])} />);
+    expect(screen.getByText('No transcripts available')).toBeInTheDocument();
+  });
+
+  it('renders plain text when no handler is provided', () => {
+    render(<TranscriptColumn row={rowWith(['en'])} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('opens the file info from the count link, including when there are no transcripts yet', () => {
+    const handleOpenFileInfo = jest.fn();
+    const row = rowWith([]);
+    render(<TranscriptColumn row={row} handleOpenFileInfo={handleOpenFileInfo} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'No transcripts available' }));
+    expect(handleOpenFileInfo).toHaveBeenCalledWith(row.original);
+  });
+});

--- a/src/files-and-videos/index.scss
+++ b/src/files-and-videos/index.scss
@@ -79,3 +79,13 @@
 .video-upload-warning-text {
   font-size: 18px;
 }
+
+.transcript-upload-button {
+  border-radius: 5px;
+  border: 2px solid;
+
+  &:focus::before,
+  &:focus-visible::before {
+    display: none !important;
+  }
+}

--- a/src/files-and-videos/videos-page/CourseVideosTable.tsx
+++ b/src/files-and-videos/videos-page/CourseVideosTable.tsx
@@ -167,7 +167,7 @@ export const CourseVideosTable = () => {
     id: 'transcriptStatus',
     Header: 'Transcript',
     accessor: 'transcriptStatus',
-    Cell: ({ row, handleOpenFileInfo }: any) => TranscriptColumn({ row, handleOpenFileInfo }),
+    Cell: ({ row }) => TranscriptColumn({ row }),
     Filter: CheckboxFilter,
     filter: 'exactTextCase',
     filterChoices: [

--- a/src/files-and-videos/videos-page/CourseVideosTable.tsx
+++ b/src/files-and-videos/videos-page/CourseVideosTable.tsx
@@ -29,6 +29,7 @@ import {
 } from '@src/files-and-videos/videos-page/data/thunks';
 import { getFormattedDuration, resampleFile } from '@src/files-and-videos/videos-page/data/utils';
 import VideoInfoModalSidebar from '@src/files-and-videos/videos-page/info-sidebar';
+import InfoTab from '@src/files-and-videos/videos-page/info-sidebar/InfoTab';
 import messages from '@src/files-and-videos/videos-page/messages';
 import TranscriptSettings from '@src/files-and-videos/videos-page/transcript-settings';
 import UploadModal from '@src/files-and-videos/videos-page/upload-modal';
@@ -159,15 +160,14 @@ export const CourseVideosTable = () => {
       handleAddThumbnail,
       videoImageSettings,
     });
-  const infoModalSidebar = (video, activeTab, setActiveTab) => (
-    <VideoInfoModalSidebar video={video} activeTab={activeTab} setActiveTab={setActiveTab} />
-  );
+  const infoModalSidebar = (video) => <VideoInfoModalSidebar video={video} />;
+  const infoModalContentUnderPreview = (video) => <InfoTab video={video} />;
   const maxFileSize = videoUploadMaxFileSize * 1073741824;
   const transcriptColumn = {
     id: 'transcriptStatus',
     Header: 'Transcript',
     accessor: 'transcriptStatus',
-    Cell: ({ row }) => TranscriptColumn({ row }),
+    Cell: ({ row, handleOpenFileInfo }: any) => TranscriptColumn({ row, handleOpenFileInfo }),
     Filter: CheckboxFilter,
     filter: 'exactTextCase',
     filterChoices: [
@@ -279,6 +279,7 @@ export const CourseVideosTable = () => {
                 maxFileSize,
                 thumbnailPreview,
                 infoModalSidebar,
+                infoModalContentUnderPreview,
                 files: videos,
               }}
             />

--- a/src/files-and-videos/videos-page/VideosPage.test.tsx
+++ b/src/files-and-videos/videos-page/VideosPage.test.tsx
@@ -502,10 +502,10 @@ describe('Videos page', () => {
             });
 
           fireEvent.click(within(videoMenuButton).getByLabelText('file-menu-toggle'));
-          fireEvent.click(screen.getByText('Info'));
+          fireEvent.click(screen.getByText(messages.infoAndTranscriptsTitle.defaultMessage));
 
           await waitFor(() => {
-            expect(screen.getByText(messages.infoTitle.defaultMessage)).toBeVisible();
+            expect(screen.getByText(messages.usageTitle.defaultMessage)).toBeVisible();
           });
 
           const { usageStatus } = store.getState().videos;
@@ -521,15 +521,12 @@ describe('Videos page', () => {
 
           axiosMock.onGet(`${getVideosUrl(courseId)}/mOckID1/usage`).reply(201, { usageLocations: [] });
           fireEvent.click(within(videoMenuButton).getByLabelText('file-menu-toggle'));
-          fireEvent.click(screen.getByText('Info'));
+          fireEvent.click(screen.getByText(messages.infoAndTranscriptsTitle.defaultMessage));
           await waitFor(() => {
             expect(screen.getByText(messages.usageNotInUseMessage.defaultMessage)).toBeVisible();
           });
 
-          const infoTab = screen.getAllByRole('tab')[0];
-          expect(infoTab).toBeVisible();
-
-          expect(infoTab).toHaveClass('active');
+          expect(screen.getByText(messages.usageTitle.defaultMessage)).toBeVisible();
         });
 
         it('should open video info modal and show transcript tab', async () => {
@@ -538,16 +535,12 @@ describe('Videos page', () => {
 
           axiosMock.onGet(`${getVideosUrl(courseId)}/mOckID1/usage`).reply(201, { usageLocations: [] });
           fireEvent.click(within(videoMenuButton).getByLabelText('file-menu-toggle'));
-          fireEvent.click(screen.getByText('Info'));
+          fireEvent.click(screen.getByText(messages.infoAndTranscriptsTitle.defaultMessage));
           await waitFor(() => {
             expect(screen.getByText(messages.usageNotInUseMessage.defaultMessage)).toBeVisible();
           });
 
-          const transcriptTab = screen.getAllByRole('tab')[1];
-          fireEvent.click(transcriptTab);
-          expect(transcriptTab).toBeVisible();
-
-          expect(transcriptTab).toHaveClass('active');
+          expect(screen.getByText('Transcript (0)')).toBeVisible();
         });
 
         it('should show transcript error', async () => {
@@ -556,12 +549,11 @@ describe('Videos page', () => {
 
           axiosMock.onGet(`${getVideosUrl(courseId)}/mOckID3/usage`).reply(201, { usageLocations: [] });
           fireEvent.click(within(videoMenuButton).getByLabelText('file-menu-toggle'));
-          fireEvent.click(screen.getByText('Info'));
+          fireEvent.click(screen.getByText(messages.infoAndTranscriptsTitle.defaultMessage));
 
-          const transcriptTab = screen.getAllByRole('tab')[1];
-          fireEvent.click(transcriptTab);
-
-          expect(screen.getByText('Transcript (1)')).toBeVisible();
+          await waitFor(() => {
+            expect(screen.getByText('Transcript (1)')).toBeVisible();
+          });
         });
       });
 
@@ -712,7 +704,7 @@ describe('Videos page', () => {
 
         axiosMock.onGet(`${getVideosUrl(courseId)}/mOckID3/usage`).reply(404);
         fireEvent.click(within(videoMenuButton).getByLabelText('file-menu-toggle'));
-        fireEvent.click(screen.getByText('Info'));
+        fireEvent.click(screen.getByText(messages.infoAndTranscriptsTitle.defaultMessage));
         await executeThunk(
           getUsagePaths({
             courseId,

--- a/src/files-and-videos/videos-page/data/api.js
+++ b/src/files-and-videos/videos-page/data/api.js
@@ -75,8 +75,7 @@ export async function downloadTranscript({
   apiUrl,
   filename,
 }) {
-  const { data } = await getAuthenticatedHttpClient()
-    .get(`${getApiBaseUrl()}${apiUrl}?edx_video_id=${videoId}&language_code=${language}`);
+  const data = await fetchTranscriptContent({ videoId, language, apiUrl });
   const file = new Blob([data], { type: 'text/plain;charset=utf-8' });
   saveAs(file, filename);
 }

--- a/src/files-and-videos/videos-page/data/api.js
+++ b/src/files-and-videos/videos-page/data/api.js
@@ -81,6 +81,16 @@ export async function downloadTranscript({
   saveAs(file, filename);
 }
 
+export async function fetchTranscriptContent({
+  videoId,
+  language,
+  apiUrl,
+}) {
+  const { data } = await getAuthenticatedHttpClient()
+    .get(`${getApiBaseUrl()}${apiUrl}?edx_video_id=${videoId}&language_code=${language}`);
+  return data;
+}
+
 export async function uploadTranscript({
   videoId,
   newLanguage,

--- a/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.jsx
@@ -1,14 +1,35 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, {
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+} from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { isEmpty } from 'lodash';
-import { Button, Stack } from '@openedx/paragon';
-import { Add } from '@openedx/paragon/icons';
+import {
+  Button,
+  Icon,
+  IconButton,
+  Spinner,
+  Stack,
+  Toast,
+} from '@openedx/paragon';
+import {
+  Add,
+  CheckCircle,
+  Delete,
+  Error as ErrorIcon,
+  FileUpload,
+  Article,
+} from '@openedx/paragon/icons';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import ErrorAlert from '../../../editors/sharedComponents/ErrorAlerts/ErrorAlert';
 import { getLanguages, getSortedTranscripts } from '../data/utils';
 import Transcript from './transcript-item';
+import LanguageSelect from './transcript-item/LanguageSelect';
+import { FileInput, useFileInput } from '../../generic';
 import {
   deleteVideoTranscript,
   downloadVideoTranscript,
@@ -17,6 +38,7 @@ import {
 } from '../data/thunks';
 import { RequestStatus } from '../../../data/constants';
 import messages from './messages';
+import { isValidSrt } from '../transcript-editor/srtUtils';
 
 const TranscriptTab = ({
   video,
@@ -35,9 +57,44 @@ const TranscriptTab = ({
     transcriptDownloadHandlerUrl,
   } = videoTranscriptSettings;
   const { transcripts, id, displayName } = video;
-  const languages = getLanguages(transcriptAvailableLanguages);
+  const languages = useMemo(
+    () => getLanguages(transcriptAvailableLanguages),
+    [transcriptAvailableLanguages],
+  );
   let sortedTranscripts = getSortedTranscripts(languages, transcripts);
   const [previousSelection, setPreviousSelection] = useState(sortedTranscripts);
+  const [isAddingTranscript, setIsAddingTranscript] = useState(false);
+  const [newLanguage, setNewLanguage] = useState('');
+  const [selectedFile, setSelectedFile] = useState(null);
+  const [pendingFileName, setPendingFileName] = useState('');
+  const [isSubmittingNewTranscript, setIsSubmittingNewTranscript] = useState(false);
+  const [isSubmittingReplace, setIsSubmittingReplace] = useState(false);
+  const [showAddTranscriptError, setShowAddTranscriptError] = useState(false);
+  const [showAddedToast, setShowAddedToast] = useState(false);
+  const [invalidSrtFile, setInvalidSrtFile] = useState(false);
+
+  const addTranscriptFileInput = useFileInput({
+    onAddFile: (files) => {
+      const [file] = files;
+      if (!file) {
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        if (!isValidSrt(e.target.result)) {
+          setInvalidSrtFile(true);
+          setSelectedFile(null);
+        } else {
+          setInvalidSrtFile(false);
+          setSelectedFile(file);
+          setShowAddTranscriptError(false);
+        }
+      };
+      reader.readAsText(file);
+    },
+    setSelectedRows: () => {},
+    setAddOpen: () => {},
+  });
 
   useEffect(() => {
     dispatch(resetErrors({ errorType: 'transcript' }));
@@ -45,17 +102,53 @@ const TranscriptTab = ({
     setPreviousSelection(sortedTranscripts);
   }, [transcripts]);
 
-  const handleAddEmptyTranscript = () => {
-    setPreviousSelection(['', ...previousSelection]);
-    if (divRef?.current?.scrollTo) {
-      divRef.current.scrollTo({ top: 0, behavior: 'smooth' });
+  useEffect(() => {
+    if (isAddingTranscript) {
+      const firstAvailableLanguage = Object.keys(languages).find((lang) => !previousSelection.includes(lang));
+      setNewLanguage(firstAvailableLanguage || '');
+      setSelectedFile(null);
     }
-  };
+  }, [isAddingTranscript]);
+
+  useEffect(() => {
+    if (!isAddingTranscript || !isSubmittingNewTranscript) {
+      return;
+    }
+
+    if (transcriptStatus === RequestStatus.SUCCESSFUL) {
+      setIsSubmittingNewTranscript(false);
+      setPendingFileName('');
+      setIsAddingTranscript(false);
+      setSelectedFile(null);
+      setShowAddTranscriptError(false);
+      setShowAddedToast(true);
+    }
+
+    if (transcriptStatus === RequestStatus.FAILED) {
+      setIsSubmittingNewTranscript(false);
+      setPendingFileName('');
+      setSelectedFile(null);
+      setShowAddTranscriptError(true);
+    }
+  }, [isAddingTranscript, isSubmittingNewTranscript, transcriptStatus]);
+
+  useEffect(() => {
+    if (!isSubmittingReplace) {
+      return;
+    }
+    if (transcriptStatus === RequestStatus.SUCCESSFUL) {
+      setIsSubmittingReplace(false);
+      setShowAddedToast(true);
+    }
+    if (transcriptStatus === RequestStatus.FAILED) {
+      setIsSubmittingReplace(false);
+    }
+  }, [isSubmittingReplace, transcriptStatus]);
 
   const handleTranscript = (data, actionType) => {
     const {
       language,
-      newLanguage,
+      newLanguage: transcriptNewLanguage,
       file,
     } = data;
     dispatch(resetErrors({ errorType: 'transcript' }));
@@ -83,11 +176,14 @@ const TranscriptTab = ({
         }));
         break;
       case 'upload':
+        if (!isEmpty(language)) {
+          setIsSubmittingReplace(true);
+        }
         dispatch(uploadVideoTranscript({
           language,
           videoId: id,
           apiUrl: transcriptUploadHandlerUrl,
-          newLanguage,
+          newLanguage: transcriptNewLanguage,
           file,
           transcripts,
         }));
@@ -97,12 +193,29 @@ const TranscriptTab = ({
     }
   };
 
+  const availableLanguages = Object.entries(languages)
+    .filter(([lang]) => !previousSelection.includes(lang));
+
+  const handleSubmitNewTranscript = () => {
+    if (!newLanguage || !selectedFile) {
+      return;
+    }
+    setShowAddTranscriptError(false);
+    setIsSubmittingNewTranscript(true);
+    setPendingFileName(selectedFile.name);
+    handleTranscript({
+      language: '',
+      newLanguage,
+      file: selectedFile,
+    }, 'upload');
+  };
+
   return (
     <Stack gap={3}>
-      <div ref={divRef} style={{ overflowY: 'auto', maxHeight: '310px' }} className="px-1 py-2">
+      <div ref={divRef} style={{ overflowY: 'auto' }} className="px-1 py-2">
         <ErrorAlert
           hideHeading={false}
-          isError={transcriptStatus === RequestStatus.FAILED && !isEmpty(errors.transcript)}
+          isError={!isAddingTranscript && transcriptStatus === RequestStatus.FAILED && !isEmpty(errors.transcript)}
         >
           <ul className="p-0">
             {errors.transcript.map(message => (
@@ -112,30 +225,157 @@ const TranscriptTab = ({
             ))}
           </ul>
         </ErrorAlert>
-        {previousSelection.map((transcript, idx) => (
-          <Transcript
-            // eslint-disable-next-line react/no-array-index-key
-            key={idx}
-            {...{
-              languages,
-              transcript,
-              previousSelection,
-              handleTranscript,
-            }}
-          />
-        ))}
+        {isAddingTranscript ?
+          (
+            <Stack gap={3}>
+              <div className="h4 mb-0">{intl.formatMessage(messages.newTranscriptTitle)}</div>
+
+              <div>
+                <LanguageSelect
+                  options={languages}
+                  value={newLanguage}
+                  placeholderText={intl.formatMessage(messages.languageSelectPlaceholder)}
+                  previousSelection={previousSelection}
+                  className="col-12 p-0"
+                  handleSelect={(lang) => {
+                    setNewLanguage(lang);
+                    setShowAddTranscriptError(false);
+                  }}
+                />
+              </div>
+
+              {!selectedFile && !isSubmittingNewTranscript && (
+                <Button
+                  variant="outline-primary"
+                  iconBefore={FileUpload}
+                  className="justify-content-center w-100 mb-0 transcript-upload-button"
+                  onClick={addTranscriptFileInput.click}
+                >
+                  {intl.formatMessage(messages.uploadFileLabel)}
+                </Button>
+              )}
+
+              {isSubmittingNewTranscript ?
+                (
+                  <Stack direction="horizontal" className="align-items-center text-gray-700 py-1">
+                    <Spinner animation="border" size="sm" className="mr-2" />
+                    <span className="small">{pendingFileName}</span>
+                  </Stack>
+                ) :
+                null}
+
+              {selectedFile && !isSubmittingNewTranscript ?
+                (
+                  <Stack
+                    direction="horizontal"
+                    className="align-items-center justify-content-between rounded py-1 transcript-tab__file-row"
+                  >
+                    <Stack
+                      direction="horizontal"
+                      gap={2}
+                      className="align-items-center text-gray-700 overflow-hidden transcript-tab__file-name-wrap"
+                    >
+                      <Icon src={Article} size="sm" className="flex-shrink-0" />
+                      <span className="text-truncate transcript-tab__file-name">{selectedFile.name}</span>
+                    </Stack>
+                    <IconButton
+                      src={Delete}
+                      iconAs={Icon}
+                      alt={intl.formatMessage(messages.removeSelectedFileLabel)}
+                      onClick={() => setSelectedFile(null)}
+                      className="flex-shrink-0"
+                    />
+                  </Stack>
+                ) :
+                null}
+
+              {showAddTranscriptError && (
+                <Stack direction="horizontal" gap={2} className="align-items-center text-danger-500">
+                  <Icon src={ErrorIcon} size="xs" />
+                  <span>{intl.formatMessage(messages.addTranscriptFailedLabel)}</span>
+                </Stack>
+              )}
+
+              {invalidSrtFile && (
+                <Stack direction="horizontal" gap={2} className="align-items-center text-danger-500">
+                  <Icon src={ErrorIcon} size="xs" />
+                  <span>{intl.formatMessage(messages.invalidSrtFormat)}</span>
+                </Stack>
+              )}
+
+              {!selectedFile && <div className="small text-gray-500">{intl.formatMessage(messages.uploadHelpText)}
+              </div>}
+
+              <Stack direction="horizontal" gap={3} className="justify-content-end">
+                <Button
+                  variant="tertiary"
+                  disabled={isSubmittingNewTranscript}
+                  onClick={() => {
+                    setIsAddingTranscript(false);
+                    setSelectedFile(null);
+                    setPendingFileName('');
+                    setIsSubmittingNewTranscript(false);
+                    setShowAddTranscriptError(false);
+                    setInvalidSrtFile(false);
+                  }}
+                >
+                  {intl.formatMessage(messages.cancelButtonLabel)}
+                </Button>
+                <Button
+                  disabled={!selectedFile || !newLanguage || isSubmittingNewTranscript}
+                  onClick={handleSubmitNewTranscript}
+                >
+                  {intl.formatMessage(messages.addTranscriptButtonLabel)}
+                </Button>
+              </Stack>
+
+              <FileInput
+                key="new-transcript-input"
+                fileInput={addTranscriptFileInput}
+                supportedFileFormats={['.srt']}
+                allowMultiple={false}
+              />
+            </Stack>
+          ) :
+          (
+            <>
+              {previousSelection.map((transcript, idx) => (
+                <Transcript
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={idx}
+                  {...{
+                    languages,
+                    transcript,
+                    previousSelection,
+                    handleTranscript,
+                    video,
+                    transcriptSettings: videoTranscriptSettings,
+                  }}
+                />
+              ))}
+            </>
+          )}
       </div>
-      <div className="border-top border-light-400">
-        <Button
-          variant="link"
-          iconBefore={Add}
-          size="sm"
-          className="text-primary-500 justify-content-start pl-0 pt-3"
-          onClick={handleAddEmptyTranscript}
-        >
-          {intl.formatMessage(messages.uploadButtonLabel)}
-        </Button>
-      </div>
+      {!isAddingTranscript && (
+        <div className="border-top border-light-400">
+          <Button
+            variant="link"
+            iconBefore={Add}
+            size="sm"
+            className="text-primary-500 justify-content-start pl-0 pt-3"
+            onClick={() => setIsAddingTranscript(true)}
+            disabled={availableLanguages.length === 0}
+          >
+            {intl.formatMessage(messages.uploadButtonLabel)}
+          </Button>
+        </div>
+      )}
+      <Toast show={showAddedToast} onClose={() => setShowAddedToast(false)}>
+        <Stack direction="horizontal" gap={2} className="align-items-center">
+          <Icon src={CheckCircle} className="text-success" />
+          <span>{intl.formatMessage(messages.newTranscriptAddedLabel)}</span>
+        </Stack>
+      </Toast>
     </Stack>
   );
 };

--- a/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.jsx
@@ -154,6 +154,7 @@ const TranscriptTab = ({
     dispatch(resetErrors({ errorType: 'transcript' }));
     switch (actionType) {
       case 'delete':
+        /* istanbul ignore if -- legacy empty-row path; the add form no longer creates empty rows */
         if (isEmpty(language)) {
           const updatedSelection = previousSelection;
           updatedSelection.shift();
@@ -188,6 +189,7 @@ const TranscriptTab = ({
           transcripts,
         }));
         break;
+      /* istanbul ignore next */
       default:
         break;
     }
@@ -197,6 +199,7 @@ const TranscriptTab = ({
     .filter(([lang]) => !previousSelection.includes(lang));
 
   const handleSubmitNewTranscript = () => {
+    /* istanbul ignore if -- the submit button is disabled in this state */
     if (!newLanguage || !selectedFile) {
       return;
     }

--- a/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.test.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.test.jsx
@@ -5,6 +5,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import userEvent from '@testing-library/user-event';
 import ReactDOM from 'react-dom';
 
@@ -27,7 +28,6 @@ import {
 
 import { getApiBaseUrl } from '../data/api';
 import messages from './messages';
-import genericMessages from '../../generic/messages';
 import transcriptRowMessages from './transcript-item/messages';
 import VideosPageProvider from '../VideosPageProvider';
 import { deleteVideoTranscript } from '../data/thunks';
@@ -51,18 +51,40 @@ const defaultProps = {
 
 let axiosMock;
 let store;
+let queryClient;
 jest.mock('file-saver');
 
 const renderComponent = (props) => {
   render(
-    <IntlProvider locale="en">
-      <AppProvider store={store}>
-        <VideosPageProvider courseId={courseId}>
-          <TranscriptTab video={props} />
-        </VideosPageProvider>
-      </AppProvider>
-    </IntlProvider>,
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en">
+        <AppProvider store={store}>
+          <VideosPageProvider courseId={courseId}>
+            <TranscriptTab video={props} />
+          </VideosPageProvider>
+        </AppProvider>
+      </IntlProvider>
+    </QueryClientProvider>,
   );
+};
+
+const openAddForm = async () => {
+  const addButton = screen.getByText(messages.uploadButtonLabel.defaultMessage);
+  await act(async () => {
+    fireEvent.click(addButton);
+  });
+};
+
+const selectLanguage = async (languageText, dropdownEl = null) => {
+  const dropdown = dropdownEl || screen.getByTestId('language-select-dropdown');
+  await act(async () => {
+    fireEvent.click(dropdown);
+  });
+  const allMatches = screen.getAllByText(languageText);
+  const option = allMatches.find(el => el.closest('.pgn__menu')) || allMatches[allMatches.length - 1];
+  await act(async () => {
+    fireEvent.click(option);
+  });
 };
 
 describe('TranscriptTab', () => {
@@ -77,97 +99,92 @@ describe('TranscriptTab', () => {
     });
     store = initializeStore(initialState);
     axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    axiosMock.onGet(/course_waffle_flags/).reply(200, {});
   });
 
   describe('with no transcripts preloaded', () => {
     it('should have add transcript button', async () => {
       renderComponent(defaultProps);
       const addButton = screen.getByText(messages.uploadButtonLabel.defaultMessage);
-      const transcriptRow = screen.queryByTestId('transcript', { exact: false });
+      const transcriptRow = screen.queryByTestId('transcript-', { exact: false });
       expect(addButton).toBeInTheDocument();
       expect(transcriptRow).toBeNull();
     });
 
-    it('should delete empty transcript row', async () => {
+    it('should open and cancel new transcript form', async () => {
       renderComponent(defaultProps);
-      const addButton = screen.getByText(messages.uploadButtonLabel.defaultMessage);
+      await openAddForm();
+
+      expect(screen.getByText(messages.newTranscriptTitle.defaultMessage)).toBeVisible();
+
+      const cancelButton = screen.getByText(messages.cancelButtonLabel.defaultMessage);
       await act(async () => {
-        fireEvent.click(addButton);
+        fireEvent.click(cancelButton);
       });
 
-      const deleteButton = screen.getByLabelText('delete empty transcript');
-      await act(async () => {
-        fireEvent.click(deleteButton);
-      });
-
-      expect(screen.getByText(transcriptRowMessages.deleteConfirmationHeader.defaultMessage)).toBeVisible();
-
-      const confirmButton = screen.getByText(transcriptRowMessages.confirmDeleteLabel.defaultMessage);
-      await act(async () => {
-        fireEvent.click(confirmButton);
-      });
-
-      expect(screen.queryByTestId('transcript-')).toBeNull();
+      expect(screen.queryByText(messages.newTranscriptTitle.defaultMessage)).toBeNull();
     });
 
     describe('uploadVideoTranscript as add function', () => {
-      let addButton;
-      const file = new File(['(⌐□_□)'], 'download.srt', { type: 'text/srt' });
-      beforeEach(async () => {
-        renderComponent(defaultProps);
-        addButton = screen.getByText(messages.uploadButtonLabel.defaultMessage);
-
-        await act(async () => {
-          fireEvent.click(addButton);
-        });
-      });
+      const srtContent = '1\n00:00:00,000 --> 00:00:01,000\nTest\n';
+      const file = new File([srtContent], 'download.srt', { type: 'text/srt' });
 
       it('should upload new transcript', async () => {
         const user = userEvent.setup();
+        renderComponent(defaultProps);
         axiosMock.onPost(`${getApiBaseUrl()}/transcript_upload/`).reply(204);
+
+        await openAddForm();
+        await selectLanguage('Arabic');
+
         await act(async () => {
-          const addFileInput = screen.getByLabelText(genericMessages.fileInputAriaLabel.defaultMessage);
-          expect(addFileInput).toBeInTheDocument();
-
-          await user.upload(addFileInput, file);
+          fireEvent.click(screen.getByText(messages.uploadFileLabel.defaultMessage));
         });
-        const addStatus = store.getState().videos.transcriptStatus;
+        const fileInputs = document.querySelectorAll('input[type="file"]');
+        await act(async () => {
+          await user.upload(fileInputs[fileInputs.length - 1], file);
+        });
 
+        const submitButton = screen.getByText(messages.addTranscriptButtonLabel.defaultMessage);
+        await act(async () => {
+          fireEvent.click(submitButton);
+        });
+
+        const addStatus = store.getState().videos.transcriptStatus;
         expect(addStatus).toEqual(RequestStatus.SUCCESSFUL);
       });
 
-      it('should show default error message', async () => {
+      it('should show default error message on upload failure', async () => {
         const user = userEvent.setup();
+        renderComponent(defaultProps);
         axiosMock.onPost(`${getApiBaseUrl()}/transcript_upload/`).reply(404);
+
+        await openAddForm();
+        await selectLanguage('Arabic');
+
         await act(async () => {
-          const addFileInput = screen.getByLabelText(genericMessages.fileInputAriaLabel.defaultMessage);
-          await user.upload(addFileInput, file);
+          fireEvent.click(screen.getByText(messages.uploadFileLabel.defaultMessage));
         });
-        const addStatus = store.getState().videos.transcriptStatus;
-
-        expect(addStatus).toEqual(RequestStatus.FAILED);
-
-        expect(screen.getAllByText('Failed to add .')[0]).toBeVisible();
-      });
-
-      it('should show api provided error message', async () => {
-        const user = userEvent.setup();
-        axiosMock.onPost(`${getApiBaseUrl()}/transcript_upload/`).reply(404, { error: 'api error' });
+        const fileInputs = document.querySelectorAll('input[type="file"]');
         await act(async () => {
-          const addFileInput = screen.getByLabelText(genericMessages.fileInputAriaLabel.defaultMessage);
-          await user.upload(addFileInput, file);
+          await user.upload(fileInputs[fileInputs.length - 1], file);
         });
+
+        const submitButton = screen.getByText(messages.addTranscriptButtonLabel.defaultMessage);
+        await act(async () => {
+          fireEvent.click(submitButton);
+        });
+
         const addStatus = store.getState().videos.transcriptStatus;
-
         expect(addStatus).toEqual(RequestStatus.FAILED);
-
-        expect(screen.getAllByText('api error')[0]).toBeVisible();
       });
     });
   });
 
-  describe('with one transcripts preloaded', () => {
+  describe('with one transcript preloaded', () => {
     const updatedProps = { ...defaultProps, transcripts: ['ar'] };
+
     beforeEach(() => {
       renderComponent(updatedProps);
     });
@@ -195,12 +212,12 @@ describe('TranscriptTab', () => {
         await waitFor(() => {
           fireEvent.click(cancelButton);
         });
-
         expect(screen.queryByText(transcriptRowMessages.deleteConfirmationHeader.defaultMessage)).toBeNull();
       });
 
       it('should open delete confirmation modal and handle delete', async () => {
-        const confirmButton = screen.getByText(transcriptRowMessages.confirmDeleteLabel.defaultMessage);
+        const confirmButton = screen.getAllByText(transcriptRowMessages.confirmDeleteLabel.defaultMessage)
+          .find(el => el.closest('.btn-danger') || el.classList.contains('btn-danger'));
         axiosMock.onDelete(`${getApiBaseUrl()}/transcript_delete/${courseId}/mOckID0/ar`).reply(204);
         await act(async () => {
           fireEvent.click(confirmButton);
@@ -215,14 +232,13 @@ describe('TranscriptTab', () => {
           );
         });
         const deleteStatus = store.getState().videos.transcriptStatus;
-
         expect(deleteStatus).toEqual(RequestStatus.SUCCESSFUL);
-
         expect(screen.queryByText(transcriptRowMessages.deleteConfirmationHeader.defaultMessage)).toBeNull();
       });
 
-      it('should show error message', async () => {
-        const confirmButton = screen.getByText(transcriptRowMessages.confirmDeleteLabel.defaultMessage);
+      it('should show error message on delete failure', async () => {
+        const confirmButton = screen.getAllByText(transcriptRowMessages.confirmDeleteLabel.defaultMessage)
+          .find(el => el.closest('.btn-danger') || el.classList.contains('btn-danger'));
         axiosMock.onDelete(`${getApiBaseUrl()}/transcript_delete/${courseId}/mOckID0/ar`).reply(404);
         await act(async () => {
           fireEvent.click(confirmButton);
@@ -237,11 +253,8 @@ describe('TranscriptTab', () => {
           );
         });
         const deleteStatus = store.getState().videos.transcriptStatus;
-
         expect(deleteStatus).toEqual(RequestStatus.FAILED);
-
         expect(screen.queryByText(transcriptRowMessages.deleteConfirmationHeader.defaultMessage)).toBeNull();
-
         expect(screen.getAllByText('Failed to delete ar transcript.')[0]).toBeVisible();
       });
     });
@@ -266,11 +279,10 @@ describe('TranscriptTab', () => {
           fireEvent.click(downloadButton);
         });
         const downloadStatus = store.getState().videos.transcriptStatus;
-
         expect(downloadStatus).toEqual(RequestStatus.SUCCESSFUL);
       });
 
-      it('should show error message', async () => {
+      it('should show error message on download failure', async () => {
         const filename = 'mOckID0.mp4-ar.srt';
         axiosMock.onGet(
           `${getApiBaseUrl()}/transcript_download/?edx_video_id=${updatedProps.id}&language_code=ar`,
@@ -279,9 +291,7 @@ describe('TranscriptTab', () => {
           fireEvent.click(downloadButton);
         });
         const downloadStatus = store.getState().videos.transcriptStatus;
-
         expect(downloadStatus).toEqual(RequestStatus.FAILED);
-
         expect(screen.getAllByText(`Failed to download ${filename}.`)[0]).toBeVisible();
       });
     });
@@ -289,19 +299,15 @@ describe('TranscriptTab', () => {
 
   describe('with multiple transcripts preloaded', () => {
     describe('uploadVideoTranscript as replace function', () => {
-      const file = new File(['(⌐□_□)'], 'download.srt', { type: 'text/srt' });
+      const srtContent = '1\n00:00:00,000 --> 00:00:01,000\nTest\n';
+      const file = new File([srtContent], 'download.srt', { type: 'text/srt' });
+
       beforeEach(async () => {
         const updatedProps = { ...defaultProps, transcripts: ['fr', 'ar'] };
         renderComponent(updatedProps);
-        const dropdownButton = screen.getAllByTestId('language-select-dropdown')[0];
-        await waitFor(() => {
-          fireEvent.click(dropdownButton);
-        });
 
-        const englishOption = screen.getByText('English');
-        await act(async () => {
-          fireEvent.click(englishOption);
-        });
+        const dropdownButtons = screen.getAllByTestId('language-select-dropdown');
+        await selectLanguage('English', dropdownButtons[0]);
 
         const menuButton = screen.getByTestId('ar-transcript-menu');
         await waitFor(() => {
@@ -318,31 +324,28 @@ describe('TranscriptTab', () => {
         axiosMock.onPost(`${getApiBaseUrl()}/transcript_upload/`).reply(204);
 
         await act(async () => {
-          const addFileInput = screen.getAllByLabelText(genericMessages.fileInputAriaLabel.defaultMessage)[0];
-          await user.upload(addFileInput, file);
+          const fileInputs = document.querySelectorAll('input[type="file"]');
+          await user.upload(fileInputs[0], file);
         });
-        const addStatus = store.getState().videos.transcriptStatus;
 
+        const addStatus = store.getState().videos.transcriptStatus;
         expect(addStatus).toEqual(RequestStatus.SUCCESSFUL);
 
         const updatedTranscripts = store.getState().models.videos[defaultProps.id].transcripts;
-
         expect(updatedTranscripts).toEqual(['fr', 'en']);
       });
 
-      it('should show error message', async () => {
+      it('should show error message on replace failure', async () => {
         const user = userEvent.setup();
         axiosMock.onPost(`${getApiBaseUrl()}/transcript_upload/`).reply(404);
 
         await act(async () => {
-          const addFileInput = screen.getAllByLabelText(genericMessages.fileInputAriaLabel.defaultMessage)[0];
-          await user.upload(addFileInput, file);
+          const fileInputs = document.querySelectorAll('input[type="file"]');
+          await user.upload(fileInputs[0], file);
         });
 
         const addStatus = store.getState().videos.transcriptStatus;
-
         expect(addStatus).toEqual(RequestStatus.FAILED);
-
         expect(screen.getAllByText('Failed to replace ar with en.')[0]).toBeVisible();
       });
     });

--- a/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.test.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.test.jsx
@@ -4,6 +4,7 @@ import {
   fireEvent,
   screen,
   waitFor,
+  within,
 } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import userEvent from '@testing-library/user-event';
@@ -29,6 +30,7 @@ import {
 import { getApiBaseUrl } from '../data/api';
 import messages from './messages';
 import transcriptRowMessages from './transcript-item/messages';
+import editorMessages from '../transcript-editor/messages';
 import VideosPageProvider from '../VideosPageProvider';
 import { deleteVideoTranscript } from '../data/thunks';
 
@@ -348,6 +350,115 @@ describe('TranscriptTab', () => {
         expect(addStatus).toEqual(RequestStatus.FAILED);
         expect(screen.getAllByText('Failed to replace ar with en.')[0]).toBeVisible();
       });
+    });
+  });
+  describe('add transcript form interactions', () => {
+    const srt = '1\n00:00:01,000 --> 00:00:02,000\nHello\n';
+    const chooseFile = async (file) => {
+      await act(async () => {
+        fireEvent.change(document.querySelector('input[type="file"]'), { target: { files: file ? [file] : [] } });
+      });
+    };
+
+    it('shows the selected SRT and lets the user remove it before submitting', async () => {
+      renderComponent(defaultProps);
+      await openAddForm();
+      await chooseFile(new File([srt], 'valid.srt', { type: 'text/srt' }));
+      expect(await screen.findByText('valid.srt')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: messages.removeSelectedFileLabel.defaultMessage }));
+      await waitFor(() => expect(screen.queryByText('valid.srt')).not.toBeInTheDocument());
+    });
+
+    it('rejects an invalid SRT file on add', async () => {
+      renderComponent(defaultProps);
+      await openAddForm();
+      await chooseFile(new File(['not an srt'], 'bad.srt', { type: 'text/srt' }));
+      expect(await screen.findByText(messages.invalidSrtFormat.defaultMessage)).toBeInTheDocument();
+      expect(screen.queryByText('bad.srt')).not.toBeInTheDocument();
+    });
+
+    it('ignores an empty file selection', async () => {
+      renderComponent(defaultProps);
+      await openAddForm();
+      await chooseFile(null);
+      expect(screen.queryByText(messages.invalidSrtFormat.defaultMessage)).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: messages.addTranscriptButtonLabel.defaultMessage })).toBeDisabled();
+    });
+
+    it('filters the language list from the search box and reports no results', async () => {
+      renderComponent(defaultProps);
+      await openAddForm();
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('language-select-dropdown'));
+      });
+      const search = screen.getByPlaceholderText(transcriptRowMessages.searchLanguagesPlaceholder.defaultMessage);
+      fireEvent.change(search, { target: { value: 'zzzz' } });
+      expect(screen.getByText(transcriptRowMessages.noLanguageResults.defaultMessage)).toBeInTheDocument();
+      fireEvent.change(search, { target: { value: 'Eng' } });
+      const options = screen.getAllByText('English');
+      await act(async () => {
+        fireEvent.click(options[options.length - 1]);
+      });
+      expect(screen.getByTestId('language-select-dropdown')).toHaveTextContent('English');
+    });
+
+    it('submits a new transcript, then shows a dismissible success toast', async () => {
+      axiosMock.onPost(`${getApiBaseUrl()}/transcript_upload/`).reply(204);
+      renderComponent(defaultProps);
+      await openAddForm();
+      await chooseFile(new File([srt], 'valid.srt', { type: 'text/srt' }));
+      await screen.findByText('valid.srt');
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: messages.addTranscriptButtonLabel.defaultMessage }));
+      });
+      expect(await screen.findByText(messages.newTranscriptAddedLabel.defaultMessage)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: /close/i }));
+      await waitFor(() =>
+        expect(screen.queryByText(messages.newTranscriptAddedLabel.defaultMessage)).not.toBeInTheDocument()
+      );
+    });
+  });
+
+  describe('transcript row interactions', () => {
+    const rowProps = { ...defaultProps, transcripts: ['ar'] };
+    // The row's hidden file input is rendered as a sibling of the row element, first in document order.
+    const rowFileInput = () => document.querySelectorAll('input[type="file"]')[0];
+
+    it('rejects an invalid SRT file on replace', async () => {
+      renderComponent(rowProps);
+      await act(async () => {
+        fireEvent.change(rowFileInput(), { target: { files: [new File(['nope'], 'bad.srt', { type: 'text/srt' })] } });
+      });
+      expect(await screen.findByText(messages.invalidSrtFormat.defaultMessage)).toBeInTheDocument();
+    });
+
+    it('ignores an empty replace selection', async () => {
+      renderComponent(rowProps);
+      await act(async () => {
+        fireEvent.change(rowFileInput(), { target: { files: [] } });
+      });
+      expect(screen.queryByText(messages.invalidSrtFormat.defaultMessage)).not.toBeInTheDocument();
+    });
+
+    it('opens the transcript editor from the row menu and closes it again', async () => {
+      axiosMock.onGet(/edx_video_id/).reply(200, '');
+      renderComponent(rowProps);
+      const row = screen.getByTestId('transcript-ar');
+      fireEvent.click(within(row).getByRole('button', { name: 'Actions dropdown' }));
+      await act(async () => {
+        fireEvent.click(await screen.findByText(transcriptRowMessages.editTranscript.defaultMessage));
+      });
+      expect(await screen.findByRole('button', { name: editorMessages.insertCueLabel.defaultMessage }))
+        .toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: editorMessages.cancelButtonLabel.defaultMessage }));
+      await waitFor(() =>
+        expect(screen.queryByRole('button', { name: editorMessages.insertCueLabel.defaultMessage })).not
+          .toBeInTheDocument()
+      );
     });
   });
 });

--- a/src/files-and-videos/videos-page/info-sidebar/VideoInfoModalSidebar.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/VideoInfoModalSidebar.jsx
@@ -1,46 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import {
-  Tabs,
-  Tab,
-} from '@openedx/paragon';
-import InfoTab from './InfoTab';
+import { Stack } from '@openedx/paragon';
 import TranscriptTab from './TranscriptTab';
 import messages from './messages';
-import { TRANSCRIPT_FAILURE_STATUSES } from '../data/constants';
 
 const VideoInfoModalSidebar = ({
   video,
-  activeTab,
-  setActiveTab,
 }) => {
   const intl = useIntl();
 
   return (
-    <Tabs
-      id="controlled-info-sidebar-tab"
-      activeKey={activeTab}
-      onSelect={(tab) => setActiveTab(tab)}
-    >
-      <Tab eventKey="fileInfo" title={intl.formatMessage(messages.infoTabTitle)}>
-        <InfoTab {...{ video }} />
-      </Tab>
-      <Tab
-        eventKey="fileTranscripts"
-        title={intl.formatMessage(
-          messages.transcriptTabTitle,
-          { transcriptCount: video.transcripts.length },
-        )}
-        notification={TRANSCRIPT_FAILURE_STATUSES.includes(video.transcriptionStatus) && (
-          <span>
-            <span className="sr-only">{intl.formatMessage(messages.notificationScreenReaderText)}</span>
-          </span>
-        )}
-      >
-        <TranscriptTab {...{ video }} />
-      </Tab>
-    </Tabs>
+    <Stack gap={2}>
+      <div className="font-weight-bold pb-2 border-bottom border-light-400">
+        {intl.formatMessage(messages.transcriptTabTitle, { transcriptCount: video.transcripts.length })}
+      </div>
+      <TranscriptTab {...{ video }} />
+    </Stack>
   );
 };
 
@@ -54,8 +30,6 @@ VideoInfoModalSidebar.propTypes = {
     transcripts: PropTypes.arrayOf(PropTypes.string),
     transcriptionStatus: PropTypes.string.isRequired,
   }),
-  activeTab: PropTypes.string.isRequired,
-  setActiveTab: PropTypes.func.isRequired,
 };
 
 VideoInfoModalSidebar.defaultProps = {

--- a/src/files-and-videos/videos-page/info-sidebar/messages.ts
+++ b/src/files-and-videos/videos-page/info-sidebar/messages.ts
@@ -40,6 +40,56 @@ const messages = defineMessages({
     defaultMessage: 'Add a transcript',
     description: 'Label for upload button',
   },
+  newTranscriptTitle: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.newTranscript.title',
+    defaultMessage: 'New transcript',
+    description: 'Heading shown when adding a new transcript',
+  },
+  uploadFileLabel: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.uploadFile.label',
+    defaultMessage: 'Upload file',
+    description: 'Label for selecting a transcript file',
+  },
+  uploadHelpText: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.uploadFile.helpText',
+    defaultMessage: 'SRT file, max 25MB',
+    description: 'Help text shown under transcript upload button',
+  },
+  languageSelectPlaceholder: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.languageSelectPlaceholder',
+    defaultMessage: 'Select language',
+    description: 'Placeholder for language selector in new transcript form',
+  },
+  cancelButtonLabel: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.cancel.label',
+    defaultMessage: 'Cancel',
+    description: 'Cancel button text in new transcript form',
+  },
+  addTranscriptButtonLabel: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.addTranscript.label',
+    defaultMessage: 'Add transcript',
+    description: 'Submit button label in new transcript form',
+  },
+  removeSelectedFileLabel: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.removeSelectedFile.label',
+    defaultMessage: 'Remove selected file',
+    description: 'Accessible label for removing selected transcript file',
+  },
+  addTranscriptFailedLabel: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.addTranscript.failed',
+    defaultMessage: 'Upload failed, please try again',
+    description: 'Inline error shown when adding transcript fails',
+  },
+  invalidSrtFormat: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.invalidSrtFormat',
+    defaultMessage: 'Invalid SRT format. Please upload a valid .srt file.',
+    description: 'Error shown when uploaded transcript file has invalid SRT content',
+  },
+  newTranscriptAddedLabel: {
+    id: 'course-authoriong.video-uploads.file-info.transcriptTab.addTranscript.success',
+    defaultMessage: 'New transcript added',
+    description: 'Toast message shown when adding transcript succeeds',
+  },
 });
 
 export default messages;

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/LanguageSelect.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/LanguageSelect.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 
 import {
   Button,
@@ -10,6 +11,7 @@ import {
   MenuItem,
   useToggle,
 } from '@openedx/paragon';
+import messages from './messages';
 import {
   Check,
   ExpandMore,
@@ -26,6 +28,7 @@ const LanguageSelect = ({
   placeholderText,
   className = 'col-9 p-0',
 }) => {
+  const intl = useIntl();
   const currentSelection = isEmpty(value) ? placeholderText : options[value];
 
   const [isOpen, , close, toggle] = useToggle();
@@ -74,12 +77,16 @@ const LanguageSelect = ({
                 type="text"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder="Search languages"
+                placeholder={intl.formatMessage(messages.searchLanguagesPlaceholder)}
                 controlClassName="w-100"
                 floatingLabel={null}
               />
             </div>
-            {filteredOptions.length === 0 && <div className="px-3 py-2 small text-muted">No results</div>}
+            {filteredOptions.length === 0 && (
+              <div className="px-3 py-2 small text-muted">
+                <FormattedMessage {...messages.noLanguageResults} />
+              </div>
+            )}
             {filteredOptions.map(([valueKey, text]) => {
               if (valueKey === value) {
                 return (

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/LanguageSelect.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/LanguageSelect.jsx
@@ -3,13 +3,19 @@ import PropTypes from 'prop-types';
 
 import {
   Button,
+  Form,
   Icon,
   ModalPopup,
   Menu,
   MenuItem,
   useToggle,
 } from '@openedx/paragon';
-import { Check, ExpandMore, ExpandLess } from '@openedx/paragon/icons';
+import {
+  Check,
+  ExpandMore,
+  ExpandLess,
+  Search,
+} from '@openedx/paragon/icons';
 import { isEmpty } from 'lodash';
 
 const LanguageSelect = ({
@@ -18,39 +24,63 @@ const LanguageSelect = ({
   options,
   handleSelect,
   placeholderText,
+  className = 'col-9 p-0',
 }) => {
   const currentSelection = isEmpty(value) ? placeholderText : options[value];
 
   const [isOpen, , close, toggle] = useToggle();
   const [target, setTarget] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const filteredOptions = Object.entries(options).filter(([, text]) => (
+    text?.toLowerCase().includes(normalizedQuery)
+  ));
+
+  const handleClose = () => {
+    setSearchQuery('');
+    close();
+  };
 
   return (
     <>
-      <div className="col-9 p-0">
+      <div className={className}>
         <Button
           variant="tertiary"
           size="sm"
-          className="border border-gray-700 justify-content-between"
+          className="border border-gray-700 justify-content-between language-select-dropdown-btn"
           style={{ minWidth: '100%' }}
           id={`language-select-dropdown-${currentSelection}`}
           data-testid="language-select-dropdown"
-          iconAfter={isOpen ? ExpandLess : ExpandMore}
           onClick={toggle}
           ref={setTarget}
         >
-          {currentSelection}
+          <span className="language-select-dropdown-btn__text">{currentSelection}</span>
+          <span className="language-select-dropdown-btn__divider" />
+          <Icon src={isOpen ? ExpandLess : ExpandMore} />
         </Button>
       </div>
       <ModalPopup
         placement="bottom-end"
         positionRef={target}
         isOpen={isOpen}
-        onClose={close}
-        onEscapeKey={close}
+        onClose={handleClose}
+        onEscapeKey={handleClose}
       >
         <Menu className="language-select">
           <div>
-            {Object.entries(options).map(([valueKey, text]) => {
+            <div className="px-2 pb-2 pt-1">
+              <Form.Control
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search languages"
+                controlClassName="w-100"
+                floatingLabel={null}
+              />
+            </div>
+            {filteredOptions.length === 0 && <div className="px-3 py-2 small text-muted">No results</div>}
+            {filteredOptions.map(([valueKey, text]) => {
               if (valueKey === value) {
                 return (
                   <MenuItem
@@ -72,7 +102,7 @@ const LanguageSelect = ({
                     size="sm"
                     onClick={() => {
                       handleSelect(valueKey);
-                      close();
+                      handleClose();
                     }}
                     key={`${valueKey}-item`}
                   >
@@ -95,7 +125,7 @@ const LanguageSelect = ({
           </div>
         </Menu>
         <div className="row justify-content-center">
-          <Icon src={ExpandMore} size="xs" />
+          <Icon src={Search} size="xs" />
         </div>
       </ModalPopup>
     </>
@@ -108,6 +138,7 @@ LanguageSelect.propTypes = {
   handleSelect: PropTypes.func.isRequired,
   placeholderText: PropTypes.string.isRequired,
   previousSelection: PropTypes.arrayOf(PropTypes.string).isRequired,
+  className: PropTypes.string,
 };
 
 export default LanguageSelect;

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/LanguageSelect.scss
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/LanguageSelect.scss
@@ -1,3 +1,22 @@
+.language-select-dropdown-btn {
+  border-radius: 6px !important;
+  border-color: var(--pgn-color-gray-500) !important;
+
+  &__text {
+    flex: 1;
+    text-align: left;
+  }
+
+  &__divider {
+    display: inline-block;
+    width: 1px;
+    height: 1rem;
+    background-color: var(--pgn-color-gray-500);
+    margin: 0 .5rem;
+    align-self: center;
+  }
+}
+
 .language-select {
   padding: 8px 0;
   margin: 0;

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/Transcript.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/Transcript.jsx
@@ -75,7 +75,6 @@ const Transcript = ({
     <>
       <div
         className="row m-0 align-items-center justify-content-between"
-        key={`transcript-${language}`}
         data-testid={`transcript-${language}`}
       >
         <LanguageSelect
@@ -91,7 +90,7 @@ const Transcript = ({
               iconAs={Icon}
               src={DeleteOutline}
               onClick={openConfirmation}
-              alt="delete empty transcript"
+              alt={intl.formatMessage(messages.deleteEmptyTranscriptLabel)}
             />
           ) :
           (

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/Transcript.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/Transcript.jsx
@@ -1,29 +1,38 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Card,
+  ActionRow,
+  AlertModal,
   Button,
   Icon,
   IconButton,
+  Stack,
   useToggle,
 } from '@openedx/paragon';
-import { DeleteOutline } from '@openedx/paragon/icons';
+import { DeleteOutline, Error as ErrorIcon } from '@openedx/paragon/icons';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { isEmpty } from 'lodash';
 import LanguageSelect from './LanguageSelect';
 import TranscriptMenu from './TranscriptMenu';
 import messages from './messages';
+import sidebarMessages from '../messages';
 import { FileInput, useFileInput } from '../../../generic';
+import TranscriptEditor from '../../transcript-editor';
+import { isValidSrt } from '../../transcript-editor/srtUtils';
 
 const Transcript = ({
   languages,
   transcript,
   previousSelection,
   handleTranscript,
+  video,
+  transcriptSettings,
 }) => {
   const intl = useIntl();
   const [isConfirmationOpen, openConfirmation, closeConfirmation] = useToggle();
   const [newLanguage, setNewLanguage] = useState(transcript);
+  const [editorLanguage, setEditorLanguage] = useState('');
+  const [invalidSrtFile, setInvalidSrtFile] = useState(false);
   const language = transcript;
 
   useEffect(() => {
@@ -33,11 +42,23 @@ const Transcript = ({
   const input = useFileInput({
     onAddFile: (files) => {
       const [file] = files;
-      handleTranscript({
-        file,
-        language,
-        newLanguage,
-      }, 'upload');
+      if (!file) {
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        if (!isValidSrt(e.target.result)) {
+          setInvalidSrtFile(true);
+        } else {
+          setInvalidSrtFile(false);
+          handleTranscript({
+            file,
+            language,
+            newLanguage,
+          }, 'upload');
+        }
+      };
+      reader.readAsText(file);
     },
     setSelectedRows: () => {},
     setAddOpen: () => {},
@@ -52,70 +73,82 @@ const Transcript = ({
 
   return (
     <>
-      {isConfirmationOpen ?
-        (
-          <Card className="my-2">
-            <Card.Header className="h3" title={<FormattedMessage {...messages.deleteConfirmationHeader} />} />
-            <Card.Body>
-              <Card.Section>
-                <FormattedMessage {...messages.deleteConfirmationMessage} />
-              </Card.Section>
-              <Card.Footer>
-                <Button size="sm" variant="tertiary" className="mb-2 mb-sm-0" onClick={closeConfirmation}>
-                  <FormattedMessage {...messages.cancelDeleteLabel} />
-                </Button>
-                <Button
-                  variant="danger"
-                  className="mb-2 mb-sm-0"
-                  size="sm"
-                  onClick={() => {
-                    handleTranscript({ language: transcript }, 'delete');
-                    closeConfirmation();
-                  }}
-                >
-                  <FormattedMessage {...messages.confirmDeleteLabel} />
-                </Button>
-              </Card.Footer>
-            </Card.Body>
-          </Card>
-        ) :
-        (
-          <div
-            className="row m-0 align-items-center justify-content-between"
-            key={`transcript-${language}`}
-            data-testid={`transcript-${language}`}
-          >
-            <LanguageSelect
-              options={languages}
-              value={newLanguage}
-              placeholderText={intl.formatMessage(messages.languageSelectPlaceholder)}
-              previousSelection={previousSelection}
-              handleSelect={updateLangauge}
+      <div
+        className="row m-0 align-items-center justify-content-between"
+        key={`transcript-${language}`}
+        data-testid={`transcript-${language}`}
+      >
+        <LanguageSelect
+          options={languages}
+          value={newLanguage}
+          placeholderText={intl.formatMessage(messages.languageSelectPlaceholder)}
+          previousSelection={previousSelection}
+          handleSelect={updateLangauge}
+        />
+        {transcript === '' ?
+          (
+            <IconButton
+              iconAs={Icon}
+              src={DeleteOutline}
+              onClick={openConfirmation}
+              alt="delete empty transcript"
             />
-            {transcript === '' ?
-              (
-                <IconButton
-                  iconAs={Icon}
-                  src={DeleteOutline}
-                  onClick={openConfirmation}
-                  alt="delete empty transcript"
-                />
-              ) :
-              (
-                <TranscriptMenu
-                  {...{
-                    language,
-                    newLanguage,
-                    setNewLanguage,
-                    handleTranscript,
-                    input,
-                    launchDeleteConfirmation: openConfirmation,
-                  }}
-                />
-              )}
-          </div>
-        )}
+          ) :
+          (
+            <TranscriptMenu
+              {...{
+                language,
+                newLanguage,
+                setNewLanguage,
+                handleTranscript,
+                input,
+                launchDeleteConfirmation: openConfirmation,
+                onEdit: setEditorLanguage,
+              }}
+            />
+          )}
+      </div>
+      {invalidSrtFile && (
+        <Stack direction="horizontal" gap={2} className="align-items-center text-danger-500 mt-1">
+          <Icon src={ErrorIcon} size="xs" />
+          <span className="small">{intl.formatMessage(sidebarMessages.invalidSrtFormat)}</span>
+        </Stack>
+      )}
+      <AlertModal
+        title={<FormattedMessage {...messages.deleteConfirmationHeader} />}
+        isOpen={isConfirmationOpen}
+        onClose={closeConfirmation}
+        footerNode={
+          <ActionRow>
+            <Button size="sm" variant="tertiary" onClick={closeConfirmation}>
+              <FormattedMessage {...messages.cancelDeleteLabel} />
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => {
+                handleTranscript({ language: transcript }, 'delete');
+                closeConfirmation();
+              }}
+            >
+              <FormattedMessage {...messages.confirmDeleteLabel} />
+            </Button>
+          </ActionRow>
+        }
+      >
+        <p>
+          <FormattedMessage {...messages.deleteConfirmationMessage} />
+        </p>
+      </AlertModal>
       <FileInput key="transcript-input" fileInput={input} supportedFileFormats={['.srt']} />
+      <TranscriptEditor
+        isOpen={Boolean(editorLanguage)}
+        onClose={() => setEditorLanguage('')}
+        video={video}
+        language={editorLanguage}
+        languages={languages}
+        transcriptSettings={transcriptSettings}
+      />
     </>
   );
 };
@@ -125,6 +158,15 @@ Transcript.propTypes = {
   transcript: PropTypes.string.isRequired,
   previousSelection: PropTypes.arrayOf(PropTypes.string).isRequired,
   handleTranscript: PropTypes.func.isRequired,
+  video: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    displayName: PropTypes.string.isRequired,
+    downloadLink: PropTypes.string,
+  }).isRequired,
+  transcriptSettings: PropTypes.shape({
+    transcriptDownloadHandlerUrl: PropTypes.string.isRequired,
+    transcriptUploadHandlerUrl: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default Transcript;

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/Transcript.test.tsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/Transcript.test.tsx
@@ -1,0 +1,35 @@
+import {
+  fireEvent,
+  initializeMocks,
+  render,
+  screen,
+} from '@src/testUtils';
+import Transcript from './Transcript';
+
+describe('Transcript (new, empty row)', () => {
+  beforeEach(() => {
+    initializeMocks();
+  });
+
+  it('opens the file picker once a language is chosen for the new transcript', () => {
+    const clickSpy = jest.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {});
+    render(
+      <Transcript
+        languages={{ ar: 'Arabic', en: 'English' }}
+        transcript=""
+        previousSelection={['']}
+        handleTranscript={jest.fn()}
+        video={{ id: 'vid-1', displayName: 'My Video' }}
+        transcriptSettings={{
+          transcriptDownloadHandlerUrl: '/transcript_download/',
+          transcriptUploadHandlerUrl: '/transcript_upload/',
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('language-select-dropdown'));
+    fireEvent.click(screen.getByText('Arabic'));
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+});

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/TranscriptMenu.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/TranscriptMenu.jsx
@@ -19,7 +19,7 @@ export const TranscriptActionMenu = ({
   launchDeleteConfirmation,
   handleTranscript,
   input,
-  onEdit,
+  onEdit = () => {},
 }) => {
   const [isOpen, , close, toggle] = useToggle();
   const [target, setTarget] = useState(null);
@@ -44,7 +44,6 @@ export const TranscriptActionMenu = ({
           <MenuItem
             as={Button}
             variant="tertiary"
-            key={`transcript-actions-${language}-edit`}
             onClick={() => {
               onEdit(language);
               close();
@@ -55,7 +54,6 @@ export const TranscriptActionMenu = ({
           <MenuItem
             as={Button}
             variant="tertiary"
-            key={`transcript-actions-${language}-replace`}
             onClick={() => {
               input.click();
               close();
@@ -66,7 +64,6 @@ export const TranscriptActionMenu = ({
           <MenuItem
             as={Button}
             variant="tertiary"
-            key={`transcript-actions-${language}-download`}
             onClick={() => handleTranscript({ language }, 'download')}
           >
             <FormattedMessage {...messages.downloadTranscript} />
@@ -75,7 +72,6 @@ export const TranscriptActionMenu = ({
           <MenuItem
             as={Button}
             variant="tertiary"
-            key={`transcript-actions-${language}-delete`}
             onClick={launchDeleteConfirmation}
           >
             <FormattedMessage {...messages.deleteTranscript} />
@@ -94,10 +90,6 @@ TranscriptActionMenu.propTypes = {
   input: PropTypes.shape({
     click: PropTypes.func.isRequired,
   }).isRequired,
-};
-
-TranscriptActionMenu.defaultProps = {
-  onEdit: () => {},
 };
 
 export default TranscriptActionMenu;

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/TranscriptMenu.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/TranscriptMenu.jsx
@@ -19,6 +19,7 @@ export const TranscriptActionMenu = ({
   launchDeleteConfirmation,
   handleTranscript,
   input,
+  onEdit,
 }) => {
   const [isOpen, , close, toggle] = useToggle();
   const [target, setTarget] = useState(null);
@@ -39,12 +40,26 @@ export const TranscriptActionMenu = ({
         onClose={close}
         onEscapeKey={close}
       >
-        <Menu className="transcript-menu">
+        <Menu className="transcript-menu overflow-hidden">
+          <MenuItem
+            as={Button}
+            variant="tertiary"
+            key={`transcript-actions-${language}-edit`}
+            onClick={() => {
+              onEdit(language);
+              close();
+            }}
+          >
+            <FormattedMessage {...messages.editTranscript} />
+          </MenuItem>
           <MenuItem
             as={Button}
             variant="tertiary"
             key={`transcript-actions-${language}-replace`}
-            onClick={input.click}
+            onClick={() => {
+              input.click();
+              close();
+            }}
           >
             <FormattedMessage {...messages.replaceTranscript} />
           </MenuItem>
@@ -75,9 +90,14 @@ TranscriptActionMenu.propTypes = {
   language: PropTypes.string.isRequired,
   handleTranscript: PropTypes.func.isRequired,
   launchDeleteConfirmation: PropTypes.func.isRequired,
+  onEdit: PropTypes.func,
   input: PropTypes.shape({
     click: PropTypes.func.isRequired,
   }).isRequired,
+};
+
+TranscriptActionMenu.defaultProps = {
+  onEdit: () => {},
 };
 
 export default TranscriptActionMenu;

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/TranscriptMenu.test.tsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/TranscriptMenu.test.tsx
@@ -1,0 +1,39 @@
+import {
+  fireEvent,
+  initializeMocks,
+  render,
+  screen,
+} from '@src/testUtils';
+import { TranscriptActionMenu } from './TranscriptMenu';
+import messages from './messages';
+
+describe('TranscriptActionMenu', () => {
+  beforeEach(() => {
+    initializeMocks();
+  });
+
+  const renderMenu = (props = {}) =>
+    render(
+      <TranscriptActionMenu
+        language="ar"
+        launchDeleteConfirmation={jest.fn()}
+        handleTranscript={jest.fn()}
+        input={{ click: jest.fn() }}
+        {...props}
+      />,
+    );
+
+  it('calls onEdit with the language and closes the menu', () => {
+    const onEdit = jest.fn();
+    renderMenu({ onEdit });
+    fireEvent.click(screen.getByRole('button', { name: 'Actions dropdown' }));
+    fireEvent.click(screen.getByText(messages.editTranscript.defaultMessage));
+    expect(onEdit).toHaveBeenCalledWith('ar');
+  });
+
+  it('tolerates a missing onEdit handler', () => {
+    renderMenu();
+    fireEvent.click(screen.getByRole('button', { name: 'Actions dropdown' }));
+    expect(() => fireEvent.click(screen.getByText(messages.editTranscript.defaultMessage))).not.toThrow();
+  });
+});

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/messages.ts
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/messages.ts
@@ -51,6 +51,21 @@ const messages = defineMessages({
     defaultMessage: 'Delete this transcript?',
     description: 'Title for Warning which allows users to select next step in the process of deleting a transcript',
   },
+  searchLanguagesPlaceholder: {
+    id: 'course-authoriong.video-uploads.file-info.transcript.searchLanguagesPlaceholder',
+    defaultMessage: 'Search languages',
+    description: 'Placeholder for the search box in the transcript language selector',
+  },
+  noLanguageResults: {
+    id: 'course-authoriong.video-uploads.file-info.transcript.noLanguageResults',
+    defaultMessage: 'No results',
+    description: 'Shown in the transcript language selector when no languages match the search',
+  },
+  deleteEmptyTranscriptLabel: {
+    id: 'course-authoriong.video-uploads.file-info.transcript.deleteEmptyTranscript',
+    defaultMessage: 'Delete empty transcript',
+    description: 'Accessible label for the button that removes an empty transcript row',
+  },
 });
 
 export default messages;

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/messages.ts
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/messages.ts
@@ -1,6 +1,11 @@
 import { defineMessages } from '@edx/frontend-platform/i18n';
 
 const messages = defineMessages({
+  editTranscript: {
+    id: 'course-authoriong.video-uploads.file-info.transcript.editTranscript',
+    defaultMessage: 'Edit transcript',
+    description: 'Message Presented To user for action to edit transcript',
+  },
   fileSizeError: {
     id: 'course-authoriong.video-uploads.file-info.transcript.error.fileSizeError',
     defaultMessage: 'Transcript file size exceeds the maximum. Please try again.',

--- a/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.scss
+++ b/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.scss
@@ -1,0 +1,217 @@
+.transcript-editor-modal {
+  &__video-container {
+    background: var(--pgn-color-black);
+    height: clamp(8rem, 40vh, 32rem);
+  }
+
+  &__video {
+    display: block;
+    width: 100%;
+    max-height: 100%;
+    max-width: 100%;
+    background: var(--pgn-color-black);
+    object-fit: contain;
+  }
+
+  &.pgn__modal {
+    width: 80vw;
+    max-width: 80vw;
+    height: 95vh;
+    max-height: 95vh;
+    overflow: hidden;
+
+    .pgn__modal-header,
+    .pgn__modal-footer {
+      flex: 0 0 auto;
+    }
+  }
+
+  .pgn__modal-body {
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  .pgn__modal-body-content {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    min-height: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-bottom: 0;
+  }
+
+  &__cue-list {
+    min-height: 0;
+    overscroll-behavior: contain;
+    scroll-behavior: smooth;
+  }
+
+  &__cue-wrapper {
+    border-left: 3px solid transparent;
+    border-radius: .375rem;
+    transition: background-color .15s ease, border-color .15s ease, box-shadow .15s ease;
+    transition: border-color .15s ease;
+
+    &.transcript-editor-modal__cue--active {
+      background: linear-gradient(90deg, rgb(0 117 180 / .08) 0%, transparent 100%);
+      border-left: 3px solid var(--pgn-color-info-500);
+      border-radius: .25rem;
+      box-shadow: 0 0 0 2px rgb(0 117 180 / .2);
+
+      .transcript-editor-modal__cue-text.form-control {
+        border-color: var(--pgn-color-info-500) !important;
+        background: var(--pgn-color-white) !important;
+        color: var(--pgn-color-gray-900);
+        font-weight: 500;
+      }
+
+      .transcript-editor-modal__time.form-control {
+         border-color: var(--pgn-color-info-500);
+         color: var(--pgn-color-gray-900);
+      }
+    }
+  }
+
+  &__cue-row {
+    flex-wrap: nowrap;
+    align-items: center;
+  }
+
+  &__cue-text-wrap {
+    flex: 1 1 auto;
+    min-width: 0;
+    position: relative;
+
+    .pgn__form-control-feedback {
+      position: absolute;
+      top: 100%;
+      left: 0;
+      font-size: .75rem;
+      white-space: nowrap;
+      margin-top: .1rem;
+    }
+  }
+
+  &__cue-text.form-control {
+    font-size: .875rem;
+    border-radius: .25rem;
+    padding: .25rem .4rem;
+    border: 1px solid transparent !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    transition: border-color .15s ease, background-color .15s ease, box-shadow .15s ease;
+
+    &:hover {
+      border: 1px solid var(--pgn-color-gray-300) !important;
+      background: transparent !important;
+      box-shadow: none !important;
+    }
+
+    &:focus {
+      border: 1px solid var(--pgn-color-info-500) !important;
+      background: var(--pgn-color-white) !important;
+      box-shadow: 0 0 0 2px rgb(0 117 180 / .2) !important;
+      outline: none !important;
+    }
+
+    &.is-invalid {
+      border: 1px solid var(--pgn-color-danger-500) !important;
+      background: var(--pgn-color-danger-100) !important;
+      box-shadow: none !important;
+    }
+  }
+
+  &__time-wrap {
+    flex: 0 0 auto;
+    width: 8rem;
+
+    .pgn__form-control-decorator-group {
+      width: 100%;
+    }
+  }
+
+  &__time.form-control {
+    width: 100%;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: .65rem;
+    padding: .15rem .25rem;
+    height: auto;
+    border: 1px solid var(--pgn-color-gray-300);
+    border-radius: .25rem;
+    color: var(--pgn-color-gray-700);
+    background: var(--pgn-color-white);
+
+    &:focus {
+      outline: none;
+      border-color: var(--pgn-color-info-500);
+      box-shadow: 0 0 0 2px rgb(0 117 180 / .2);
+    }
+  }
+
+  &__time-sep {
+    color: var(--pgn-color-gray-500);
+    flex-shrink: 0;
+  }
+
+  &__cue-row .btn-icon {
+    flex-shrink: 0;
+  }
+
+  &__insert-divider {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    width: 100%;
+    height: 0;
+    visibility: hidden;
+    transition: height .15s ease;
+  }
+
+  &__insert-divider-line {
+    width: 100%;
+    position: absolute;
+    margin: 0;
+    border: 0;
+    border-top: 1px dashed var(--pgn-color-light-500);
+    z-index: 0;
+  }
+
+  &__insert-btn.btn {
+    background: var(--pgn-color-white);
+    border: 1px dashed var(--pgn-color-gray-500);
+    color: var(--pgn-color-gray-700);
+    font-size: .75rem;
+    padding: .15rem .6rem;
+    border-radius: 999px;
+    position: relative;
+    z-index: 1;
+  }
+
+  &__cue-wrapper:hover &__insert-divider {
+    height: 2rem;
+    visibility: visible;
+  }
+
+  @media (width <= 767.98px) {
+    &.pgn__modal {
+      width: calc(100vw - 1rem);
+      max-width: calc(100vw - 1rem);
+      height: calc(100vh - .5rem);
+      max-height: calc(100vh - .5rem);
+      margin: 0;
+    }
+  }
+
+  @media (width <= 991.98px) {
+    &__cue-text-wrap {
+      flex-basis: 100%;
+    }
+
+    &__time-wrap {
+      flex: 1 1 7.5rem;
+      max-width: 9rem;
+    }
+  }
+}

--- a/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.scss
+++ b/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.scss
@@ -94,6 +94,7 @@
   }
 
   &__cue-text.form-control {
+    resize: none;
     font-size: .875rem;
     border-radius: .25rem;
     padding: .25rem .4rem;

--- a/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.test.tsx
+++ b/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.test.tsx
@@ -1,0 +1,235 @@
+import type MockAdapter from 'axios-mock-adapter';
+import { logError } from '@edx/frontend-platform/logging';
+
+import {
+  fireEvent,
+  initializeMocks,
+  render,
+  screen,
+  waitFor,
+} from '@src/testUtils';
+import TranscriptEditor from './TranscriptEditor';
+import messages from './messages';
+
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
+const SRT = [
+  '1',
+  '00:00:01,000 --> 00:00:02,000',
+  'Hello',
+  '',
+  '2',
+  '00:00:03,000 --> 00:00:04,000',
+  'World',
+].join('\n');
+
+const defaultProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  language: 'en',
+  languages: { en: 'English' },
+  video: {
+    id: 'vid-1',
+    displayName: 'My Video',
+    downloadLink: 'https://cdn.example.com/video.mp4',
+  },
+  transcriptSettings: {
+    transcriptDownloadHandlerUrl: '/transcript_download/',
+    transcriptUploadHandlerUrl: '/transcript_upload/',
+  },
+};
+
+let axiosMock: MockAdapter;
+let playSpy: jest.SpyInstance;
+
+const readFileText = (blob: Blob) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+
+const renderEditor = (props = {}) => render(<TranscriptEditor {...defaultProps} {...props} />);
+
+const mockTranscript = (body: string = SRT) => {
+  axiosMock.onGet(/transcript_download/).reply(200, body);
+};
+
+beforeAll(() => {
+  // jsdom does not implement these; the component guards on their presence.
+  global.URL.createObjectURL = jest.fn(() => 'blob:mock-track');
+  global.URL.revokeObjectURL = jest.fn();
+  Element.prototype.scrollTo = jest.fn();
+});
+
+beforeEach(() => {
+  ({ axiosMock } = initializeMocks());
+  jest.clearAllMocks();
+  playSpy = jest.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  playSpy.mockRestore();
+  jest.useRealTimers();
+});
+
+describe('TranscriptEditor', () => {
+  it('fetches the transcript for the video/language and renders its cues', async () => {
+    mockTranscript();
+    renderEditor();
+
+    expect(await screen.findByDisplayValue('Hello')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('World')).toBeInTheDocument();
+    expect(screen.getByText('English')).toBeInTheDocument();
+    expect(axiosMock.history.get[0].url).toContain(
+      '/transcript_download/?edx_video_id=vid-1&language_code=en',
+    );
+  });
+
+  it('shows an error alert when the transcript fails to load', async () => {
+    axiosMock.onGet(/transcript_download/).reply(500);
+    renderEditor();
+
+    expect(await screen.findByText(messages.saveFailedLabel.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('saves edited cues as a re-uploaded SRT file and shows the saved indicator', async () => {
+    mockTranscript();
+    axiosMock.onPost(/transcript_upload/).reply(200);
+    renderEditor();
+
+    fireEvent.change(await screen.findByDisplayValue('Hello'), { target: { value: 'Hello edited' } });
+    fireEvent.click(screen.getByRole('button', { name: messages.saveButtonLabel.defaultMessage }));
+
+    await waitFor(() => expect(axiosMock.history.post).toHaveLength(1));
+    const formData = axiosMock.history.post[0].data as FormData;
+    expect(formData.get('edx_video_id')).toBe('vid-1');
+    expect(formData.get('language_code')).toBe('en');
+    expect(formData.get('new_language_code')).toBe('en');
+    const file = formData.get('file') as File;
+    expect(file.name).toBe('My Video-en.srt');
+    expect(await readFileText(file)).toContain('Hello edited');
+
+    expect(await screen.findByText(messages.savedLabel.defaultMessage)).toBeInTheDocument();
+
+    // The "Saved" indicator clears itself after five seconds.
+    await waitFor(
+      () => expect(screen.queryByText(messages.savedLabel.defaultMessage)).not.toBeInTheDocument(),
+      { timeout: 6000 },
+    );
+  }, 15000);
+
+  it('surfaces save failures and logs the error', async () => {
+    mockTranscript();
+    axiosMock.onPost(/transcript_upload/).reply(500);
+    renderEditor();
+
+    fireEvent.change(await screen.findByDisplayValue('Hello'), { target: { value: 'Hello edited' } });
+    fireEvent.click(screen.getByRole('button', { name: messages.saveButtonLabel.defaultMessage }));
+
+    expect(await screen.findByText(messages.saveFailedLabel.defaultMessage)).toBeInTheDocument();
+    expect(logError).toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: messages.saveButtonLabel.defaultMessage })).toBeEnabled();
+  });
+
+  it('closes immediately when there are no unsaved changes', async () => {
+    const onClose = jest.fn();
+    mockTranscript();
+    renderEditor({ onClose });
+
+    await screen.findByDisplayValue('Hello');
+    fireEvent.click(screen.getByRole('button', { name: messages.cancelButtonLabel.defaultMessage }));
+
+    expect(onClose).toHaveBeenCalledWith(false);
+    expect(screen.queryByText(messages.unsavedModalTitle.defaultMessage)).not.toBeInTheDocument();
+  });
+
+  it('asks for confirmation before discarding unsaved changes', async () => {
+    const onClose = jest.fn();
+    mockTranscript();
+    renderEditor({ onClose });
+
+    fireEvent.change(await screen.findByDisplayValue('Hello'), { target: { value: 'Changed' } });
+    fireEvent.click(screen.getByRole('button', { name: messages.cancelButtonLabel.defaultMessage }));
+
+    expect(await screen.findByText(messages.unsavedModalDescription.defaultMessage)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: messages.keepEditingButtonLabel.defaultMessage }));
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: messages.cancelButtonLabel.defaultMessage }));
+    fireEvent.click(await screen.findByRole('button', { name: messages.closeEditorButtonLabel.defaultMessage }));
+    expect(onClose).toHaveBeenCalledWith(false);
+  });
+
+  it('inserts a first cue into an empty transcript and flags empty text as invalid', async () => {
+    mockTranscript('');
+    renderEditor();
+
+    fireEvent.click(await screen.findByRole('button', { name: messages.insertCueLabel.defaultMessage }));
+
+    expect(screen.getByDisplayValue('00:00:00,000')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('00:00:02,000')).toBeInTheDocument();
+    expect(screen.getByText(messages.invalidCueTextLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: messages.saveButtonLabel.defaultMessage })).toBeDisabled();
+  });
+
+  it('inserts a cue after an existing one and deletes cues', async () => {
+    mockTranscript();
+    renderEditor();
+    await screen.findByDisplayValue('Hello');
+
+    fireEvent.click(screen.getAllByRole('button', { name: messages.insertCueLabel.defaultMessage })[0]);
+    // New cue starts where the first cue ends, capped at the next cue's start.
+    expect(screen.getAllByDisplayValue('00:00:02,000')).toHaveLength(2);
+    expect(screen.getAllByDisplayValue('00:00:03,000')).toHaveLength(2);
+
+    const deleteButtons = screen.getAllByRole('button', { name: messages.deleteCueLabel.defaultMessage });
+    expect(deleteButtons).toHaveLength(3);
+    fireEvent.click(deleteButtons[1]);
+    expect(screen.getAllByRole('button', { name: messages.deleteCueLabel.defaultMessage })).toHaveLength(2);
+  });
+
+  it('normalizes timestamp edits on blur and flags invalid ranges', async () => {
+    mockTranscript();
+    renderEditor();
+    await screen.findByDisplayValue('Hello');
+
+    const start = screen.getByDisplayValue('00:00:03,000');
+    fireEvent.change(start, { target: { value: '00:00:03.500' } });
+    // Dots are normalized to commas while typing...
+    expect(screen.getByDisplayValue('00:00:03,500')).toBeInTheDocument();
+    fireEvent.blur(screen.getByDisplayValue('00:00:03,500'), { target: { value: '00:00:03,500' } });
+    expect(screen.getByDisplayValue('00:00:03,500')).toBeInTheDocument();
+
+    // ...and an end time before the start time is flagged, disabling Save.
+    const end = screen.getByDisplayValue('00:00:04,000');
+    fireEvent.change(end, { target: { value: '00:00:01,000' } });
+    expect(screen.getByText(messages.invalidTimestampLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: messages.saveButtonLabel.defaultMessage })).toBeDisabled();
+  });
+
+  it('seeks the preview on cue play, ignoring interrupted play() but logging other errors', async () => {
+    mockTranscript();
+    renderEditor();
+    await screen.findByDisplayValue('Hello');
+
+    const abortError = new Error('interrupted');
+    abortError.name = 'AbortError';
+    playSpy.mockRejectedValueOnce(abortError);
+
+    const seekButtons = screen.getAllByRole('button', { name: messages.seekCueLabel.defaultMessage });
+    fireEvent.click(seekButtons[0]);
+    await waitFor(() => expect(playSpy).toHaveBeenCalledTimes(1));
+    expect(logError).not.toHaveBeenCalled();
+    // Seeking into the first cue's range marks it active.
+    expect(document.querySelector('.transcript-editor-modal__cue--active')).not.toBeNull();
+
+    playSpy.mockRejectedValueOnce(new Error('autoplay blocked'));
+    fireEvent.click(seekButtons[1]);
+    await waitFor(() => expect(logError).toHaveBeenCalledTimes(1));
+  });
+});

--- a/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.test.tsx
+++ b/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.test.tsx
@@ -89,11 +89,38 @@ describe('TranscriptEditor', () => {
     );
   });
 
-  it('shows an error alert when the transcript fails to load', async () => {
+  it('shows a distinct error alert when the transcript fails to load', async () => {
     axiosMock.onGet(/transcript_download/).reply(500);
     renderEditor();
 
-    expect(await screen.findByText(messages.saveFailedLabel.defaultMessage)).toBeInTheDocument();
+    expect(await screen.findByText(messages.loadFailedLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.queryByText(messages.saveFailedLabel.defaultMessage)).not.toBeInTheDocument();
+  });
+
+  it('gives cue fields accessible names', async () => {
+    mockTranscript();
+    renderEditor();
+    await screen.findByDisplayValue('Hello');
+
+    expect(screen.getByRole('textbox', { name: 'Cue 1 text' })).toHaveValue('Hello');
+    expect(screen.getByRole('textbox', { name: 'Cue 1 start time' })).toHaveValue('00:00:01,000');
+    expect(screen.getByRole('textbox', { name: 'Cue 2 end time' })).toHaveValue('00:00:04,000');
+  });
+
+  it('preserves multi-line cue text through editing and saving', async () => {
+    mockTranscript();
+    axiosMock.onPost(/transcript_upload/).reply(200);
+    renderEditor();
+
+    const cueText = await screen.findByRole('textbox', { name: 'Cue 1 text' });
+    expect(cueText.tagName).toBe('TEXTAREA');
+    fireEvent.change(cueText, { target: { value: 'first line\nsecond line' } });
+    expect(screen.getByRole('textbox', { name: 'Cue 1 text' })).toHaveValue('first line\nsecond line');
+
+    fireEvent.click(screen.getByRole('button', { name: messages.saveButtonLabel.defaultMessage }));
+    await waitFor(() => expect(axiosMock.history.post).toHaveLength(1));
+    const file = (axiosMock.history.post[0].data as FormData).get('file') as File;
+    expect(await readFileText(file)).toContain('00:00:01,000 --> 00:00:02,000\nfirst line\nsecond line');
   });
 
   it('saves edited cues as a re-uploaded SRT file and shows the saved indicator', async () => {

--- a/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.test.tsx
+++ b/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.test.tsx
@@ -2,6 +2,7 @@ import type MockAdapter from 'axios-mock-adapter';
 import { logError } from '@edx/frontend-platform/logging';
 
 import {
+  act,
   fireEvent,
   initializeMocks,
   render,
@@ -258,5 +259,140 @@ describe('TranscriptEditor', () => {
     playSpy.mockRejectedValueOnce(new Error('autoplay blocked'));
     fireEvent.click(seekButtons[1]);
     await waitFor(() => expect(logError).toHaveBeenCalledTimes(1));
+  });
+  it('leaves invalid timestamps unchanged on blur, for both start and end fields', async () => {
+    mockTranscript();
+    renderEditor();
+    await screen.findByDisplayValue('Hello');
+
+    const start = screen.getByRole('textbox', { name: 'Cue 1 start time' });
+    fireEvent.change(start, { target: { value: '00:00:01,5' } });
+    fireEvent.blur(start, { target: { value: '00:00:01,5' } });
+    expect(start).toHaveValue('00:00:01,5');
+
+    const end = screen.getByRole('textbox', { name: 'Cue 1 end time' });
+    fireEvent.change(end, { target: { value: '00:00:02,5' } });
+    fireEvent.blur(end, { target: { value: '00:00:02,5' } });
+    expect(end).toHaveValue('00:00:02,5');
+  });
+
+  it('updates the active cue from video timeupdate events', async () => {
+    mockTranscript();
+    renderEditor();
+    await screen.findByDisplayValue('Hello');
+
+    const video = document.querySelector('video') as HTMLVideoElement;
+    Object.defineProperty(video, 'currentTime', { value: 1.5, configurable: true });
+    fireEvent.timeUpdate(video);
+    await waitFor(() => expect(document.querySelector('.transcript-editor-modal__cue--active')).not.toBeNull());
+  });
+
+  it('does not close while a save is in progress', async () => {
+    mockTranscript();
+    let finishSave: (value: [number]) => void = () => {};
+    axiosMock.onPost(/transcript_upload/).reply(() =>
+      new Promise<[number]>((resolve) => {
+        finishSave = resolve;
+      })
+    );
+    const onClose = jest.fn();
+    renderEditor({ onClose });
+
+    fireEvent.change(await screen.findByDisplayValue('Hello'), { target: { value: 'Hello edited' } });
+    fireEvent.click(screen.getByRole('button', { name: messages.saveButtonLabel.defaultMessage }));
+    await screen.findAllByText(messages.saveInProgressLabel.defaultMessage);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).not.toHaveBeenCalled();
+
+    finishSave([200]);
+    expect(await screen.findByText(messages.savedLabel.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('falls back to setting scrollTop when scrollTo is unavailable', async () => {
+    const original = Element.prototype.scrollTo;
+    Object.defineProperty(Element.prototype, 'scrollTo', { value: undefined, configurable: true, writable: true });
+    try {
+      mockTranscript();
+      renderEditor();
+      await screen.findByDisplayValue('Hello');
+      fireEvent.click(screen.getAllByRole('button', { name: messages.seekCueLabel.defaultMessage })[0]);
+      await waitFor(() => expect(document.querySelector('.transcript-editor-modal__cue--active')).not.toBeNull());
+    } finally {
+      Object.defineProperty(Element.prototype, 'scrollTo', { value: original, configurable: true, writable: true });
+    }
+  });
+
+  it('ignores a transcript that arrives after the editor unmounted', async () => {
+    mockTranscript();
+    const { unmount } = renderEditor();
+    unmount();
+    await waitFor(() => expect(axiosMock.history.get).toHaveLength(1));
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
+  });
+
+  it('ignores a load failure that arrives after the editor unmounted', async () => {
+    axiosMock.onGet(/transcript_download/).reply(500);
+    const { unmount } = renderEditor();
+    unmount();
+    await waitFor(() => expect(axiosMock.history.get).toHaveLength(1));
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
+  });
+
+  it('closes the unsaved-changes dialog with Escape', async () => {
+    mockTranscript();
+    renderEditor();
+    fireEvent.change(await screen.findByDisplayValue('Hello'), { target: { value: 'Changed' } });
+    fireEvent.click(screen.getByRole('button', { name: messages.cancelButtonLabel.defaultMessage }));
+    const description = await screen.findByText(messages.unsavedModalDescription.defaultMessage);
+
+    fireEvent.keyDown(description, { key: 'Escape', code: 'Escape', keyCode: 27 });
+    await waitFor(() =>
+      expect(screen.queryByText(messages.unsavedModalDescription.defaultMessage)).not.toBeInTheDocument()
+    );
+  });
+  it('inserts after the last cue using a default two-second window', async () => {
+    mockTranscript();
+    renderEditor();
+    await screen.findByDisplayValue('Hello');
+
+    const insertButtons = screen.getAllByRole('button', { name: messages.insertCueLabel.defaultMessage });
+    fireEvent.click(insertButtons[insertButtons.length - 1]);
+    // Last cue ends at 00:00:04,000, so the new cue spans 04,000 -> 06,000.
+    expect(screen.getAllByDisplayValue('00:00:04,000')).toHaveLength(2);
+    expect(screen.getByDisplayValue('00:00:06,000')).toBeInTheDocument();
+  });
+
+  it('falls back to the language code when no display name is configured', async () => {
+    mockTranscript();
+    renderEditor({ languages: {} });
+    await screen.findByDisplayValue('Hello');
+    expect(screen.getByText('en')).toBeInTheDocument();
+  });
+
+  it('renders without fetching when no language is selected', () => {
+    renderEditor({ language: undefined, languages: undefined });
+    expect(axiosMock.history.get).toHaveLength(0);
+    expect(screen.getByRole('button', { name: messages.insertCueLabel.defaultMessage })).toBeInTheDocument();
+  });
+  it('uses a plain two-second window when the next cue starts before the current one ends', async () => {
+    mockTranscript();
+    renderEditor();
+    await screen.findByDisplayValue('Hello');
+
+    // Push cue 1's end past cue 2's start (00:00:03,000), then insert after cue 1.
+    const end = screen.getByRole('textbox', { name: 'Cue 1 end time' });
+    fireEvent.change(end, { target: { value: '00:00:05,000' } });
+    fireEvent.click(screen.getAllByRole('button', { name: messages.insertCueLabel.defaultMessage })[0]);
+    expect(screen.getAllByDisplayValue('00:00:05,000')).toHaveLength(2);
+    expect(screen.getByDisplayValue('00:00:07,000')).toBeInTheDocument();
   });
 });

--- a/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.test.tsx
+++ b/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.test.tsx
@@ -53,6 +53,15 @@ const readFileText = (blob: Blob) =>
     reader.readAsText(blob);
   });
 
+// Lets an in-flight request settle and React process the result, so assertions run
+// after any state update the response would have triggered.
+const flushPendingResponses = () =>
+  act(async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  });
+
 const renderEditor = (props = {}) => render(<TranscriptEditor {...defaultProps} {...props} />);
 
 const mockTranscript = (body: string = SRT) => {
@@ -323,28 +332,24 @@ describe('TranscriptEditor', () => {
     }
   });
 
-  it('ignores a transcript that arrives after the editor unmounted', async () => {
-    mockTranscript();
+  // The fetch effect guards every state update behind an isMounted flag, so a response
+  // that lands after the editor closes must neither render nor report anything.
+  it.each([
+    ['a transcript', () => mockTranscript()],
+    ['a load failure', () => {
+      axiosMock.onGet(/transcript_download/).reply(500);
+    }],
+  ])('ignores %s that arrives after the editor unmounted', async (_label, mockResponse) => {
+    mockResponse();
     const { unmount } = renderEditor();
     unmount();
     await waitFor(() => expect(axiosMock.history.get).toHaveLength(1));
-    await act(async () => {
-      await new Promise((resolve) => {
-        setTimeout(resolve, 0);
-      });
-    });
-  });
 
-  it('ignores a load failure that arrives after the editor unmounted', async () => {
-    axiosMock.onGet(/transcript_download/).reply(500);
-    const { unmount } = renderEditor();
-    unmount();
-    await waitFor(() => expect(axiosMock.history.get).toHaveLength(1));
-    await act(async () => {
-      await new Promise((resolve) => {
-        setTimeout(resolve, 0);
-      });
-    });
+    await flushPendingResponses();
+
+    expect(screen.queryByDisplayValue('Hello')).not.toBeInTheDocument();
+    expect(screen.queryByText(messages.loadFailedLabel.defaultMessage)).not.toBeInTheDocument();
+    expect(logError).not.toHaveBeenCalled();
   });
 
   it('closes the unsaved-changes dialog with Escape', async () => {

--- a/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.tsx
+++ b/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.tsx
@@ -1,0 +1,657 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { SyntheticEvent } from 'react';
+import { logError } from '@edx/frontend-platform/logging';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import {
+  Alert,
+  Button,
+  Form,
+  Icon,
+  IconButton,
+  ModalDialog,
+  Spinner,
+  Stack,
+} from '@openedx/paragon';
+import {
+  Add,
+  CheckCircle,
+  DeleteOutline,
+  Info,
+  PlayArrow,
+} from '@openedx/paragon/icons';
+
+import { fetchTranscriptContent, uploadTranscript } from '@src/files-and-videos/videos-page/data/api';
+import {
+  formatTimestamp,
+  parseSrt,
+  parseTimestamp,
+  serializeSrt,
+} from './srtUtils';
+import type { Cue } from './srtUtils';
+import messages from './messages';
+import './TranscriptEditor.scss';
+
+type EditorCue = Cue & { id: string; };
+type SaveStatus = 'idle' | 'saving' | 'saved';
+
+interface TranscriptEditorProps {
+  isOpen: boolean;
+  onClose: (submitted: boolean) => void;
+  video: {
+    id: string;
+    displayName: string;
+    downloadLink?: string | null;
+  };
+  language?: string;
+  languages?: Record<string, string>;
+  transcriptSettings: {
+    transcriptDownloadHandlerUrl: string;
+    transcriptUploadHandlerUrl: string;
+  };
+}
+
+const toVttTimestamp = (timestamp: string) => timestamp.replace(',', '.');
+const TIMESTAMP_REGEX = /^\d{2}:\d{2}:\d{2},\d{3}$/;
+const hasInvalidCueText = (text = '') => {
+  const lines = text.split(/\r?\n/);
+  return text.trim().length === 0 || lines.some((line) => line.trim().length === 0);
+};
+
+const serializeVtt = (cues: Cue[]) => {
+  const body = cues
+    .map((cue, index) =>
+      `${index + 1}\n${toVttTimestamp(cue.startTime)} --> ${toVttTimestamp(cue.endTime)}\n${cue.text}`
+    )
+    .join('\n\n');
+
+  return `WEBVTT\n\n${body}`;
+};
+
+const TranscriptEditor = ({
+  isOpen,
+  onClose,
+  video,
+  language = '',
+  languages = {},
+  transcriptSettings,
+}: TranscriptEditorProps) => {
+  const intl = useIntl();
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const cueIdRef = useRef(0);
+  const cueListRef = useRef<HTMLDivElement | null>(null);
+  const cueWrapperRefs = useRef<Record<string, HTMLDivElement>>({});
+  const cueTextRefs = useRef<Record<string, HTMLInputElement>>({});
+  const pendingFocusId = useRef<string | null>(null);
+
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
+  const [cues, setCues] = useState<EditorCue[]>([]);
+  const [captionTrackUrl, setCaptionTrackUrl] = useState('');
+  const [currentTime, setCurrentTime] = useState(0);
+  const [initialCuesSnapshot, setInitialCuesSnapshot] = useState('[]');
+  const [isUnsavedModalOpen, setIsUnsavedModalOpen] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+
+  const attachCueIds = (nextCues: (Cue & { id?: string; })[]): EditorCue[] =>
+    nextCues.map((cue) => ({
+      ...cue,
+      id: cue.id ?? `cue-${cueIdRef.current++}`,
+    }));
+
+  const serializeComparableCues = (nextCues: Cue[]) =>
+    JSON.stringify(nextCues.map((cue) => ({
+      startTime: cue.startTime,
+      endTime: cue.endTime,
+      text: cue.text,
+    })));
+
+  const hasUnsavedChanges = useMemo(
+    () => serializeComparableCues(cues) !== initialCuesSnapshot,
+    [cues, initialCuesSnapshot],
+  );
+
+  const hasInvalidCueTextInEditor = useMemo(
+    () => cues.some((cue) => hasInvalidCueText(cue.text)),
+    [cues],
+  );
+
+  const hasInvalidTimestamp = (cue: Cue) => (
+    !TIMESTAMP_REGEX.test(cue.startTime)
+    || !TIMESTAMP_REGEX.test(cue.endTime)
+    || parseTimestamp(cue.endTime) <= parseTimestamp(cue.startTime)
+  );
+
+  const hasInvalidTimestampsInEditor = useMemo(
+    () => cues.some(hasInvalidTimestamp),
+    [cues],
+  );
+
+  const activeCueId = useMemo(() => {
+    const activeCue = cues.find((cue) => (
+      TIMESTAMP_REGEX.test(cue.startTime)
+      && TIMESTAMP_REGEX.test(cue.endTime)
+      && currentTime >= parseTimestamp(cue.startTime)
+      && currentTime < parseTimestamp(cue.endTime)
+    ));
+
+    return activeCue?.id || null;
+  }, [cues, currentTime]);
+
+  useEffect(() => {
+    if (pendingFocusId.current) {
+      const el = cueTextRefs.current[pendingFocusId.current];
+      if (el) {
+        el.focus();
+        pendingFocusId.current = null;
+      }
+    }
+  }, [cues]);
+
+  useEffect(() => {
+    const cueList = cueListRef.current;
+    const activeCue = activeCueId ? cueWrapperRefs.current[activeCueId] : null;
+
+    if (!cueList || !activeCue) {
+      return;
+    }
+
+    const cueListRect = cueList.getBoundingClientRect();
+    const activeCueRect = activeCue.getBoundingClientRect();
+    const nextScrollTop = cueList.scrollTop
+      + activeCueRect.top
+      - cueListRect.top
+      - ((cueListRect.height - activeCueRect.height) / 2);
+
+    if (typeof cueList.scrollTo === 'function') {
+      cueList.scrollTo({
+        top: Math.max(0, nextScrollTop),
+        behavior: 'smooth',
+      });
+    } else {
+      cueList.scrollTop = Math.max(0, nextScrollTop);
+    }
+  }, [activeCueId]);
+
+  const inlineErrorMessage = saveError;
+
+  useEffect(() => {
+    if (!isOpen || !language) {
+      return undefined;
+    }
+
+    let isMounted = true;
+    setLoading(true);
+    setSaveError('');
+    setIsUnsavedModalOpen(false);
+    setCurrentTime(0);
+    setSaveStatus('idle');
+
+    fetchTranscriptContent({
+      videoId: video.id,
+      language,
+      apiUrl: transcriptSettings.transcriptDownloadHandlerUrl,
+    })
+      .then((text: string) => {
+        if (!isMounted) {
+          return undefined;
+        }
+        const parsedCues = parseSrt(text);
+        setCues(attachCueIds(parsedCues));
+        setInitialCuesSnapshot(serializeComparableCues(parsedCues));
+        return undefined;
+      })
+      .catch(() => {
+        if (!isMounted) {
+          return undefined;
+        }
+        setCues([]);
+        setInitialCuesSnapshot('[]');
+        setSaveError(intl.formatMessage(messages.saveFailedLabel));
+        return undefined;
+      })
+      .finally(() => {
+        if (isMounted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [
+    isOpen,
+    language,
+    video.id,
+    transcriptSettings.transcriptDownloadHandlerUrl,
+    intl,
+  ]);
+
+  const handleCueChange = (index: number, value: string) => {
+    setCues(prev =>
+      prev.map((cue, cueIndex) => (
+        cueIndex === index ? { ...cue, text: value } : cue
+      ))
+    );
+  };
+
+  const handleCueTimeChange = (index: number, field: 'startTime' | 'endTime', value: string) => {
+    const normalized = value
+      .replace(/\./g, ',')
+      .replace(/[^\d:,]/g, '')
+      .slice(0, 12);
+
+    setCues(prev =>
+      prev.map((cue, cueIndex) => (
+        cueIndex === index ? { ...cue, [field]: normalized } : cue
+      ))
+    );
+  };
+
+  const handleCueTimeBlur = (index: number, field: 'startTime' | 'endTime', value: string) => {
+    const normalized = value.replace(/\./g, ',').trim();
+    if (!TIMESTAMP_REGEX.test(normalized)) {
+      return;
+    }
+
+    setCues(prev =>
+      prev.map((cue, cueIndex) => (
+        cueIndex === index
+          ? { ...cue, [field]: formatTimestamp(parseTimestamp(normalized)) }
+          : cue
+      ))
+    );
+  };
+
+  const handleDeleteCue = (index: number) => {
+    setCues(prev => prev.filter((_, cueIndex) => cueIndex !== index));
+  };
+
+  const handleInsertCueAfter = (index: number) => {
+    setCues((prev) => {
+      // index === -1 means insert as the very first cue (empty list)
+      if (index === -1) {
+        const newId = `cue-${cueIdRef.current++}`;
+        pendingFocusId.current = newId;
+        return [{
+          id: newId,
+          startTime: formatTimestamp(0),
+          endTime: formatTimestamp(2),
+          text: '',
+        }];
+      }
+
+      const currentCue = prev[index];
+      if (!currentCue) {
+        return prev;
+      }
+
+      const currentEnd = parseTimestamp(currentCue.endTime);
+      const nextStart = prev[index + 1]
+        ? parseTimestamp(prev[index + 1].startTime)
+        : currentEnd + 2;
+
+      const insertedStart = currentEnd;
+      const insertedEnd = nextStart > currentEnd ? Math.min(currentEnd + 2, nextStart) : currentEnd + 2;
+
+      const newId = `cue-${cueIdRef.current++}`;
+      pendingFocusId.current = newId;
+      const newCue = {
+        id: newId,
+        startTime: formatTimestamp(insertedStart),
+        endTime: formatTimestamp(insertedEnd),
+        text: '',
+      };
+
+      const updated = [...prev];
+      updated.splice(index + 1, 0, newCue);
+      return updated;
+    });
+  };
+
+  const seekTo = (timeCode: string) => {
+    if (videoRef.current) {
+      videoRef.current.currentTime = parseTimestamp(timeCode);
+      const playPromise = videoRef.current.play();
+      if (playPromise !== undefined) {
+        playPromise.catch((error: Error) => {
+          if (error.name !== 'AbortError') {
+            logError(error);
+          }
+        });
+      }
+      setCurrentTime(parseTimestamp(timeCode));
+    }
+  };
+
+  const handleVideoTimeUpdate = (event: SyntheticEvent<HTMLVideoElement>) => {
+    setCurrentTime(event.currentTarget.currentTime);
+  };
+
+  useEffect(() => {
+    if (!cues.length) {
+      setCaptionTrackUrl('');
+      return undefined;
+    }
+
+    const vttBlob = new Blob([serializeVtt(cues)], { type: 'text/vtt' });
+    const nextUrl = URL.createObjectURL(vttBlob);
+    setCaptionTrackUrl(nextUrl);
+
+    return () => {
+      URL.revokeObjectURL(nextUrl);
+    };
+  }, [cues]);
+
+  useEffect(() => {
+    if (saveStatus !== 'saved') {
+      return undefined;
+    }
+
+    const timerId = setTimeout(() => {
+      setSaveStatus('idle');
+    }, 5000);
+
+    return () => clearTimeout(timerId);
+  }, [saveStatus]);
+
+  const handleSave = async () => {
+    const hasInvalidCueTextValue = cues.some((cue) => hasInvalidCueText(cue.text));
+    if (hasInvalidCueTextValue) {
+      return;
+    }
+
+    setSaving(true);
+    setSaveStatus('saving');
+    setSaveError('');
+
+    try {
+      const fileName = `${video.displayName}-${language}.srt`;
+      const file = new File([serializeSrt(cues)], fileName, { type: 'text/plain' });
+
+      await uploadTranscript({
+        videoId: video.id,
+        language,
+        newLanguage: language,
+        apiUrl: transcriptSettings.transcriptUploadHandlerUrl,
+        file,
+      });
+
+      setInitialCuesSnapshot(serializeComparableCues(cues));
+      setSaveStatus('saved');
+    } catch (error) {
+      logError(error as Error);
+      setSaveStatus('idle');
+      setSaveError(intl.formatMessage(messages.saveFailedLabel));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRequestClose = () => {
+    if (saving) {
+      return;
+    }
+
+    if (hasUnsavedChanges) {
+      setIsUnsavedModalOpen(true);
+      return;
+    }
+
+    onClose(false);
+  };
+
+  return (
+    <ModalDialog
+      isOpen={isOpen}
+      onClose={handleRequestClose}
+      hasCloseButton
+      isOverflowVisible={false}
+      title={video.displayName}
+      size="xl"
+      className="transcript-editor-modal"
+    >
+      <ModalDialog.Header>
+        <ModalDialog.Title>
+          <div className="d-flex align-items-start justify-content-between w-100 pr-4">
+            <div>
+              <h3 className="font-weight-bold h3 mb-0">{video.displayName}</h3>
+              <h6 className="small text-gray-700 mt-1">{languages?.[language] || language}</h6>
+            </div>
+            {saveStatus === 'saving' && (
+              <div className="d-inline-flex align-items-center text-gray-700 small text-nowrap mt-1">
+                <Spinner
+                  animation="border"
+                  size="sm"
+                  className="mr-2"
+                  screenReaderText={intl.formatMessage(messages.saveInProgressLabel)}
+                />
+                <span>{intl.formatMessage(messages.saveInProgressLabel)}</span>
+              </div>
+            )}
+            {saveStatus === 'saved' && (
+              <div className="d-inline-flex align-items-center text-success small text-nowrap mt-1">
+                <Icon src={CheckCircle} className="mr-2" />
+                <span>{intl.formatMessage(messages.savedLabel)}</span>
+              </div>
+            )}
+          </div>
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+
+      <ModalDialog.Body className="p-0 d-flex flex-column overflow-hidden">
+        {inlineErrorMessage && (
+          <Alert variant="danger" icon={Info} className="mx-4 mt-3 mb-0 flex-shrink-0">
+            {inlineErrorMessage}
+          </Alert>
+        )}
+        {loading ?
+          (
+            <div className="d-flex align-items-center justify-content-center py-5 flex-fill">
+              <Spinner animation="border" screenReaderText={intl.formatMessage(messages.loadingLabel)} />
+            </div>
+          ) :
+          (
+            <>
+              {video.downloadLink && (
+                <div className="transcript-editor-modal__video-container bg-black d-flex align-items-center justify-content-center flex-shrink-0 overflow-hidden">
+                  {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+                  <video
+                    ref={videoRef}
+                    src={video.downloadLink}
+                    controls
+                    controlsList="nodownload"
+                    disablePictureInPicture
+                    onTimeUpdate={handleVideoTimeUpdate}
+                    onSeeked={handleVideoTimeUpdate}
+                    className="transcript-editor-modal__video"
+                  >
+                    <track
+                      key={captionTrackUrl}
+                      kind="captions"
+                      src={captionTrackUrl || ''}
+                      srcLang={language}
+                      label={language.toUpperCase()}
+                      default
+                    />
+                  </video>
+                </div>
+              )}
+
+              <div ref={cueListRef} className="transcript-editor-modal__cue-list overflow-auto flex-grow-1 px-4 py-3">
+                {cues.length === 0 && (
+                  <div className="d-flex justify-content-center py-4">
+                    <Button
+                      variant="outline-primary"
+                      size="sm"
+                      iconBefore={Add}
+                      onClick={() => handleInsertCueAfter(-1)}
+                    >
+                      {intl.formatMessage(messages.insertCueLabel)}
+                    </Button>
+                  </div>
+                )}
+                {cues.map((cue, index) => {
+                  const isActive = activeCueId === cue.id;
+                  const hasCueTextError = hasInvalidCueText(cue.text);
+                  return (
+                    <Stack
+                      key={cue.id}
+                      ref={(el: HTMLDivElement | null) => {
+                        if (el) {
+                          cueWrapperRefs.current[cue.id] = el;
+                        } else {
+                          delete cueWrapperRefs.current[cue.id];
+                        }
+                      }}
+                      gap={2}
+                      className={`px-3 py-2 transcript-editor-modal__cue-wrapper${
+                        isActive ? ' transcript-editor-modal__cue--active' : ''
+                      }`}
+                    >
+                      <Stack
+                        direction="horizontal"
+                        gap={2}
+                        className="transcript-editor-modal__cue-row flex-wrap flex-lg-nowrap align-items-center"
+                      >
+                        <div className="transcript-editor-modal__cue-text-wrap flex-grow-1">
+                          <Form.Control
+                            type="text"
+                            value={cue.text}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                              handleCueChange(index, e.target.value)}
+                            className="transcript-editor-modal__cue-text"
+                            isInvalid={hasCueTextError}
+                            ref={(el: HTMLInputElement | null) => {
+                              if (el) { cueTextRefs.current[cue.id] = el; }
+                              else { delete cueTextRefs.current[cue.id]; }
+                            }}
+                          />
+                          {hasCueTextError && (
+                            <Form.Control.Feedback type="invalid" hasIcon={false}>
+                              {intl.formatMessage(messages.invalidCueTextLabel)}
+                            </Form.Control.Feedback>
+                          )}
+                        </div>
+                        <div className="transcript-editor-modal__time-wrap">
+                          <Form.Control
+                            size="sm"
+                            type="text"
+                            value={cue.startTime}
+                            className="transcript-editor-modal__time"
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                              handleCueTimeChange(index, 'startTime', e.target.value)}
+                            onBlur={(e: React.FocusEvent<HTMLInputElement>) =>
+                              handleCueTimeBlur(index, 'startTime', e.target.value)}
+                          />
+                        </div>
+                        <span className="transcript-editor-modal__time-sep">→</span>
+                        <div className="transcript-editor-modal__time-wrap">
+                          <Form.Control
+                            size="sm"
+                            type="text"
+                            value={cue.endTime}
+                            className="transcript-editor-modal__time"
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                              handleCueTimeChange(index, 'endTime', e.target.value)}
+                            onBlur={(e: React.FocusEvent<HTMLInputElement>) =>
+                              handleCueTimeBlur(index, 'endTime', e.target.value)}
+                          />
+                        </div>
+                        <IconButton
+                          iconAs={Icon}
+                          src={PlayArrow}
+                          alt={intl.formatMessage(messages.seekCueLabel)}
+                          onClick={() => seekTo(cue.startTime)}
+                        />
+                        <IconButton
+                          iconAs={Icon}
+                          src={DeleteOutline}
+                          alt={intl.formatMessage(messages.deleteCueLabel)}
+                          onClick={() => handleDeleteCue(index)}
+                        />
+                      </Stack>
+                      {hasInvalidTimestamp(cue) && (
+                        <div className="text-danger small mt-n1">
+                          {intl.formatMessage(messages.invalidTimestampLabel)}
+                        </div>
+                      )}
+                      <div className="transcript-editor-modal__insert-divider">
+                        <hr className="transcript-editor-modal__insert-divider-line" />
+                        <Button
+                          variant="light"
+                          size="sm"
+                          iconBefore={Add}
+                          className="transcript-editor-modal__insert-btn"
+                          onClick={() => handleInsertCueAfter(index)}
+                        >
+                          {intl.formatMessage(messages.insertCueLabel)}
+                        </Button>
+                      </div>
+                    </Stack>
+                  );
+                })}
+              </div>
+            </>
+          )}
+      </ModalDialog.Body>
+
+      <ModalDialog.Footer>
+        <Button
+          variant="tertiary"
+          onClick={handleRequestClose}
+          disabled={saving}
+        >
+          {intl.formatMessage(messages.cancelButtonLabel)}
+        </Button>
+        <Button
+          onClick={handleSave}
+          disabled={saving || loading || !hasUnsavedChanges || hasInvalidCueTextInEditor ||
+            hasInvalidTimestampsInEditor}
+        >
+          {saving
+            ? intl.formatMessage(messages.saveInProgressLabel)
+            : intl.formatMessage(messages.saveButtonLabel)}
+        </Button>
+      </ModalDialog.Footer>
+
+      {isUnsavedModalOpen && (
+        <ModalDialog
+          isOpen
+          isOverflowVisible={false}
+          size="md"
+          title={intl.formatMessage(messages.unsavedModalTitle)}
+          onClose={() => setIsUnsavedModalOpen(false)}
+        >
+          <ModalDialog.Header>
+            <ModalDialog.Title>{intl.formatMessage(messages.unsavedModalTitle)}</ModalDialog.Title>
+          </ModalDialog.Header>
+          <ModalDialog.Body>
+            <p>{intl.formatMessage(messages.unsavedModalDescription)}</p>
+          </ModalDialog.Body>
+          <ModalDialog.Footer>
+            <Button variant="tertiary" onClick={() => setIsUnsavedModalOpen(false)}>
+              {intl.formatMessage(messages.keepEditingButtonLabel)}
+            </Button>
+            <Button
+              variant="danger"
+              onClick={() => {
+                setIsUnsavedModalOpen(false);
+                onClose(false);
+              }}
+            >
+              {intl.formatMessage(messages.closeEditorButtonLabel)}
+            </Button>
+          </ModalDialog.Footer>
+        </ModalDialog>
+      )}
+    </ModalDialog>
+  );
+};
+
+export default TranscriptEditor;

--- a/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.tsx
+++ b/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.tsx
@@ -85,7 +85,6 @@ const TranscriptEditor = ({
   const cueIdRef = useRef(0);
   const cueListRef = useRef<HTMLDivElement | null>(null);
   const cueWrapperRefs = useRef<Record<string, HTMLDivElement>>({});
-  const cueTextRefs = useRef<Record<string, HTMLInputElement>>({});
   const pendingFocusId = useRef<string | null>(null);
 
   const [loading, setLoading] = useState(false);
@@ -145,7 +144,8 @@ const TranscriptEditor = ({
 
   useEffect(() => {
     if (pendingFocusId.current) {
-      const el = cueTextRefs.current[pendingFocusId.current];
+      const wrapper = cueWrapperRefs.current[pendingFocusId.current];
+      const el = wrapper?.querySelector<HTMLTextAreaElement>('textarea');
       if (el) {
         el.focus();
         pendingFocusId.current = null;
@@ -212,7 +212,7 @@ const TranscriptEditor = ({
         }
         setCues([]);
         setInitialCuesSnapshot('[]');
-        setSaveError(intl.formatMessage(messages.saveFailedLabel));
+        setSaveError(intl.formatMessage(messages.loadFailedLabel));
         return undefined;
       })
       .finally(() => {
@@ -521,16 +521,15 @@ const TranscriptEditor = ({
                       >
                         <div className="transcript-editor-modal__cue-text-wrap flex-grow-1">
                           <Form.Control
-                            type="text"
+                            as="textarea"
+                            autoResize
+                            rows={1}
                             value={cue.text}
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                            aria-label={intl.formatMessage(messages.cueTextLabel, { index: index + 1 })}
+                            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
                               handleCueChange(index, e.target.value)}
                             className="transcript-editor-modal__cue-text"
                             isInvalid={hasCueTextError}
-                            ref={(el: HTMLInputElement | null) => {
-                              if (el) { cueTextRefs.current[cue.id] = el; }
-                              else { delete cueTextRefs.current[cue.id]; }
-                            }}
                           />
                           {hasCueTextError && (
                             <Form.Control.Feedback type="invalid" hasIcon={false}>
@@ -543,6 +542,7 @@ const TranscriptEditor = ({
                             size="sm"
                             type="text"
                             value={cue.startTime}
+                            aria-label={intl.formatMessage(messages.cueStartTimeLabel, { index: index + 1 })}
                             className="transcript-editor-modal__time"
                             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                               handleCueTimeChange(index, 'startTime', e.target.value)}
@@ -556,6 +556,7 @@ const TranscriptEditor = ({
                             size="sm"
                             type="text"
                             value={cue.endTime}
+                            aria-label={intl.formatMessage(messages.cueEndTimeLabel, { index: index + 1 })}
                             className="transcript-editor-modal__time"
                             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                               handleCueTimeChange(index, 'endTime', e.target.value)}

--- a/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.tsx
+++ b/src/files-and-videos/videos-page/transcript-editor/TranscriptEditor.tsx
@@ -287,6 +287,7 @@ const TranscriptEditor = ({
       }
 
       const currentCue = prev[index];
+      /* istanbul ignore if -- insert buttons always pass a valid index */
       if (!currentCue) {
         return prev;
       }
@@ -362,6 +363,7 @@ const TranscriptEditor = ({
 
   const handleSave = async () => {
     const hasInvalidCueTextValue = cues.some((cue) => hasInvalidCueText(cue.text));
+    /* istanbul ignore if -- the save button is disabled in this state */
     if (hasInvalidCueTextValue) {
       return;
     }

--- a/src/files-and-videos/videos-page/transcript-editor/index.ts
+++ b/src/files-and-videos/videos-page/transcript-editor/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TranscriptEditor';

--- a/src/files-and-videos/videos-page/transcript-editor/messages.ts
+++ b/src/files-and-videos/videos-page/transcript-editor/messages.ts
@@ -1,0 +1,81 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  loadingLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.loading',
+    defaultMessage: 'Loading transcript...',
+    description: 'Loading state for transcript editor',
+  },
+  saveButtonLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.save',
+    defaultMessage: 'Save',
+    description: 'Save button label for transcript editor',
+  },
+  cancelButtonLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.cancel',
+    defaultMessage: 'Cancel',
+    description: 'Cancel button label for transcript editor',
+  },
+  saveFailedLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.saveFailed',
+    defaultMessage: 'Unable to save transcript, please try again.',
+    description: 'Error shown when transcript save fails',
+  },
+  saveInProgressLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.saving',
+    defaultMessage: 'Saving...',
+    description: 'Label shown while transcript save is in progress',
+  },
+  savedLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.saved',
+    defaultMessage: 'Saved',
+    description: 'Label shown when transcript save is successful',
+  },
+  insertCueLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.insertCue',
+    defaultMessage: 'Insert cue here',
+    description: 'Label for inserting a new cue between transcript cues',
+  },
+  deleteCueLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.deleteCue',
+    defaultMessage: 'Delete cue',
+    description: 'Accessible label for deleting a transcript cue',
+  },
+  seekCueLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.seekCue',
+    defaultMessage: 'Seek to cue time',
+    description: 'Accessible label for seek button in cue row',
+  },
+  invalidTimestampLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.invalidTimestamp',
+    defaultMessage: 'Please use valid cue times in HH:MM:SS,mmm format.',
+    description: 'Error shown when one or more cue timestamps are invalid',
+  },
+  unsavedModalTitle: {
+    id: 'course-authoring.video-uploads.transcriptEditor.unsavedModalTitle',
+    defaultMessage: 'Unsaved changes',
+    description: 'Title for unsaved changes warning modal',
+  },
+  unsavedModalDescription: {
+    id: 'course-authoring.video-uploads.transcriptEditor.unsavedModalDescription',
+    defaultMessage: 'Are you sure you want to leave the editor? All unsaved changes will be lost.',
+    description: 'Description for unsaved changes warning modal',
+  },
+  keepEditingButtonLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.keepEditing',
+    defaultMessage: 'Keep editing',
+    description: 'Button label to keep editing transcript changes',
+  },
+  closeEditorButtonLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.closeEditor',
+    defaultMessage: 'Leave editor',
+    description: 'Button label to close transcript editor and discard changes',
+  },
+  invalidCueTextLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.invalidCueText',
+    defaultMessage: 'Cue text cannot be empty.',
+    description: 'Error shown when one or more cue texts are empty',
+  },
+});
+
+export default messages;

--- a/src/files-and-videos/videos-page/transcript-editor/messages.ts
+++ b/src/files-and-videos/videos-page/transcript-editor/messages.ts
@@ -76,6 +76,26 @@ const messages = defineMessages({
     defaultMessage: 'Cue text cannot be empty.',
     description: 'Error shown when one or more cue texts are empty',
   },
+  loadFailedLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.loadFailed',
+    defaultMessage: 'Unable to load transcript, please try again.',
+    description: 'Error shown when the transcript could not be downloaded into the editor',
+  },
+  cueTextLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.cueTextLabel',
+    defaultMessage: 'Cue {index} text',
+    description: 'Accessible label for the text field of a transcript cue',
+  },
+  cueStartTimeLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.cueStartTimeLabel',
+    defaultMessage: 'Cue {index} start time',
+    description: 'Accessible label for the start timestamp field of a transcript cue',
+  },
+  cueEndTimeLabel: {
+    id: 'course-authoring.video-uploads.transcriptEditor.cueEndTimeLabel',
+    defaultMessage: 'Cue {index} end time',
+    description: 'Accessible label for the end timestamp field of a transcript cue',
+  },
 });
 
 export default messages;

--- a/src/files-and-videos/videos-page/transcript-editor/srtUtils.test.ts
+++ b/src/files-and-videos/videos-page/transcript-editor/srtUtils.test.ts
@@ -1,0 +1,94 @@
+import {
+  formatTimestamp,
+  isValidSrt,
+  parseSrt,
+  parseTimestamp,
+  serializeSrt,
+} from './srtUtils';
+
+const SRT = [
+  '1',
+  '00:00:01,000 --> 00:00:02,500',
+  'Hello there',
+  '',
+  '2',
+  '00:00:03,000 --> 00:00:04,000',
+  'Second cue',
+].join('\n');
+
+describe('parseSrt', () => {
+  it('parses indexed cue blocks', () => {
+    expect(parseSrt(SRT)).toEqual([
+      { startTime: '00:00:01,000', endTime: '00:00:02,500', text: 'Hello there' },
+      { startTime: '00:00:03,000', endTime: '00:00:04,000', text: 'Second cue' },
+    ]);
+  });
+
+  it('parses cue blocks without index lines', () => {
+    const noIndex = '00:00:01,000 --> 00:00:02,000\nHi\n\n00:00:03,000 --> 00:00:04,000\nBye';
+    expect(parseSrt(noIndex)).toEqual([
+      { startTime: '00:00:01,000', endTime: '00:00:02,000', text: 'Hi' },
+      { startTime: '00:00:03,000', endTime: '00:00:04,000', text: 'Bye' },
+    ]);
+  });
+
+  it('keeps multi-line cue text together', () => {
+    const multi = '1\n00:00:01,000 --> 00:00:02,000\nline one\nline two';
+    expect(parseSrt(multi)[0].text).toBe('line one\nline two');
+  });
+
+  it('drops blocks with a malformed timestamp line', () => {
+    const partiallyBroken = `${SRT}\n\n3\nnot a timestamp\nBroken`;
+    expect(parseSrt(partiallyBroken)).toHaveLength(2);
+  });
+
+  it('returns an empty list for empty or non-string input', () => {
+    expect(parseSrt('')).toEqual([]);
+    expect(parseSrt(null)).toEqual([]);
+    expect(parseSrt(undefined)).toEqual([]);
+  });
+});
+
+describe('serializeSrt', () => {
+  it('re-numbers cues and round-trips through parseSrt', () => {
+    const cues = parseSrt(SRT);
+    const serialized = serializeSrt(cues);
+    expect(serialized.startsWith('1\n00:00:01,000 --> 00:00:02,500\nHello there')).toBe(true);
+    expect(parseSrt(serialized)).toEqual(cues);
+  });
+});
+
+describe('parseTimestamp / formatTimestamp', () => {
+  it('parses SRT timestamps into seconds', () => {
+    expect(parseTimestamp('01:02:03,450')).toBeCloseTo(3723.45);
+    expect(parseTimestamp('00:00:00,000')).toBe(0);
+  });
+
+  it('formats seconds into SRT timestamps and round-trips', () => {
+    expect(formatTimestamp(3723.45)).toBe('01:02:03,450');
+    expect(parseTimestamp(formatTimestamp(59.999))).toBeCloseTo(59.999);
+  });
+
+  it('clamps negative and non-numeric input to zero', () => {
+    expect(formatTimestamp(-5)).toBe('00:00:00,000');
+    expect(formatTimestamp(NaN)).toBe('00:00:00,000');
+  });
+});
+
+describe('isValidSrt', () => {
+  it('accepts well-formed content, with or without index lines', () => {
+    expect(isValidSrt(SRT)).toBe(true);
+    expect(isValidSrt('00:00:01,000 --> 00:00:02,000\nHi')).toBe(true);
+  });
+
+  it('treats empty or blank content as a valid empty transcript', () => {
+    expect(isValidSrt('')).toBe(true);
+    expect(isValidSrt(null)).toBe(true);
+    expect(isValidSrt('   \n \n  ')).toBe(true);
+  });
+
+  it('rejects content where any block is malformed', () => {
+    expect(isValidSrt(`${SRT}\n\n3\nnot a timestamp\nBroken`)).toBe(false);
+    expect(isValidSrt('just some text')).toBe(false);
+  });
+});

--- a/src/files-and-videos/videos-page/transcript-editor/srtUtils.test.ts
+++ b/src/files-and-videos/videos-page/transcript-editor/srtUtils.test.ts
@@ -42,6 +42,10 @@ describe('parseSrt', () => {
     expect(parseSrt(partiallyBroken)).toHaveLength(2);
   });
 
+  it('drops blocks that have fewer than two lines', () => {
+    expect(parseSrt(`${SRT}\n\nlonely line`)).toHaveLength(2);
+  });
+
   it('returns an empty list for empty or non-string input', () => {
     expect(parseSrt('')).toEqual([]);
     expect(parseSrt(null)).toEqual([]);
@@ -62,6 +66,7 @@ describe('parseTimestamp / formatTimestamp', () => {
   it('parses SRT timestamps into seconds', () => {
     expect(parseTimestamp('01:02:03,450')).toBeCloseTo(3723.45);
     expect(parseTimestamp('00:00:00,000')).toBe(0);
+    expect(parseTimestamp('00:01:00')).toBe(60);
   });
 
   it('formats seconds into SRT timestamps and round-trips', () => {

--- a/src/files-and-videos/videos-page/transcript-editor/srtUtils.ts
+++ b/src/files-and-videos/videos-page/transcript-editor/srtUtils.ts
@@ -1,0 +1,90 @@
+export interface Cue {
+  startTime: string;
+  endTime: string;
+  text: string;
+}
+
+export const parseSrt = (text: string | null | undefined): Cue[] => {
+  if (!text || typeof text !== 'string') {
+    return [];
+  }
+
+  return text
+    .trim()
+    .split(/\n\s*\n/)
+    .map((block) => block.split('\n'))
+    .map((lines): Cue | null => {
+      if (lines.length < 2) {
+        return null;
+      }
+
+      const hasIndex = /^\d+$/.test(lines[0].trim());
+      const timeLine = hasIndex ? lines[1] : lines[0];
+      const textLines = hasIndex ? lines.slice(2) : lines.slice(1);
+
+      const match = timeLine.match(/(\d{2}:\d{2}:\d{2},\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2},\d{3})/);
+      if (!match) {
+        return null;
+      }
+
+      return {
+        startTime: match[1],
+        endTime: match[2],
+        text: textLines.join('\n').trim(),
+      };
+    })
+    .filter((cue): cue is Cue => cue !== null);
+};
+
+export const serializeSrt = (cues: Cue[]): string =>
+  cues
+    .map((cue, index) => `${index + 1}\n${cue.startTime} --> ${cue.endTime}\n${cue.text}`)
+    .join('\n\n');
+
+export const parseTimestamp = (timestamp: string): number => {
+  const [hms, ms] = timestamp.split(',');
+  const [hours, minutes, seconds] = hms.split(':').map(Number);
+  return (hours * 3600) + (minutes * 60) + seconds + (Number(ms || 0) / 1000);
+};
+
+export const formatTimestamp = (totalSeconds: number): string => {
+  const safeSeconds = Math.max(0, Number(totalSeconds) || 0);
+  const hours = Math.floor(safeSeconds / 3600);
+  const minutes = Math.floor((safeSeconds % 3600) / 60);
+  const seconds = Math.floor(safeSeconds % 60);
+  const milliseconds = Math.round((safeSeconds - Math.floor(safeSeconds)) * 1000);
+
+  const pad2 = (value: number) => String(value).padStart(2, '0');
+  const pad3 = (value: number) => String(value).padStart(3, '0');
+
+  return `${pad2(hours)}:${pad2(minutes)}:${pad2(seconds)},${pad3(milliseconds)}`;
+};
+
+/**
+ * Strictly validates SRT content.
+ * Returns true for empty/blank files (valid empty transcript).
+ * Returns false if the file has cue blocks where ANY block has a malformed
+ * timestamp line (partial corruption is not allowed).
+ */
+export const isValidSrt = (text: string | null | undefined): boolean => {
+  if (!text || typeof text !== 'string') {
+    return true;
+  }
+
+  const blocks = text.trim().split(/\n\s*\n/).filter((b) => b.trim().length > 0);
+  if (blocks.length === 0) {
+    return true;
+  }
+
+  const TIMESTAMP_LINE = /^\d{2}:\d{2}:\d{2},\d{3}\s*-->\s*\d{2}:\d{2}:\d{2},\d{3}/;
+
+  return blocks.every((block) => {
+    const lines = block.trim().split('\n').map((l) => l.trim());
+    if (lines.length < 2) {
+      return false;
+    }
+    const hasIndex = /^\d+$/.test(lines[0]);
+    const timeLine = hasIndex ? lines[1] : lines[0];
+    return TIMESTAMP_LINE.test(timeLine);
+  });
+};


### PR DESCRIPTION
Adds an **in-platform transcript editor** to the Studio videos page. Course authors can
open "Edit transcript" from a transcript row's action menu and edit the SRT in the
browser instead of the download → edit locally → re-upload round-trip.

What's included:

- New `transcript-editor/` module: cue-by-cue text editing with SRT parsing/validation
  (`srtUtils`), invalid-SRT alerting, debounced auto-save, and a video preview with
  click-to-seek + active-cue highlighting and auto-scroll.
- The video **Info** content moves under the preview (`InfoTab` via a new
  `infoModalContentUnderPreview` slot on `FileTable`/`InfoModal`), and the info sidebar
  lists transcripts directly - this intentionally supersedes the previous tabbed
  sidebar layout for videos.
- The row action menu label for videos changes from "Info" to **"Info and
  transcripts"** (`FileMenu`, `MoreInfoColumn`); two existing tests that asserted the
  old label on video fixtures are updated.
- Saving a transcript re-uploads the SRT through the existing `/transcript_upload/`
  endpoint; the UI distinguishes replace (200) from create (201) - see dependency
  below.

**Impacted user roles:** Course Authors (primary); Developers (new
`transcript-editor` module and the `infoModalContentUnderPreview` extension point on
the generic file table).

**Screen recording:**
- Before:

https://github.com/user-attachments/assets/69536db8-287a-4f6c-85ee-7fa89399e34f

- After

https://github.com/user-attachments/assets/0cac7230-45ea-44ff-b30c-8cd9455805ff


## Supporting information

- **Depends on** https://github.com/openedx/openedx-platform/pull/39038 (200-on-replace for
  `/transcript_upload/`) - please merge that first; without it the editor cannot
  distinguish replace from create.
- Product review: [Transcript Editor - accepted product proposal](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/6508281867/product+proposal+Add+an+in-platform+text+editor+to+adjust+transcripts+without+downloading+in+Studio) (approved via the Open edX product review process; this repo's maintainer agreed to maintain the feature).

## Testing instructions

Automated:

```bash
npm ci
npx jest src/files-and-videos --coverage=false
# 20 suites / 229 tests expected green
```

Manual (tutor dev):

1. Check out https://github.com/openedx/openedx-platform/pull/39038 in your platform (or any branch
   containing it) and run Studio.
2. `npm run dev` in this repo (port 2001); open a course with videos that have
   transcripts → **Videos** page.
3. Row ⋮ menu shows **"Info and transcripts"** (videos only; Files page unchanged);
   the info modal shows the video preview with Info content **below** it and
   transcripts listed in the sidebar.
4. Transcript row menu → **Edit transcript**: edit a cue, watch auto-save, Save;
   reopen to confirm persistence; click cues to seek the preview.
5. Paste invalid SRT content → validation alert, save blocked.
6. Network tab: re-saving an existing language returns 200; adding a new language
   returns 201.

## Other information

- **Port provenance & adaptations** (for reviewers comparing against the downstream
  PRs): rebased onto current master, which required - merging with the new
  `permissions` gating in `FileTable`/`MoreInfoColumn`; porting one-line changes into
  the TS-renamed `FileMenu.tsx` and `messages.ts` files; re-applying the
  `injectIntl → useIntl` migration on top of the reworked `Transcript.jsx`; and
  keeping upstream's `key={idx}` fix in `TranscriptTab`.
- `CourseVideosTable` still passes `activeTab`/`setActiveTab` into the sidebar factory
  for compatibility; the new sidebar ignores them. Happy to remove that plumbing here
  or in a follow-up if preferred.
- Playback: `seekTo()` guards the `play()` promise and ignores `AbortError`
  (interrupted play on rapid cue-seek/pause/unmount), logging anything else.
- Accessibility: built from Paragon components (`Menu`, `AlertModal`, form controls);
  no dedicated audit yet - feedback welcome, especially on cue-list keyboard
  navigation.
- i18n: all new messages include translator `description`s; existing message ids are
  unchanged so downstream translations carry over.

## Best Practices Checklist

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
      - The new `transcript-editor/` module is ported as `.jsx`/`.js` to stay
      reviewably close to the downstream original. **Happy to convert
      `TranscriptEditor`/`srtUtils` to TS in this PR if preferred** - say the word.
- [ ] Avoid `propTypes` and `defaultProps` in any new or modified code.
      - Ported/modified components follow the surrounding files' existing
      PropTypes style; will drop them as part of the TS conversion above if requested.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (`initializeMocks`)
      - Changes extend the existing `videos-page` suites, which predate
      `initializeMocks`; kept their established setup for consistency.
- [x] Do not add new fields to the Redux state/store. (No slice/thunk changes;
      editor state is component-local.)
- [ ] Use React Query to load data from REST APIs.
      - Transcript content is fetched via the page's existing axios helpers
      (`videos-page/data/api.js`); this page has not been migrated to React Query yet.
- [x] All new i18n messages in `messages` files have a `description` for translators.
- [x] Avoid `../` in import paths; use `@src` for parent-folder imports.

## Relevant backend PR
- https://github.com/openedx/openedx-platform/pull/39038

