### PR TITLE
fix: unit page title no longer overlaps the Live/Discussions badges

### DIFF
--- a/src/course-unit/CourseUnit.scss
+++ b/src/course-unit/CourseUnit.scss
@@ -12,8 +12,16 @@
   min-width: 900px;
 
   .sub-header {
-    // To clean the blank space in the bottom of the sub header
-    margin-bottom: -35px;
+    // Remove the blank space at the bottom of the sub header at the source.
+    // The shared SubHeader reserves 1.75rem under its action buttons, which the
+    // unit page does not want because it renders its own status bar right below.
+    // Do not do this with a negative margin on `.sub-header`: that pulls the
+    // status bar up by a fixed amount regardless of how tall the title is, so a
+    // display name that wraps to two or more lines ends up underneath the
+    // "Live" / "Discussions Enabled" badges.
+    .sub-header-actions {
+      margin-bottom: 0;
+    }
   }
 }
 


### PR DESCRIPTION
## Description

To hide blank space under the sub header's action buttons, the unit page pulled everything below the sub header up by a fixed 35px (`.course-unit .sub-header { margin-bottom: -35px }`). Once the unit display name wraps to a second line the title, not the buttons, sets the header's height, so those 35px come out of the title and the "Live" / "Discussions Enabled" badges are painted over it.

This zeroes the `.sub-header-actions` bottom margin inside `.course-unit` instead, closing the same gap by the right amount at any title height. Scoped to `.course-unit`, so the shared `SubHeader` on other pages is untouched.

### Before

1000px-wide window, display name wrapping to three lines:

![before](https://raw.githubusercontent.com/AhtishamShahid/frontend-app-authoring/assets/hq-12844/hq-12844-before.png)

### After

![after](https://raw.githubusercontent.com/AhtishamShahid/frontend-app-authoring/assets/hq-12844/hq-12844-after.png)

## Supporting information

Reported as `mitodl/hq#12844` (MIT Open Learning, private tracker).

## Testing instructions

1. Give a unit a display name long enough to wrap, publish it with the course start date in the past (**Live** badge), and turn on `openedx` discussions plus `discussion_enabled` on the unit (**Discussions Enabled** badge).
2. Open the unit page at a window width of about 1000px so the title wraps: the badges should sit below the title instead of on top of its last line.
3. Widen until the title fits on one line and confirm the spacing there is unchanged.

## Other information

- CSS only. No behaviour, API, dependency, or migration changes.
- Checked by hand on Verawood (`openedx-authoring-dev:22.0.0`) at 1000px (three-line title), 1500px (two-line title), and with a one-line title. `npx stylelint src/course-unit/CourseUnit.scss` passes; the Jest suite was not run locally.
- Backported to `release/verawood` in #3244 as the same commit.

## Best Practices Checklist

CSS-only change: no new files, components, state, API calls, or translated strings, so none of the checklist items apply.
