### PR TITLE
feat: Migrate pages and resources to React Query

### DIFF
--- a/src/CourseAuthoringContext.test.tsx
+++ b/src/CourseAuthoringContext.test.tsx
@@ -1,0 +1,38 @@
+import { CourseAuthoringProvider, useCourseAuthoringContext } from './CourseAuthoringContext';
+import { getApiWaffleFlagsUrl, getCourseAppsApiUrl } from './data/api';
+import { initializeMocks, render, screen } from './testUtils';
+
+const courseId = 'course-v1:edX+DemoX+Demo_Course';
+
+const CourseAppsList = () => {
+  const { courseApps } = useCourseAuthoringContext();
+  return (
+    <ul>
+      {courseApps.map(app => <li key={app.id}>{app.id}</li>)}
+    </ul>
+  );
+};
+
+describe('CourseAuthoringProvider', () => {
+  it('sorts course apps according to COURSE_APPS_ORDER', async () => {
+    const { axiosMock } = initializeMocks();
+    axiosMock.onGet(getApiWaffleFlagsUrl(courseId)).reply(200, {});
+    axiosMock.onGet(`${getCourseAppsApiUrl()}/${courseId}`).reply(200, [
+      {
+        id: 'wiki', name: 'Wiki', description: '', enabled: true, allowed_operations: { enable: true, configure: true },
+      },
+      {
+        id: 'discussion', name: 'Discussion', description: '', enabled: true, allowed_operations: { enable: true, configure: true },
+      },
+    ]);
+
+    render(
+      <CourseAuthoringProvider courseId={courseId}>
+        <CourseAppsList />
+      </CourseAuthoringProvider>,
+    );
+
+    const items = await screen.findAllByRole('listitem');
+    expect(items.map(item => item.textContent)).toEqual(['discussion', 'wiki']);
+  });
+});

--- a/src/data/apiHooks.test.tsx
+++ b/src/data/apiHooks.test.tsx
@@ -1,12 +1,16 @@
+import { renderHook } from '@testing-library/react';
 import {
   initializeMocks,
   cleanup,
   screen,
   render,
   waitFor,
+  makeQueryClientWrapper,
 } from '../testUtils';
-import { useWaffleFlags } from './apiHooks';
-import { getApiWaffleFlagsUrl } from './api';
+import { useWaffleFlags, useUpdateCourseAppStatus, useUpdateCourseAdvancedSettings } from './apiHooks';
+import { getApiWaffleFlagsUrl, getCourseAppsApiUrl, getCourseAdvancedSettingsApiUrl } from './api';
+
+const courseId = 'course-v1:edX+DemoX+Demo_Course';
 
 // A little component for testing our waffle flag hooks.
 const FlagComponent = ({ courseId }: { courseId?: string; }) => {
@@ -108,5 +112,46 @@ describe('useWaffleFlags', () => {
     });
     expect(await screen.findByLabelText('isError')).toHaveTextContent('false');
     expect(await screen.findByLabelText('useReactMarkdownEditor')).toHaveTextContent('enabled');
+  });
+});
+
+describe('useUpdateCourseAppStatus', () => {
+  it('sends a PATCH request and invalidates the course apps query on success', async () => {
+    const { axiosMock, queryClient } = initializeMocks();
+    axiosMock.onPatch(`${getCourseAppsApiUrl()}/${courseId}`).reply(200);
+    const invalidateQueriesSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(
+      () => useUpdateCourseAppStatus(courseId),
+      { wrapper: makeQueryClientWrapper(queryClient) },
+    );
+
+    result.current.mutate({ appId: 'discussion', state: true });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(axiosMock.history.patch[0].url).toBe(`${getCourseAppsApiUrl()}/${courseId}`);
+    expect(JSON.parse(axiosMock.history.patch[0].data)).toEqual({ id: 'discussion', enabled: true });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ['courseApps', courseId] });
+  });
+});
+
+describe('useUpdateCourseAdvancedSettings', () => {
+  it('sends a PATCH request and invalidates the course settings and apps queries on success', async () => {
+    const { axiosMock, queryClient } = initializeMocks();
+    axiosMock.onPatch(`${getCourseAdvancedSettingsApiUrl()}/${courseId}`).reply(200, {});
+    const invalidateQueriesSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(
+      () => useUpdateCourseAdvancedSettings(courseId),
+      { wrapper: makeQueryClientWrapper(queryClient) },
+    );
+
+    result.current.mutate({ setting: 'courseDisplayName', value: 'New Name' });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(axiosMock.history.patch[0].url).toBe(`${getCourseAdvancedSettingsApiUrl()}/${courseId}`);
+    expect(JSON.parse(axiosMock.history.patch[0].data)).toEqual({ course_display_name: { value: 'New Name' } });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ['courseSettings', courseId] });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ['courseApps', courseId] });
   });
 });


### PR DESCRIPTION
## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be linked here.

Useful information to include:

- Which user roles will this change impact? Common user roles are "Learner", "Course Author",
  "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).

## Supporting information

Link to other information about the change, such as GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for manually testing this change.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Avoid using `../` in import paths. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
