### PR TITLE
fix: correct course outline control semantics

### DIFF
--- a/src/course-outline/card-header/CardHeader.test.tsx
+++ b/src/course-outline/card-header/CardHeader.test.tsx
@@ -121,6 +121,7 @@ describe('<CardHeader />', () => {
     expect(await screen.findByText(cardHeaderProps.title)).toBeInTheDocument();
     expect(await screen.findByTestId('subsection-card-header__expanded-btn')).toBeInTheDocument();
     expect(await screen.findByTestId('subsection-card-header__menu')).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: `Actions for ${cardHeaderProps.title}` })).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.queryByTestId('edit field')).not.toBeInTheDocument();
     });

--- a/src/course-outline/card-header/CardHeader.tsx
+++ b/src/course-outline/card-header/CardHeader.tsx
@@ -322,7 +322,7 @@ const CardHeader = ({
                 data-testid={`${namePrefix}-card-header__menu-button`}
                 as={IconButton}
                 src={MoveVertIcon}
-                alt={`${namePrefix}-card-header__menu`}
+                alt={intl.formatMessage(messages.cardActions, { title })}
                 iconAs={Icon}
               />
               <Dropdown.Menu>

--- a/src/course-outline/card-header/messages.ts
+++ b/src/course-outline/card-header/messages.ts
@@ -37,6 +37,11 @@ const messages = defineMessages({
     id: 'course-authoring.course-outline.card.button.edit.alt',
     defaultMessage: 'Rename',
   },
+  cardActions: {
+    id: 'course-authoring.course-outline.card.actions',
+    defaultMessage: 'Actions for {title}',
+    description: 'Accessible label for the menu of actions available for a course outline card.',
+  },
   menuPublish: {
     id: 'course-authoring.course-outline.card.menu.publish',
     defaultMessage: 'Publish',

--- a/src/generic/sidebar/Sidebar.test.tsx
+++ b/src/generic/sidebar/Sidebar.test.tsx
@@ -60,17 +60,19 @@ describe('<Sidebar>', () => {
     // Check the Page 1 content
     expect(screen.getByText('Component 1')).toBeInTheDocument();
 
-    // Check the IconButtonToggle
+    // Check the sidebar toggle buttons
     const sidebarToggle = screen.getByTestId('sidebar-toggle');
     expect(sidebarToggle).toBeInTheDocument();
 
     const page1Button = within(sidebarToggle).getByRole('button', { name: 'Page 1' });
     expect(page1Button).toBeInTheDocument();
-    expect(page1Button).toHaveAttribute('aria-selected', 'true');
+    expect(page1Button).toHaveAttribute('aria-pressed', 'true');
+    expect(page1Button).not.toHaveAttribute('aria-selected');
 
     const page2Button = within(sidebarToggle).getByRole('button', { name: 'Page 2' });
     expect(page2Button).toBeInTheDocument();
-    expect(page2Button).toHaveAttribute('aria-selected', 'false');
+    expect(page2Button).toHaveAttribute('aria-pressed', 'false');
+    expect(page2Button).not.toHaveAttribute('aria-selected');
   });
 
   it('should change pages using the icon button', async () => {
@@ -82,13 +84,13 @@ describe('<Sidebar>', () => {
     const page2Button = screen.getByRole('button', { name: 'Page 2' });
     await userEvent.click(page2Button);
 
-    expect(page2Button).toHaveAttribute('aria-selected', 'true');
+    expect(page2Button).toHaveAttribute('aria-pressed', 'true');
 
     // Check the Page 2 content
     expect(screen.getByText('Component 2')).toBeInTheDocument();
 
     const page1Button = screen.getByRole('button', { name: 'Page 1' });
-    expect(page1Button).toHaveAttribute('aria-selected', 'false');
+    expect(page1Button).toHaveAttribute('aria-pressed', 'false');
     await userEvent.click(page1Button);
 
     // Check the Page 1 content

--- a/src/generic/sidebar/Sidebar.tsx
+++ b/src/generic/sidebar/Sidebar.tsx
@@ -4,7 +4,6 @@ import {
   Dropdown,
   Icon,
   IconButton,
-  IconButtonToggle,
   IconButtonWithTooltip,
   Stack,
 } from '@openedx/paragon';
@@ -144,17 +143,19 @@ export function Sidebar<T extends SidebarPages>({
           variant="primary"
           className="mb-2"
         />
-        <IconButtonToggle
-          activeValue={activeKey}
-          onChange={setCurrentPageKey}
-        >
+        <div className="pgn__icon-button-toggle__container">
           {Object.entries(pages).map(([key, page]) => {
+            const pageKey = key as keyof T;
+            const isActive = pageKey === activeKey;
             const buttonData = {
-              value: key,
               src: page.icon,
               alt: intl.formatMessage(page.title),
               className: 'rounded-iconbutton my-2',
               disabled: page.disabled,
+              isActive,
+              'aria-pressed': isActive,
+              'data-testid': `icon-btn-val-${key}`,
+              onClick: () => setCurrentPageKey(pageKey),
             };
 
             if (page.tooltip) {
@@ -170,7 +171,7 @@ export function Sidebar<T extends SidebarPages>({
 
             return <IconButton key={key} {...buttonData} />;
           })}
-        </IconButtonToggle>
+        </div>
       </div>
     </Stack>
   );


### PR DESCRIPTION
## Description

Fixes two critical accessibility violations in the course outline chrome:

- The sidebar page selectors now use `aria-pressed` on ordinary buttons instead of the unsupported `aria-selected` attribute injected by `IconButtonToggle`.
- The card actions menu button now has a translated, contextual accessible name (`Actions for {title}`) instead of an internal identifier.

The sidebar keeps the existing appearance, active styling, click behavior, disabled state, tooltips, and test IDs. This affects course authors and staff using the course outline, particularly people navigating with assistive technology. There is no intended visual change, so before/after screenshots would be identical.

## Supporting information

Fixes #3231.

## Testing instructions

1. Open a course outline with the Info, Add, Align, and Help sidebar controls.
2. Inspect each sidebar selector and confirm it is a named button with `aria-pressed="true"` only for the active open page and `aria-pressed="false"` otherwise; none should have `aria-selected`.
3. Activate another sidebar selector and confirm the pressed state and visible panel update together.
4. Inspect a course outline card's vertical-ellipsis menu button and confirm its accessible name is `Actions for <card title>`.
5. Run an axe WCAG 2.2 AA scan and confirm the reported `aria-allowed-attr` and `button-name` violations are gone.

Automated validation:

- `TZ=UTC npx fedx-scripts jest --coverage=false --runInBand src/generic/sidebar/Sidebar.test.tsx src/course-outline/card-header/CardHeader.test.tsx` (41 tests passed)
- `npm run i18n_extract`
- `npm run lint`
- `npm run types`
- `npm run test:ci -- --maxWorkers=4` (560 suites and 5,059 tests passed)
- `npm run build`

## Other information

This change has no external dependencies, migrations, or visual behavior changes.

AI assistance disclosure: OpenAI Codex was used to investigate the issue, implement the code and tests, and run validation. The account holder must still personally review and understand the contribution before this draft is marked ready for review, in accordance with the Open edX AI Contribution Policy.

## Best Practices Checklist

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`). (No new files.)
- [x] Avoid `propTypes` and `defaultProps` in any new or modified code.
- [x] Tests use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`).
- [x] Do not add new fields to the Redux state/store. Use React Context to share state among multiple components.
- [x] Use React Query to load data from REST APIs. (No data loading changes.)
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Avoid using `../` in import paths. (No imports from parent folders were added.)
