### PR TITLE
fix: repair the image gallery sort control [backport to verawood]

### DIFF
--- a/src/editors/sharedComponents/SelectionModal/SearchSort.jsx
+++ b/src/editors/sharedComponents/SelectionModal/SearchSort.jsx
@@ -71,7 +71,7 @@ const SearchSort = ({
           >
             <span className="search-sort-menu-by">
               <FormattedMessage {...messages.sortBy} />
-              <span style={{ whiteSpace: 'pre-wrap' }}></span>
+              <span style={{ whiteSpace: 'pre-wrap' }}>{' '}</span>
             </span>
             <FormattedMessage {...sortMessages[key]} />
           </MenuItem>

--- a/src/editors/sharedComponents/SelectionModal/SearchSort.test.jsx
+++ b/src/editors/sharedComponents/SelectionModal/SearchSort.test.jsx
@@ -71,6 +71,11 @@ describe('SearchSort component', () => {
           .toBeInTheDocument();
       });
   });
+  test('separates "By" from the sort option', () => {
+    getComponent();
+    expect(screen.getByRole('button', { name: /By oldest/i }))
+      .toHaveTextContent('By oldest');
+  });
   test('adds a filter option for each filter key', () => {
     const { getByTestId } = getComponent();
     fireEvent.click(getByTestId('dropdown-filter'));

--- a/src/editors/sharedComponents/SelectionModal/index.scss
+++ b/src/editors/sharedComponents/SelectionModal/index.scss
@@ -38,3 +38,9 @@
     max-width: 100%;
     max-height: 100%;
 }
+
+/* The sort menu is wider than its toggle; anchor it right so it stays inside the modal. */
+.search-sort-menu .pgn__menu-select-popup > div {
+    left: auto !important;
+    right: 0 !important;
+}


### PR DESCRIPTION
## Description

The "Add an image" gallery in the rich-text editors has two problems with its sort control.

Its label reads `Bynewest` — the space between the "By" prefix and the sort option is missing, so every option renders as `Byoldest`, `ByName A-Z` and so on. The label now reads "By newest" again.

Opening that control made the whole modal scroll sideways: the menu is wider than the button it hangs from, so it spilled past the modal's right edge and the modal grew a horizontal scrollbar. The menu now stays inside the modal and the scrollbar is gone.

Both apply to the video gallery too, which uses the same control.

<details><summary>Implementation notes</summary>

- The space was a literal JSX text node in `SearchSort.jsx`. dprint strips those between elements, and it did so in #2997 when it replaced eslint — running `dprint fmt` on the restored literal removes it again. `{' '}` survives formatting.
- The existing `SearchSort` tests already match on `By oldest`, but that is the accessible name, and the accname algorithm space-joins text across element boundaries, so they read "By oldest" from markup that displays "Byoldest". The new test asserts the rendered text instead.
- `SelectMenu` hard-codes `placement="bottom-start"` and exposes no alignment prop, and its menu is `--pgn-size-menu-item-width-base`, 19rem, against a toggle of about 9rem. Measured in the running Studio: the menu ran to x=1258 while the modal ended at x=1120, and the modal's `scrollWidth` exceeded its `clientWidth` by 138px.
- The popper wrapper carries the placement inline, so overriding it needs `!important`. Popper's own transform stays 0,0 here, so the menu simply anchors to the toggle's other edge.

</details>

## Screenshot/Video

| Before | After |
|:------:|:-----:|
| <img width="2880" height="1726" alt="before-01-label" src="https://github.com/user-attachments/assets/ddf1270a-c689-4320-a100-9c1ffcaf4b74" /> | <img width="2880" height="1726" alt="after-01-label" src="https://github.com/user-attachments/assets/e29fba93-1fdd-482d-99f2-3b8b5de47ff8" /> |
| <img width="2880" height="1726" alt="before-02-menu" src="https://github.com/user-attachments/assets/1a533915-65db-4227-872b-ca8d9b320dcf" /> | <img width="2880" height="1726" alt="after-02-menu" src="https://github.com/user-attachments/assets/4d7e5c04-b097-423c-8817-5dc42292d1f3" /> |


## Testing

1. In Studio, open any Problem component for editing — for example a Single select.
2. In the Question toolbar, click the image button. The "Add an image" modal opens.
3. Expected: the control in the top right reads "By newest". Before this change it read "Bynewest".
4. Click it to open the sort menu.
5. Expected: the menu stays inside the modal and no horizontal scrollbar appears along the bottom of the modal. Before this change the menu hung past the modal's right edge and the modal scrolled sideways.
6. Pick each option in turn — Oldest, Name A-Z, Name Z-A, Shortest, Longest.
7. Expected: the label reads "By oldest", "By Name A-Z" and so on, and the gallery reorders.
8. Repeat from a Text component and from a course custom page.
9. Expected: the same.
10. Add a Video component to a unit so the video gallery opens.
11. Expected: the same sort control, also with a space and also contained. Its filter dropdown and the "Show only my videos" switch are unchanged.

## Verified locally

| Check | Result |
|---|---|
| Sort label in a running Studio | "By newest"; the button's text content went from `Bynewest` to `By newest` |
| Menu geometry with the menu open | menu 772–1076 against a modal of 320–1120; before the fix 954–1258 |
| Modal overflow | `scrollWidth - clientWidth` went from 138px to 0; no element in the modal reports a horizontal scrollbar |
| Toggle placed mid-row, as in the video gallery | menu 462–766 inside a body of 174–1266, still no overflow |
| `dprint fmt` on the restored literal space | strips it again; `{' '}` survives — this is why the fix takes that form |
| New test red/green | fails with `Bynewest`, passes after; the four existing tests pass either way |
| `jest` on SelectionModal, ImageUploadModal, VideoGallery | 14 suites, 168 tests |
| `npm run lint`, `tsc --noEmit` | clean |
| **Not verified** | The video gallery was not opened in the browser — adding a Video component creates a block in the course. Its layout was checked by placing the sort toggle mid-row in the image gallery, which is the same component with the same neighbours. |