### PR TITLE
fix: leave new dropdown answers empty instead of "undefined" [backport to verawood]

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -261,7 +261,7 @@ export class OLXParser {
         const preservedFeedback = preservedAnswers[index].filter(answer =>
           Object.keys(answer).includes(`${option}hint`)
         );
-        let title = String(element['#text']);
+        let title = String(element['#text'] ?? '');
 
         if (isComplexAnswer && preservedAnswer) {
           title = this.richTextBuilder.build(preservedAnswer);
@@ -281,7 +281,7 @@ export class OLXParser {
     } else {
       const preservedAnswer = preservedAnswers[0].filter(answer => !Object.keys(answer).includes(`${option}hint`));
       const preservedFeedback = preservedAnswers[0].filter(answer => Object.keys(answer).includes(`${option}hint`));
-      let title = String(choice['#text']);
+      let title = String(choice['#text'] ?? '');
 
       if (isComplexAnswer && preservedAnswer) {
         title = this.richTextBuilder.build(preservedAnswer);

--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -1,3 +1,4 @@
+import dropdownTemplate from '@src/editors/data/constants/basicProblemTemplates/dropdown';
 import { OLXParser } from './OLXParser';
 import {
   checkboxesOLXWithFeedbackAndHintsOLX,
@@ -132,6 +133,13 @@ describe('OLXParser', () => {
       const problemType = numericOlxParser.getProblemType();
       it('should equal ProblemTypeKeys.NUMERIC', () => {
         expect(problemType).toEqual(ProblemTypeKeys.NUMERIC);
+      });
+    });
+    describe('given the blank dropdown template', () => {
+      const olxparser = new OLXParser(dropdownTemplate.olx);
+      const { answers } = olxparser.parseMultipleChoiceAnswers('optionresponse', 'optioninput', 'option');
+      it('should leave every answer empty, so the editor shows its placeholder', () => {
+        expect(answers.map(answer => answer.title)).toEqual(['', '', '']);
       });
     });
     describe('given dropdown olx with feedback and hints', () => {


### PR DESCRIPTION
## Description

Backport of #3216 to `release/verawood`.

Adding a dropdown problem in Studio used to fill all three answers with the word `undefined`. The fields look filled in, their "Enter an answer" placeholder never shows, and an author has to clear each one before typing. Every other problem type starts with empty answers.

New dropdown answers now start empty, like the rest.

<details><summary>Implementation notes</summary>

- The blank dropdown template writes `<option correct="True"></option>`, so the parsed element has no `#text`. `OLXParser.parseMultipleChoiceAnswers` ran that through `String()`, which turns `undefined` into the string `"undefined"`.
- Single select and multi-select never showed it because they are in `RichTextProblems`: their titles are rebuilt from the preserved rich text on the very next line. Dropdown answers are plain text, so the string survived.
- `?? ''` rather than a falsy check, so an option whose text is `0` or `false` still parses to that value.
- Both branches of the parser are fixed — the one for several options and the one for a single option.

</details>

## Screenshot/Video

| Before | After |
|:------:|:-----:|
|   <img width="1440" height="863" alt="01-dropdown-before" src="https://github.com/user-attachments/assets/20f53e93-2f8f-493f-8a1f-a933468c60d0" />     |    <img width="1440" height="863" alt="02-dropdown-after" src="https://github.com/user-attachments/assets/a990dbc9-5c9b-4420-9d55-c292d4215443" />   |

## Testing

1. In Studio, add a new Problem component to a unit and pick **Dropdown**.
2. Expected: the three answer fields are empty and show the "Enter an answer" placeholder. Before this change each held the word `undefined`.
3. Type an answer into the first field and save, then reopen the editor.
4. Expected: the answer is what you typed.
5. Repeat step 1 for Single select, Multi-select, Numerical input and Text input.
6. Expected: unchanged — all of them already started empty.
7. Open an existing dropdown problem that has answers.
8. Expected: its answers are unchanged.

## Verified locally

| Check | Result |
|---|---|
| New dropdown problem in the running Studio | three answer fields empty with the placeholder visible; before the fix each held `undefined` |
| Parser on the blank templates | dropdown now yields `["", "", ""]`, matching single select; before it yielded `["undefined", "undefined", "undefined"]` |
| Regression test in `OLXParser.test.js` | the blank dropdown template parses to three empty titles |
| Red/green | restoring the old `String()` call fails exactly that test |
| `jest src/editors/containers/ProblemEditor` | 44 suites, 326 tests |
| `tsc`, `dprint`, `oxlint` | clean, including the stricter upstream rule set |
| **Not verified** | Only the five basic problem types were checked by hand; advanced types open in the raw OLX editor and do not go through this parser path. |
